### PR TITLE
docs(main): add Grafana investigation skill for Claude Code

### DIFF
--- a/.claude/skills/grafana-investigation/SKILL.md
+++ b/.claude/skills/grafana-investigation/SKILL.md
@@ -1,0 +1,483 @@
+---
+name: grafana-investigation
+description: >-
+  Investigate production issues, diagnose performance problems, and analyze
+  service health using Grafana MCP servers (Prometheus, Loki, Tempo, Sift).
+  Use when the user asks to check logs, investigate errors, analyze latency,
+  monitor resources, query metrics, debug slowness, check alerts, or
+  investigate any environment (QA, UAT, prod, tenant-specific).
+---
+
+# Grafana Investigation
+
+Investigate service health, diagnose errors, and analyze performance across Unique platform environments using Grafana MCP servers. Tailored for the connectors monorepo services and the upstream Unique platform services they depend on.
+
+## Enhanced Details (Private Monorepo)
+
+If you have filesystem access to the Unique monorepo, check for `../monorepo/.claude/skills/grafana-investigation/SKILL.md` (relative to this repo root). If it exists, read it — it contains internal details not included here:
+
+- Grafana URL patterns and DNS hostnames
+- Tenant environment slugs (all production single-tenant names)
+- Loki datasource UIDs per environment
+- Complete namespace-to-service mapping
+- Full upstream service label table (including web apps and Python AI services)
+- Additional Prometheus metrics (chat LLM, ingestion embeddings, Node.js process, Elasticsearch)
+
+Use those concrete values instead of the generic placeholders in this file. If the monorepo is not available, this skill is fully self-contained — proceed with discovery steps below.
+
+## Prerequisites
+
+1. Install `uv` (Python package manager — provides `uvx`)
+2. Be connected to the internal VPN/tailnet (Grafana URLs use internal DNS)
+3. Add Grafana MCP servers to your Claude Code MCP config (see setup below)
+
+### MCP Server Setup
+
+Add Grafana MCP servers to your Claude Code settings (project `.claude/settings.json` or user `~/.claude/settings.json`) under `mcpServers`:
+
+```json
+"<env>-grafana": {
+  "command": "uvx",
+  "args": ["mcp-grafana"],
+  "env": {
+    "GRAFANA_URL": "<your-grafana-url-for-this-environment>"
+  }
+}
+```
+
+Ask your team for the Grafana URLs for each environment. Add one entry per environment you need to query.
+
+Each configured server becomes available as MCP tools with the server name prefix (e.g. `qa-grafana` key gives tools like `mcp__qa-grafana__list_datasources`).
+
+## Environment Servers
+
+| MCP Server Key | Environment | Use Case |
+|----------------|-------------|----------|
+| `qa-grafana` | QA | Development testing, pre-merge validation |
+| `uat-grafana` | UAT | Pre-production validation |
+| `prod-grafana` | Production (shared) | Multi-tenant production |
+| `{tenant}-prod-grafana` | Tenant-specific prod | One per single-tenant deployment |
+
+**Choosing the right server:** Match the environment where the issue was reported. For multi-tenant investigations, run parallel queries across tenant servers.
+
+## Quick Reference — Connectors Service Names
+
+### Connector Services (this repo)
+
+All services emit Prometheus metrics via OpenTelemetry (port **51346** for most services; **51350** for `confluence-connector`).
+
+| Service directory | Helm chart name | Grafana dashboard folder | Loki `app` label (verify) |
+|-------------------|-----------------|--------------------------|---------------------------|
+| `services/sharepoint-connector` | `sharepoint-connector` | `connectors` | `sharepoint-connector` |
+| `services/confluence-connector` | `confluence-connector` | `connectors` | `confluence-connector` |
+| `services/outlook-mcp` | `mcp-server-outlook` | `mcp-servers` | `mcp-server-outlook` |
+| `services/outlook-semantic-mcp` | `outlook-semantic-mcp` | `mcp-servers` | `outlook-semantic-mcp` |
+| `services/teams-mcp` | `teams-mcp` | `mcp-servers` | `teams-mcp` |
+| `services/factset-mcp` | `mcp-server-factset` | `mcp-servers` | `mcp-server-factset` |
+
+**Important:** Loki `app` labels typically match the Helm chart name, but always verify with `list_loki_label_values` since naming can vary per cluster.
+
+### Upstream Unique Platform Services (monorepo)
+
+Connectors interact heavily with these services. Use the Prometheus/Loki labels below when correlating issues.
+
+| Service | Prometheus `app` label | Loki `app` label | What it does |
+|---------|----------------------|-----------------|--------------|
+| `node-ingestion` | `node_ingestion` | `ingestion` | Content ingestion (connectors push content here) |
+| `node-ingestion-worker` | `node_ingestion_worker` | `ingestion-worker` | Async ingestion processing |
+| `node-scope-management` | `node_scope_management` | `scope-management` | Scope/permission management |
+| `node-chat` | `node_chat` | `chat` | Chat service (MCP tools are called from here) |
+| `gatekeeper` | `gatekeeper` | `gatekeeper` | Auth gateway |
+| `unique-api` | `unique_api` | `unique-api` | API gateway |
+| `mcp-hub` | `mcp_hub` | `mcp-hub` | MCP tool orchestration |
+
+**Label naming difference:** Prometheus uses underscores (`node_ingestion`), Loki uses hyphens (`ingestion`). Always verify with `list_*_label_values`.
+
+### Common Namespaces
+
+Namespaces are **cluster-specific** and vary across environments. Always discover them:
+```
+list_loki_label_values
+  arguments: { "datasourceUid": "<loki-uid>", "labelName": "namespace" }
+```
+
+Connector and MCP services may deploy to their own namespaces.
+
+### Common Prometheus Metrics
+
+**OpenTelemetry metrics (all connector services):**
+Connectors use the `@unique-ag/instrumentation` package with OpenTelemetry. Metric names vary by service — discover with:
+```
+list_prometheus_metric_names
+  arguments: { "datasourceUid": "prometheus", "regex": ".*sharepoint.*|.*confluence.*|.*outlook.*|.*teams.*|.*factset.*" }
+```
+
+**NestJS HTTP metrics (upstream platform services):**
+- `nestjs_http_server_request_duration_ms` (histogram — use for p95/p99)
+- `nestjs_http_server_requests_total` / `nestjs_http_server_responses_total`
+- `nestjs_http_server_responses_error_total`
+
+**Kubernetes container metrics (all services):**
+- `container_cpu_usage_seconds_total{container="...", namespace="..."}`
+- `container_memory_working_set_bytes{container="...", namespace="..."}`
+
+**Elasticsearch (used by ingestion):**
+- `elasticsearch_cluster_health_status{cluster="elasticsearch-ingestion"}`
+- `elasticsearch_cluster_health_unassigned_shards`
+
+### Common Loki Labels
+
+| Label | What it filters | Example values |
+|-------|----------------|----------------|
+| `app` | Service name (Helm chart name) | `sharepoint-connector`, `mcp-server-outlook`, `ingestion` |
+| `namespace` | Kubernetes namespace | Discover with `list_loki_label_values` |
+| `context` | NestJS logger class name | `SharepointSynchronizationService`, `ConfluenceSynchronizationService` |
+| `level` | Log level | `error`, `warn`, `info`, `debug` |
+| `container` | Container name in pod | `sharepoint-connector`, `outlook-mcp` |
+
+### Common GraphQL Operation Names
+
+Used as `operationName` label when connectors call upstream services:
+
+**Ingestion:** `Content`, `PaginatedContent`, `CreateScopeAccesses`, `DeleteScopeAccesses`, `BulkMove`
+**Scopes:** `AllScopesIdsByCompany`
+
+## Investigation Workflow
+
+Always follow this sequence. Do NOT skip discovery steps — label names and datasource UIDs vary across environments.
+
+### Step 1: Discover Datasources
+
+```
+list_datasources
+  server: "<env>-grafana"
+  arguments: {}
+```
+
+Record the `uid` values — they vary per environment. Always discover them rather than hardcoding.
+
+### Step 2: Discover Labels and Metrics
+
+Before writing any PromQL or LogQL, discover what actually exists.
+
+**For Prometheus:**
+```
+list_prometheus_metric_names   → regex: ".*sharepoint.*", ".*confluence.*", ".*nestjs.*"
+list_prometheus_label_values   → labelName: "app" or "job" or "container"
+```
+
+**For Loki:**
+```
+list_loki_label_names          → see available labels
+list_loki_label_values         → labelName: "app", then "namespace", "context"
+```
+
+**Why this matters:** Label values use inconsistent naming across services and environments. Always verify before querying.
+
+### Step 3: Search Existing Dashboards
+
+Each connector service has a Grafana dashboard. Search for it:
+
+```
+search_dashboards
+  arguments: { "query": "sharepoint" }
+```
+
+Use `get_dashboard_summary` or `get_dashboard_panel_queries` to extract useful queries from existing dashboards rather than writing PromQL from scratch.
+
+### Step 4: Query Metrics and Logs
+
+Choose the right tool based on what you need. See sections below.
+
+---
+
+## Prometheus Queries (Metrics)
+
+### query_prometheus
+
+```
+query_prometheus
+  server: "<env>-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "<PromQL>",
+    "queryType": "range",
+    "startTime": "now-1h",
+    "endTime": "now",
+    "stepSeconds": 60
+  }
+```
+
+### query_prometheus_histogram
+
+Convenience tool for percentile calculations:
+
+```
+query_prometheus_histogram
+  arguments: {
+    "datasourceUid": "prometheus",
+    "metric": "nestjs_http_server_request_duration_ms",
+    "percentile": 0.95,
+    "labels": "{app=\"node_ingestion\"}",
+    "rateInterval": "5m",
+    "startTime": "now-1h",
+    "endTime": "now",
+    "stepSeconds": 300
+  }
+```
+
+### Common PromQL Patterns
+
+**Container CPU (connector service):**
+```promql
+sum(rate(container_cpu_usage_seconds_total{container="sharepoint-connector"}[5m])) by (pod)
+```
+
+**Container memory (bytes to MiB):**
+```promql
+container_memory_working_set_bytes{container="confluence-connector"} / 1024 / 1024
+```
+
+**Upstream ingestion latency (when investigating slow connector syncs):**
+```promql
+histogram_quantile(0.95, sum(rate(nestjs_http_server_request_duration_ms_bucket{app="node_ingestion", operationName="Content"}[5m])) by (le))
+```
+
+**Upstream scope-management latency:**
+```promql
+histogram_quantile(0.95, sum(rate(nestjs_http_server_request_duration_ms_bucket{app="node_scope_management", operationName="CreateScopeAccesses"}[5m])) by (le))
+```
+
+---
+
+## Loki Queries (Logs)
+
+### query_loki_logs
+
+```
+query_loki_logs
+  server: "<env>-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"sharepoint-connector\"} |= \"error\"",
+    "startRfc3339": "2026-04-01T13:00:00Z",
+    "endRfc3339": "2026-04-01T14:00:00Z",
+    "limit": 50,
+    "direction": "backward"
+  }
+```
+
+### Common LogQL Patterns
+
+**Connector service errors:**
+```logql
+{app="sharepoint-connector"} | level = "error"
+```
+
+**Confluence connector sync issues:**
+```logql
+{app="confluence-connector"} |= "failed" | level = "error"
+```
+
+**MCP server errors (Outlook, Teams):**
+```logql
+{app="mcp-server-outlook"} | level = "error"
+```
+
+```logql
+{app="teams-mcp"} | level = "error"
+```
+
+**Correlate connector with upstream ingestion:**
+```logql
+{app="ingestion"} |= "sharepoint" | level = "error"
+```
+
+**Search by NestJS context (class name):**
+```logql
+{app="sharepoint-connector", context="SharepointScannerService"}
+```
+
+**Count occurrences (metric query):**
+```logql
+sum(count_over_time({app="confluence-connector"} |= "ingestion" [24h]))
+```
+Use `queryType: "instant"` for metric LogQL.
+
+**Search by trace ID:**
+```logql
+{namespace="<connector-namespace>"} |= "a1cfdb..."
+```
+Narrow namespace first — `{} |= "traceId"` is extremely expensive.
+
+### LogQL Pitfalls
+
+1. **Wide queries cause 502/timeout:** Always narrow with `app`, `namespace`, or `context` labels AND short time windows (15min ideally)
+2. **NestJS colored/ANSI logs break `| json`:** Use `|=` (contains) or `|~` (regex) line filters instead
+3. **`limit` max is 100** per the MCP tool — paginate with time windows if you need more
+4. **Label discovery first:** Always run `list_loki_label_values` for `app` before guessing
+
+---
+
+## Tempo / Traces
+
+`find_slow_requests` requires Tempo and may not be available on all environments.
+
+**When Tempo is available:**
+```
+find_slow_requests
+  arguments: {
+    "name": "sharepoint-connector slow requests",
+    "labels": { "app": "sharepoint-connector" },
+    "start": "2026-04-01T13:00:00Z",
+    "end": "2026-04-01T14:00:00Z"
+  }
+```
+
+**When Tempo is unavailable — fallback:**
+1. Use `generate_deeplink` to create an Explore URL the user can open manually
+2. Query Loki for logs containing the trace ID (narrow by namespace)
+3. Use PromQL histogram percentiles as a proxy for latency
+
+---
+
+## Connector-Specific Investigation Patterns
+
+### SharePoint Connector Sync Issues
+
+1. Check connector logs for sync errors:
+```logql
+{app="sharepoint-connector"} |= "sync" | level = "error"
+```
+
+2. Check if upstream ingestion is slow/failing:
+```logql
+{app="ingestion"} |= "sharepoint" | level = "error"
+```
+
+3. Check scope-management for permission sync:
+```logql
+{app="scope-management"} |= "CreateScopeAccesses" | level = "error"
+```
+
+### Confluence Connector Ingestion
+
+1. Check connector processing:
+```logql
+{app="confluence-connector"} | level = "error"
+```
+
+2. Correlate with ingestion worker:
+```logql
+{app="ingestion-worker"} |= "confluence"
+```
+
+### MCP Server Issues (Outlook, Teams, FactSet)
+
+MCP servers are called from `mcp-hub` in the platform. Investigate both sides:
+
+1. Check MCP server logs:
+```logql
+{app="mcp-server-outlook"} | level = "error"
+```
+
+2. Check mcp-hub for dispatch errors:
+```logql
+{app="mcp-hub"} |= "outlook" | level = "error"
+```
+
+3. Check chat service (MCP tools are invoked from chat):
+```logql
+{app="chat"} |= "mcp" | level = "error"
+```
+
+---
+
+## Multi-Tenant Investigation
+
+For cross-tenant analysis, run parallel queries across Grafana servers:
+
+1. Call `list_datasources` on each server to get UIDs
+2. Run the same query against each server in parallel
+3. Aggregate results into a comparison table
+
+---
+
+## Before/After Performance Comparison
+
+To validate a code change after a PR merge:
+
+1. Get the merge timestamp: `gh pr view <number> --json mergedAt`
+2. Query the same metric for a window before and after the merge time
+3. Compare p95/p99 latencies or throughput
+
+```
+Before: startTime = merge - 2d, endTime = merge
+After:  startTime = merge, endTime = now
+```
+
+---
+
+## Dashboard and Panel Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `search_dashboards` | Find relevant dashboards by keyword |
+| `get_dashboard_summary` | Quick overview of panels and variables |
+| `get_dashboard_panel_queries` | Extract PromQL/LogQL from existing panels |
+| `get_dashboard_property` | Efficient JSONPath slice |
+| `get_panel_image` | Render a panel as PNG for evidence/sharing |
+
+Avoid `get_dashboard_by_uid` — returns very large JSON. Use summary or property tools instead.
+
+---
+
+## Alerting and Incidents
+
+**Check firing alerts:**
+```
+list_alert_groups
+  arguments: { "state": "firing" }
+```
+
+**Check active incidents:**
+```
+list_incidents
+  arguments: { "status": "active" }
+```
+
+**Caution:** `create_incident` may trigger wide notifications — always confirm with the user first.
+
+---
+
+## Sift Investigations
+
+Automated root-cause analysis when available:
+
+```
+find_error_pattern_logs
+  arguments: {
+    "name": "sharepoint-connector errors",
+    "labels": { "app": "sharepoint-connector" }
+  }
+```
+
+---
+
+## Common Pitfalls Reference
+
+| Pitfall | Solution |
+|---------|----------|
+| Wrong `app` label for connector | Verify with `list_loki_label_values` — may be chart name or directory name |
+| Prometheus underscore vs Loki hyphen | Platform services differ: `node_ingestion` (Prom) vs `ingestion` (Loki) |
+| Loki 502 on wide queries | Narrow time window (15min), add label selectors |
+| `| json` fails on colored logs | Use `|=` or `|~` line filters |
+| Connector issue is actually upstream | Always check both connector AND platform service logs |
+| `find_slow_requests` unavailable | Tempo not deployed; use PromQL histograms + Loki |
+| Tool param naming varies | Pyroscope uses snake_case, others camelCase |
+| Dashboard JSON too large | Use `get_dashboard_summary` or `get_dashboard_property` |
+
+## Additional Resources
+
+- For end-to-end investigation walkthroughs, see [examples.md](examples.md)
+- For complete tool schemas and parameter details, see [tool-reference.md](tool-reference.md)

