### PR TITLE
feat(sharepoint-connector): make Unique group names unique by embedding group identifier

### DIFF
--- a/services/sharepoint-connector/src/permissions-sync/sync-sharepoint-groups-to-unique.command.ts
+++ b/services/sharepoint-connector/src/permissions-sync/sync-sharepoint-groups-to-unique.command.ts
@@ -78,12 +78,12 @@ export class SyncSharepointGroupsToUniqueCommand {
       // per-subsite) and Entra groups are tenant-wide. Neither is subsite-specific.
       const correspondingUniqueGroup = unique.groupsMap[sharePointGroup.id];
       if (!correspondingUniqueGroup) {
-        const newUniqueGroup = await this.createUniqueGroup(
+        const newUniqueGroup = await this.createUniqueGroup({
           siteId,
           siteName,
           sharePointGroup,
-          unique.usersMap,
-        );
+          uniqueUsersMap: unique.usersMap,
+        });
         updatedUniqueGroupsMap[sharePointGroup.id] = newUniqueGroup;
         if (newUniqueGroup) {
           groupsSyncStats.created++;
@@ -159,12 +159,13 @@ export class SyncSharepointGroupsToUniqueCommand {
     };
   }
 
-  private async createUniqueGroup(
-    siteId: Smeared,
-    siteName: Smeared,
-    sharePointGroup: SharepointGroupWithMembers,
-    uniqueUsersMap: UniqueUsersMap,
-  ): Promise<UniqueGroupWithMembers | null> {
+  private async createUniqueGroup(input: {
+    siteId: Smeared;
+    siteName: Smeared;
+    sharePointGroup: SharepointGroupWithMembers;
+    uniqueUsersMap: UniqueUsersMap;
+  }): Promise<UniqueGroupWithMembers | null> {
+    const { siteId, siteName, sharePointGroup, uniqueUsersMap } = input;
     const memberIds = getUniqueMemberIds(sharePointGroup, uniqueUsersMap);
 
     if (memberIds.length === 0) {
@@ -172,7 +173,7 @@ export class SyncSharepointGroupsToUniqueCommand {
     }
 
     const uniqueGroup = await this.uniqueGroupsService.createGroup({
-      name: getUniqueGroupName(siteName, sharePointGroup.displayName),
+      name: getUniqueGroupName(siteName, sharePointGroup),
       externalId: getSharepointConnectorGroupExternalId(siteId.value, sharePointGroup.id),
     });
 
@@ -201,10 +202,10 @@ export class SyncSharepointGroupsToUniqueCommand {
     let groupUpdated = false;
 
     // Currently nothing other than name is used in the Unique Groups so we keep check simple
-    if (uniqueGroup.name !== getUniqueGroupName(siteName, sharePointGroup.displayName)) {
+    if (uniqueGroup.name !== getUniqueGroupName(siteName, sharePointGroup)) {
       const updatedUniqueGroup = await this.uniqueGroupsService.updateGroup({
         id: uniqueGroup.id,
-        name: getUniqueGroupName(siteName, sharePointGroup.displayName),
+        name: getUniqueGroupName(siteName, sharePointGroup),
       });
       uniqueGroup = { ...updatedUniqueGroup, memberIds: uniqueGroup.memberIds };
       groupUpdated = true;
@@ -233,8 +234,24 @@ export class SyncSharepointGroupsToUniqueCommand {
   }
 }
 
-function getUniqueGroupName(siteName: Smeared, sharePointGroupName: string): string {
-  return `[SPC-${siteName.value}] ${sharePointGroupName}`;
+function getGroupIdentifier(groupDistinctId: GroupDistinctId): string {
+  const [type, ...rest] = groupDistinctId.split(':');
+  const id = rest.join(':');
+
+  if (type === 'siteGroup') {
+    return id.split('|').pop() ?? id;
+  }
+
+  const shortId = id.split('-')[0] ?? id;
+  return type === 'groupOwners' ? `${shortId}_o` : shortId;
+}
+
+function getUniqueGroupName(
+  siteName: Smeared,
+  sharePointGroup: Pick<SharepointGroupWithMembers, 'id' | 'displayName'>,
+): string {
+  const identifier = getGroupIdentifier(sharePointGroup.id);
+  return `[SPC-${siteName.value}][${identifier}] ${sharePointGroup.displayName}`;
 }
 
 function getUniqueMemberIds(


### PR DESCRIPTION
- Embeds a short group identifier in the Unique group name prefix to guarantee uniqueness across different group types
- New format: `[SPC-{siteName}][{identifier}] {groupName}`
  - Site groups use their numeric ID: `[SPC-Contoso][5] Engineering`
  - Entra group members use first UUID section: `[SPC-Contoso][838f7d2d] Engineering`
  - Entra group owners use first UUID section + `_o`: `[SPC-Contoso][838f7d2d_o] Engineering`
- Resolves name collisions between SharePoint site groups and Entra groups with the same display name, between Entra members and owners of the same group, and between different Entra groups with the same display name
- Existing groups will be renamed automatically on the next sync cycle (name drift detection already exists)

Refs: UN-19511