### PR TITLE
fix(teams-mcp): clarify tool descriptions — search works without running integration

### DIFF
--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -77,7 +77,7 @@ export class FindTranscriptsTool {
     name: 'find_transcripts',
     title: 'Search Meeting Transcripts',
     description:
-      'Search for content within meeting transcripts using semantic search. Returns relevant passages that can be cited using [N] notation where N is the result index.',
+      'Search for content within meeting transcripts using semantic search. Returns relevant passages that can be cited using [N] notation where N is the result index. This searches all transcripts the user has access to, including meetings ingested by other participants — a running integration is not required.',
     parameters: FindTranscriptsInputSchema,
     outputSchema: FindTranscriptsOutputSchema,
     annotations: {
@@ -90,7 +90,7 @@ export class FindTranscriptsTool {
     _meta: {
       'unique.app/icon': 'search',
       'unique.app/system-prompt':
-        'Use this tool to search meeting transcripts. Cite results using [N] where N is the array index (e.g., [0] for first result, [1] for second). The platform will automatically convert these to proper references.',
+        'Use this tool to search meeting transcripts. This does NOT require a running integration — the user can search all transcripts they have access to, including meetings ingested by other participants. Cite results using [N] where N is the array index (e.g., [0] for first result, [1] for second). The platform will automatically convert these to proper references.',
     },
   })
   @Span()

--- a/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
@@ -34,7 +34,7 @@ export class StartKbIntegrationTool {
     name: 'start_kb_integration',
     title: 'Start Knowledge Base Integration',
     description:
-      'Start the knowledge base integration to begin ingesting Microsoft Teams meeting transcripts. This creates a subscription with Microsoft Graph to receive notifications when new transcripts are available.',
+      'Start the knowledge base integration to begin ingesting Microsoft Teams meeting transcripts owned by the user. This creates a subscription with Microsoft Graph to receive notifications when new transcripts are available. Note: the user can already search transcripts from meetings ingested by other participants without starting their own integration.',
     parameters: StartKbIntegrationInputSchema,
     outputSchema: StartKbIntegrationOutputSchema,
     annotations: {
@@ -47,7 +47,7 @@ export class StartKbIntegrationTool {
     _meta: {
       'unique.app/icon': 'play',
       'unique.app/system-prompt':
-        'Starts the knowledge base integration for meeting transcripts. Use verify_kb_integration_status first to check if it is already running. If already active, inform the user that ingestion is already running.',
+        'Starts the knowledge base integration for meeting transcripts owned by the user. Use verify_kb_integration_status first to check if it is already running. If already active, inform the user that ingestion is already running. Important: starting integration is only needed to ingest meetings the user owns — they can already search transcripts from meetings where they are a participant (ingested by other users) without this.',
     },
   })
   @Span()

--- a/services/teams-mcp/src/transcript/tools/verify-kb-integration-status.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/verify-kb-integration-status.tool.ts
@@ -38,7 +38,7 @@ export class VerifyKbIntegrationStatusTool {
     name: 'verify_kb_integration_status',
     title: 'Verify Knowledge Base Integration Status',
     description:
-      'Check the status of the knowledge base integration for Microsoft Teams meeting transcripts. Returns whether ingestion is active, expiring soon, expired, or not configured.',
+      'Check the status of the knowledge base integration for Microsoft Teams meeting transcripts. Returns whether ingestion is active, expiring soon, expired, or not configured. Note: an inactive integration does not prevent searching — the user can still search transcripts from meetings ingested by other participants.',
     parameters: VerifyKbIntegrationStatusInputSchema,
     outputSchema: VerifyKbIntegrationStatusOutputSchema,
     annotations: {
@@ -51,7 +51,7 @@ export class VerifyKbIntegrationStatusTool {
     _meta: {
       'unique.app/icon': 'status',
       'unique.app/system-prompt':
-        'Returns the current status of the knowledge base integration for meeting transcripts. Use this to verify if transcription ingestion is running before suggesting to start or stop it.',
+        'Returns the current status of the knowledge base integration for meeting transcripts. Use this before suggesting to start or stop integration, but do NOT require it before searching — find_transcripts works independently and returns all transcripts the user has access to as a participant.',
     },
   })
   @Span()


### PR DESCRIPTION
## Summary
- Update tool descriptions and system prompts to clarify that `find_transcripts` works independently of integration status
- Integration (subscription) only ingests meetings the user **owns** — but the user has access to all transcripts from meetings they **participate** in, even if ingested by someone else
- Prevents the agent from requiring `verify_kb_integration_status` before every search

### Tools updated
- **find_transcripts** — description and system prompt clarify no integration required
- **verify_kb_integration_status** — system prompt no longer implies it must be called before searching
- **start_kb_integration** — description and system prompt clarify it only ingests owned meetings

## Test plan
- [x] `pnpm --filter teams-mcp check-types` compiles cleanly
- [x] `pnpm --filter teams-mcp style` — linter passes