--- a/.claude/skills/grafana-investigation/examples.md
+++ b/.claude/skills/grafana-investigation/examples.md
@@ -1,0 +1,417 @@
+# Grafana Investigation Examples
+
+Real-world investigation patterns for connectors and MCP services.
+
+---
+
+## Example 1: SharePoint Connector Sync Failures (QA)
+
+**Scenario:** SharePoint sync reports failing for a tenant on QA.
+
+**Steps:**
+
+1. Discover datasources:
+```
+list_datasources
+  server: "qa-grafana"
+  arguments: {}
+```
+
+2. Check connector error logs:
+```
+query_loki_logs
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"sharepoint-connector\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T10:00:00Z",
+    "endRfc3339": "2026-04-01T11:00:00Z",
+    "limit": 50,
+    "direction": "backward"
+  }
+```
+
+3. Check if upstream ingestion is receiving content:
+```
+query_loki_logs
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"ingestion\"} |= \"sharepoint\"",
+    "startRfc3339": "2026-04-01T10:00:00Z",
+    "endRfc3339": "2026-04-01T11:00:00Z",
+    "limit": 50
+  }
+```
+
+4. Check scope-management for permission sync errors:
+```
+query_loki_logs
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"scope-management\"} |= \"CreateScopeAccesses\" | level = \"error\"",
+    "startRfc3339": "2026-04-01T10:00:00Z",
+    "endRfc3339": "2026-04-01T11:00:00Z",
+    "limit": 50
+  }
+```
+
+**Key lesson:** SharePoint connector issues often surface as ingestion or scope-management errors upstream. Always check both sides.
+
+---
+
+## Example 2: Confluence Connector Ingestion Slow (Production)
+
+**Scenario:** Confluence content taking too long to appear after sync on a tenant.
+
+**Steps:**
+
+1. Check confluence-connector logs for slow processing:
+```
+query_loki_logs
+  server: "<tenant>-prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"confluence-connector\"} |~ \"completed|duration|elapsed\"",
+    "startRfc3339": "2026-04-01T08:00:00Z",
+    "endRfc3339": "2026-04-01T10:00:00Z",
+    "limit": 50,
+    "direction": "backward"
+  }
+```
+
+2. Check upstream ingestion p95 latency:
+```
+query_prometheus_histogram
+  server: "<tenant>-prod-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "metric": "nestjs_http_server_request_duration_ms",
+    "percentile": 0.95,
+    "labels": "{app=\"node_ingestion\", operationName=\"Content\"}",
+    "startTime": "now-2h",
+    "endTime": "now",
+    "stepSeconds": 60
+  }
+```
+
+3. Check ingestion-worker for queued work:
+```
+query_loki_logs
+  server: "<tenant>-prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"ingestion-worker\"} |= \"confluence\"",
+    "startRfc3339": "2026-04-01T08:00:00Z",
+    "endRfc3339": "2026-04-01T10:00:00Z",
+    "limit": 50
+  }
+```
+
+4. Check container resources — connector might be memory-constrained:
+```
+query_prometheus
+  server: "<tenant>-prod-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "container_memory_working_set_bytes{container=\"confluence-connector\"} / 1024 / 1024",
+    "queryType": "range",
+    "startTime": "now-2h",
+    "endTime": "now",
+    "stepSeconds": 60
+  }
+```
+
+**Key lesson:** Slow ingestion can be the connector, the upstream ingestion service, or the ingestion worker. Check all three and correlate timestamps.
+
+---
+
+## Example 3: Outlook MCP Tool Failures (UAT)
+
+**Scenario:** Users report Outlook MCP tools failing in chat on UAT.
+
+**Steps:**
+
+1. Check MCP server logs:
+```
+query_loki_logs
+  server: "uat1-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"mcp-server-outlook\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T14:00:00Z",
+    "endRfc3339": "2026-04-01T15:00:00Z",
+    "limit": 50,
+    "direction": "backward"
+  }
+```
+
+2. Check mcp-hub for dispatch errors:
+```
+query_loki_logs
+  server: "uat1-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"mcp-hub\"} |= \"outlook\" | level = \"error\"",
+    "startRfc3339": "2026-04-01T14:00:00Z",
+    "endRfc3339": "2026-04-01T15:00:00Z",
+    "limit": 50
+  }
+```
+
+3. Check chat service for MCP invocation errors:
+```
+query_loki_logs
+  server: "uat1-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"chat\"} |= \"mcp\" | level = \"error\"",
+    "startRfc3339": "2026-04-01T14:00:00Z",
+    "endRfc3339": "2026-04-01T15:00:00Z",
+    "limit": 50
+  }
+```
+
+4. Check if the MCP pod is healthy:
+```
+query_prometheus
+  server: "uat1-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "container_cpu_usage_seconds_total{container=\"mcp-server-outlook\"}",
+    "queryType": "range",
+    "startTime": "now-1h",
+    "endTime": "now",
+    "stepSeconds": 60
+  }
+```
+
+**Key lesson:** MCP tool failures involve three layers: chat -> mcp-hub -> mcp-server. Check all three to isolate where the failure occurs.
+
+---
+
+## Example 4: Teams MCP GraphQL Error Rate Spike (Production)
+
+**Scenario:** Alert fires for Teams MCP GraphQL error rate > 1%.
+
+**Steps:**
+
+1. Check existing dashboard for the alert context:
+```
+search_dashboards
+  server: "prod-grafana"
+  arguments: { "query": "teams" }
+```
+
+2. Extract queries from the dashboard:
+```
+get_dashboard_panel_queries
+  server: "prod-grafana"
+  arguments: { "uid": "<teams-dashboard-uid>" }
+```
+
+3. Check error logs with details:
+```
+query_loki_logs
+  server: "prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"teams-mcp\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T12:00:00Z",
+    "endRfc3339": "2026-04-01T12:30:00Z",
+    "limit": 100,
+    "direction": "backward"
+  }
+```
+
+4. Check if it correlates with upstream Unique API errors:
+```
+query_loki_logs
+  server: "prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"unique-api\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T12:00:00Z",
+    "endRfc3339": "2026-04-01T12:30:00Z",
+    "limit": 50
+  }
+```
+
+**Key lesson:** Teams MCP has PrometheusRule alerts for GraphQL errors and Unique API errors. Check the alert definition first to understand thresholds, then investigate root cause.
+
+---
+
+## Example 5: Cross-Tenant Connector Resource Usage (Multi-Prod)
+
+**Scenario:** Need to compare SharePoint connector memory usage across tenants before adjusting resource limits.
+
+**Steps:**
+
+1. Run the same query across tenant Grafana servers in parallel:
+```
+query_prometheus
+  server: "<tenant>-prod-grafana"    (repeat for each tenant)
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "max(max_over_time(container_memory_working_set_bytes{container=\"sharepoint-connector\"}[7d])) / 1024 / 1024",
+    "queryType": "instant",
+    "startTime": "now"
+  }
+```
+
+2. Also get average:
+```
+  "expr": "avg(avg_over_time(container_memory_working_set_bytes{container=\"sharepoint-connector\"}[7d])) / 1024 / 1024"
+```
+
+3. Aggregate results into a comparison table:
+```
+| Tenant   | Avg (MiB) | Max (MiB) |
+|----------|-----------|-----------|
+| tenant-a | 450       | 780       |
+| tenant-b | 320       | 550       |
+| ...      | ...       | ...       |
+```
+
+**Key lesson:** 30d averages hide spikes. Always include `max_over_time` with a shorter window (7d) to show the real peak.
+
+---
+
+## Example 6: Before/After Validation for Connector PR (QA)
+
+**Scenario:** PR merged that optimizes SharePoint scanning — validate improvement.
+
+**Steps:**
+
+1. Get merge timestamp:
+```bash
+gh pr view 450 --repo Unique-AG/connectors --json mergedAt --jq '.mergedAt'
+```
+
+2. Check connector CPU usage before vs after:
+```
+query_prometheus
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"sharepoint-connector\"}[5m])) by (pod)",
+    "queryType": "range",
+    "startTime": "<merge - 2d>",
+    "endTime": "<merge>",
+    "stepSeconds": 300
+  }
+```
+
+3. Same query for after window:
+```
+  "startTime": "<merge>",
+  "endTime": "now"
+```
+
+4. Also compare memory:
+```
+  "expr": "container_memory_working_set_bytes{container=\"sharepoint-connector\"} / 1024 / 1024"
+```
+
+**Key lesson:** For connector performance validation, CPU and memory are the primary indicators since connectors don't expose NestJS HTTP histograms the same way platform services do.
+
+---
+
+## Example 7: Outlook Semantic MCP Sync Monitoring
+
+**Scenario:** Full sync running on outlook-semantic-mcp — monitor progress and detect stalls.
+
+**Steps:**
+
+1. Watch sync progress logs:
+```
+query_loki_logs
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"outlook-semantic-mcp\"} |~ \"sync|checkpoint|resume|completed\"",
+    "startRfc3339": "2026-04-01T06:00:00Z",
+    "endRfc3339": "2026-04-01T12:00:00Z",
+    "limit": 100,
+    "direction": "forward"
+  }
+```
+
+2. Check for errors during sync:
+```
+query_loki_logs
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"outlook-semantic-mcp\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T06:00:00Z",
+    "endRfc3339": "2026-04-01T12:00:00Z",
+    "limit": 50
+  }
+```
+
+3. Monitor resource consumption during sync:
+```
+query_prometheus
+  server: "qa-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "sum(rate(container_cpu_usage_seconds_total{container=\"outlook-semantic-mcp\"}[2m])) by (pod)",
+    "queryType": "range",
+    "startTime": "2026-04-01T06:00:00Z",
+    "endTime": "2026-04-01T12:00:00Z",
+    "stepSeconds": 60
+  }
+```
+
+**Key lesson:** Outlook semantic MCP uses checkpoint-based full sync with resume. Monitor for stalls by checking if new log entries stop appearing.
+
+---
+
+## Example 8: FactSet MCP Data Query Issues
+
+**Scenario:** FactSet MCP returning errors when users invoke it from chat.
+
+**Steps:**
+
+1. Check FactSet MCP server logs:
+```
+query_loki_logs
+  server: "prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"mcp-server-factset\"} | level = \"error\"",
+    "startRfc3339": "2026-04-01T09:00:00Z",
+    "endRfc3339": "2026-04-01T10:00:00Z",
+    "limit": 50,
+    "direction": "backward"
+  }
+```
+
+2. Check mcp-hub dispatch:
+```
+query_loki_logs
+  server: "prod-grafana"
+  arguments: {
+    "datasourceUid": "<loki-uid>",
+    "logql": "{app=\"mcp-hub\"} |= \"factset\"",
+    "startRfc3339": "2026-04-01T09:00:00Z",
+    "endRfc3339": "2026-04-01T10:00:00Z",
+    "limit": 50
+  }
+```
+
+3. Check pod health:
+```
+query_prometheus
+  server: "prod-grafana"
+  arguments: {
+    "datasourceUid": "prometheus",
+    "expr": "up{job=~\".*factset.*\"}",
+    "queryType": "instant",
+    "startTime": "now"
+  }
+```
+
+**Key lesson:** FactSet MCP depends on external FactSet APIs. Errors may be upstream (FactSet service) rather than internal. Check response codes in logs to distinguish.

