### PR TITLE
fix(deps): enable stripLeadingPaths in SWC builder for all services

### DIFF
--- a/services/confluence-connector/nest-cli.json
+++ b/services/confluence-connector/nest-cli.json
@@ -4,7 +4,10 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "builder": {
-      "type": "swc"
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
     }
   }
 }

--- a/services/factset-mcp/nest-cli.json
+++ b/services/factset-mcp/nest-cli.json
@@ -3,7 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "builder": "swc",
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    },
     "typeCheck": false
   }
 }

--- a/services/outlook-mcp/nest-cli.json
+++ b/services/outlook-mcp/nest-cli.json
@@ -3,7 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "builder": "swc",
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    },
     "typeCheck": false
   }
 }

--- a/services/outlook-semantic-mcp/nest-cli.json
+++ b/services/outlook-semantic-mcp/nest-cli.json
@@ -3,7 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "builder": "swc",
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    },
     "typeCheck": false
   }
 }

--- a/services/sharepoint-connector/nest-cli.json
+++ b/services/sharepoint-connector/nest-cli.json
@@ -3,6 +3,11 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "builder": "swc"
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    }
   }
 }

--- a/services/teams-mcp/nest-cli.json
+++ b/services/teams-mcp/nest-cli.json
@@ -3,7 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "builder": "swc",
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    },
     "typeCheck": false
   }
 }


### PR DESCRIPTION
## Summary
- The `@swc/cli` 0.8.x upgrade introduced a `stripLeadingPaths` option. The NestJS CLI defaults this to `false` when `rootDir` is set in tsconfig (`stripLeadingPaths: !tsOptions?.rootDir`), causing SWC to output files to `dist/src/` instead of `dist/`.
- This broke runtime imports of `../package.json` from `main.ts` in all services, since `dist/src/main.js` resolves `../package.json` to `dist/package.json` which doesn't exist.
- Adds `"stripLeadingPaths": true` to the SWC builder options in `nest-cli.json` for all 6 services: sharepoint-connector, confluence-connector, outlook-mcp, outlook-semantic-mcp, teams-mcp, and factset-mcp.

## Test plan
- [x] Verified `nest build` produces flat `dist/` output (no `dist/src/` subdirectory) for sharepoint-connector, confluence-connector, and outlook-mcp
- [x] Verify `pnpm dev` starts successfully for each service
- [x] CI passes
