### PR TITLE
feat(ms-graph-sdk,main): typed MS Graph API client package for NestJS

### DIFF
--- a/.gitcommitizen
+++ b/.gitcommitizen
@@ -33,6 +33,7 @@ teams-mcp = services/teams-mcp/**
 
 # Packages
 aes-gcm-encryption = packages/aes-gcm-encryption/**
+ms-graph-sdk = packages/ms-graph-sdk/**
 instrumentation = packages/instrumentation/**
 logger = packages/logger/**
 mcp-oauth = packages/mcp-oauth/**

--- a/packages/ms-graph-sdk/package.json
+++ b/packages/ms-graph-sdk/package.json
@@ -14,16 +14,16 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@proventuslabs/nestjs-zod": "2.1.0",
+    "@proventuslabs/nestjs-zod": "^2.0.0",
     "@proventuslabs/retry-strategies": "0.1.2",
     "@qfetch/qfetch": "0.1.0",
     "@unique-ag/utils": "workspace:*",
     "zod": "^4.1.5"
   },
   "devDependencies": {
-    "@nestjs/common": "^11.0.0",
-    "@nestjs/core": "^11.0.0",
-    "@nestjs/testing": "^11.0.0",
+    "@nestjs/common": "^11.1.6",
+    "@nestjs/core": "^11.1.6",
+    "@nestjs/testing": "^11.1.6",
     "@suites/di.nestjs": "^3.0.1",
     "@suites/doubles.vitest": "^3.0.1",
     "@suites/unit": "^3.0.1",

--- a/packages/ms-graph-sdk/package.json
+++ b/packages/ms-graph-sdk/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@unique-ag/ms-graph-sdk",
+  "description": "Typed Microsoft Graph API client for NestJS services",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "style": "biome check .",
+    "style:fix": "biome check . --write",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@proventuslabs/nestjs-zod": "2.1.0",
+    "@proventuslabs/retry-strategies": "0.1.2",
+    "@qfetch/qfetch": "0.1.0",
+    "@unique-ag/utils": "workspace:*",
+    "zod": "^4.1.5"
+  },
+  "devDependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/testing": "^11.0.0",
+    "@suites/di.nestjs": "^3.0.1",
+    "@suites/doubles.vitest": "^3.0.1",
+    "@suites/unit": "^3.0.1",
+    "@swc/core": "^1.13.5",
+    "@types/node": "^22.13.14",
+    "reflect-metadata": "^0.2.2",
+    "typescript": "^5.9.2",
+    "unplugin-swc": "^1.5.7",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^10 || ^11",
+    "@nestjs/core": "^10 || ^11"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./outlook": {
+      "types": "./src/outlook/index.ts",
+      "import": "./src/outlook/index.ts",
+      "require": "./dist/outlook/index.js",
+      "default": "./dist/outlook/index.js"
+    },
+    "./teams": {
+      "types": "./src/teams/index.ts",
+      "import": "./src/teams/index.ts",
+      "require": "./dist/teams/index.js",
+      "default": "./dist/teams/index.js"
+    }
+  }
+}

--- a/packages/ms-graph-sdk/src/client/graph-client.service.ts
+++ b/packages/ms-graph-sdk/src/client/graph-client.service.ts
@@ -1,0 +1,62 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { constant, fullJitter, upto } from '@proventuslabs/retry-strategies';
+import {
+  pipeline,
+  withAuthorization,
+  withBaseUrl,
+  withHeaders,
+  withResponseError,
+  withRetryAfter,
+  withRetryStatus,
+} from '@qfetch/qfetch';
+import { GraphError } from './graph-error';
+import { MODULE_OPTIONS_TOKEN, OPTIONS_TYPE } from './graph-sdk.module.options';
+import { GraphUserClient } from './graph-user-client';
+
+@Injectable()
+export class GraphClientService {
+  public constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly options: typeof OPTIONS_TYPE) {}
+
+  public forUser(userProfileId: string): GraphUserClient {
+    const baseUrl = `https://graph.microsoft.com/${this.options.apiVersion}`;
+    const { maxAttempts, maxServerDelay } = this.options.retry;
+
+    const fetchFn = pipeline(
+      withBaseUrl(baseUrl),
+
+      withHeaders({
+        'Content-Type': 'application/json',
+        ...this.options.defaultHeaders,
+      }),
+
+      withAuthorization({
+        tokenProvider: {
+          getToken: async () => ({
+            accessToken: await this.options.getToken(userProfileId),
+            tokenType: 'Bearer',
+          }),
+        },
+        strategy: () => upto(1, constant(0)),
+      }),
+
+      withRetryAfter({
+        strategy: () => upto(maxAttempts, fullJitter(100, 5_000)),
+        maxServerDelay,
+      }),
+
+      withRetryStatus({
+        strategy: () => upto(maxAttempts, fullJitter(200, 10_000)),
+        retryableStatuses: new Set([500, 502, 503, 504]),
+      }),
+
+      withResponseError({
+        defaultMapper: async (response: Response) => {
+          const body: unknown = await response.json().catch(() => ({}));
+          return GraphError.fromResponse(response.status, body, response.headers);
+        },
+      }),
+    )(fetch);
+
+    return new GraphUserClient(fetchFn);
+  }
+}

--- a/packages/ms-graph-sdk/src/client/graph-error.ts
+++ b/packages/ms-graph-sdk/src/client/graph-error.ts
@@ -1,0 +1,102 @@
+import z from 'zod/v4';
+
+export enum GraphErrorCode {
+  BadRequest = 'BadRequest',
+  Unauthorized = 'Unauthorized',
+  Forbidden = 'Forbidden',
+  NotFound = 'NotFound',
+  Conflict = 'Conflict',
+  TooManyRequests = 'TooManyRequests',
+  InternalServerError = 'InternalServerError',
+  ServiceUnavailable = 'ServiceUnavailable',
+  GatewayTimeout = 'GatewayTimeout',
+  NetworkError = 'NetworkError',
+  ParseError = 'ParseError',
+  StreamError = 'StreamError',
+  Unknown = 'Unknown',
+}
+
+const RETRYABLE_CODES = new Set<GraphErrorCode>([
+  GraphErrorCode.TooManyRequests,
+  GraphErrorCode.ServiceUnavailable,
+  GraphErrorCode.GatewayTimeout,
+]);
+
+const STATUS_TO_CODE: Record<number, GraphErrorCode> = {
+  400: GraphErrorCode.BadRequest,
+  401: GraphErrorCode.Unauthorized,
+  403: GraphErrorCode.Forbidden,
+  404: GraphErrorCode.NotFound,
+  409: GraphErrorCode.Conflict,
+  429: GraphErrorCode.TooManyRequests,
+  500: GraphErrorCode.InternalServerError,
+  503: GraphErrorCode.ServiceUnavailable,
+  504: GraphErrorCode.GatewayTimeout,
+};
+
+/**
+ * The error response body returned by Microsoft Graph API on failure.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/errors
+ */
+const GraphErrorBody = z.object({
+  error: z
+    .object({
+      code: z.string().optional(),
+      message: z.string().optional(),
+      innerError: z
+        .object({
+          code: z.string().optional(),
+          date: z.string().optional(),
+          'request-id': z.string().optional(),
+          'client-request-id': z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export type GraphErrorBody = z.infer<typeof GraphErrorBody>;
+
+export class GraphError extends Error {
+  public readonly code: GraphErrorCode;
+  public readonly statusCode: number | undefined;
+  public readonly requestId: string | undefined;
+  public readonly graphErrorBody: GraphErrorBody | undefined;
+
+  public constructor(options: {
+    message: string;
+    code: GraphErrorCode;
+    statusCode?: number;
+    requestId?: string;
+    graphErrorBody?: GraphErrorBody;
+    cause?: unknown;
+  }) {
+    super(options.message, { cause: options.cause });
+    this.name = 'GraphError';
+    this.code = options.code;
+    this.statusCode = options.statusCode;
+    this.requestId = options.requestId;
+    this.graphErrorBody = options.graphErrorBody;
+  }
+
+  public get isRetryable(): boolean {
+    return RETRYABLE_CODES.has(this.code);
+  }
+
+  public static fromResponse(status: number, rawBody: unknown, headers: Headers): GraphError {
+    const code = STATUS_TO_CODE[status] ?? GraphErrorCode.Unknown;
+    const body = GraphErrorBody.safeParse(rawBody).data;
+    const requestId =
+      headers.get('x-ms-request-id') ?? body?.error?.innerError?.['request-id'] ?? undefined;
+    const message = body?.error?.message ?? `Graph API responded with ${status}`;
+
+    return new GraphError({
+      message,
+      code,
+      statusCode: status,
+      requestId,
+      graphErrorBody: body,
+    });
+  }
+}

--- a/packages/ms-graph-sdk/src/client/graph-sdk.module.options.ts
+++ b/packages/ms-graph-sdk/src/client/graph-sdk.module.options.ts
@@ -1,0 +1,20 @@
+import { ZodConfigurableModuleBuilder } from '@proventuslabs/nestjs-zod';
+import z from 'zod/v4';
+
+const schema = z.object({
+  getToken: z.custom<(userProfileId: string) => Promise<string>>(
+    (val) => typeof val === 'function',
+    { message: 'getToken must be a function' },
+  ),
+  apiVersion: z.enum(['v1.0', 'beta']).default('v1.0'),
+  defaultHeaders: z.record(z.string(), z.string()).optional(),
+  retry: z
+    .object({
+      maxAttempts: z.number().int().min(1),
+      maxServerDelay: z.number().int().min(0),
+    })
+    .default({ maxAttempts: 3, maxServerDelay: 30_000 }),
+});
+
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN, OPTIONS_TYPE, OPTIONS_INPUT_TYPE } =
+  new ZodConfigurableModuleBuilder(schema).setClassMethodName('register').build();

--- a/packages/ms-graph-sdk/src/client/graph-sdk.module.ts
+++ b/packages/ms-graph-sdk/src/client/graph-sdk.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GraphClientService } from './graph-client.service';
+import { ConfigurableModuleClass } from './graph-sdk.module.options';
+
+@Module({
+  providers: [GraphClientService],
+  exports: [GraphClientService],
+})
+export class GraphSdkModule extends ConfigurableModuleClass {}

--- a/packages/ms-graph-sdk/src/client/graph-user-client.ts
+++ b/packages/ms-graph-sdk/src/client/graph-user-client.ts
@@ -1,0 +1,15 @@
+import { OutlookClient } from '../outlook/outlook-client';
+import { SubscriptionsClient } from '../shared/subscriptions-client';
+import { TeamsClient } from '../teams/teams-client';
+
+export class GraphUserClient {
+  public readonly teams: TeamsClient;
+  public readonly outlook: OutlookClient;
+  public readonly subscriptions: SubscriptionsClient;
+
+  public constructor(fetch: typeof globalThis.fetch) {
+    this.teams = new TeamsClient(fetch);
+    this.outlook = new OutlookClient(fetch);
+    this.subscriptions = new SubscriptionsClient(fetch);
+  }
+}

--- a/packages/ms-graph-sdk/src/index.ts
+++ b/packages/ms-graph-sdk/src/index.ts
@@ -1,0 +1,31 @@
+export { GraphClientService } from './client/graph-client.service';
+export type { GraphErrorBody } from './client/graph-error';
+export { GraphError, GraphErrorCode } from './client/graph-error';
+export { GraphSdkModule } from './client/graph-sdk.module';
+export {
+  MODULE_OPTIONS_TOKEN,
+  OPTIONS_INPUT_TYPE,
+  OPTIONS_TYPE,
+} from './client/graph-sdk.module.options';
+export { GraphUserClient } from './client/graph-user-client';
+export type { BatchRequestPayload, BatchResponsePayload, ODataQueryParams } from './shared/odata';
+export {
+  BatchRequest,
+  BatchResponse,
+  buildUrl,
+  ODataCollection,
+  ODataDeltaCollection,
+} from './shared/odata';
+export type { DeltaPage, GraphPage } from './shared/pagination';
+export { DeltaResponse, GraphPagedResponse, paginate, paginateDelta } from './shared/pagination';
+export { DateTimeTimeZone, IdentitySet, ItemBody, Recipient } from './shared/primitives';
+export {
+  CreateSubscriptionRequest,
+  UpdateSubscriptionRequest,
+} from './shared/subscriptions.requests';
+export {
+  ChangeNotification,
+  LifecycleChangeNotification,
+  Subscription,
+} from './shared/subscriptions.schema';
+export { SubscriptionsClient } from './shared/subscriptions-client';

--- a/packages/ms-graph-sdk/src/outlook/file-attachment.schema.ts
+++ b/packages/ms-graph-sdk/src/outlook/file-attachment.schema.ts
@@ -1,0 +1,15 @@
+import z from 'zod/v4';
+
+/**
+ * A file (such as a text file or Word document) attached to a message or event.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-1.0
+ */
+export const FileAttachment = z.object({
+  '@odata.type': z.literal('#microsoft.graph.fileAttachment'),
+  name: z.string().describe('The name of the attachment.'),
+  contentType: z.string().describe('The MIME type of the attachment.'),
+  contentBytes: z.string().describe('The base64-encoded contents of the file.'),
+});
+
+export type FileAttachment = z.infer<typeof FileAttachment>;

--- a/packages/ms-graph-sdk/src/outlook/index.ts
+++ b/packages/ms-graph-sdk/src/outlook/index.ts
@@ -1,0 +1,14 @@
+export { FileAttachment } from './file-attachment.schema';
+export { MailFolder } from './mail-folders.schema';
+export { FollowupFlag, Message } from './messages.schema';
+export type {
+  CreateMessageRequest,
+  GetMailFolderRequest,
+  GetMailFoldersDeltaRequest,
+  GetMessageRequest,
+  GetSystemFolderRequest,
+  ListMailFoldersRequest,
+  ListMessagesRequest,
+} from './outlook.requests';
+export { OutlookCategory } from './outlook-category.schema';
+export { OutlookClient } from './outlook-client';

--- a/packages/ms-graph-sdk/src/outlook/mail-folders.schema.ts
+++ b/packages/ms-graph-sdk/src/outlook/mail-folders.schema.ts
@@ -1,0 +1,30 @@
+import z from 'zod/v4';
+
+export interface MailFolder {
+  id: string;
+  displayName: string;
+  parentFolderId?: string;
+  childFolderCount?: number;
+  totalItemCount?: number;
+  unreadItemCount?: number;
+  isHidden?: boolean;
+  childFolders?: MailFolder[];
+}
+
+/**
+ * Represents a mail folder in a user's mailbox.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/mailfolder?view=graph-rest-1.0
+ */
+export const MailFolder: z.ZodType<MailFolder> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    displayName: z.string(),
+    parentFolderId: z.string().optional(),
+    childFolderCount: z.number().optional(),
+    totalItemCount: z.number().optional(),
+    unreadItemCount: z.number().optional(),
+    isHidden: z.boolean().optional(),
+    childFolders: z.array(MailFolder).optional(),
+  }),
+);

--- a/packages/ms-graph-sdk/src/outlook/messages.schema.ts
+++ b/packages/ms-graph-sdk/src/outlook/messages.schema.ts
@@ -1,0 +1,53 @@
+import z from 'zod/v4';
+import { ItemBody, isoDatetimeToDate, Recipient } from '../shared/primitives';
+
+/**
+ * Indicates the follow-up status of an item for the user to follow up on later.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/followupflag?view=graph-rest-1.0
+ */
+export const FollowupFlag = z.object({
+  flagStatus: z.enum(['notFlagged', 'complete', 'flagged']).optional(),
+  dueDateTime: z.object({ dateTime: z.string(), timeZone: z.string() }).optional(),
+  startDateTime: z.object({ dateTime: z.string(), timeZone: z.string() }).optional(),
+  completedDateTime: z.object({ dateTime: z.string(), timeZone: z.string() }).optional(),
+});
+
+/**
+ * A message in a mailbox folder.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0
+ */
+export const Message = z.object({
+  id: z.string(),
+  subject: z.string().optional(),
+  bodyPreview: z.string().optional(),
+  body: ItemBody.optional().nullable(),
+  uniqueBody: ItemBody.optional().nullable(),
+  from: Recipient.optional().nullable(),
+  sender: Recipient.optional().nullable(),
+  toRecipients: z.array(Recipient).optional(),
+  ccRecipients: z.array(Recipient).optional(),
+  bccRecipients: z.array(Recipient).optional(),
+  replyTo: z.array(Recipient).optional(),
+  conversationId: z.string().optional(),
+  internetMessageId: z.string().optional(),
+  internetMessageHeaders: z.array(z.object({ name: z.string(), value: z.string() })).optional(),
+  parentFolderId: z.string().optional(),
+  receivedDateTime: isoDatetimeToDate({ offset: true }).optional(),
+  sentDateTime: isoDatetimeToDate({ offset: true }).optional(),
+  createdDateTime: isoDatetimeToDate({ offset: true }).optional(),
+  lastModifiedDateTime: isoDatetimeToDate({ offset: true }).optional(),
+  isRead: z.boolean().optional().nullable(),
+  isDraft: z.boolean().optional().nullable(),
+  hasAttachments: z.boolean().optional(),
+  importance: z.enum(['low', 'normal', 'high']).optional(),
+  inferenceClassification: z.enum(['focused', 'other']).optional(),
+  categories: z.array(z.string()).optional(),
+  flag: FollowupFlag.optional(),
+  webLink: z.string().optional(),
+  isDeliveryReceiptRequested: z.boolean().optional().nullable(),
+  isReadReceiptRequested: z.boolean().optional().nullable(),
+});
+
+export type Message = z.infer<typeof Message>;

--- a/packages/ms-graph-sdk/src/outlook/outlook-category.schema.ts
+++ b/packages/ms-graph-sdk/src/outlook/outlook-category.schema.ts
@@ -1,0 +1,14 @@
+import z from 'zod/v4';
+
+/**
+ * Represents a category by which a user can group Outlook items such as messages and events.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/outlookcategory?view=graph-rest-1.0
+ */
+export const OutlookCategory = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  color: z.string(),
+});
+
+export type OutlookCategory = z.infer<typeof OutlookCategory>;

