### PR TITLE
fix(teams-mcp): parse GraphError body from ReadableStream on getStream() failures

### DIFF
--- a/services/teams-mcp/src/msgraph/graph-client.factory.ts
+++ b/services/teams-mcp/src/msgraph/graph-client.factory.ts
@@ -92,7 +92,10 @@ export class GraphClientFactory {
     // Pass the first middleware in the chain to initialize the client
     const clientOptions: ClientOptions = {
       middleware: middlewares[0],
-      debugLogging: this.configService.get('app.isDebuggingOn', { infer: true }),
+      // The SDK's debugLogging does a raw `console.log(url)` for every request,
+      // which bypasses pino and produces unstructured log lines. Our own
+      // MetricsMiddleware already captures request details in structured form.
+      debugLogging: false,
     };
 
     return Client.initWithMiddleware(clientOptions);

--- a/services/teams-mcp/src/utils/graph-error.filter.ts
+++ b/services/teams-mcp/src/utils/graph-error.filter.ts
@@ -9,6 +9,39 @@ import {
 import type { Response } from 'express';
 
 /**
+ * MS Graph SDK bug: `.getStream()` error responses leave `GraphError.body` as
+ * an unconsumed ReadableStream instead of parsed JSON. The SDK's
+ * `GraphResponseHandler` converts the body using the requested responseType
+ * (STREAM) *before* checking `rawResponse.ok`, so the JSON error is never parsed.
+ *
+ * This function consumes the stream and backfills code/message/requestId on the
+ * exception so the filter can log them. Mirrors the SDK's internal parsing from
+ * `GraphErrorHandler.constructErrorFromResponse` (which is not publicly exported).
+ */
+async function hydrateStreamBody(exception: GraphError): Promise<void> {
+  if (!(exception.body instanceof ReadableStream)) {
+    return;
+  }
+
+  try {
+    const text = await new Response(exception.body).text();
+    const parsed = JSON.parse(text);
+    const error = parsed?.error;
+
+    if (error) {
+      exception.code ??= error.code ?? null;
+      exception.message ||= error.message ?? '';
+      exception.requestId ??= error.innerError?.['request-id'] ?? null;
+      exception.body = JSON.stringify(error);
+    } else {
+      exception.body = text;
+    }
+  } catch {
+    exception.body = null;
+  }
+}
+
+/**
  * Exception filter to handle Microsoft Graph API errors.
  *
  * Catches GraphError exceptions and formats them into structured log output
@@ -18,9 +51,11 @@ import type { Response } from 'express';
 export class GraphErrorFilter implements ExceptionFilter {
   private readonly logger = new Logger(GraphErrorFilter.name);
 
-  public catch(exception: GraphError, host: ArgumentsHost) {
+  public async catch(exception: GraphError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
+
+    await hydrateStreamBody(exception);
 
     const formattedCode = exception.code ? `[${exception.code ?? ''}] ` : ' ';
     this.logger.error(


### PR DESCRIPTION
## Summary

- The MS Graph JS SDK has a bug where `.getStream()` error responses set `GraphError.body` to an unconsumed `ReadableStream` instead of parsed JSON — the SDK's `GraphResponseHandler` converts the body using the requested `responseType` (STREAM) *before* checking `rawResponse.ok`, so the JSON error payload is never parsed
- This caused empty error logs (`body={}, code=null, message=""`) for 401s on transcript content fetches, making production debugging impossible
- Adds a `hydrateStreamBody()` function in the existing `GraphErrorFilter` that detects the `ReadableStream` body, consumes it, parses the OData error JSON, and backfills `code`/`message`/`requestId` on the exception before logging
- Disables the SDK's `debugLogging` option which does a bare `console.log(url)` for every Graph request, bypassing pino and producing unstructured log lines. Our `MetricsMiddleware` already captures request details in structured form.

## Error reference

[QA Grafana logs](https://qa-grafana.alpine-bowfin.ts.net/explore?schemaVersion=1&panes=%7B%225sx%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22teams-mcp%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22,%22hide%22:false%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%7Bapp%3D%5C%22node-ingestion%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22,%22hide%22:true%7D,%7B%22refId%22:%22C%22,%22expr%22:%22%7Bapp%3D%5C%22node-ingestion-worker%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22,%22hide%22:true%7D%5D,%22range%22:%7B%22from%22:%221775814078800%22,%22to%22:%221775815067843%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22logs%22:%7B%22visualisationType%22:%22logs%22%7D,%22sortOrder%22:%22Descending%22%7D%7D,%22compact%22:false%7D%7D&orgId=1)

## Root cause

### Empty error body (`body={}`)

SDK path for `.getStream()` errors:
1. `GraphRequest.getStream()` → sets `responseType = STREAM`
2. `GraphResponseHandler.convertResponse()` → returns `rawResponse.body` (ReadableStream) for STREAM type
3. `GraphResponseHandler.getResponse()` → `throw response` (throws the ReadableStream, not parsed JSON)
4. `GraphRequest.send()` catch → `GraphErrorHandler.getError(readableStream, 401)` → can't extract `.error` from a stream → bare `GraphError(401)` with all fields null/empty

### Unstructured URL log lines

The SDK's `debugLogging` option (`GraphRequest.ts:209-210`) does `console.log(url)` for every request, bypassing pino and breaking the `pino-json` log format. Was enabled when app log level is `debug` or `trace`.

## Test plan

- [ ] Deploy to QA and trigger a transcript 401 (e.g. expired token)
- [ ] Verify log now shows actual Graph error code/message instead of `body={}`
- [ ] Verify non-stream Graph errors (regular `.get()` 401/403/404) are unaffected
- [ ] Verify no more bare URL lines in logs