--- a/.claude/skills/grafana-investigation/tool-reference.md
+++ b/.claude/skills/grafana-investigation/tool-reference.md
@@ -1,0 +1,283 @@
+# Grafana MCP Tool Reference
+
+Complete parameter reference for all 50 Grafana MCP tools. Organized by category.
+
+## Datasources
+
+### list_datasources
+List configured datasources to discover UIDs.
+- `type` — filter by type (e.g. `prometheus`, `loki`, `tempo`)
+- `limit` — max 100, default 50
+- `offset` — default 0
+
+### get_datasource
+Full datasource model.
+- `uid` — preferred identifier
+- `name` — fallback if uid unknown; uid wins if both provided
+
+## Dashboards and Folders
+
+### search_dashboards
+Text search dashboards by title/metadata.
+- `query` — search string
+- `limit` — max 100, default 50
+- `page` — default 1
+
+### search_folders
+Search folders by query string.
+- `query` — search string
+
+### get_dashboard_by_uid
+**Warning: returns very large JSON.** Use summary or property tools instead.
+- `uid` — required
+
+### get_dashboard_summary
+Compact overview: panels, variables, metadata.
+- `uid` — required
+
+### get_dashboard_property
+Efficient JSONPath slices of a dashboard.
+- `uid` — required
+- `jsonPath` — e.g. `$.title`, `$.panels[*].targets[*].expr`
+
+### get_dashboard_panel_queries
+Extract panel queries and datasource info.
+- `uid` — required
+- `panelId` — optional, specific panel
+- `variables` — map of template variable values for `processedQuery`
+
+### update_dashboard
+Create or update dashboards. Full JSON or patch mode.
+- Full: `dashboard` (complete JSON object)
+- Patch: `uid` + `operations` array (`op`: replace/add/remove, `path`, `value`)
+- Optional: `folderUid`, `message`, `overwrite`, `userId`
+
+### create_folder
+- `title` — required
+- `uid` — optional
+- `parentUid` — optional
+
+## Rendering and Navigation
+
+### get_panel_image
+Render panel or dashboard as PNG (base64). Requires Image Renderer plugin.
+- `dashboardUid` — required
+- `panelId` — optional (omit for full dashboard)
+- `timeRange` — `{ "from": "...", "to": "..." }`
+- `variables` — template variable map
+- `width`, `height`, `scale` (1-3), `theme` (light/dark), `timeout` (seconds)
+
+### generate_deeplink
+Create URLs for dashboards, panels, or Explore.
+- `resourceType` — required: `dashboard` | `panel` | `explore`
+- For dashboard/panel: `dashboardUid`; panel also needs `panelId`
+- For explore: `datasourceUid`
+- `timeRange` — optional `{ "from", "to" }`
+- `queryParams` — optional key-value map
+
+## Annotations
+
+### create_annotation
+- `text` — required (unless graphite format)
+- Optional: `dashboardUID`, `panelId`, `time`, `timeEnd`, `tags`, `data`
+- Graphite format: `format: "graphite"`, `what`, `when`
+
+### get_annotations
+- `DashboardUID`, `PanelID`, `From`/`To` (epoch ms), `Tags`, `MatchAny`, `Limit`, `Type`, `AlertUID`, `UserID`
+
+### get_annotation_tags
+- `tag` — optional filter
+- `limit` — default "100"
+
+### update_annotation
+- `id` — required (numeric)
+- Partial: `text`, `tags`, `time`, `timeEnd`, `data`
+
+## Prometheus (Metrics)
+
+### list_prometheus_metric_names
+- `datasourceUid` — required
+- `regex` — filter pattern
+- `limit` — default 10
+- `page` — default 1
+
+### list_prometheus_metric_metadata
+Experimental metadata API.
+- `datasourceUid` — required
+- `metric` — optional filter
+- `limit` — default 10
+- `limitPerMetric` — optional
+
+### list_prometheus_label_names
+- `datasourceUid` — required
+- `matches` — array of `{ filters: [{ name, value, type }] }`, type: `=`, `!=`, `=~`, `!~`
+- `startRfc3339`, `endRfc3339` — optional
+- `limit` — default 100
+
+### list_prometheus_label_values
+- `datasourceUid` — required
+- `labelName` — required
+- `matches`, `startRfc3339`, `endRfc3339`, `limit` — same as label names
+
+### query_prometheus
+**Required:** `datasourceUid`, `expr`, `startTime`
+- `queryType` — `range` or `instant`
+- For range: `endTime`, `stepSeconds`
+- Times: RFC3339 or relative (`now`, `now-1h`)
+
+### query_prometheus_histogram
+Convenience for `histogram_quantile`.
+- **Required:** `datasourceUid`, `metric` (base name without `_bucket`), `percentile`
+- Optional: `labels`, `rateInterval` (default 5m), `startTime`, `endTime`, `stepSeconds`
+
+## Loki (Logs)
+
+### list_loki_label_names
+- `datasourceUid` — required
+- `startRfc3339`, `endRfc3339` — optional (default last hour)
+
+### list_loki_label_values
+- `datasourceUid` — required
+- `labelName` — required
+- `startRfc3339`, `endRfc3339` — optional
+
+### query_loki_stats
+Stream stats for a selector (no line filters).
+- `datasourceUid` — required
+- `logql` — **stream selector only** (e.g. `{app="sharepoint-connector"}`)
+- `startRfc3339`, `endRfc3339` — optional
+
+### query_loki_patterns
+Pattern detection on log streams.
+- `datasourceUid` — required
+- `logql` — **stream selector only**
+- `startRfc3339`, `endRfc3339`, `step` — optional
+
+### query_loki_logs
+Full LogQL execution.
+- `datasourceUid` — required
+- `logql` — required
+- `startRfc3339`, `endRfc3339` — optional
+- `limit` — max 100, default 10
+- `direction` — `forward` or `backward`
+- `queryType` — `range` or `instant` (use instant for metric queries like `count_over_time`)
+- `stepSeconds` — for range metric queries
+
+## Pyroscope (Profiling)
+
+**Note:** Pyroscope tools use **snake_case** parameters (`data_source_uid`, `start_rfc_3339`).
+
+### list_pyroscope_profile_types
+- `data_source_uid` — required
+- `start_rfc_3339`, `end_rfc_3339` — optional
+
+### list_pyroscope_label_names
+- `data_source_uid` — required
+- `matchers` — optional (string in Prom selector style, e.g. `{service_name="foo"}`)
+- `start_rfc_3339`, `end_rfc_3339` — optional
+
+### list_pyroscope_label_values
+- `data_source_uid` — required
+- `name` — label name, required
+- `matchers`, `start_rfc_3339`, `end_rfc_3339` — optional
+
+### fetch_pyroscope_profile
+Returns profile in DOT format.
+- `data_source_uid` — required
+- `profile_type` — required
+- `matchers`, `start_rfc_3339`, `end_rfc_3339` — optional
+- `max_node_depth` — default 100, -1 for unbounded
+
+## Alerting
+
+### alerting_manage_rules
+- **Required:** `operation` — `list` | `get` | `versions` | `create` | `update` | `delete`
+- List: `folder_uid` or `search_folder`, `label_selectors`, `datasource_uid`, `rule_limit`, `limit_alerts`
+- Get/versions/update/delete: `rule_uid`
+- Create/update: `title`, `folder_uid`, `rule_group`, `org_id`, `for`, `condition`, `data` (queries array), `no_data_state`, `exec_err_state`, labels, annotations
+
+### alerting_manage_routing
+Read-only routing information.
+- **Required:** `operation` — `get_notification_policies` | `get_contact_points` | `get_contact_point` | `get_time_intervals` | `get_time_interval`
+- Optional: `datasource_uid`, `limit`, `name`, `contact_point_title`, `time_interval_name`
+
+## Incidents
+
+### list_incidents
+- `status` — `active` or `resolved`
+- `drill` — boolean
+- `limit` — default 10
+
+### get_incident
+- `id` — required
+
+### create_incident
+**Caution: may trigger wide notifications.** Confirm with user first.
+- `title`, `severity`, `roomPrefix` — required
+- Optional: `status`, `isDrill`, `labels`, `attachUrl`, `attachCaption`
+
+### add_activity_to_incident
+- `incidentId` — required
+- `body` — required
+- `eventTime` — optional
+
+## OnCall
+
+### list_alert_groups
+- Filters: `id`, `routeId`, `integrationId`, `state`, `teamId`, `name`, `labels` (array of `key:value`), `startedAt` (`start_end` ISO range), `page`
+
+### get_alert_group
+- `alertGroupId` — required
+
+### list_oncall_schedules
+- `teamId`, `scheduleId`, `page`
+
+### get_oncall_shift
+- `shiftId` — required
+
+### get_current_oncall_users
+- `scheduleId` — required
+
+### list_oncall_teams
+- `page`
+
+### list_oncall_users
+- `page`, `userId`, `username`
+
+## Sift (Automated Analysis)
+
+### list_sift_investigations
+- `limit` — default 10
+
+### get_sift_investigation
+- `id` — UUID string
+
+### get_sift_analysis
+- `investigationId` — UUID
+- `analysisId` — UUID
+
+### find_error_pattern_logs
+Loki error-pattern analysis vs baseline.
+- **Required:** `name`, `labels` (object)
+- Optional: `start`, `end` (defaults ~30min window)
+
+### find_slow_requests
+Tempo-based slow-request analysis. **Requires Tempo datasource.**
+- **Required:** `name`, `labels` (object)
+- Optional: `start`, `end`
+
+## Assertions
+
+### get_assertions
+- **Required:** `startTime`, `endTime` (RFC3339)
+- Optional: `entityType`, `entityName`, `env`, `site`, `namespace`
+
+## Parameter Naming Conventions
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Prometheus/Loki | camelCase | `datasourceUid`, `startRfc3339` |
+| Pyroscope | snake_case | `data_source_uid`, `start_rfc_3339` |
+| Alerting rules | snake_case | `datasource_uid`, `folder_uid` |
+| Annotations | PascalCase | `DashboardUID`, `PanelID` |
+| Time formats | Mixed | RFC3339 strings, `now-1h` relative, epoch ms (annotations) |

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,9 @@ lerna-debug.log*
 .cursor/
 # We do not use .zed/ because we want to ignore symlinks
 .zed