--- a/packages/ms-graph-sdk/src/outlook/outlook-client.ts
+++ b/packages/ms-graph-sdk/src/outlook/outlook-client.ts
@@ -1,0 +1,128 @@
+import { buildUrl, ODataCollection } from '../shared/odata';
+import type { DeltaResponse, GraphPagedResponse } from '../shared/pagination';
+import { paginate, paginateDelta } from '../shared/pagination';
+import { MailFolder } from './mail-folders.schema';
+import { Message } from './messages.schema';
+import {
+  CreateMessageRequest,
+  GetMailFolderRequest,
+  GetMailFoldersDeltaRequest,
+  GetMessageRequest,
+  GetSystemFolderRequest,
+  ListMailFoldersRequest,
+  ListMessagesRequest,
+} from './outlook.requests';
+import { OutlookCategory } from './outlook-category.schema';
+
+export type {
+  CreateMessageRequest,
+  GetMailFolderRequest,
+  GetMailFoldersDeltaRequest,
+  GetMessageRequest,
+  GetSystemFolderRequest,
+  ListMailFoldersRequest,
+  ListMessagesRequest,
+} from './outlook.requests';
+export type { OutlookCategory } from './outlook-category.schema';
+
+const IMMUTABLE_IDS_HEADER = { Prefer: 'IdType="ImmutableId"' } as const;
+
+export class OutlookClient {
+  public constructor(private readonly fetch: typeof globalThis.fetch) {}
+
+  /**
+   * Get the mail folder collection directly under the root folder of the signed-in user.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0
+   */
+  public listMailFolders(params: ListMailFoldersRequest = {}): GraphPagedResponse<MailFolder> {
+    const { immutableIds, ...odata } = params;
+    const url = buildUrl('/me/mailFolders', odata);
+    const headers = immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    return paginate(this.fetch, url, MailFolder, headers ? { headers } : undefined);
+  }
+
+  /**
+   * Retrieve the properties and relationships of a mail folder object.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0
+   */
+  public async getMailFolder(params: GetMailFolderRequest): Promise<MailFolder> {
+    const url = buildUrl(`/me/mailFolders/${params.folderId}`, { $expand: params.expand });
+    const headers = params.immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    const response = await this.fetch(url, headers ? { headers } : undefined);
+    return MailFolder.parse(await response.json());
+  }
+
+  /**
+   * Retrieve a mail folder by its well-known folder name (e.g. inbox, drafts, sentitems).
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0
+   */
+  public async getSystemFolder(params: GetSystemFolderRequest): Promise<MailFolder> {
+    const headers = params.immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    const response = await this.fetch(
+      `/me/mailFolders/${params.folderName}`,
+      headers ? { headers } : undefined,
+    );
+    return MailFolder.parse(await response.json());
+  }
+
+  /**
+   * Get a set of mail folders that have been added, deleted, or removed from the user's mailbox.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-delta?view=graph-rest-1.0
+   */
+  public getMailFoldersDelta(params: GetMailFoldersDeltaRequest = {}): DeltaResponse<MailFolder> {
+    const url = params.deltaLink ?? '/me/mailFolders/delta';
+    const headers = params.immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    return paginateDelta(this.fetch, url, MailFolder, headers ? { headers } : undefined);
+  }
+
+  /**
+   * Get all the categories that have been defined for the signed-in user.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/outlookuser-list-mastercategories?view=graph-rest-1.0
+   */
+  public async listMasterCategories(): Promise<OutlookCategory[]> {
+    const response = await this.fetch('/me/outlook/masterCategories');
+    return ODataCollection(OutlookCategory).parse(await response.json()).value;
+  }
+
+  /**
+   * Retrieve the properties and relationships of a message object.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/message-get?view=graph-rest-1.0
+   */
+  public async getMessage(params: GetMessageRequest): Promise<Message> {
+    const url = buildUrl(`/me/messages/${params.messageId}`, { $select: params.select });
+    const headers = params.immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    const response = await this.fetch(url, headers ? { headers } : undefined);
+    return Message.parse(await response.json());
+  }
+
+  /**
+   * Get the messages in the signed-in user's mailbox, including the Deleted Items and Clutter folders.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0
+   */
+  public listMessages(params: ListMessagesRequest = {}): GraphPagedResponse<Message> {
+    const { immutableIds, ...odata } = params;
+    const url = buildUrl('/me/messages', odata);
+    const headers = immutableIds ? IMMUTABLE_IDS_HEADER : undefined;
+    return paginate(this.fetch, url, Message, headers ? { headers } : undefined);
+  }
+
+  /**
+   * Create a draft of a new message in JSON format. The draft is saved in the Drafts folder.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/user-post-messages?view=graph-rest-1.0
+   */
+  public async createDraft(params: CreateMessageRequest): Promise<Message> {
+    const response = await this.fetch('/me/messages', {
+      method: 'POST',
+      body: JSON.stringify(CreateMessageRequest.parse(params)),
+    });
+    return Message.parse(await response.json());
+  }
+}

