### PR TITLE
docs(sharepoint-connector): document ingested metadata fields

### DIFF
--- a/services/sharepoint-connector/docs/README.md
+++ b/services/sharepoint-connector/docs/README.md
@@ -297,6 +297,7 @@ Planned enhancements:
 - [Technical Reference](./technical/README.md) - Architecture, flows, and design decisions
   - [Architecture](./technical/architecture.md) - System components and infrastructure
   - [Flows](./technical/flows.md) - Content sync, permission sync, file diff mechanism
+  - [Metadata](./technical/metadata.md) - Ingested metadata fields for documents and SitePages
   - [Permissions](./technical/permissions.md) - Microsoft Graph and SharePoint REST permissions
   - [Security](./technical/security.md) - Security updates and SBOM
 

--- a/services/sharepoint-connector/docs/technical/README.md
+++ b/services/sharepoint-connector/docs/technical/README.md
@@ -18,6 +18,7 @@ The SharePoint Connector is a Node.js-based service that integrates Microsoft Sh
 |----------|-------------|
 | [Architecture](./architecture.md) | System components, hosting models, connectivity |
 | [Flows](./flows.md) | Content sync, permission sync, file diff mechanism |
+| [Metadata](./metadata.md) | Ingested metadata fields for documents and SitePages |
 | [Permissions](./permissions.md) | Microsoft Graph and SharePoint REST API permissions |
 | [Security](./security.md) | Security updates, reports, and SBOM |
 

--- a/services/sharepoint-connector/docs/technical/architecture.md
+++ b/services/sharepoint-connector/docs/technical/architecture.md
@@ -275,6 +275,7 @@ These settings ensure the service has sufficient capacity for expected workloads
 ## Related Documentation
 
 - [Flows](./flows.md) - Content sync, subsite discovery, permission sync, file diff mechanism
+- [Metadata](./metadata.md) - Ingested metadata fields for documents and SitePages
 - [Permissions](./permissions.md) - Microsoft Graph and SharePoint REST permissions
 - [Security](./security.md) - Security updates and SBOM
 - [Operator Guide](../operator/README.md) - Deployment and operations

--- a/services/sharepoint-connector/docs/technical/flows.md
+++ b/services/sharepoint-connector/docs/technical/flows.md
@@ -453,6 +453,7 @@ flowchart TB
 ## Related Documentation
 
 - [Architecture](./architecture.md) - System components and infrastructure
+- [Metadata](./metadata.md) - Ingested metadata fields for documents and SitePages
 - [Permissions](./permissions.md) - Required API permissions
 - [Configuration](../operator/configuration.md) - Scheduler and processing settings
 

--- a/services/sharepoint-connector/docs/technical/metadata.md
+++ b/services/sharepoint-connector/docs/technical/metadata.md
@@ -1,4 +1,4 @@
-<!-- confluence-page-id: TODO - FILL BEFORE MERGE -->
+<!-- confluence-page-id: 2133983459 -->
 <!-- confluence-space-key: PUBDOC -->
 
 ## Ingested Metadata

