### PR TITLE
docs(teams-mcp): document Microsoft Graph sync limitations and operational constraints

### DIFF
--- a/services/teams-mcp/docs/README.md
+++ b/services/teams-mcp/docs/README.md
@@ -292,8 +292,60 @@ See [Authentication Architecture - Single App Registration Architecture](./techn
 
 - **Real-time transcription**: Only processes completed transcripts, not live captions
 - **Meeting creation**: Read-only access; cannot create or modify meetings
-- **Selective meeting capture**: All meetings with transcription enabled are captured
+- **Selective meeting capture**: All meetings with transcription enabled are captured (no organizer-only or meeting-type filter)
 - **Token introspection**: Tokens validated locally with short TTLs for performance
+- **Historical/full sync**: No mechanism to backfill transcripts from meetings that took place before the user connected; see [Why can't historical transcripts be synced?](./faq.md#why-cant-historical-transcripts-be-synced)
+- **Delta/incremental sync**: No ability to poll for missed or updated transcripts since a given point in time; see [Why is there no delta sync?](./faq.md#why-is-there-no-delta-sync)
+- **Missed-notification recovery**: If a subscription lapses, any transcripts produced during the gap are permanently lost — there is no catch-up or replay mechanism
+- **Multi-tenant in one session**: A user belonging to multiple Microsoft tenants must authenticate separately for each tenant; one OAuth session covers exactly one tenant
+- **Transcript format variants**: Only VTT-format transcripts are processed; meetings with transcripts in other formats are silently skipped
+- **Recording size assurance**: No application-level size check on recordings; very large files (e.g., multi-hour all-hands) may time out during download and be skipped, while the transcript is still ingested
+
+### Microsoft Graph API Constraints
+
+The following limitations originate directly from the Microsoft Graph API and cannot be worked around while using **delegated permissions**.
+
+#### No Delta Sync with Delegated Permissions
+
+Microsoft Graph does expose a delta API for transcripts and recordings:
+
+```
+GET /users/{userId}/onlineMeetings/getAllTranscripts(...)/delta
+GET /users/{userId}/onlineMeetings/getAllRecordings(...)/delta
+```
+
+These APIs support both full initial synchronization and incremental sync (returning only transcripts added since the last `$deltaToken`). However, the official permission table is:
+
+| Permission type | Support |
+|---|---|
+| Delegated (work or school account) | **Not supported** |
+| Delegated (personal Microsoft account) | **Not supported** |
+| Application | `OnlineMeetingTranscript.Read.All` / `OnlineMeetingRecording.Read.All` |
+
+Source: [callTranscript: delta — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/calltranscript-delta) · [callRecording: delta — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/callrecording-delta)
+
+Teams MCP uses delegated permissions so that users can connect their own Microsoft account without IT administrator involvement. Switching to application permissions would enable delta sync, but would require tenant administrators to configure [Application Access Policies](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) via PowerShell for every user — defeating the self-service connection model.
+
+#### No Historical/Full Sync with Delegated Permissions
+
+The only Microsoft Graph API capable of listing transcripts across all of a user's meetings (without knowing individual meeting IDs in advance) is `getAllTranscripts`:
+
+```
+GET /users/{userId}/onlineMeetings/getAllTranscripts(meetingOrganizerUserId='{userId}',startDateTime=...)
+```
+
+This API also requires **application permissions only** — delegated permissions are explicitly not supported.
+
+Source: [onlineMeeting: getAllTranscripts — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-getalltranscripts)
+
+With delegated permissions, the only available path to read transcripts is `GET /users/{userId}/onlineMeetings/{meetingId}/transcripts`, which requires knowing the meeting ID in advance. There is no delegated-permission API that enumerates past meetings and their transcripts in bulk. As a result, Teams MCP can only capture transcripts going forward from the moment the user connects — not from any earlier meetings.
+
+**Additional constraints on historical data (even with application permissions):**
+
+- Transcripts are only accessible for meetings that have not expired. One-time meetings expire 60 days after their scheduled time; recurring meetings with no end date expire 1 year after the last activity.
+- Recording and transcript files are subject to the tenant's admin-configured expiration policy (Microsoft default: 120 days after creation).
+
+Source: [Limits and specifications for Microsoft Teams — Meeting expiration](https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams)
 
 ### Single App Registration Architecture
 

--- a/services/teams-mcp/docs/faq.md
+++ b/services/teams-mcp/docs/faq.md
@@ -313,6 +313,67 @@ Renewal (PATCH) keeps the subscription continuously active, eliminating this gap
 - [Authentication Architecture - MCP OAuth (Internal)](./technical/architecture.md#mcp-oauth-internal)
 - [MCP Authorization](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) - MCP protocol authorization spec
 
+## Data Sync
+
+### Why can't historical transcripts be synced?
+
+**Answer:** Microsoft Graph does not provide a way to list transcripts across all past meetings using delegated permissions. The only cross-meeting transcript listing API is `getAllTranscripts`:
+
+```
+GET /users/{userId}/onlineMeetings/getAllTranscripts(meetingOrganizerUserId='{userId}',startDateTime=...)
+```
+
+This API requires **application permissions** (`OnlineMeetingTranscript.Read.All`). Microsoft explicitly marks delegated (user) permissions as **Not supported** for this endpoint.
+
+Teams MCP uses delegated permissions so users can connect their own Microsoft account without IT administrator involvement. With delegated permissions the only supported path is `GET /users/{userId}/onlineMeetings/{meetingId}/transcripts`, which requires knowing the meeting ID in advance — making bulk historical enumeration impossible.
+
+As a result, Teams MCP can only capture transcripts for meetings that occur **after** the user connects. Any meetings that took place before the subscription was created are inaccessible.
+
+**Additional historical limits (even with application permissions):**
+
+- One-time meetings expire 60 days after their scheduled time; the transcript API returns an error for expired meetings.
+- Recording/transcript files are deleted after the tenant's expiration policy window (Microsoft default: 120 days).
+
+**See also:**
+
+- [onlineMeeting: getAllTranscripts — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-getalltranscripts)
+- [Limits and specifications for Microsoft Teams — Meeting expiration](https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams)
+- [Microsoft Graph Constraints](./README.md#microsoft-graph-api-constraints)
+
+### Why is there no delta sync?
+
+**Answer:** Microsoft Graph does expose delta APIs for transcripts and recordings — `callTranscript: delta` and `callRecording: delta` — which support both full initial sync and incremental sync (returning only items added since a `$deltaToken`). However, these APIs require **application permissions**. Microsoft explicitly marks delegated permissions as **Not supported**:
+
+| Permission type | Support |
+|---|---|
+| Delegated (work or school account) | **Not supported** |
+| Delegated (personal Microsoft account) | **Not supported** |
+| Application | `OnlineMeetingTranscript.Read.All` |
+
+Because Teams MCP uses delegated permissions, delta sync is unavailable. The service instead relies on real-time webhook notifications (change notifications), which deliver new transcript events as they occur. This covers all meetings going forward but cannot recover transcripts missed due to a subscription gap.
+
+Switching to application permissions would unlock delta sync, but would require tenant administrators to configure [Application Access Policies](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) via PowerShell for each individual user — defeating the self-service connection model.
+
+**See also:**
+
+- [callTranscript: delta — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/calltranscript-delta)
+- [callRecording: delta — Microsoft Graph API reference](https://learn.microsoft.com/en-us/graph/api/callrecording-delta)
+- [Microsoft Graph Constraints](./README.md#microsoft-graph-api-constraints)
+
+### What happens if I miss transcripts during a subscription gap?
+
+**Answer:** They are permanently lost. Microsoft Graph only delivers webhook notifications for transcripts created while a subscription is active. If a subscription expires (or is deleted and recreated), any transcripts produced during the gap will never generate a notification.
+
+This is a fundamental limitation of the change notification model combined with the unavailability of delta sync under delegated permissions. There is no catch-up or replay mechanism.
+
+To minimise the risk:
+
+- Ensure the renewal cron runs reliably (default: 3 AM UTC daily).
+- Monitor for `subscription_renewal_failed` log events — a failed renewal is the most common cause of gaps.
+- Use subscription **renewal** (PATCH) rather than recreation (DELETE + POST). See [Why are subscriptions renewed instead of recreated?](./faq.md#why-are-subscriptions-renewed-instead-of-recreated)
+
+**See also:** [Subscription Lifecycle](./technical/flows.md#subscription-lifecycle)
+
 ## Subscriptions & Processing
 
 ### Why do subscriptions expire?
@@ -328,7 +389,12 @@ Renewal (PATCH) keeps the subscription continuously active, eliminating this gap
 - User revoked app consent
 - Network issues reaching Microsoft
 
-**See also:** [Subscription Lifecycle](./technical/flows.md#subscription-lifecycle)
+Any transcripts produced between the failed renewal and the user reconnecting are **permanently lost** — there is no backfill or catch-up mechanism once a subscription lapses.
+
+**See also:**
+
+- [Subscription Lifecycle](./technical/flows.md#subscription-lifecycle)
+- [What happens if I miss transcripts during a subscription gap?](./faq.md#what-happens-if-i-miss-transcripts-during-a-subscription-gap)
 
 ### Why aren't transcripts appearing in Unique?
 
@@ -383,6 +449,14 @@ This ensures we meet Microsoft's strict timeout requirements while processing tr
 **Answer:** The request is rejected with 401 Unauthorized. Microsoft will retry the notification. If validation consistently fails, Microsoft may stop sending notifications for that subscription.
 
 **See also:** [Webhook Validation](./technical/security.md#webhook-validation)
+
+### What happens to messages that fail processing?
+
+**Answer:** Failed transcript processing messages are nacked and routed to a Dead Letter Exchange (DLX). Messages accumulate there indefinitely — there is no automatic TTL or retry from the DLQ.
+
+An operator must inspect the DLQ manually (e.g., via the RabbitMQ management UI) to decide whether to republish a message for retry or discard it. Because there is no delta sync available, a message in the DLQ represents the only copy of that webhook notification — if discarded without successful processing, the transcript will not be ingested.
+
+**See also:** [Why use RabbitMQ for webhook processing?](./faq.md#why-use-rabbitmq-for-webhook-processing)
 
 ## Deployment
 
@@ -485,6 +559,14 @@ This ensures we meet Microsoft's strict timeout requirements while processing tr
 - [Microsoft Entra ID Documentation](https://learn.microsoft.com/en-us/entra/identity/)
 
 ## Multi-Tenant
+
+### Can a user connect multiple Microsoft tenants?
+
+**Answer:** Not in a single session. One OAuth login covers exactly one Microsoft tenant. If a user belongs to multiple tenants (e.g., their home tenant plus a guest tenant), they must authenticate separately for each tenant they want to capture meetings from.
+
+Each tenant authentication creates an independent user profile in Teams MCP. Transcripts from each tenant are ingested separately under the identity used to connect that tenant.
+
+**See also:** [Single App Registration Architecture](./technical/architecture.md#single-app-registration-architecture)
 
 ### Can one deployment serve multiple Microsoft tenants?
 


### PR DESCRIPTION
## Summary

This PR documents the limitations of `teams-mcp` that stem from Microsoft Graph API constraints under delegated permissions, as well as several operational constraints identified through code review. It also explains **why these features exist in `outlook-semantic-mcp` but are absent from `teams-mcp`**.

---

## Feature imparity with `outlook-semantic-mcp`

The Outlook connector supports **full initial sync** (bulk-fetching all historical emails) and **live catch-up sync** (delta-based incremental updates). Users familiar with the Outlook connector reasonably expect similar behaviour from the Teams connector. It does not — and cannot, given the current delegated-permission architecture. The root cause is a set of hard Microsoft Graph API restrictions:

### No historical/full sync

The only Microsoft Graph API that lists transcripts across all of a user's meetings without knowing individual meeting IDs is `getAllTranscripts`:

```
GET /users/{userId}/onlineMeetings/getAllTranscripts(meetingOrganizerUserId='{userId}',startDateTime=...)
```

Microsoft explicitly marks **delegated permissions as Not supported** for this endpoint. Application permissions (`OnlineMeetingTranscript.Read.All`) are required.

Reference: https://learn.microsoft.com/en-us/graph/api/onlinemeeting-getalltranscripts

### No delta/incremental sync

Microsoft Graph does expose delta APIs:

```
GET /users/{userId}/onlineMeetings/getAllTranscripts(...)/delta
GET /users/{userId}/onlineMeetings/getAllRecordings(...)/delta
```

These support both full initial sync and incremental sync via `$deltaToken`. Again, Microsoft explicitly marks **delegated permissions as Not supported**:

| Permission type | Support |
|---|---|
| Delegated (work or school account) | **Not supported** |
| Application | `OnlineMeetingTranscript.Read.All` |

Reference: https://learn.microsoft.com/en-us/graph/api/calltranscript-delta · https://learn.microsoft.com/en-us/graph/api/callrecording-delta

### Why not switch to application permissions?

Application permissions would unlock both delta and full sync. However, they require tenant administrators to configure [Application Access Policies](https://learn.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) via PowerShell for every individual user. This defeats the self-service model (users connect their own account without IT involvement) that is central to `teams-mcp`'s design.

---

## Changes

### `docs/README.md`

- Expanded **"Not Supported"** bullet list with: historical sync, delta sync, missed-notification recovery, multi-tenant sessions, VTT-only transcripts, recording size caveats.
- Added new **"Microsoft Graph API Constraints"** section with:
  - Full explanation of delta sync limitation, permission table, official Graph docs link.
  - Full explanation of historical sync limitation, permission table, official Graph docs link.
  - Additional historical data limits (meeting expiration, recording TTL).

### `docs/faq.md`

- Added new **"Data Sync"** section with three Q&As:
  - *Why can't historical transcripts be synced?* — explains delegated permission constraint with Graph docs link.
  - *Why is there no delta sync?* — explains delta API restriction with Graph docs links and Application Access Policy trade-off.
  - *What happens if I miss transcripts during a subscription gap?* — explains permanent data loss and mitigation steps.
- Updated **"What happens if a subscription renewal fails?"** — explicitly notes that transcripts during the gap are permanently lost, with cross-reference to the new gap entry.
- Added **"Can a user connect multiple Microsoft tenants?"** in the Multi-Tenant section.
- Added **"What happens to messages that fail processing?"** in Webhooks & Processing — documents DLQ behaviour and manual operator intervention requirement.