--- a/packages/ms-graph-sdk/src/outlook/outlook.requests.ts
+++ b/packages/ms-graph-sdk/src/outlook/outlook.requests.ts
@@ -1,0 +1,114 @@
+import z from 'zod/v4';
+import { ODataQueryParamsSchema } from '../shared/odata';
+import { Recipient } from '../shared/primitives';
+import { FileAttachment } from './file-attachment.schema';
+
+/**
+ * Parameters for listing mail folders under the root folder of the signed-in user.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0
+ */
+const ListMailFoldersRequest = ODataQueryParamsSchema.extend({
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type ListMailFoldersRequest = z.input<typeof ListMailFoldersRequest>;
+
+/**
+ * Parameters for retrieving a single mail folder by ID.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0
+ */
+const GetMailFolderRequest = z.object({
+  folderId: z.string().describe('The mail folder ID to retrieve.'),
+  expand: z.string().optional().describe('OData $expand clause to include related entities.'),
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type GetMailFolderRequest = z.infer<typeof GetMailFolderRequest>;
+
+/**
+ * Parameters for retrieving a mail folder by its well-known name (e.g. inbox, drafts, sentitems).
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0
+ */
+const GetSystemFolderRequest = z.object({
+  folderName: z
+    .string()
+    .describe('The well-known folder name (e.g. inbox, drafts, sentitems, deleteditems).'),
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type GetSystemFolderRequest = z.infer<typeof GetSystemFolderRequest>;
+
+/**
+ * Parameters for retrieving incremental changes to mail folders using delta query.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/mailfolder-delta?view=graph-rest-1.0
+ */
+const GetMailFoldersDeltaRequest = z.object({
+  deltaLink: z
+    .string()
+    .optional()
+    .describe('The delta link from a previous delta response to resume change tracking.'),
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type GetMailFoldersDeltaRequest = z.infer<typeof GetMailFoldersDeltaRequest>;
+
+/**
+ * Parameters for retrieving a single message by ID.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/message-get?view=graph-rest-1.0
+ */
+const GetMessageRequest = z.object({
+  messageId: z.string().describe('The message ID to retrieve.'),
+  select: z.array(z.string()).optional().describe('OData $select properties to return.'),
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type GetMessageRequest = z.infer<typeof GetMessageRequest>;
+
+/**
+ * Parameters for listing messages in the signed-in user's mailbox.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0
+ */
+const ListMessagesRequest = ODataQueryParamsSchema.extend({
+  immutableIds: z
+    .boolean()
+    .optional()
+    .describe('When true, requests immutable IDs in the response.'),
+});
+export type ListMessagesRequest = z.input<typeof ListMessagesRequest>;
+
+/**
+ * Request body for creating a draft message in the signed-in user's Drafts folder.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/user-post-messages?view=graph-rest-1.0
+ */
+export const CreateMessageRequest = z.object({
+  subject: z.string().describe('The subject of the message.'),
+  body: z
+    .object({
+      contentType: z
+        .enum(['HTML', 'Text'])
+        .describe('The type of the content. Possible values are text and html.'),
+      content: z.string().describe('The content of the item body.'),
+    })
+    .describe('The body of the message. It can be in HTML or text format.'),
+  toRecipients: z.array(Recipient).describe('The To: recipients for the message.'),
+  ccRecipients: z.array(Recipient).optional().describe('The Cc: recipients for the message.'),
+  attachments: z.array(FileAttachment).optional().describe('The file attachments for the message.'),
+});
+export type CreateMessageRequest = z.infer<typeof CreateMessageRequest>;

--- a/packages/ms-graph-sdk/src/shared/odata.ts
+++ b/packages/ms-graph-sdk/src/shared/odata.ts
@@ -1,0 +1,67 @@
+import z from 'zod/v4';
+
+export const ODataCollection = <S extends z.core.$ZodType>(itemSchema: S) =>
+  z.object({
+    '@odata.context': z.string().optional(),
+    '@odata.count': z.number().optional(),
+    '@odata.nextLink': z.string().optional(),
+    value: z.array(itemSchema),
+  });
+
+export const ODataDeltaCollection = <S extends z.core.$ZodType>(itemSchema: S) =>
+  ODataCollection(itemSchema).extend({
+    '@odata.deltaLink': z.string().optional(),
+  });
+
+export const BatchRequestPayload = z.object({
+  id: z.string(),
+  method: z.enum(['GET', 'POST', 'PATCH', 'DELETE']),
+  url: z.string(),
+  headers: z.record(z.string(), z.string()).optional(),
+  body: z.unknown().optional(),
+});
+
+export const BatchResponsePayload = z.object({
+  id: z.string(),
+  status: z.number(),
+  headers: z.record(z.string(), z.string()).optional(),
+  body: z.unknown().nullish(),
+});
+
+export const BatchRequest = z.object({ requests: z.array(BatchRequestPayload) });
+export const BatchResponse = z.object({ responses: z.array(BatchResponsePayload) });
+
+export type BatchRequestPayload = z.infer<typeof BatchRequestPayload>;
+export type BatchResponsePayload = z.infer<typeof BatchResponsePayload>;
+
+// Each field carries a transform that serialises it to a URL param string.
+// z.input<> gives the natural call-site type; z.output<> is all-strings for buildUrl.
+export const ODataQueryParamsSchema = z.object({
+  $select: z
+    .array(z.string())
+    .transform((v) => v.join(','))
+    .optional(),
+  $filter: z.string().optional(),
+  $expand: z.string().optional(),
+  $top: z.number().int().positive().transform(String).optional(),
+  $skip: z.number().int().nonnegative().transform(String).optional(),
+  $orderby: z.string().optional(),
+  $count: z
+    .literal(true)
+    .transform(() => 'true')
+    .optional(),
+  $search: z.string().optional(),
+});
+
+export type ODataQueryParams = z.input<typeof ODataQueryParamsSchema>;
+
+export function buildUrl(path: string, params?: ODataQueryParams): string {
+  if (!params) return path;
+  const serialized = ODataQueryParamsSchema.parse(params);
+  const entries = Object.entries(serialized).filter(
+    (e): e is [string, string] => e[1] !== undefined,
+  );
+  if (!entries.length) return path;
+  const qs = entries.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+  return `${path}?${qs}`;
+}

--- a/packages/ms-graph-sdk/src/shared/pagination.ts
+++ b/packages/ms-graph-sdk/src/shared/pagination.ts
@@ -1,0 +1,129 @@
+import z from 'zod/v4';
+import { ODataDeltaCollection } from './odata';
+
+export interface GraphPage<T> {
+  readonly value: T[];
+  readonly nextLink: string | undefined;
+  readonly deltaLink: string | undefined;
+  readonly count: number | undefined;
+}
+
+export interface DeltaPage<T> extends GraphPage<T> {
+  readonly isTerminal: boolean;
+}
+
+export class GraphPagedResponse<T> implements AsyncIterable<T> {
+  public constructor(
+    private readonly fetchFn: typeof globalThis.fetch,
+    private readonly initialUrl: string,
+    private readonly itemSchema: z.ZodType<T>,
+    private readonly init?: RequestInit,
+  ) {}
+
+  private async fetchPage(url: string): Promise<GraphPage<T>> {
+    const schema = ODataDeltaCollection(this.itemSchema);
+    const response = await this.fetchFn(url, this.init);
+    const raw: unknown = await response.json();
+    const parsed = schema.parse(raw);
+    return {
+      value: parsed.value,
+      nextLink: parsed['@odata.nextLink'],
+      deltaLink: parsed['@odata.deltaLink'],
+      count: parsed['@odata.count'],
+    };
+  }
+
+  public async *[Symbol.asyncIterator](): AsyncIterator<T> {
+    let page = await this.fetchPage(this.initialUrl);
+    yield* page.value;
+    while (page.nextLink) {
+      page = await this.fetchPage(page.nextLink);
+      yield* page.value;
+    }
+  }
+
+  public async *pages(): AsyncGenerator<GraphPage<T>> {
+    let page = await this.fetchPage(this.initialUrl);
+    yield page;
+    while (page.nextLink) {
+      page = await this.fetchPage(page.nextLink);
+      yield page;
+    }
+  }
+
+  public async toArray(): Promise<T[]> {
+    const items: T[] = [];
+    for await (const item of this) items.push(item);
+    return items;
+  }
+
+  public async first(): Promise<GraphPage<T>> {
+    return this.fetchPage(this.initialUrl);
+  }
+}
+
+export class DeltaResponse<T> {
+  public constructor(
+    private readonly fetchFn: typeof globalThis.fetch,
+    private readonly initialUrl: string,
+    private readonly itemSchema: z.ZodType<T>,
+    private readonly init?: RequestInit,
+  ) {}
+
+  private async fetchPage(url: string): Promise<DeltaPage<T>> {
+    const schema = ODataDeltaCollection(this.itemSchema);
+    const response = await this.fetchFn(url, this.init);
+    const raw: unknown = await response.json();
+    const parsed = schema.parse(raw);
+    return {
+      value: parsed.value,
+      nextLink: parsed['@odata.nextLink'],
+      deltaLink: parsed['@odata.deltaLink'],
+      count: parsed['@odata.count'],
+      isTerminal: !!parsed['@odata.deltaLink'] && !parsed['@odata.nextLink'],
+    };
+  }
+
+  public async *pages(): AsyncGenerator<DeltaPage<T>> {
+    let page = await this.fetchPage(this.initialUrl);
+    yield page;
+    while (page.nextLink) {
+      page = await this.fetchPage(page.nextLink);
+      yield page;
+    }
+  }
+
+  public async *items(): AsyncGenerator<T> {
+    for await (const page of this.pages()) {
+      yield* page.value;
+    }
+  }
+
+  public async drain(): Promise<{ items: T[]; deltaLink: string | null }> {
+    const items: T[] = [];
+    let deltaLink: string | null = null;
+    for await (const page of this.pages()) {
+      items.push(...page.value);
+      if (page.deltaLink) deltaLink = page.deltaLink;
+    }
+    return { items, deltaLink };
+  }
+}
+
+export function paginate<T>(
+  fetchFn: typeof globalThis.fetch,
+  initialUrl: string,
+  itemSchema: z.ZodType<T>,
+  init?: RequestInit,
+): GraphPagedResponse<T> {
+  return new GraphPagedResponse(fetchFn, initialUrl, itemSchema, init);
+}
+
+export function paginateDelta<T>(
+  fetchFn: typeof globalThis.fetch,
+  initialUrl: string,
+  itemSchema: z.ZodType<T>,
+  init?: RequestInit,
+): DeltaResponse<T> {
+  return new DeltaResponse(fetchFn, initialUrl, itemSchema, init);
+}

--- a/packages/ms-graph-sdk/src/shared/primitives.ts
+++ b/packages/ms-graph-sdk/src/shared/primitives.ts
@@ -1,0 +1,66 @@
+import z from 'zod/v4';
+
+/** Codec that parses ISO 8601 datetime strings into Date objects. */
+export const isoDatetimeToDate = (opts?: { offset?: boolean }) =>
+  z.codec(opts?.offset ? z.iso.datetime({ offset: true }) : z.iso.datetime(), z.instanceof(Date), {
+    decode: (value) => new Date(value),
+    encode: (date) => date.toISOString(),
+  });
+
+/** Codec that parses URL strings into URL objects. */
+export const stringToURL = () =>
+  z.codec(z.url(), z.instanceof(URL), {
+    decode: (value) => new URL(value),
+    encode: (url) => url.href,
+  });
+
+/**
+ * Represents identities of an actor in an activity.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/identityset?view=graph-rest-1.0
+ */
+export const IdentitySet = z.object({
+  application: z.object({ id: z.string(), displayName: z.string().nullish() }).nullish(),
+  device: z.object({ id: z.string(), displayName: z.string().nullish() }).nullish(),
+  user: z
+    .object({
+      id: z.string(),
+      displayName: z.string().nullish(),
+      tenantId: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+/**
+ * Represents information about a user in the sending or receiving end of an event or message.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/recipient?view=graph-rest-1.0
+ */
+export const Recipient = z.object({
+  emailAddress: z
+    .object({
+      address: z.string().optional(),
+      name: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Represents properties of the body of an item, such as a message, event or group post.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/itembody?view=graph-rest-1.0
+ */
+export const ItemBody = z.object({
+  contentType: z.enum(['text', 'html']).optional(),
+  content: z.string().optional(),
+});
+
+/**
+ * Describes the date, time, and time zone of a point in time.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0
+ */
+export const DateTimeTimeZone = z.object({
+  dateTime: z.string(),
+  timeZone: z.string(),
+});

--- a/packages/ms-graph-sdk/src/shared/subscriptions-client.ts
+++ b/packages/ms-graph-sdk/src/shared/subscriptions-client.ts
@@ -1,0 +1,26 @@
+import { CreateSubscriptionRequest, UpdateSubscriptionRequest } from './subscriptions.requests';
+import { Subscription } from './subscriptions.schema';
+
+export class SubscriptionsClient {
+  public constructor(private readonly fetch: typeof globalThis.fetch) {}
+
+  public async create(params: CreateSubscriptionRequest): Promise<Subscription> {
+    const response = await this.fetch('/subscriptions', {
+      method: 'POST',
+      body: JSON.stringify(CreateSubscriptionRequest.parse(params)),
+    });
+    return Subscription.parse(await response.json());
+  }
+
+  public async update(params: UpdateSubscriptionRequest): Promise<Subscription> {
+    const response = await this.fetch(`/subscriptions/${params.subscriptionId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(UpdateSubscriptionRequest.parse(params)),
+    });
+    return Subscription.parse(await response.json());
+  }
+
+  public async delete(params: { subscriptionId: string }): Promise<void> {
+    await this.fetch(`/subscriptions/${params.subscriptionId}`, { method: 'DELETE' });
+  }
+}

--- a/packages/ms-graph-sdk/src/shared/subscriptions.requests.ts
+++ b/packages/ms-graph-sdk/src/shared/subscriptions.requests.ts
@@ -1,0 +1,29 @@
+import z from 'zod/v4';
+
+/**
+ * Request body for subscribing to change notifications on a Microsoft Graph resource.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/subscription-post-subscriptions?view=graph-rest-1.0
+ */
+export const CreateSubscriptionRequest = z.object({
+  changeType: z.string(),
+  resource: z.string(),
+  notificationUrl: z.string(),
+  lifecycleNotificationUrl: z.string().optional(),
+  expirationDateTime: z.instanceof(Date).transform((d) => d.toISOString()),
+  clientState: z.string().optional(),
+});
+
+/**
+ * Request body for renewing a subscription before it expires.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/subscription-update?view=graph-rest-1.0
+ */
+export const UpdateSubscriptionRequest = z.object({
+  expirationDateTime: z.instanceof(Date).transform((d) => d.toISOString()),
+});
+
+export type CreateSubscriptionRequest = z.input<typeof CreateSubscriptionRequest>;
+export type UpdateSubscriptionRequest = z.input<typeof UpdateSubscriptionRequest> & {
+  subscriptionId: string;
+};

--- a/packages/ms-graph-sdk/src/shared/subscriptions.schema.ts
+++ b/packages/ms-graph-sdk/src/shared/subscriptions.schema.ts
@@ -1,0 +1,101 @@
+import z from 'zod/v4';
+import { isoDatetimeToDate, stringToURL } from './primitives';
+
+/**
+ * The type of change in the subscribed resource that raises a change notification.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-1.0
+ */
+export const SubscriptionChangeType = z.enum(['created', 'updated', 'deleted']);
+
+/**
+ * The type of lifecycle event for a subscription.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/changenotification?view=graph-rest-1.0
+ */
+export const LifecycleEventType = z.enum([
+  'subscriptionRemoved',
+  'missed',
+  'reauthorizationRequired',
+]);
+
+/**
+ * A subscription that allows a client app to receive change notifications about changes
+ * to data in Microsoft Graph.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/subscription?view=graph-rest-1.0
+ */
+export const Subscription = z.object({
+  id: z.string(),
+  resource: z.string(),
+  applicationId: z.string(),
+  changeType: z.string(),
+  clientState: z.string().nullable(),
+  notificationUrl: stringToURL(),
+  lifecycleNotificationUrl: stringToURL().nullable(),
+  expirationDateTime: isoDatetimeToDate({ offset: true }),
+  creatorId: z.string(),
+  latestSupportedTlsVersion: z.string(),
+  notificationUrlAppId: z.string().nullable(),
+  notificationQueryOptions: z.string().nullable(),
+  encryptionCertificate: z.string().nullable(),
+  encryptionCertificateId: z.string().nullable(),
+  includeResourceData: z.boolean().nullable(),
+});
+
+/**
+ * Provides additional data about the resource that changed.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/resourcedata?view=graph-rest-1.0
+ */
+export const ChangeNotificationResourceData = z.object({
+  '@odata.type': z.string(),
+  '@odata.id': z.string(),
+  id: z.string(),
+});
+
+/**
+ * Represents the notification sent to the subscriber when data changes for which
+ * a notification is requested.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/changenotification?view=graph-rest-1.0
+ */
+export const ChangeNotification = z.object({
+  '@odata.type': z.string().optional(),
+  changeType: SubscriptionChangeType,
+  clientState: z.string().nullable(),
+  resource: z.string(),
+  resourceData: ChangeNotificationResourceData.nullish(),
+  subscriptionExpirationDateTime: isoDatetimeToDate({ offset: true }),
+  subscriptionId: z.string(),
+  tenantId: z.string(),
+});
+
+/**
+ * Represents a lifecycle notification sent when a subscription is about to expire,
+ * is removed, or requires reauthorization.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/concepts/change-notifications-lifecycle-events?view=graph-rest-1.0
+ */
+export const LifecycleChangeNotification = z.object({
+  subscriptionId: z.string(),
+  subscriptionExpirationDateTime: isoDatetimeToDate({ offset: true }),
+  tenantId: z.string().optional(),
+  organizationId: z.string().optional(),
+  clientState: z.string().nullable(),
+  lifecycleEvent: LifecycleEventType,
+});
+
+/**
+ * Represents a collection of change notifications sent to the subscriber.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/changenotificationcollection?view=graph-rest-1.0
+ */
+export const ChangeNotificationCollection = z.object({
+  value: z.array(ChangeNotification),
+  validationTokens: z.array(z.string()).optional(),
+});
+
+export type Subscription = z.infer<typeof Subscription>;
+export type ChangeNotification = z.infer<typeof ChangeNotification>;
+export type LifecycleChangeNotification = z.infer<typeof LifecycleChangeNotification>;

--- a/packages/ms-graph-sdk/src/teams/call-recording.schema.ts
+++ b/packages/ms-graph-sdk/src/teams/call-recording.schema.ts
@@ -1,0 +1,21 @@
+import z from 'zod/v4';
+import { isoDatetimeToDate, stringToURL } from '../shared/primitives';
+import { MeetingOrganizer } from './online-meeting.schema';
+
+/**
+ * Represents a recording associated with an online meeting.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/callrecording?view=graph-rest-1.0
+ */
+export const CallRecording = z.object({
+  id: z.string(),
+  meetingId: z.string(),
+  callId: z.string(),
+  contentCorrelationId: z.string(),
+  recordingContentUrl: stringToURL(),
+  createdDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  meetingOrganizer: MeetingOrganizer,
+});
+
+export type CallRecording = z.infer<typeof CallRecording>;

--- a/packages/ms-graph-sdk/src/teams/call-transcript.schema.ts
+++ b/packages/ms-graph-sdk/src/teams/call-transcript.schema.ts
@@ -1,0 +1,21 @@
+import z from 'zod/v4';
+import { isoDatetimeToDate, stringToURL } from '../shared/primitives';
+import { MeetingOrganizer } from './online-meeting.schema';
+
+/**
+ * Represents a transcript associated with an online meeting.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/calltranscript?view=graph-rest-1.0
+ */
+export const CallTranscript = z.object({
+  id: z.string(),
+  meetingId: z.string(),
+  callId: z.string(),
+  contentCorrelationId: z.string(),
+  transcriptContentUrl: stringToURL(),
+  createdDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  meetingOrganizer: MeetingOrganizer,
+});
+
+export type CallTranscript = z.infer<typeof CallTranscript>;

--- a/packages/ms-graph-sdk/src/teams/index.ts
+++ b/packages/ms-graph-sdk/src/teams/index.ts
@@ -1,0 +1,12 @@
+export { CallRecording } from './call-recording.schema';
+export { CallTranscript } from './call-transcript.schema';
+export type { MeetingParticipantInfo } from './online-meeting.schema';
+export { MeetingOrganizer, OnlineMeeting } from './online-meeting.schema';
+export type {
+  GetCallRecordingContentRequest,
+  GetCallTranscriptContentRequest,
+  GetCallTranscriptRequest,
+  GetOnlineMeetingRequest,
+  ListCallRecordingsRequest,
+} from './teams.requests';
+export { TeamsClient } from './teams-client';

--- a/packages/ms-graph-sdk/src/teams/meetings.schema.ts
+++ b/packages/ms-graph-sdk/src/teams/meetings.schema.ts
@@ -1,0 +1,65 @@
+import z from 'zod/v4';
+import { isoDatetimeToDate, stringToURL } from '../shared/primitives';
+
+export const MeetingParticipantInfo = z.object({
+  upn: z.string(),
+  identity: z.object({
+    user: z.object({
+      id: z.string().nullish(),
+      tenantId: z.string().nullish(),
+      displayName: z.string().nullish(),
+    }),
+  }),
+});
+
+export const OnlineMeeting = z.object({
+  id: z.string(),
+  subject: z.string().nullish(),
+  startDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  joinWebUrl: stringToURL(),
+  recordAutomatically: z.boolean().nullish(),
+  allowTranscription: z.boolean().nullish(),
+  allowRecording: z.boolean().nullish(),
+  participants: z.object({
+    organizer: MeetingParticipantInfo,
+    attendees: z.array(MeetingParticipantInfo),
+  }),
+});
+
+const MeetingOrganizer = z.object({
+  application: z.string().nullable(),
+  device: z.string().nullable(),
+  user: z.object({
+    userIdentityType: z.string(),
+    tenantId: z.string(),
+    id: z.string(),
+    displayName: z.string().nullable(),
+  }),
+});
+
+export const Transcript = z.object({
+  id: z.string(),
+  meetingId: z.string(),
+  callId: z.string(),
+  contentCorrelationId: z.string(),
+  transcriptContentUrl: stringToURL(),
+  createdDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  meetingOrganizer: MeetingOrganizer,
+});
+
+export const Recording = z.object({
+  id: z.string(),
+  meetingId: z.string(),
+  callId: z.string(),
+  contentCorrelationId: z.string(),
+  recordingContentUrl: stringToURL(),
+  createdDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  meetingOrganizer: MeetingOrganizer,
+});
+
+export type OnlineMeeting = z.infer<typeof OnlineMeeting>;
+export type Transcript = z.infer<typeof Transcript>;
+export type Recording = z.infer<typeof Recording>;

--- a/packages/ms-graph-sdk/src/teams/online-meeting.schema.ts
+++ b/packages/ms-graph-sdk/src/teams/online-meeting.schema.ts
@@ -1,0 +1,56 @@
+import z from 'zod/v4';
+import { isoDatetimeToDate, stringToURL } from '../shared/primitives';
+
+const MeetingParticipantInfo = z.object({
+  upn: z.string(),
+  identity: z.object({
+    user: z.object({
+      id: z.string().nullish(),
+      tenantId: z.string().nullish(),
+      displayName: z.string().nullish(),
+    }),
+  }),
+});
+
+export type MeetingParticipantInfo = z.infer<typeof MeetingParticipantInfo>;
+
+/**
+ * Represents the organizer of an online meeting, using the identitySet resource type.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/identityset?view=graph-rest-1.0
+ */
+export const MeetingOrganizer = z.object({
+  application: z.string().nullable(),
+  device: z.string().nullable(),
+  user: z.object({
+    userIdentityType: z.string(),
+    tenantId: z.string(),
+    id: z.string(),
+    displayName: z.string().nullable(),
+  }),
+});
+
+export type MeetingOrganizer = z.infer<typeof MeetingOrganizer>;
+
+/**
+ * Contains information about a meeting, including the URL used to join a meeting,
+ * the attendees list, and the description.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/resources/onlinemeeting?view=graph-rest-1.0
+ */
+export const OnlineMeeting = z.object({
+  id: z.string(),
+  subject: z.string().nullish(),
+  startDateTime: isoDatetimeToDate({ offset: true }),
+  endDateTime: isoDatetimeToDate({ offset: true }),
+  joinWebUrl: stringToURL(),
+  recordAutomatically: z.boolean().nullish(),
+  allowTranscription: z.boolean().nullish(),
+  allowRecording: z.boolean().nullish(),
+  participants: z.object({
+    organizer: MeetingParticipantInfo,
+    attendees: z.array(MeetingParticipantInfo),
+  }),
+});
+
+export type OnlineMeeting = z.infer<typeof OnlineMeeting>;

--- a/packages/ms-graph-sdk/src/teams/teams-client.ts
+++ b/packages/ms-graph-sdk/src/teams/teams-client.ts
@@ -1,0 +1,74 @@
+import { buildUrl } from '../shared/odata';
+import type { GraphPagedResponse } from '../shared/pagination';
+import { paginate } from '../shared/pagination';
+import { CallRecording } from './call-recording.schema';
+import { CallTranscript } from './call-transcript.schema';
+import { OnlineMeeting } from './online-meeting.schema';
+import type {
+  GetCallRecordingContentRequest,
+  GetCallTranscriptContentRequest,
+  GetCallTranscriptRequest,
+  GetOnlineMeetingRequest,
+  ListCallRecordingsRequest,
+} from './teams.requests';
+
+export class TeamsClient {
+  public constructor(private readonly fetch: typeof globalThis.fetch) {}
+
+  /**
+   * Retrieve the properties and relationships of an online meeting object.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0
+   */
+  public async getMeeting(params: GetOnlineMeetingRequest): Promise<OnlineMeeting> {
+    const response = await this.fetch(`/users/${params.userId}/onlineMeetings/${params.meetingId}`);
+    return OnlineMeeting.parse(await response.json());
+  }
+
+  /**
+   * Retrieve a callTranscript object associated with a scheduled online meeting.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/calltranscript-get?view=graph-rest-1.0
+   */
+  public async getTranscript(params: GetCallTranscriptRequest): Promise<CallTranscript> {
+    const response = await this.fetch(
+      `/users/${params.userId}/onlineMeetings/${params.meetingId}/transcripts/${params.transcriptId}`,
+    );
+    return CallTranscript.parse(await response.json());
+  }
+
+  /**
+   * Retrieve the content stream of a callTranscript associated with a scheduled online meeting.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/calltranscript-get?view=graph-rest-1.0
+   */
+  public getTranscriptContent(params: GetCallTranscriptContentRequest): Promise<Response> {
+    return this.fetch(
+      `/users/${params.userId}/onlineMeetings/${params.meetingId}/transcripts/${params.transcriptId}/content`,
+      { headers: { Accept: params.accept } },
+    );
+  }
+
+  /**
+   * Get the list of callRecording objects associated with a scheduled online meeting.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-recordings?view=graph-rest-1.0
+   */
+  public listRecordings(params: ListCallRecordingsRequest): GraphPagedResponse<CallRecording> {
+    const { userId, meetingId, ...odata } = params;
+    const url = buildUrl(`/users/${userId}/onlineMeetings/${meetingId}/recordings`, odata);
+    return paginate(this.fetch, url, CallRecording);
+  }
+
+  /**
+   * Retrieve the content stream of a callRecording associated with a scheduled online meeting.
+   *
+   * @see https://learn.microsoft.com/en-us/graph/api/callrecording-get?view=graph-rest-1.0
+   */
+  public getRecordingContent(params: GetCallRecordingContentRequest): Promise<Response> {
+    return this.fetch(
+      `/users/${params.userId}/onlineMeetings/${params.meetingId}/recordings/${params.recordingId}/content`,
+      { headers: { Accept: 'video/mp4' } },
+    );
+  }
+}

--- a/packages/ms-graph-sdk/src/teams/teams.requests.ts
+++ b/packages/ms-graph-sdk/src/teams/teams.requests.ts
@@ -1,0 +1,61 @@
+import z from 'zod/v4';
+import { ODataQueryParamsSchema } from '../shared/odata';
+
+/**
+ * Parameters for retrieving a specific online meeting.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get?view=graph-rest-1.0
+ */
+const GetOnlineMeetingRequest = z.object({
+  userId: z.string(),
+  meetingId: z.string(),
+});
+export type GetOnlineMeetingRequest = z.infer<typeof GetOnlineMeetingRequest>;
+
+/**
+ * Parameters for retrieving a specific call transcript's metadata.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/calltranscript-get?view=graph-rest-1.0
+ */
+const GetCallTranscriptRequest = z.object({
+  userId: z.string(),
+  meetingId: z.string(),
+  transcriptId: z.string(),
+});
+export type GetCallTranscriptRequest = z.infer<typeof GetCallTranscriptRequest>;
+
+/**
+ * Parameters for retrieving the content stream of a call transcript.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/calltranscript-get?view=graph-rest-1.0
+ */
+const GetCallTranscriptContentRequest = z.object({
+  userId: z.string(),
+  meetingId: z.string(),
+  transcriptId: z.string(),
+  accept: z.enum(['text/vtt', 'text/plain']).default('text/vtt'),
+});
+export type GetCallTranscriptContentRequest = z.infer<typeof GetCallTranscriptContentRequest>;
+
+/**
+ * Parameters for listing call recordings associated with an online meeting.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-recordings?view=graph-rest-1.0
+ */
+const ListCallRecordingsRequest = ODataQueryParamsSchema.extend({
+  userId: z.string(),
+  meetingId: z.string(),
+});
+export type ListCallRecordingsRequest = z.input<typeof ListCallRecordingsRequest>;
+
+/**
+ * Parameters for retrieving the content stream of a call recording.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/api/callrecording-get?view=graph-rest-1.0
+ */
+const GetCallRecordingContentRequest = z.object({
+  userId: z.string(),
+  meetingId: z.string(),
+  recordingId: z.string(),
+});
+export type GetCallRecordingContentRequest = z.infer<typeof GetCallRecordingContentRequest>;

--- a/packages/ms-graph-sdk/tsconfig.json
+++ b/packages/ms-graph-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
   packages/ms-graph-sdk:
     dependencies:
       '@proventuslabs/nestjs-zod':
-        specifier: 2.1.0
+        specifier: ^2.0.0
         version: 2.1.0(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(zod@4.1.5)
       '@proventuslabs/retry-strategies':
         specifier: 0.1.2
@@ -280,13 +280,13 @@ importers:
         version: 4.1.5
     devDependencies:
       '@nestjs/common':
-        specifier: ^11.0.0
+        specifier: ^11.1.6
         version: 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^11.0.0
+        specifier: ^11.1.6
         version: 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/testing':
-        specifier: ^11.0.0
+        specifier: ^11.1.6
         version: 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@nestjs/platform-express@11.1.6)
       '@suites/di.nestjs':
         specifier: ^3.0.1
@@ -9627,6 +9627,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(vite@7.1.4(@types/node@24.4.0)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -13080,7 +13088,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@24.4.0)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,61 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/ms-graph-sdk:
+    dependencies:
+      '@proventuslabs/nestjs-zod':
+        specifier: 2.1.0
+        version: 2.1.0(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(zod@4.1.5)
+      '@proventuslabs/retry-strategies':
+        specifier: 0.1.2
+        version: 0.1.2
+      '@qfetch/qfetch':
+        specifier: 0.1.0
+        version: 0.1.0(@proventuslabs/retry-strategies@0.1.2)
+      '@unique-ag/utils':
+        specifier: workspace:*
+        version: link:../utils
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
+    devDependencies:
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.0
+        version: 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/testing':
+        specifier: ^11.0.0
+        version: 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@nestjs/platform-express@11.1.6)
+      '@suites/di.nestjs':
+        specifier: ^3.0.1
+        version: 3.0.1(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      '@suites/doubles.vitest':
+        specifier: ^3.0.1
+        version: 3.0.1(@vitest/spy@3.2.4)(vitest@3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))
+      '@suites/unit':
+        specifier: ^3.0.1
+        version: 3.0.1
+      '@swc/core':
+        specifier: ^1.13.5
+        version: 1.13.5
+      '@types/node':
+        specifier: ^22.13.14
+        version: 22.16.5
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      unplugin-swc:
+        specifier: ^1.5.7
+        version: 1.5.7(@swc/core@1.13.5)(rollup@4.50.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/probe:
     dependencies:
       '@nestjs/common':
@@ -406,7 +461,7 @@ importers:
         version: link:../../packages/probe
       '@unique-ag/unique-api':
         specifier: workspace:*
-        version: link:../../packages/unique-api
+        version: file:packages/unique-api(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(@nestjs/core@11.1.6)(@opentelemetry/api@1.9.0)(nestjs-otel@7.0.1(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6))(typeid-js@1.2.0)
       '@unique-ag/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -910,7 +965,7 @@ importers:
         version: link:../../packages/probe
       '@unique-ag/unique-api':
         specifier: workspace:*
-        version: link:../../packages/unique-api
+        version: file:packages/unique-api(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(@nestjs/core@11.1.6)(@opentelemetry/api@1.9.0)(nestjs-otel@7.0.1(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6))(typeid-js@1.2.0)
       '@unique-ag/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -3046,6 +3101,13 @@ packages:
       '@nestjs/config': ^3.0.0 || ^4.0.0
       zod: ^3.25.0 || ^4.0.0
 
+  '@proventuslabs/nestjs-zod@2.1.0':
+    resolution: {integrity: sha512-jk9jFjzkMOPA2FLqcLdkIuTzbhsL6aaWGr0rNRhwGbD210NuEMn9/AuB+mNX/zR62X4Jc61O587SgQvb+DbA6g==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/config': ^3.0.0 || ^4.0.0
+      zod: ^3.25.0 || ^4.0.0
+
   '@proventuslabs/retry-strategies@0.1.2':
     resolution: {integrity: sha512-RPZz3sGmXfr2zrlEve696wnr6ZSNujQrWx/stdBgz3Rcz7ec/jgSmWuTF2gCXcnu/s5IomzY2+daIoyVe9EjpA==}
 
@@ -3508,9 +3570,6 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node@22.13.17':
-    resolution: {integrity: sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==}
-
   '@types/node@22.16.5':
     resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
 
@@ -3592,6 +3651,25 @@ packages:
       '@nestjs/core': ^10 || ^11
       '@opentelemetry/api': ^1.9.0
       nestjs-otel: ^7
+
+  '@unique-ag/unique-api@file:packages/unique-api':
+    resolution: {directory: packages/unique-api, type: directory}
+    peerDependencies:
+      '@nestjs/common': ^10 || ^11
+      '@nestjs/core': ^10 || ^11
+      '@opentelemetry/api': ^1.9.0
+      nestjs-otel: ^7
+
+  '@unique-ag/utils@file:packages/utils':
+    resolution: {directory: packages/utils, type: directory}
+    peerDependencies:
+      typeid-js: ^1.2.0
+      zod: ^4.1.5
+    peerDependenciesMeta:
+      typeid-js:
+        optional: true
+      zod:
+        optional: true
 
   '@vitest/coverage-istanbul@3.2.4':
     resolution: {integrity: sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==}
@@ -6682,9 +6760,6 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -8826,6 +8901,13 @@ snapshots:
       lodash: 4.17.21
       zod: 4.1.5
 
+  '@proventuslabs/nestjs-zod@2.1.0(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(zod@4.1.5)':
+    dependencies:
+      '@nestjs/common': 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config': 4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+      lodash: 4.17.21
+      zod: 4.1.5
+
   '@proventuslabs/retry-strategies@0.1.2': {}
 
   '@qfetch/core@0.2.2': {}
@@ -9317,7 +9399,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.13.17
+      '@types/node': 22.16.5
 
   '@types/luxon@3.6.2': {}
 
@@ -9336,10 +9418,6 @@ snapshots:
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 22.16.5
-
-  '@types/node@22.13.17':
-    dependencies:
-      undici-types: 6.20.0
 
   '@types/node@22.16.5':
     dependencies:
@@ -9480,6 +9558,31 @@ snapshots:
       - '@cfworker/json-schema'
       - hono
       - supports-color
+
+  '@unique-ag/unique-api@file:packages/unique-api(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(@nestjs/core@11.1.6)(@opentelemetry/api@1.9.0)(nestjs-otel@7.0.1(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6))(typeid-js@1.2.0)':
+    dependencies:
+      '@nestjs/common': 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@opentelemetry/api': 1.9.0
+      '@proventuslabs/nestjs-zod': 2.1.0(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/config@4.0.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2))(zod@4.1.5)
+      '@unique-ag/utils': file:packages/utils(typeid-js@1.2.0)(zod@4.1.5)
+      bottleneck: 2.19.5
+      graphql: 16.11.0
+      graphql-request: 7.2.0(graphql@16.11.0)
+      nestjs-otel: 7.0.1(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)
+      remeda: 2.32.0
+      undici: 7.18.2
+      zod: 4.1.5
+    transitivePeerDependencies:
+      - '@nestjs/config'
+      - typeid-js
+
+  '@unique-ag/utils@file:packages/utils(typeid-js@1.2.0)(zod@4.1.5)':
+    dependencies:
+      remeda: 2.32.0
+    optionalDependencies:
+      typeid-js: 1.2.0
+      zod: 4.1.5
 
   '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
@@ -12838,8 +12941,6 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
-
-  undici-types@6.20.0: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

Introduces `@unique-ag/ms-graph-sdk` — a typed, NestJS-native Microsoft Graph API client package.

- **OOP domain clients** — `GraphUserClient` with namespaced `outlook`, `teams`, `subscriptions` clients; returned from `GraphClientService.forUser(userProfileId)`
- **Zod schemas throughout** — all request params, response bodies, and error shapes are Zod schemas; types derived via `z.infer<>` / `z.input<>`; codecs handle `Date` ↔ ISO string and `URL` ↔ string transforms automatically
- **MS Graph API object structure** — schemas split by resource type (`OnlineMeeting`, `CallTranscript`, `CallRecording`, `MailFolder`, `Message`, `FileAttachment`, `OutlookCategory`, `Subscription`, etc.) with separate `*.requests.ts` files for request param schemas
- **`GraphErrorBody` as Zod schema** — `fromResponse` uses `safeParse` to safely handle malformed/non-JSON error responses; `requestId` resolved from header or `innerError['request-id']`
- **Typed pagination** — `GraphPagedResponse<T>` and `DeltaResponse<T>` as concrete classes implementing `AsyncIterable<T>` with `pages()`, `toArray()`, `first()`, `drain()`
- **JSDoc + `@see` links** — every schema and request type links to the relevant MS Graph API docs on `learn.microsoft.com`
- **NestJS module** — `GraphSdkModule.register({...})` with Zod-validated options; retry defaults defined once in schema, no duplication in service

## Packages changed

`packages/ms-graph-sdk/` — new package (all changes scoped here + `pnpm-lock.yaml`)