--- a/services/sharepoint-connector/docs/technical/metadata.md
+++ b/services/sharepoint-connector/docs/technical/metadata.md
@@ -1,0 +1,76 @@
+<!-- confluence-page-id: TODO - FILL BEFORE MERGE -->
+<!-- confluence-space-key: PUBDOC -->
+
+## Ingested Metadata
+
+The connector retrieves documents and their metadata via the Microsoft Graph API. For each document, it calls the Graph drive items endpoint with an expanded `listItem` and `fields`, which returns all SharePoint list columns. During ingestion, the connector passes these column values as metadata to the Unique platform.
+
+### Regular Documents (Document Libraries)
+
+For regular documents in document libraries, the connector passes through **all SharePoint column values** as-is (the full `fields` bag from Graph), plus the following derived fields:
+
+| Field | Source | Description |
+| ----- | ------ | ----------- |
+| `Url` | `webUrl` property on the list item | The document's web URL |
+| `Link` | Same as `Url` | Alias for the document's web URL |
+| `Path` | Parent reference path | The folder path within the drive |
+| `DriveId` | Drive identifier | The Microsoft Graph drive ID |
+| `ItemInternalId` | `id` property from Graph API response | The Microsoft Graph drive item ID (a longer unique identifier) |
+| `Filename` | `FileLeafRef` SharePoint field | The file's leaf name |
+| `Author` | `createdBy` property | Structured object with `email`, `displayName`, and `id` |
+
+Native SharePoint columns that come through include (among others): `FileLeafRef`, `Modified`, `Created`, `ContentType`, `AuthorLookupId`, `EditorLookupId`, `FileSizeDisplay`, `Title`, plus any custom columns defined on the library.
+
+#### Graph API Call
+
+```
+GET /drives/{driveId}/items/{itemId}/children
+    ?$select=id,name,webUrl,size,createdDateTime,lastModifiedDateTime,createdBy,folder,file,listItem,parentReference
+    &$expand=listItem($expand=fields)
+```
+
+### SitePages
+
+SitePages (pages created directly in SharePoint such as news posts or wiki pages) are handled differently from regular documents:
+
+| Field | Source | Description |
+| ----- | ------ | ----------- |
+| `Url` | `webUrl` property on the list item | The page's web URL |
+| `Link` | Same as `Url` | Alias for the page's web URL |
+| `Path` | `webUrl` property | The page's web URL (used as folder path) |
+| `DriveId` | SitePages list ID | The SitePages list identifier (not a document library drive ID) |
+| `ItemInternalId` | `id` property from Graph API response | Sequential list item ID (e.g. 1, 2, 3), unique only within that SitePages list |
+| `Filename` | `FileLeafRef` SharePoint field | The page's file name |
+| `Author` | `createdBy` property | Structured object with `email`, `displayName`, and `id` |
+| `ModerationStatus` | `_ModerationStatus` SharePoint field | Content approval status (only present for SitePages) |
+
+SitePages carry a **reduced set** of SharePoint column values: `FileLeafRef`, `FileSizeDisplay`, `Title`, `AuthorLookupId`, `EditorLookupId`, `_ModerationStatus`, and the sync flag column.
+
+#### Graph API Call
+
+```
+GET /sites/{siteId}/lists/{listId}/items
+    ?$select=id,createdDateTime,lastModifiedDateTime,webUrl,createdBy,lastModifiedBy
+    &$expand=fields($select=FileLeafRef,FileSizeDisplay,_ModerationStatus,Title,AuthorLookupId,EditorLookupId)
+```
+
+### Key Differences Between Regular Documents and SitePages
+
+| Aspect | Regular Documents | SitePages |
+| ------ | ----------------- | --------- |
+| **Metadata fields** | Full set of all SharePoint column values | Reduced set (`FileLeafRef`, `FileSizeDisplay`, `Title`, `AuthorLookupId`, `EditorLookupId`, `_ModerationStatus`, sync column) |
+| **ItemInternalId** | Graph API drive item ID (long unique identifier) | Sequential list item ID (e.g. 1, 2, 3), unique only within that SitePages list |
+| **DriveId** | Document library drive ID | SitePages list ID |
+| **ModerationStatus** | Not present | Content approval status from `_ModerationStatus` field |
+
+## Related Documentation
+
+- [Flows](./flows.md) - Content sync, ASPX page processing, file diff mechanism
+- [Architecture](./architecture.md) - System components and Graph API endpoints
+- [Permissions](./permissions.md) - Required API permissions
+
+## Standard References
+
+- [Microsoft Graph API - DriveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem) - DriveItem resource
+- [Microsoft Graph API - ListItem](https://learn.microsoft.com/en-us/graph/api/resources/listitem) - ListItem resource
+- [Microsoft Graph API - FieldValueSet](https://learn.microsoft.com/en-us/graph/api/resources/fieldvalueset) - SharePoint column values


### PR DESCRIPTION
 Adds a dedicated `docs/technical/metadata.md` reference page describing which SharePoint fields the connector passes through as metadata during ingestion
- Covers both regular document libraries (full `fields` bag from Graph + derived fields) and SitePages (reduced column set), including the exact Graph API calls and a comparison table of key differences
- Cross-links the new page from `README.md`, `technical/README.md`, `architecture.md`, and `flows.md`