### PR TITLE
docs(outlook-semantic-mcp): fix broken links to non-existent full-sync.md and live-catchup.md

### DIFF
--- a/services/outlook-semantic-mcp/docs/operator/disaster-recovery.md
+++ b/services/outlook-semantic-mcp/docs/operator/disaster-recovery.md
@@ -50,7 +50,7 @@ Emails are sourced from Microsoft Graph, which retains the authoritative copy. I
 
 - **Webhook notifications lost during an outage** are recovered by the live catch-up recovery scheduler — if no new activity occurs for 4 hours it retriggers live catch-up, which polls Microsoft Graph for any emails modified since the last known watermark.
 - **If a webhook subscription expires during an extended outage** (subscriptions renew daily), users must call `reconnect_inbox` to re-create it. Emails received during the gap are picked up by the subsequent full re-sync.
-- **Worst case:** emails received between the last successful live catch-up and service restoration are delayed, not lost. Full re-sync recovers all emails from Microsoft Graph that match the operator-configured [Inbox Filters](../technical/full-sync.md#Inbox-Filters) — emails outside the configured date window or matching exclusion rules are not synced.
+- **Worst case:** emails received between the last successful live catch-up and service restoration are delayed, not lost. Full re-sync recovers all emails from Microsoft Graph that match the operator-configured [Mail Filters](./configuration.md#Mail-Filters) — emails outside the configured date window or matching exclusion rules are not synced.
 
 ### Personnel
 

--- a/services/outlook-semantic-mcp/docs/technical/tools.md
+++ b/services/outlook-semantic-mcp/docs/technical/tools.md
@@ -506,7 +506,7 @@ Restart the full sync from scratch, discarding all previous progress.
 
 ## Related Documentation
 
-- [Full Sync](./full-sync.md) - Full sync mechanics, states, and filters
-- [Live Catch-Up](./live-catchup.md) - Webhook-driven real-time ingestion
+- [Full Sync](./flows.md#Full-Sync:-Historical-Email-Ingestion) - Full sync mechanics and states
+- [Live Catch-Up](./flows.md#Live-Catch-Up:-Webhook-Driven-Email-Ingestion) - Webhook-driven real-time ingestion
 - [Flows](./flows.md) - Sequence diagrams for OAuth, sync, and draft creation flows
 - [Permissions](./permissions.md) - Microsoft Graph permissions required by these tools


### PR DESCRIPTION
- Fix broken doc links in Outlook Semantic MCP docs that caused the Confluence publish GitHub Action to fail (`md2conf.converter.DocumentError`).
- `disaster-recovery.md`: replace dangling `../technical/full-sync.md#Inbox-Filters` with `./configuration.md#Mail-Filters` (the actual section for mail filter config).
- `tools.md`: replace dangling `./full-sync.md` and `./live-catchup.md` references with anchored links to the corresponding sections in `flows.md`.