### PR TITLE
fix(teams-mcp): pass through Graph API status codes to MCP clients

### DIFF
--- a/services/teams-mcp/src/utils/graph-error.filter.ts
+++ b/services/teams-mcp/src/utils/graph-error.filter.ts
@@ -35,11 +35,10 @@ export class GraphErrorFilter implements ExceptionFilter {
       `${formattedCode}Microsoft Graph API: ${exception.message}`,
     );
 
-    // Always return 500 regardless of the Graph API's actual status code (e.g., 401/403).
-    // These errors occur during internal async processing, so from the client's perspective
-    // this is an internal server error. We intentionally don't expose the upstream status
-    // to avoid leaking implementation details about our internal MS Graph API interactions.
-    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+    // Pass through the Graph API status code so MCP clients can react appropriately —
+    // e.g., a 401 lets the client retrigger authentication. Fall back to 500 for unknown codes.
+    const statusCode = exception.statusCode ?? HttpStatus.INTERNAL_SERVER_ERROR;
+    response.status(statusCode).json({
       error: 'Microsoft Graph API Error',
       code: exception.code,
       message: exception.message,

--- a/services/teams-mcp/src/utils/graph-error.filter.ts
+++ b/services/teams-mcp/src/utils/graph-error.filter.ts
@@ -37,7 +37,10 @@ export class GraphErrorFilter implements ExceptionFilter {
 
     // Pass through the Graph API status code so MCP clients can react appropriately —
     // e.g., a 401 lets the client retrigger authentication. Fall back to 500 for unknown codes.
-    const statusCode = exception.statusCode ?? HttpStatus.INTERNAL_SERVER_ERROR;
+    // GraphError initializes statusCode to -1 (not null/undefined) when no HTTP status is available,
+    // so we validate the range rather than using ??.
+    const isValidHttpStatus = exception.statusCode >= 100 && exception.statusCode <= 599;
+    const statusCode = isValidHttpStatus ? exception.statusCode : HttpStatus.INTERNAL_SERVER_ERROR;
     response.status(statusCode).json({
       error: 'Microsoft Graph API Error',
       code: exception.code,


### PR DESCRIPTION
## Summary

- `GraphErrorFilter` previously hardcoded HTTP 500 for all Microsoft Graph API errors, swallowing the original status code
- A 401 returned by Graph (expired token that can't be refreshed) now propagates correctly to MCP clients
- MCP clients can use the 401 to retrigger the authentication flow

## Test plan

- [ ] Trigger a Graph API call with an expired token that cannot be refreshed — MCP client should receive 401
- [ ] Verify other Graph errors (403, 429, etc.) also pass through with their correct status codes
- [ ] Verify that Graph errors without a status code still fall back to 500