### PR TITLE
fix(confluence-connector): remove os_authType=basic from Data Center API URLs

### DIFF
--- a/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
+++ b/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
@@ -63,7 +63,7 @@ describe('DataCenterConfluenceApiClient', () => {
       expect(decodedUrl).toContain('type != attachment');
     });
 
-    it('uses /rest/api/content/search with os_authType=basic', async () => {
+    it('uses /rest/api/content/search without os_authType', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce({
         results: [],
         _links: {},
@@ -73,7 +73,7 @@ describe('DataCenterConfluenceApiClient', () => {
 
       const url = vi.mocked(mockHttpClient.rateLimitedRequest).mock.calls[0]?.[0] as string;
       expect(url).toContain('/rest/api/content/search');
-      expect(url).toContain('os_authType=basic');
+      expect(url).not.toContain('os_authType');
     });
 
     it('does not include collaboration space type (unsupported by Data Center)', async () => {
@@ -103,14 +103,14 @@ describe('DataCenterConfluenceApiClient', () => {
   });
 
   describe('getPageById', () => {
-    it('uses direct content endpoint with os_authType=basic', async () => {
+    it('uses direct content endpoint without os_authType', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce(makePage({ id: '42' }));
 
       await client.getPageById('42');
 
       const url = vi.mocked(mockHttpClient.rateLimitedRequest).mock.calls[0]?.[0] as string;
       expect(url).toContain('/rest/api/content/42');
-      expect(url).toContain('os_authType=basic');
+      expect(url).not.toContain('os_authType');
       expect(url).toContain('expand=body.storage,version,space,metadata.labels');
     });
 
@@ -167,7 +167,7 @@ describe('DataCenterConfluenceApiClient', () => {
       expect(mockHttpClient.rateLimitedRequest).not.toHaveBeenCalled();
     });
 
-    it('uses CQL ancestor IN (...) with os_authType=basic for single root ID', async () => {
+    it('uses CQL ancestor IN (...) without os_authType for single root ID', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce({
         results: [],
         _links: {},
@@ -178,7 +178,7 @@ describe('DataCenterConfluenceApiClient', () => {
       const url = vi.mocked(mockHttpClient.rateLimitedRequest).mock.calls[0]?.[0] as string;
       const decodedUrl = decodeURIComponent(url);
       expect(decodedUrl).toContain('ancestor IN (55)');
-      expect(url).toContain('os_authType=basic');
+      expect(url).not.toContain('os_authType');
     });
 
     it('uses CQL ancestor IN (...) for multiple root IDs', async () => {

--- a/services/confluence-connector/src/confluence-api/data-center-api-client.ts
+++ b/services/confluence-connector/src/confluence-api/data-center-api-client.ts
@@ -36,7 +36,7 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
     // We exclude them because we already get attachments via the expand=children.attachment parameter.
     const cql = `((label="${this.config.ingestSingleLabel}") OR (label="${this.config.ingestAllLabel}")) AND ${spaceTypeFilter} AND type != attachment`;
     const expand = `metadata.labels,version,space${this.attachmentExpand}`;
-    const url = `${this.config.baseUrl}/rest/api/content/search?cql=${encodeURIComponent(cql)}&expand=${expand}&os_authType=basic&limit=${SEARCH_PAGE_SIZE}&start=0`;
+    const url = `${this.config.baseUrl}/rest/api/content/search?cql=${encodeURIComponent(cql)}&expand=${expand}&limit=${SEARCH_PAGE_SIZE}&start=0`;
 
     const pages = await fetchAllPaginated(
       url,
@@ -55,7 +55,7 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
 
   public async getPageById(pageId: string): Promise<ConfluencePage | null> {
     const expand = 'body.storage,version,space,metadata.labels';
-    const url = `${this.config.baseUrl}/rest/api/content/${pageId}?os_authType=basic&expand=${expand}`;
+    const url = `${this.config.baseUrl}/rest/api/content/${pageId}?expand=${expand}`;
     const raw = await this.makeAuthenticatedRequest(url);
     const result = confluencePageSchema.safeParse(raw);
     return result.success ? result.data : null;
@@ -74,7 +74,7 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
       // Attachments are child content in Confluence and would appear as top-level results here.
       // We exclude them because we already get attachments via the expand=children.attachment parameter.
       const cql = `ancestor IN (${batch.join(',')}) AND type != attachment`;
-      const url = `${this.config.baseUrl}/rest/api/content/search?cql=${encodeURIComponent(cql)}&expand=${expand}&os_authType=basic&limit=${SEARCH_PAGE_SIZE}`;
+      const url = `${this.config.baseUrl}/rest/api/content/search?cql=${encodeURIComponent(cql)}&expand=${expand}&limit=${SEARCH_PAGE_SIZE}`;
 
       const pages = await fetchAllPaginated(
         url,


### PR DESCRIPTION
## Summary

While testing OAuth2 (2LO) service account authentication on Data Center, all API requests returned 401 even though the token was valid. After isolating each query parameter one by one, I found that `os_authType=basic` was the culprit.

This parameter tells Confluence to authenticate the request using HTTP Basic Auth, which makes it ignore the `Authorization: Bearer` header entirely. PAT auth was never affected because Confluence accepts PAT bearer tokens regardless of this parameter. But OAuth2 tokens get silently rejected.

I verified the fix by curling the same endpoint with and without `os_authType=basic` using both PAT and OAuth2 tokens, on both our local Confluence 8.5 and dogfood QA instance. Both auth methods work without the parameter.

- Removed `os_authType=basic` from all three Data Center URL constructions (`searchPagesByLabel`, `getPageById`, `getDescendantPages`)
- Updated tests to assert the parameter is absent

## Test plan

- [x] Unit tests updated and passing (26/26)
- [x] Manual curl verification: PAT without `os_authType=basic` returns 200 (local + dogfood)
- [x] Manual curl verification: OAuth2 without `os_authType=basic` returns 200 (dogfood)
- [x] Manual curl verification: OAuth2 with `os_authType=basic` returns 401 (dogfood, confirms the bug)