### PR TITLE
fix(spc): clarify sites parameter

### DIFF
--- a/services/sharepoint-connector/README.md
+++ b/services/sharepoint-connector/README.md
@@ -36,3 +36,10 @@ The service exposes standard metrics and health endpoints:
 - `/probe` - Health check endpoint
 - `/metrics` - Prometheus metrics (if configured)
 - Structured logging with correlation IDs for request tracing
+
+## Troubleshooting
+
+### `Invalid hostname for this tenancy`
+Double-check the `Sites` you are supplying. Sites are UUIDs (`00000000-0000-0000-0000-000000000000` format) and not names or URL/URIs.
+
+A site ID can be grabbed from suffixing `_api/site/id` to your site, like `https://<your-site>.sharepoint.com/sites/<real-site>/_api/site/id` ([Test](https://uniqueapp.sharepoint.com/sites/UniqueAG/_api/site/id)) and then using `Edm.Guid`.

--- a/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/templates/config.yaml
+++ b/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/templates/config.yaml
@@ -13,7 +13,7 @@ data:
   PROCESSING_CONCURRENCY: {{ .Values.connectorConfig.processingConcurrency | quote }}
   SHAREPOINT_BASE_URL: {{ .Values.connectorConfig.sharepoint.baseUrl | quote }}
   SHAREPOINT_MAX_FILES_TO_SCAN: {{ .Values.connectorConfig.sharepoint.maxFilesToScan | quote }}
-  SHAREPOINT_SITES: {{ .Values.connectorConfig.sharepoint.sites | quote }}
+  SHAREPOINT_SITES: {{ .Values.connectorConfig.sharepoint.sites | join "," }}
   SHAREPOINT_SYNC_COLUMN_NAME: {{ .Values.connectorConfig.sharepoint.syncColumnName | quote }}
   STEP_TIMEOUT_SECONDS: {{ .Values.connectorConfig.stepTimeoutSeconds | quote }}
   UNIQUE_FILE_DIFF_BASE_PATH: {{ .Values.connectorConfig.unique.fileDiffBasePath | quote }}

--- a/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.schema.json
+++ b/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.schema.json
@@ -91,8 +91,11 @@
               "description": "Maximum number of files to scan"
             },
             "sites": {
-              "type": "string",
-              "description": "SharePoint sites configuration"
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "SharePoint sites list (UUIDs)"
             },
             "syncColumnName": {
               "type": "string",

--- a/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.yaml
+++ b/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.yaml
@@ -91,8 +91,9 @@ connectorConfig:
     baseUrl: unset_default_value
     maxFilesToScan: 2
     # -- sites to scan
-    # example: sharepoint-site-id-1,sharepoint-site-id-2 @lorand93: make concrete examples here
-    sites: unset_default_value
+    # example: 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000001
+    # Note: these are the site IDs, not the site URLs or names
+    sites: []
     # -- column name against which the files are synced
     # example: FinanceGPTKnowledge
     syncColumnName: unset_default_value


### PR DESCRIPTION
clarifies:

```
{"level":50,"time":1759921496891,"pid":8,"hostname":"sharepoint-connector-776c74cc57-db4sk","context":"SharepointSynchronizationService","msg":"Failed during processing of site UniqueAG: Invalid hostname for this tenancy","err":{"type":"GraphError","message":"Invalid hostname for this tenancy","stack":"Error: Invalid hostname for this tenancy\n at new GraphError 
```