### PR TITLE
feat(teams-mcp): organizer metadata, hybrid search, and list_meetings tool

### DIFF
--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -20,11 +20,19 @@ const FindTranscriptsInputSchema = z.object({
   dateFrom: z.iso
     .datetime()
     .optional()
-    .describe('Filter transcripts from this datetime (ISO 8601, e.g., 2024-01-15T00:00:00.000Z)'),
+    .describe(
+      'Filter transcripts from this datetime (ISO 8601, e.g., 2024-01-15T00:00:00.000Z). Matches the meeting start date.',
+    ),
   dateTo: z.iso
     .datetime()
     .optional()
-    .describe('Filter transcripts until this datetime (ISO 8601, e.g., 2024-01-31T23:59:59.999Z)'),
+    .describe(
+      'Filter transcripts until this datetime (ISO 8601, e.g., 2024-01-31T23:59:59.999Z). Matches the meeting start date.',
+    ),
+  organizer: z
+    .string()
+    .optional()
+    .describe('Filter by meeting organizer name or email (partial match)'),
   participant: z
     .string()
     .optional()
@@ -52,6 +60,7 @@ const TranscriptChunkSchema = z.object({
   text: z.string().describe('The relevant passage'),
   url: z.string().optional().describe('External URL if applicable'),
   meetingDate: z.string().optional().describe('Date of the meeting'),
+  organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participants'),
   score: z.number().optional().describe('Relevance score'),
 });
@@ -77,7 +86,7 @@ export class FindTranscriptsTool {
     name: 'find_transcripts',
     title: 'Search Meeting Transcripts',
     description:
-      'Search for content within meeting transcripts using semantic search. Returns relevant passages that can be cited using [N] notation where N is the result index.',
+      'Search for content within meeting transcripts using hybrid semantic + keyword search. Supports filtering by date range (dateFrom/dateTo), meeting organizer, participant, and subject. Returns relevant passages that can be cited using [N] notation where N is the result index.',
     parameters: FindTranscriptsInputSchema,
     outputSchema: FindTranscriptsOutputSchema,
     annotations: {
@@ -110,6 +119,7 @@ export class FindTranscriptsTool {
     span?.setAttribute('filter.has_subject', !!input.subject);
     span?.setAttribute('filter.has_date_from', !!input.dateFrom);
     span?.setAttribute('filter.has_date_to', !!input.dateTo);
+    span?.setAttribute('filter.has_organizer', !!input.organizer);
     span?.setAttribute('filter.has_participant', !!input.participant);
 
     const scopeContext = await this.userMapping.resolve(userProfileId);
@@ -123,6 +133,7 @@ export class FindTranscriptsTool {
         hasSubject: !!input.subject,
         hasDateFrom: !!input.dateFrom,
         hasDateTo: !!input.dateTo,
+        hasOrganizer: !!input.organizer,
         hasParticipant: !!input.participant,
         limit: input.limit,
       },
@@ -153,6 +164,7 @@ export class FindTranscriptsTool {
         text: item.text,
         url: `unique://content/${item.id}`,
         meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
+        organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
         participants: participants?.length ? participants : undefined,
         score: undefined, // Score not available in current response
       };
@@ -211,6 +223,23 @@ export class FindTranscriptsTool {
       });
     }
 
+    if (input.organizer) {
+      conditions.push({
+        or: [
+          {
+            path: ['metadata', 'organizer_name'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.organizer,
+          },
+          {
+            path: ['metadata', 'organizer_email'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.organizer,
+          },
+        ],
+      });
+    }
+
     if (input.participant) {
       conditions.push({
         or: [
@@ -230,7 +259,7 @@ export class FindTranscriptsTool {
 
     return {
       searchString: input.query,
-      searchType: SearchType.VECTOR,
+      searchType: SearchType.COMBINED,
       limit: input.limit,
       scoreThreshold: input.scoreThreshold,
       metaDataFilter: { and: conditions },

--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -5,14 +5,10 @@ import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import type { UniqueConfigNamespaced } from '~/config';
-import {
-  type MetadataFilter,
-  type PublicSearchRequest,
-  SearchType,
-  UniqueQLOperator,
-} from '~/unique/unique.dtos';
+import { type PublicSearchRequest, SearchType } from '~/unique/unique.dtos';
 import { UniqueContentService } from '~/unique/unique-content.service';
 import { UniqueUserMappingService } from '~/unique/unique-user-mapping.service';
+import { buildTranscriptFilter, parseTranscriptMetadata } from './transcript-tools.helpers';
 
 const FindTranscriptsInputSchema = z.object({
   query: z.string().describe('Search query to find relevant content within transcripts'),
@@ -139,15 +135,9 @@ export class FindTranscriptsTool {
     const result = await this.contentService.scopedSearch(searchRequest, scopeContext);
 
     const results = result.data.map((item) => {
-      const metadata = item.metadata as Record<string, unknown> | null;
-      const participantNames = metadata?.participant_names;
-      const participants =
-        typeof participantNames === 'string'
-          ? participantNames
-              .split(',')
-              .map((p) => p.trim())
-              .filter(Boolean)
-          : undefined;
+      const { meetingDate, organizer, participants } = parseTranscriptMetadata(
+        item.metadata as Record<string, unknown> | null,
+      );
 
       return {
         id: item.id,
@@ -156,10 +146,9 @@ export class FindTranscriptsTool {
         key: item.key,
         text: item.text,
         url: `unique://content/${item.id}`,
-        meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
-        organizer:
-          typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
-        participants: participants?.length ? participants : undefined,
+        meetingDate,
+        organizer,
+        participants,
       };
     });
 
@@ -177,84 +166,11 @@ export class FindTranscriptsTool {
     rootScopeId: string,
     input: z.infer<typeof FindTranscriptsInputSchema>,
   ): PublicSearchRequest {
-    const conditions: MetadataFilter[] = [
-      // Scope filter: only return content under our root scope
-      {
-        path: ['folderIdPath'],
-        operator: UniqueQLOperator.CONTAINS,
-        value: `uniquepathid://${rootScopeId}`,
-      },
-      // Type filter: only return transcripts (VTT files), not recordings
-      {
-        path: ['mimeType'],
-        operator: UniqueQLOperator.EQUALS,
-        value: 'text/vtt',
-      },
-    ];
-
-    if (input.subject) {
-      conditions.push({
-        path: ['title'],
-        operator: UniqueQLOperator.CONTAINS,
-        value: input.subject,
-      });
-    }
-
-    if (input.dateFrom) {
-      conditions.push({
-        path: ['metadata', 'date'],
-        operator: UniqueQLOperator.GREATER_THAN_OR_EQUAL,
-        value: input.dateFrom,
-      });
-    }
-
-    if (input.dateTo) {
-      conditions.push({
-        path: ['metadata', 'date'],
-        operator: UniqueQLOperator.LESS_THAN_OR_EQUAL,
-        value: input.dateTo,
-      });
-    }
-
-    if (input.organizer) {
-      conditions.push({
-        or: [
-          {
-            path: ['metadata', 'organizer_name'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.organizer,
-          },
-          {
-            path: ['metadata', 'organizer_email'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.organizer,
-          },
-        ],
-      });
-    }
-
-    if (input.participant) {
-      conditions.push({
-        or: [
-          {
-            path: ['metadata', 'participant_names'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.participant,
-          },
-          {
-            path: ['metadata', 'participant_emails'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.participant,
-          },
-        ],
-      });
-    }
-
     return {
       searchString: input.query,
       searchType: SearchType.COMBINED,
       limit: input.limit,
-      metaDataFilter: { and: conditions },
+      metaDataFilter: buildTranscriptFilter(rootScopeId, input),
     };
   }
 }

--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -44,12 +44,6 @@ const FindTranscriptsInputSchema = z.object({
     .max(100)
     .default(10)
     .describe('Maximum number of results to return'),
-  scoreThreshold: z
-    .number()
-    .min(0)
-    .max(1)
-    .optional()
-    .describe('Minimum relevance score threshold (0-1)'),
 });
 
 const TranscriptChunkSchema = z.object({
@@ -62,7 +56,6 @@ const TranscriptChunkSchema = z.object({
   meetingDate: z.string().optional().describe('Date of the meeting'),
   organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participants'),
-  score: z.number().optional().describe('Relevance score'),
 });
 
 const FindTranscriptsOutputSchema = z.object({
@@ -167,7 +160,6 @@ export class FindTranscriptsTool {
         organizer:
           typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
         participants: participants?.length ? participants : undefined,
-        score: undefined, // Score not available in current response
       };
     });
 
@@ -262,7 +254,6 @@ export class FindTranscriptsTool {
       searchString: input.query,
       searchType: SearchType.COMBINED,
       limit: input.limit,
-      scoreThreshold: input.scoreThreshold,
       metaDataFilter: { and: conditions },
     };
   }

--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -164,7 +164,8 @@ export class FindTranscriptsTool {
         text: item.text,
         url: `unique://content/${item.id}`,
         meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
-        organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
+        organizer:
+          typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
         participants: participants?.length ? participants : undefined,
         score: undefined, // Score not available in current response
       };

--- a/services/teams-mcp/src/transcript/tools/index.ts
+++ b/services/teams-mcp/src/transcript/tools/index.ts
@@ -1,4 +1,5 @@
 export { FindTranscriptsTool } from './find-transcripts.tool';
+export { ListMeetingsTool } from './list-meetings.tool';
 export { StartKbIntegrationTool } from './start-kb-integration.tool';
 export { StopKbIntegrationTool } from './stop-kb-integration.tool';
 export { VerifyKbIntegrationStatusTool } from './verify-kb-integration-status.tool';

--- a/services/teams-mcp/src/transcript/tools/index.ts
+++ b/services/teams-mcp/src/transcript/tools/index.ts
@@ -2,4 +2,8 @@ export { FindTranscriptsTool } from './find-transcripts.tool';
 export { ListMeetingsTool } from './list-meetings.tool';
 export { StartKbIntegrationTool } from './start-kb-integration.tool';
 export { StopKbIntegrationTool } from './stop-kb-integration.tool';
+export {
+  buildTranscriptFilter,
+  parseTranscriptMetadata,
+} from './transcript-tools.helpers';
 export { VerifyKbIntegrationStatusTool } from './verify-kb-integration-status.tool';

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -1,0 +1,227 @@
+import { type McpAuthenticatedRequest } from '@unique-ag/mcp-oauth';
+import { type Context, Tool } from '@unique-ag/mcp-server-module';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Span, TraceService } from 'nestjs-otel';
+import * as z from 'zod';
+import type { UniqueConfigNamespaced } from '~/config';
+import { type MetadataFilter, UniqueQLOperator } from '~/unique/unique.dtos';
+import { UniqueContentService } from '~/unique/unique-content.service';
+
+const ListMeetingsInputSchema = z.object({
+  dateFrom: z.iso
+    .datetime()
+    .optional()
+    .describe(
+      'List meetings on or after this datetime (ISO 8601, e.g., 2024-01-15T00:00:00.000Z). Matches the meeting start date.',
+    ),
+  dateTo: z.iso
+    .datetime()
+    .optional()
+    .describe(
+      'List meetings on or before this datetime (ISO 8601, e.g., 2024-01-31T23:59:59.999Z). Matches the meeting start date.',
+    ),
+  organizer: z
+    .string()
+    .optional()
+    .describe('Filter by meeting organizer name or email (partial match)'),
+  participant: z
+    .string()
+    .optional()
+    .describe('Filter by participant name or email (partial match)'),
+  subject: z.string().optional().describe('Filter by meeting subject (partial match)'),
+  skip: z.number().int().min(0).default(0).describe('Number of results to skip (for pagination)'),
+  take: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum number of meetings to return'),
+});
+
+const MeetingItemSchema = z.object({
+  id: z.string().describe('Content ID — use this to reference the meeting in other tools'),
+  title: z.string().describe('Meeting subject / title'),
+  meetingDate: z.string().optional().describe('Meeting start date (ISO 8601)'),
+  organizer: z.string().optional().describe('Name of the meeting organizer'),
+  participants: z.array(z.string()).optional().describe('List of participant names'),
+});
+
+const ListMeetingsOutputSchema = z.object({
+  meetings: z.array(MeetingItemSchema).describe('List of meetings matching the filters'),
+  total: z.number().optional().describe('Total number of matching meetings'),
+});
+
+@Injectable()
+export class ListMeetingsTool {
+  private readonly logger = new Logger(this.constructor.name);
+
+  public constructor(
+    private readonly config: ConfigService<UniqueConfigNamespaced, true>,
+    private readonly contentService: UniqueContentService,
+    private readonly traceService: TraceService,
+  ) {}
+
+  @Tool({
+    name: 'list_meetings',
+    title: 'List Meeting Transcripts',
+    description:
+      'Browse and list meetings with transcripts without requiring a search query. Use this to discover meetings by date range, organizer, participant, or subject. Returns meeting metadata including title, date, organizer, and participants. Use find_transcripts to search within a specific meeting\'s content.',
+    parameters: ListMeetingsInputSchema,
+    outputSchema: ListMeetingsOutputSchema,
+    annotations: {
+      title: 'List Meeting Transcripts',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    _meta: {
+      'unique.app/icon': 'list',
+      'unique.app/system-prompt':
+        'Use this tool to browse meetings by date, organizer, or participant without a search query. Returns meeting IDs that can be used with find_transcripts for deeper search.',
+    },
+  })
+  @Span()
+  public async listMeetings(
+    input: z.infer<typeof ListMeetingsInputSchema>,
+    _context: Context,
+    _request: McpAuthenticatedRequest,
+  ): Promise<z.output<typeof ListMeetingsOutputSchema>> {
+    const span = this.traceService.getSpan();
+    span?.setAttribute('filter.has_date_from', !!input.dateFrom);
+    span?.setAttribute('filter.has_date_to', !!input.dateTo);
+    span?.setAttribute('filter.has_organizer', !!input.organizer);
+    span?.setAttribute('filter.has_participant', !!input.participant);
+    span?.setAttribute('filter.has_subject', !!input.subject);
+    span?.setAttribute('skip', input.skip);
+    span?.setAttribute('take', input.take);
+
+    this.logger.debug(
+      {
+        hasDateFrom: !!input.dateFrom,
+        hasDateTo: !!input.dateTo,
+        hasOrganizer: !!input.organizer,
+        hasParticipant: !!input.participant,
+        hasSubject: !!input.subject,
+        skip: input.skip,
+        take: input.take,
+      },
+      'Listing meeting transcripts',
+    );
+
+    const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
+    const filter = this.buildFilter(rootScopeId, input);
+
+    const result = await this.contentService.findByMetadata(filter, {
+      skip: input.skip,
+      take: input.take,
+    });
+
+    const meetings = result.contents.map((item) => {
+      const metadata = item.metadata as Record<string, unknown> | null;
+      const participantNames = metadata?.participant_names;
+      const participants =
+        typeof participantNames === 'string'
+          ? participantNames
+              .split(',')
+              .map((p) => p.trim())
+              .filter(Boolean)
+          : undefined;
+
+      return {
+        id: item.id,
+        title: item.title ?? 'Untitled Meeting',
+        meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
+        organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
+        participants: participants?.length ? participants : undefined,
+      };
+    });
+
+    span?.setAttribute('result_count', meetings.length);
+    span?.setAttribute('total', result.total);
+
+    this.logger.debug({ resultCount: meetings.length, total: result.total }, 'Listed meeting transcripts');
+
+    return { meetings, total: result.total };
+  }
+
+  private buildFilter(
+    rootScopeId: string,
+    input: z.infer<typeof ListMeetingsInputSchema>,
+  ): MetadataFilter {
+    const conditions: MetadataFilter[] = [
+      {
+        path: ['folderIdPath'],
+        operator: UniqueQLOperator.CONTAINS,
+        value: `uniquepathid://${rootScopeId}`,
+      },
+      {
+        path: ['mimeType'],
+        operator: UniqueQLOperator.EQUALS,
+        value: 'text/vtt',
+      },
+    ];
+
+    if (input.subject) {
+      conditions.push({
+        path: ['title'],
+        operator: UniqueQLOperator.CONTAINS,
+        value: input.subject,
+      });
+    }
+
+    if (input.dateFrom) {
+      conditions.push({
+        path: ['metadata', 'date'],
+        operator: UniqueQLOperator.GREATER_THAN_OR_EQUAL,
+        value: input.dateFrom,
+      });
+    }
+
+    if (input.dateTo) {
+      conditions.push({
+        path: ['metadata', 'date'],
+        operator: UniqueQLOperator.LESS_THAN_OR_EQUAL,
+        value: input.dateTo,
+      });
+    }
+
+    if (input.organizer) {
+      conditions.push({
+        or: [
+          {
+            path: ['metadata', 'organizer_name'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.organizer,
+          },
+          {
+            path: ['metadata', 'organizer_email'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.organizer,
+          },
+        ],
+      });
+    }
+
+    if (input.participant) {
+      conditions.push({
+        or: [
+          {
+            path: ['metadata', 'participant_names'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.participant,
+          },
+          {
+            path: ['metadata', 'participant_emails'],
+            operator: UniqueQLOperator.CONTAINS,
+            value: input.participant,
+          },
+        ],
+      });
+    }
+
+    return { and: conditions };
+  }
+}

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -50,7 +50,7 @@ const MeetingItemSchema = z.object({
 
 const ListMeetingsOutputSchema = z.object({
   meetings: z.array(MeetingItemSchema).describe('List of meetings matching the filters'),
-  total: z.number().optional().describe('Total number of matching meetings'),
+  total: z.number().describe('Total number of matching meetings'),
 });
 
 @Injectable()
@@ -87,6 +87,7 @@ export class ListMeetingsTool {
   public async listMeetings(
     input: z.infer<typeof ListMeetingsInputSchema>,
     _context: Context,
+    // Access control is enforced by the KB platform; no user identity resolution needed here
     _request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof ListMeetingsOutputSchema>> {
     const span = this.traceService.getSpan();

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -1,12 +1,13 @@
 import { type McpAuthenticatedRequest } from '@unique-ag/mcp-oauth';
 import { type Context, Tool } from '@unique-ag/mcp-server-module';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import type { UniqueConfigNamespaced } from '~/config';
 import { type MetadataFilter, UniqueQLOperator } from '~/unique/unique.dtos';
 import { UniqueContentService } from '~/unique/unique-content.service';
+import { UniqueUserMappingService } from '~/unique/unique-user-mapping.service';
 
 const ListMeetingsInputSchema = z.object({
   dateFrom: z.iso
@@ -60,6 +61,7 @@ export class ListMeetingsTool {
   public constructor(
     private readonly config: ConfigService<UniqueConfigNamespaced, true>,
     private readonly contentService: UniqueContentService,
+    private readonly userMapping: UniqueUserMappingService,
     private readonly traceService: TraceService,
   ) {}
 
@@ -87,10 +89,18 @@ export class ListMeetingsTool {
   public async listMeetings(
     input: z.infer<typeof ListMeetingsInputSchema>,
     _context: Context,
-    // Access control is enforced by the KB platform; no user identity resolution needed here
-    _request: McpAuthenticatedRequest,
+    request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof ListMeetingsOutputSchema>> {
+    const userProfileId = request.user?.userProfileId;
+    if (!userProfileId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const scopeContext = await this.userMapping.resolve(userProfileId);
+
     const span = this.traceService.getSpan();
+    span?.setAttribute('user_profile_id', userProfileId);
+    span?.setAttribute('unique_user_id', scopeContext.userId);
     span?.setAttribute('filter.has_date_from', !!input.dateFrom);
     span?.setAttribute('filter.has_date_to', !!input.dateTo);
     span?.setAttribute('filter.has_organizer', !!input.organizer);
@@ -115,7 +125,7 @@ export class ListMeetingsTool {
     const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
     const filter = this.buildFilter(rootScopeId, input);
 
-    const result = await this.contentService.findByMetadata(filter, {
+    const result = await this.contentService.scopedFindByMetadata(filter, scopeContext, {
       skip: input.skip,
       take: input.take,
     });

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -67,7 +67,7 @@ export class ListMeetingsTool {
     name: 'list_meetings',
     title: 'List Meeting Transcripts',
     description:
-      'Browse and list meetings with transcripts without requiring a search query. Use this to discover meetings by date range, organizer, participant, or subject. Returns meeting metadata including title, date, organizer, and participants. Use find_transcripts to search within a specific meeting\'s content.',
+      "Browse and list meetings with transcripts without requiring a search query. Use this to discover meetings by date range, organizer, participant, or subject. Returns meeting metadata including title, date, organizer, and participants. Use find_transcripts to search within a specific meeting's content.",
     parameters: ListMeetingsInputSchema,
     outputSchema: ListMeetingsOutputSchema,
     annotations: {
@@ -134,7 +134,8 @@ export class ListMeetingsTool {
         id: item.id,
         title: item.title ?? 'Untitled Meeting',
         meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
-        organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
+        organizer:
+          typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
         participants: participants?.length ? participants : undefined,
       };
     });
@@ -142,7 +143,10 @@ export class ListMeetingsTool {
     span?.setAttribute('result_count', meetings.length);
     span?.setAttribute('total', result.total);
 
-    this.logger.debug({ resultCount: meetings.length, total: result.total }, 'Listed meeting transcripts');
+    this.logger.debug(
+      { resultCount: meetings.length, total: result.total },
+      'Listed meeting transcripts',
+    );
 
     return { meetings, total: result.total };
   }

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -5,9 +5,9 @@ import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import type { UniqueConfigNamespaced } from '~/config';
-import { type MetadataFilter, UniqueQLOperator } from '~/unique/unique.dtos';
 import { UniqueContentService } from '~/unique/unique-content.service';
 import { UniqueUserMappingService } from '~/unique/unique-user-mapping.service';
+import { buildTranscriptFilter, parseTranscriptMetadata } from './transcript-tools.helpers';
 
 const ListMeetingsInputSchema = z.object({
   dateFrom: z.iso
@@ -123,31 +123,24 @@ export class ListMeetingsTool {
     );
 
     const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
-    const filter = this.buildFilter(rootScopeId, input);
 
-    const result = await this.contentService.scopedFindByMetadata(filter, scopeContext, {
-      skip: input.skip,
-      take: input.take,
-    });
+    const result = await this.contentService.scopedFindByMetadata(
+      buildTranscriptFilter(rootScopeId, input),
+      scopeContext,
+      { skip: input.skip, take: input.take },
+    );
 
     const meetings = result.contents.map((item) => {
-      const metadata = item.metadata as Record<string, unknown> | null;
-      const participantNames = metadata?.participant_names;
-      const participants =
-        typeof participantNames === 'string'
-          ? participantNames
-              .split(',')
-              .map((p) => p.trim())
-              .filter(Boolean)
-          : undefined;
+      const { meetingDate, organizer, participants } = parseTranscriptMetadata(
+        item.metadata as Record<string, unknown> | null,
+      );
 
       return {
         id: item.id,
         title: item.title ?? 'Untitled Meeting',
-        meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
-        organizer:
-          typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
-        participants: participants?.length ? participants : undefined,
+        meetingDate,
+        organizer,
+        participants,
       };
     });
 
@@ -160,83 +153,5 @@ export class ListMeetingsTool {
     );
 
     return { meetings, total: result.total };
-  }
-
-  private buildFilter(
-    rootScopeId: string,
-    input: z.infer<typeof ListMeetingsInputSchema>,
-  ): MetadataFilter {
-    const conditions: MetadataFilter[] = [
-      {
-        path: ['folderIdPath'],
-        operator: UniqueQLOperator.CONTAINS,
-        value: `uniquepathid://${rootScopeId}`,
-      },
-      {
-        path: ['mimeType'],
-        operator: UniqueQLOperator.EQUALS,
-        value: 'text/vtt',
-      },
-    ];
-
-    if (input.subject) {
-      conditions.push({
-        path: ['title'],
-        operator: UniqueQLOperator.CONTAINS,
-        value: input.subject,
-      });
-    }
-
-    if (input.dateFrom) {
-      conditions.push({
-        path: ['metadata', 'date'],
-        operator: UniqueQLOperator.GREATER_THAN_OR_EQUAL,
-        value: input.dateFrom,
-      });
-    }
-
-    if (input.dateTo) {
-      conditions.push({
-        path: ['metadata', 'date'],
-        operator: UniqueQLOperator.LESS_THAN_OR_EQUAL,
-        value: input.dateTo,
-      });
-    }
-
-    if (input.organizer) {
-      conditions.push({
-        or: [
-          {
-            path: ['metadata', 'organizer_name'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.organizer,
-          },
-          {
-            path: ['metadata', 'organizer_email'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.organizer,
-          },
-        ],
-      });
-    }
-
-    if (input.participant) {
-      conditions.push({
-        or: [
-          {
-            path: ['metadata', 'participant_names'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.participant,
-          },
-          {
-            path: ['metadata', 'participant_emails'],
-            operator: UniqueQLOperator.CONTAINS,
-            value: input.participant,
-          },
-        ],
-      });
-    }
-
-    return { and: conditions };
   }
 }

--- a/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
+++ b/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
@@ -1,0 +1,122 @@
+import { type MetadataFilter, UniqueQLOperator } from '~/unique/unique.dtos';
+
+export interface TranscriptFilterInput {
+  subject?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  organizer?: string;
+  participant?: string;
+}
+
+export interface ParsedTranscriptMetadata {
+  meetingDate?: string;
+  organizer?: string;
+  participants?: string[];
+}
+
+/**
+ * Builds the shared UniqueQL metadata filter for transcript tools.
+ * Always restricts to the root scope and VTT mime type; optional filters
+ * narrow by subject, date range, organizer, and participant.
+ */
+export function buildTranscriptFilter(
+  rootScopeId: string,
+  input: TranscriptFilterInput,
+): MetadataFilter {
+  const conditions: MetadataFilter[] = [
+    // Scope filter: only return content under our root scope
+    {
+      path: ['folderIdPath'],
+      operator: UniqueQLOperator.CONTAINS,
+      value: `uniquepathid://${rootScopeId}`,
+    },
+    // Type filter: only return transcripts (VTT files), not recordings
+    {
+      path: ['mimeType'],
+      operator: UniqueQLOperator.EQUALS,
+      value: 'text/vtt',
+    },
+  ];
+
+  if (input.subject) {
+    conditions.push({
+      path: ['title'],
+      operator: UniqueQLOperator.CONTAINS,
+      value: input.subject,
+    });
+  }
+
+  if (input.dateFrom) {
+    conditions.push({
+      path: ['metadata', 'date'],
+      operator: UniqueQLOperator.GREATER_THAN_OR_EQUAL,
+      value: input.dateFrom,
+    });
+  }
+
+  if (input.dateTo) {
+    conditions.push({
+      path: ['metadata', 'date'],
+      operator: UniqueQLOperator.LESS_THAN_OR_EQUAL,
+      value: input.dateTo,
+    });
+  }
+
+  if (input.organizer) {
+    conditions.push({
+      or: [
+        {
+          path: ['metadata', 'organizer_name'],
+          operator: UniqueQLOperator.CONTAINS,
+          value: input.organizer,
+        },
+        {
+          path: ['metadata', 'organizer_email'],
+          operator: UniqueQLOperator.CONTAINS,
+          value: input.organizer,
+        },
+      ],
+    });
+  }
+
+  if (input.participant) {
+    conditions.push({
+      or: [
+        {
+          path: ['metadata', 'participant_names'],
+          operator: UniqueQLOperator.CONTAINS,
+          value: input.participant,
+        },
+        {
+          path: ['metadata', 'participant_emails'],
+          operator: UniqueQLOperator.CONTAINS,
+          value: input.participant,
+        },
+      ],
+    });
+  }
+
+  return { and: conditions };
+}
+
+/**
+ * Extracts well-known transcript metadata fields from a raw KB content metadata object.
+ */
+export function parseTranscriptMetadata(
+  metadata: Record<string, unknown> | null,
+): ParsedTranscriptMetadata {
+  const participantNames = metadata?.participant_names;
+  const participants =
+    typeof participantNames === 'string'
+      ? participantNames
+          .split(',')
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : undefined;
+
+  return {
+    meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
+    organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
+    participants: participants?.length ? participants : undefined,
+  };
+}

--- a/services/teams-mcp/src/transcript/transcript.module.ts
+++ b/services/teams-mcp/src/transcript/transcript.module.ts
@@ -7,6 +7,7 @@ import { SubscriptionReauthorizeService } from './subscription-reauthorize.servi
 import { SubscriptionRemoveService } from './subscription-remove.service';
 import {
   FindTranscriptsTool,
+  ListMeetingsTool,
   StartKbIntegrationTool,
   StopKbIntegrationTool,
   VerifyKbIntegrationStatusTool,
@@ -29,8 +30,9 @@ import { TranscriptUtilsService } from './transcript-utils.service';
     VerifyKbIntegrationStatusTool,
     StartKbIntegrationTool,
     StopKbIntegrationTool,
-    // Transcript Search Tool
+    // Transcript Search Tools
     FindTranscriptsTool,
+    ListMeetingsTool,
   ],
   controllers: [TranscriptController],
 })

--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -169,6 +169,41 @@ export class UniqueContentService {
   }
 
   /**
+   * Scoped variant of findByMetadata — passes `x-user-id` and `x-company-id` headers
+   * so results are filtered to what the given user is permitted to access.
+   */
+  @Span()
+  public async scopedFindByMetadata(
+    filter: MetadataFilter,
+    scopeContext: UniqueIdentity,
+    options?: { skip?: number; take?: number },
+  ): Promise<{ contents: ContentInfoItem[]; total: number }> {
+    const request: PublicContentInfosRequest = {
+      skip: options?.skip ?? 0,
+      take: options?.take ?? 50,
+      metadataFilter: filter,
+    };
+
+    const payload = PublicContentInfosRequestSchema.encode(request);
+
+    const response = await this.fetch('content/infos', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-user-id': scopeContext.userId,
+        'x-company-id': scopeContext.companyId,
+      },
+      body: JSON.stringify(payload),
+    });
+    const result = PublicContentInfosResultSchema.parse(await response.json());
+
+    return {
+      contents: result.contents,
+      total: result.total ?? result.contents.length,
+    };
+  }
+
+  /**
    * @param scopeContext - When provided, overrides `x-user-id` and `x-company-id` headers
    *   to scope the search to the given user's permissions. When `undefined`, the search
    *   runs unscoped with service-level credentials — this is intentional for admin/ingestion flows.

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -242,11 +242,14 @@ export class UniqueService {
   private buildContentMetadata(meeting: {
     startDateTime: Date;
     contentCorrelationId: string;
+    owner: { name: string; email: string };
     participants: { name: string; email: string }[];
   }): Record<string, string> {
     const metadata: Record<string, string> = {
       date: meeting.startDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,
+      organizer_name: meeting.owner.name,
+      organizer_email: meeting.owner.email.toLowerCase(),
     };
 
     // Filter out empty names/emails before joining

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -248,9 +248,12 @@ export class UniqueService {
     const metadata: Record<string, string> = {
       date: meeting.startDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,
-      organizer_name: meeting.owner.name,
       organizer_email: meeting.owner.email.toLowerCase(),
     };
+
+    if (meeting.owner.name) {
+      metadata.organizer_name = meeting.owner.name;
+    }
 
     // Filter out empty names/emails before joining
     const names = meeting.participants.map((p) => p.name).filter(Boolean);


### PR DESCRIPTION
## Summary

- **Organizer metadata at ingest**: `organizer_name` and `organizer_email` are now stored in KB metadata for every ingested transcript/recording, enabling organizer-based filtering
- **Hybrid search**: `find_transcripts` switches from pure `VECTOR` to `COMBINED` (hybrid semantic + keyword) search for better precision on exact terms
- **Organizer filter**: `find_transcripts` now accepts an `organizer` parameter (partial match on name or email) and returns `organizer` in each result
- **New `list_meetings` tool**: Browse meetings by metadata (date range, organizer, participant, subject) without requiring a semantic query — returns `id`, `title`, `meetingDate`, `organizer`, `participants` with skip/take pagination

## Notes

- Existing transcripts will not have `organizer_name`/`organizer_email` in metadata until re-ingested
- `list_meetings` uses `UniqueContentService.findByMetadata` (KB access control enforced by the platform)

## Test plan

- [ ] Build passes (`pnpm turbo run build --filter=@unique-ag/teams-mcp`)
- [ ] Call `list_meetings` with a date range — confirm meetings returned with `organizer` populated (newly ingested only)
- [ ] Call `find_transcripts` with `organizer: "<name>"` — confirm filter applied and `organizer` field in results
- [ ] Call `find_transcripts` without organizer — confirm existing behaviour unchanged

Refs: UN-18910