### PR TITLE
fix(teams-mcp): set scoreThreshold 0 in find_transcripts to stop silent result filtering

### DIFF
--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -170,6 +170,7 @@ export class FindTranscriptsTool {
       searchString: input.query,
       searchType: SearchType.COMBINED,
       limit: input.limit,
+      scoreThreshold: 0,
       metaDataFilter: buildTranscriptFilter(rootScopeId, input),
     };
   }


### PR DESCRIPTION
## Summary

- `find_transcripts` tool was not setting `scoreThreshold` in its search request, leaving Unique's backend default in effect
- Any non-zero default threshold silently drops valid transcript chunks — causing the tool to return partial or empty results non-deterministically
- `search-emails` in `outlook-semantic-mcp` already explicitly sets `scoreThreshold: 0`; this PR aligns `teams-mcp` to the same behavior

## Test plan

- [ ] Run a transcript search that previously returned empty or inconsistent results and confirm it now returns results
- [ ] Confirm search still respects date/organizer/participant filters