-# We do not use .claude/ because we want to ignore symlinks
-.claude
+# Ignore .claude contents (symlinks, settings, worktrees) but track skills
+.claude/*
+!.claude/skills/
 *.code-workspace
 
 # OS — macOS


### PR DESCRIPTION
## Summary
Starting from the monorepo PR https://github.com/Unique-AG/monorepo/pull/22168 i adapted it for connectors repository. 
  The key differences in ours are intentional:
  - Claude Code instead of Cursor
  - Connector-specific service mappings instead of monorepo services
  - Scrubbed sensitive info because this is a public repo.
  - Cross-repo bridge to the private monorepo skill to get private data like urls 
  - .gitignore update to track .claude/skills/
 
### Cross-repo reference

The public skill contains a "Enhanced Details" section that bridges to the private monorepo skill:

```markdown
## Enhanced Details (Private Monorepo)

If you have filesystem access to the Unique monorepo, check for `../monorepo/.claude/skills/grafana-investigation/SKILL.md`
(relative to this repo root). If it exists, read it — it contains internal details not included here:

- Grafana URL patterns and DNS hostnames
- Tenant environment slugs (all production single-tenant names)
- Loki datasource UIDs per environment
- Complete namespace-to-service mapping
- Full upstream service label table (including web apps and Python AI services)
- Additional Prometheus metrics (chat LLM, ingestion embeddings, Node.js process, Elasticsearch)

Use those concrete values instead of the generic placeholders in this file. If the monorepo is not available, this skill
is fully self-contained — proceed with discovery steps below.
```
<img width="1156" height="1030" alt="image" src="https://github.com/user-attachments/assets/7e7b3b29-55bd-4168-8f67-8c43c9a45230" />

## Test plan
- [ ] Verify skill is discovered by Claude Code when mentioning Grafana, logs, metrics, or investigation
- [ ] Validate that service name mappings match actual Helm chart names in this repo
- [ ] Confirm examples use correct tool names and parameter schemas
- [ ] Verify no sensitive internal details (URLs, tenant names, UIDs) are present in the public files
- [ ] Test cross-repo bridge: when monorepo is available at `../monorepo/`, Claude reads the enriched skill