### PR TITLE
fix(spc): provider naming mismatch

### DIFF
--- a/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-entra-application-registration/versions.tf
+++ b/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-entra-application-registration/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 1.10"
   required_providers {
-    azurerm = {
+    azuread = {
       source  = "hashicorp/azuread"
       version = "~> 3"
     }


### PR DESCRIPTION
fixes

```
│ Warning: Duplicate required provider
│ 
│   on .terraform/modules/sharepoint_connector/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-entra-application-registration/main.tf line 1:
│    1: resource "azuread_application" "sharepoint_connector" {
│ 
│ Provider "registry.terraform.io/hashicorp/azuread" was implicitly required
│ via resource "azuread_application.sharepoint_connector", but listed in
│ required_providers as "azurerm". Either the local name in
│ required_providers must match the resource name, or the "azurerm" provider
│ must be assigned within the resource block.
│ 
│ (and one more similar warning elsewhere)
╵
```