### PR TITLE
feat(sharepoint-connector): stale scopes deletion

### DIFF
--- a/services/sharepoint-connector/docs/technical/flows.md
+++ b/services/sharepoint-connector/docs/technical/flows.md
@@ -194,7 +194,7 @@ sequenceDiagram
     Connector->>Unique: Create scopes<br/>(subsites as folders in parent's tree)
     Connector->>Unique: Content sync (new/modified/deleted)
     Connector->>Unique: Permission sync
-    Connector->>Unique: Delete orphaned scopes
+    Connector->>Unique: Delete stale scopes
 ```
 
 ### Key Behaviors

--- a/services/sharepoint-connector/src/constants/sync-step.enum.ts
+++ b/services/sharepoint-connector/src/constants/sync-step.enum.ts
@@ -20,7 +20,7 @@ export const SiteSyncStep = {
   FilePermissionsSync: 'file_permissions_sync',
   FolderPermissionsSync: 'folder_permissions_sync',
   UnknownPermissionsSync: 'unknown_permissions_sync',
-  OrphanScopeCleanup: 'orphan_scope_cleanup',
+  StaleScopeCleanup: 'stale_scope_cleanup',
 } as const;
 
 export type SiteSyncStep = (typeof SiteSyncStep)[keyof typeof SiteSyncStep];

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
@@ -89,4 +89,14 @@ describe('groupScopesByRootSiteId', () => {
     const groups = groupScopesByRootSiteId([root, child1, child2, grandchild]);
     expect(groups.get('memo-site')).toEqual([root, child1, child2, grandchild]);
   });
+
+  it('does not treat pending-delete roots as active-root grouping anchors', () => {
+    const pendingDeleteRoot = scope('pd', null, `spc:pending-delete:${ROOT_SITE_A}/site`);
+    const pendingDeleteChild = scope('pd-c', 'pd', `spc:pending-delete:${ROOT_SITE_A}/drive:x/y`);
+
+    const groups = groupScopesByRootSiteId([pendingDeleteRoot, pendingDeleteChild]);
+
+    expect(groups.has(`pending-delete:${ROOT_SITE_A}`)).toBe(false);
+    expect(groups.size).toBe(0);
+  });
 });

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { Scope } from '../unique-api/unique-scopes/unique-scopes.types';
+import { groupScopesByRootSiteId } from './group-scopes-by-root-site-id';
+
+function scope(id: string, parentId: string | null, externalId: string | null): Scope {
+  return { id, name: `scope-${id}`, parentId, externalId };
+}
+
+const ROOT_SITE_A = 'site-a';
+const ROOT_SITE_B = 'site-b';
+
+describe('groupScopesByRootSiteId', () => {
+  it('groups scopes under their root site', () => {
+    const rootA = scope('r-a', null, `spc:site:${ROOT_SITE_A}`);
+    const driveA = scope('d-a', 'r-a', `spc:drive:${ROOT_SITE_A}/drive-1`);
+    const folderA = scope('f-a', 'd-a', `spc:folder:${ROOT_SITE_A}/item-1`);
+
+    const rootB = scope('r-b', null, `spc:site:${ROOT_SITE_B}`);
+    const driveB = scope('d-b', 'r-b', `spc:drive:${ROOT_SITE_B}/drive-2`);
+
+    const groups = groupScopesByRootSiteId([rootA, driveA, folderA, rootB, driveB]);
+
+    expect(groups.get(ROOT_SITE_A)).toEqual([rootA, driveA, folderA]);
+    expect(groups.get(ROOT_SITE_B)).toEqual([rootB, driveB]);
+  });
+
+  it('excludes scopes whose parent chain does not reach a root scope', () => {
+    const rootA = scope('r-a', null, `spc:site:${ROOT_SITE_A}`);
+    const orphan = scope('orphan', 'nonexistent-parent', 'spc:drive:unknown-site/drive-x');
+
+    const groups = groupScopesByRootSiteId([rootA, orphan]);
+
+    expect(groups.get(ROOT_SITE_A)).toEqual([rootA]);
+    expect([...groups.values()].flat()).not.toContainEqual(orphan);
+  });
+
+  it('returns empty map for empty input', () => {
+    expect(groupScopesByRootSiteId([]).size).toBe(0);
+  });
+
+  it('handles deeply nested parentId chains', () => {
+    const root = scope('r', null, 'spc:site:deep-site');
+    const child1 = scope('c1', 'r', null);
+    const child2 = scope('c2', 'c1', null);
+    const child3 = scope('c3', 'c2', null);
+
+    const groups = groupScopesByRootSiteId([root, child1, child2, child3]);
+    expect(groups.get('deep-site')).toEqual([root, child1, child2, child3]);
+  });
+
+  it('resolves all children when they are input in arbitrary order', () => {
+    const root = scope('r', null, 'spc:site:ordered-site');
+    const child = scope('c', 'r', null);
+    const grandchild = scope('gc', 'c', null);
+
+    const groups = groupScopesByRootSiteId([grandchild, child, root]);
+    expect(groups.get('ordered-site')).toEqual(expect.arrayContaining([root, child, grandchild]));
+    expect(groups.get('ordered-site')).toHaveLength(3);
+  });
+
+  it('ignores scopes with new-format externalIds as root markers', () => {
+    // A scope with a new-format externalId is not a legacy root; it must not
+    // be treated as a grouping anchor.
+    const newFormatRoot = scope('nf', null, 'spc:nf-site/site');
+    const child = scope('c', 'nf', null);
+
+    const groups = groupScopesByRootSiteId([newFormatRoot, child]);
+    expect(groups.size).toBe(0);
+  });
+
+  it('groups multiple disjoint trees independently', () => {
+    const rootA = scope('r-a', null, `spc:site:${ROOT_SITE_A}`);
+    const childA = scope('c-a', 'r-a', null);
+    const rootB = scope('r-b', null, `spc:site:${ROOT_SITE_B}`);
+    const childB = scope('c-b', 'r-b', null);
+
+    const groups = groupScopesByRootSiteId([rootA, childA, rootB, childB]);
+    expect(groups.size).toBe(2);
+    expect(groups.get(ROOT_SITE_A)).toEqual([rootA, childA]);
+    expect(groups.get(ROOT_SITE_B)).toEqual([rootB, childB]);
+  });
+
+  it('attributes sibling subtrees sharing a parent to the same root', () => {
+    const root = scope('r', null, 'spc:site:memo-site');
+    const child1 = scope('c1', 'r', null);
+    const child2 = scope('c2', 'r', null);
+    const grandchild = scope('gc', 'c1', null);
+
+    const groups = groupScopesByRootSiteId([root, child1, child2, grandchild]);
+    expect(groups.get('memo-site')).toEqual([root, child1, child2, grandchild]);
+  });
+});

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
@@ -58,14 +58,15 @@ describe('groupScopesByRootSiteId', () => {
     expect(groups.get('ordered-site')).toHaveLength(3);
   });
 
-  it('ignores scopes with new-format externalIds as root markers', () => {
-    // A scope with a new-format externalId is not a legacy root; it must not
-    // be treated as a grouping anchor.
+  it('recognizes new-format root externalIds as grouping anchors', () => {
+    // A partially-migrated site may have the root already in new format while
+    // some children are still in legacy format — grouping must still attribute
+    // those stranded children to the same root so the next sync can retry.
     const newFormatRoot = scope('nf', null, 'spc:nf-site/site');
     const child = scope('c', 'nf', null);
 
     const groups = groupScopesByRootSiteId([newFormatRoot, child]);
-    expect(groups.size).toBe(0);
+    expect(groups.get('nf-site')).toEqual([newFormatRoot, child]);
   });
 
   it('groups multiple disjoint trees independently', () => {

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.spec.ts
@@ -59,9 +59,8 @@ describe('groupScopesByRootSiteId', () => {
   });
 
   it('recognizes new-format root externalIds as grouping anchors', () => {
-    // A partially-migrated site may have the root already in new format while
-    // some children are still in legacy format — grouping must still attribute
-    // those stranded children to the same root so the next sync can retry.
+    // While case of partially-migrated site having the root already in new format is purely
+    // theoretical, we still handle it just in case. In practice the root scope is migrated last.
     const newFormatRoot = scope('nf', null, 'spc:nf-site/site');
     const child = scope('c', 'nf', null);
 

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
@@ -3,10 +3,10 @@ import { extractRootSiteId } from '../utils/scope-external-id';
 
 // Attributes each scope to its root site by walking parentId chains upward.
 // Scopes form a tree: root scope -> drives -> folders -> etc.
-// Root scopes are recognized in BOTH legacy (spc:site:{id}) and new
-// (spc:{id}/site) formats so that a partially-migrated site — where the root
-// has already been flipped to new format but some children are still legacy —
-// continues to group children correctly.
+// Root scopes are recognized in BOTH legacy (spc:site:{id}) and new (spc:{id}/site) formats so that
+// a partially-migrated site — where the root has already been flipped to new format but some
+// children are still legacy — continues to group children correctly. In practice the root scope is
+// migrated last, but we handle that case just in case.
 export function groupScopesByRootSiteId(scopes: Scope[]): Map<string, Scope[]> {
   const scopeById = new Map<string, Scope>();
   const rootScopeIdToSiteId = new Map<string, string>();

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
@@ -1,10 +1,12 @@
 import { Scope } from '../unique-api/unique-scopes/unique-scopes.types';
-import { parseLegacyExternalId } from '../utils/scope-external-id';
+import { extractRootSiteId } from '../utils/scope-external-id';
 
 // Attributes each scope to its root site by walking parentId chains upward.
-// Scopes form a tree: root scope (spc:site:{id}) -> drives -> folders -> etc.
-// We need to know which root site each scope belongs to so the migration can
-// process one site at a time.
+// Scopes form a tree: root scope -> drives -> folders -> etc.
+// Root scopes are recognized in BOTH legacy (spc:site:{id}) and new
+// (spc:{id}/site) formats so that a partially-migrated site — where the root
+// has already been flipped to new format but some children are still legacy —
+// continues to group children correctly.
 export function groupScopesByRootSiteId(scopes: Scope[]): Map<string, Scope[]> {
   const scopeById = new Map<string, Scope>();
   const rootScopeIdToSiteId = new Map<string, string>();
@@ -12,9 +14,9 @@ export function groupScopesByRootSiteId(scopes: Scope[]): Map<string, Scope[]> {
   for (const scope of scopes) {
     scopeById.set(scope.id, scope);
     if (scope.externalId) {
-      const parsed = parseLegacyExternalId(scope.externalId);
-      if (parsed?.type === 'root') {
-        rootScopeIdToSiteId.set(scope.id, parsed.siteId);
+      const rootSiteId = extractRootSiteId(scope.externalId);
+      if (rootSiteId) {
+        rootScopeIdToSiteId.set(scope.id, rootSiteId);
       }
     }
   }

--- a/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/group-scopes-by-root-site-id.ts
@@ -1,0 +1,78 @@
+import { Scope } from '../unique-api/unique-scopes/unique-scopes.types';
+import { parseLegacyExternalId } from '../utils/scope-external-id';
+
+// Attributes each scope to its root site by walking parentId chains upward.
+// Scopes form a tree: root scope (spc:site:{id}) -> drives -> folders -> etc.
+// We need to know which root site each scope belongs to so the migration can
+// process one site at a time.
+export function groupScopesByRootSiteId(scopes: Scope[]): Map<string, Scope[]> {
+  const scopeById = new Map<string, Scope>();
+  const rootScopeIdToSiteId = new Map<string, string>();
+
+  for (const scope of scopes) {
+    scopeById.set(scope.id, scope);
+    if (scope.externalId) {
+      const parsed = parseLegacyExternalId(scope.externalId);
+      if (parsed?.type === 'root') {
+        rootScopeIdToSiteId.set(scope.id, parsed.siteId);
+      }
+    }
+  }
+
+  // Memoize resolved root site IDs so deeply nested chains only walk once —
+  // each intermediate scope's result is cached for subsequent lookups.
+  const resolvedRootSiteId = new Map<string, string | null>();
+
+  const findRootSiteId = (scope: Scope): string | null => {
+    const cached = resolvedRootSiteId.get(scope.id);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let current: Scope | undefined = scope;
+    const chain: string[] = [];
+
+    while (current) {
+      if (resolvedRootSiteId.has(current.id)) {
+        const result = resolvedRootSiteId.get(current.id) ?? null;
+        for (const id of chain) {
+          resolvedRootSiteId.set(id, result);
+        }
+        return result;
+      }
+
+      const siteId = rootScopeIdToSiteId.get(current.id);
+      if (siteId) {
+        chain.push(current.id);
+        for (const id of chain) {
+          resolvedRootSiteId.set(id, siteId);
+        }
+        return siteId;
+      }
+
+      chain.push(current.id);
+      current = current.parentId ? scopeById.get(current.parentId) : undefined;
+    }
+
+    // No root scope found — these are orphans (e.g., parent not in the fetched set).
+    for (const id of chain) {
+      resolvedRootSiteId.set(id, null);
+    }
+    return null;
+  };
+
+  const groups = new Map<string, Scope[]>();
+  for (const scope of scopes) {
+    const rootSiteId = findRootSiteId(scope);
+    if (rootSiteId) {
+      let group = groups.get(rootSiteId);
+      if (!group) {
+        group = [];
+        groups.set(rootSiteId, group);
+      }
+      group.push(scope);
+    }
+  }
+
+  return groups;
+}

--- a/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.module.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UniqueApiModule } from '../unique-api/unique-api.module';
+import { ScopeExternalIdMigrationService } from './scope-external-id-migration.service';
+
+@Module({
+  imports: [UniqueApiModule],
+  providers: [ScopeExternalIdMigrationService],
+  exports: [ScopeExternalIdMigrationService],
+})
+export class ScopeExternalIdMigrationModule {}

--- a/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.spec.ts
@@ -1,0 +1,254 @@
+import { TestBed } from '@suites/unit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
+import { Scope } from '../unique-api/unique-scopes/unique-scopes.types';
+import { EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
+import { Smeared } from '../utils/smeared';
+import { ScopeExternalIdMigrationService } from './scope-external-id-migration.service';
+
+const ROOT_SITE_ID = 'site-abc';
+
+function scope(id: string, parentId: string | null, externalId: string | null): Scope {
+  return { id, name: `scope-${id}`, parentId, externalId };
+}
+
+const rootScope = scope('root-1', null, `spc:site:${ROOT_SITE_ID}`);
+const driveScope = scope('drive-1', 'root-1', `spc:drive:${ROOT_SITE_ID}/d1`);
+const folderScope = scope('folder-1', 'drive-1', `spc:folder:${ROOT_SITE_ID}/item1`);
+
+describe('ScopeExternalIdMigrationService', () => {
+  let service: ScopeExternalIdMigrationService;
+  let listScopesByExternalIdPrefixMock: ReturnType<typeof vi.fn>;
+  let updateScopeExternalIdMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    listScopesByExternalIdPrefixMock = vi.fn();
+    updateScopeExternalIdMock = vi.fn();
+
+    const { unit } = await TestBed.solitary(ScopeExternalIdMigrationService)
+      .mock<UniqueScopesService>(UniqueScopesService)
+      .impl((stubFn) => ({
+        ...stubFn(),
+        listScopesByExternalIdPrefix: listScopesByExternalIdPrefixMock,
+        updateScopeExternalId: updateScopeExternalIdMock,
+      }))
+      .compile();
+
+    service = unit;
+
+    Object.defineProperty(service, 'logger', {
+      value: {
+        log: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        verbose: vi.fn(),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('migrateSiteScopes', () => {
+    it('fetches scopes with the spc: prefix', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+      const arg = listScopesByExternalIdPrefixMock.mock.calls[0]?.[0];
+      expect(arg).toBeInstanceOf(Smeared);
+      expect(arg.value).toBe(EXTERNAL_ID_PREFIX);
+    });
+
+    it('returns no_migration_needed when scope list is empty', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({ status: 'no_migration_needed' });
+    });
+
+    it('returns no_migration_needed when no root scope with legacy format exists', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([
+        scope('s1', null, `spc:${ROOT_SITE_ID}/site`),
+      ]);
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({ status: 'no_migration_needed' });
+    });
+
+    it('returns migration_completed when all scopes are migrated', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({ status: 'migration_completed', migratedCount: 3 });
+    });
+
+    it('skips scopes already in new format', async () => {
+      const newFormatScope = scope('new-1', 'root-1', `spc:${ROOT_SITE_ID}/drive:site/d2`);
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, newFormatScope]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({ status: 'migration_completed', migratedCount: 2 });
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips scopes with null externalId', async () => {
+      const nullScope = scope('null-1', 'root-1', null);
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, nullScope]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({ status: 'migration_completed', migratedCount: 1 });
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns migration_failed with counts on partial failure', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
+      updateScopeExternalIdMock
+        .mockRejectedValueOnce(new Error('API error'))
+        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' })
+        .mockResolvedValueOnce({ id: 'root-1', externalId: 'new' });
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({
+        status: 'migration_failed',
+        migratedCount: 2,
+        failedCount: 1,
+      });
+    });
+
+    it('returns migration_failed when root scope update fails', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope]);
+      updateScopeExternalIdMock
+        .mockResolvedValueOnce({ id: 'drive-1', externalId: 'new' })
+        .mockRejectedValueOnce(new Error('Root update error'));
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({
+        status: 'migration_failed',
+        migratedCount: 1,
+        failedCount: 1,
+      });
+    });
+
+    it('migrates root scope last', async () => {
+      const updateOrder: string[] = [];
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
+      updateScopeExternalIdMock.mockImplementation((scopeId: string) => {
+        updateOrder.push(scopeId);
+        return Promise.resolve({ id: scopeId, externalId: 'new' });
+      });
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(updateOrder).toHaveLength(3);
+      expect(updateOrder[updateOrder.length - 1]).toBe(rootScope.id);
+
+      const rootIndex = updateOrder.indexOf(rootScope.id);
+      const driveIndex = updateOrder.indexOf(driveScope.id);
+      const folderIndex = updateOrder.indexOf(folderScope.id);
+      expect(driveIndex).toBeLessThan(rootIndex);
+      expect(folderIndex).toBeLessThan(rootIndex);
+    });
+
+    it('passes Smeared values to updateScopeExternalId', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'root-1', externalId: 'new' });
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
+      const [scopeId, smearedArg] = updateScopeExternalIdMock.mock.calls[0] ?? [];
+      expect(scopeId).toBe(rootScope.id);
+      expect(smearedArg).toBeInstanceOf(Smeared);
+      expect(smearedArg.value).toBe(`spc:${ROOT_SITE_ID}/site`);
+    });
+
+    it('continues migrating remaining children when one fails', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
+      updateScopeExternalIdMock
+        .mockRejectedValueOnce(new Error('API error'))
+        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' })
+        .mockResolvedValueOnce({ id: 'root-1', externalId: 'new' });
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns migration_failed with zero counts when fetch fails', async () => {
+      listScopesByExternalIdPrefixMock.mockRejectedValue(new Error('Network error'));
+
+      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+
+      expect(result).toEqual({
+        status: 'migration_failed',
+        migratedCount: 0,
+        failedCount: 0,
+      });
+    });
+
+    it('reuses cached scopes for other sites without re-fetching', async () => {
+      const siteB = 'site-xyz';
+      const rootB = scope('root-b', null, `spc:site:${siteB}`);
+
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, rootB]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateSiteScopes(siteB);
+
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('evicts only the migrated site from cache after successful migration', async () => {
+      const siteB = 'site-xyz';
+      const rootB = scope('root-b', null, `spc:site:${siteB}`);
+
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, rootB]);
+      updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+
+      // Site B's cache entry still valid — no re-fetch needed
+      await service.migrateSiteScopes(siteB);
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+
+      // Requesting ROOT_SITE_ID again triggers re-fetch (evicted after migration)
+      listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+      await service.migrateSiteScopes(ROOT_SITE_ID);
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-fetches when cache entry has expired', async () => {
+      vi.useFakeTimers();
+      try {
+        listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+
+        await service.migrateSiteScopes(ROOT_SITE_ID);
+        expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(2 * 60 * 60 * 1000 + 1);
+
+        await service.migrateSiteScopes(ROOT_SITE_ID);
+        expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.spec.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.spec.ts
@@ -56,7 +56,7 @@ describe('ScopeExternalIdMigrationService', () => {
     it('fetches scopes with the spc: prefix', async () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([]);
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
       const arg = listScopesByExternalIdPrefixMock.mock.calls[0]?.[0];
@@ -67,7 +67,7 @@ describe('ScopeExternalIdMigrationService', () => {
     it('returns no_migration_needed when scope list is empty', async () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([]);
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({ status: 'no_migration_needed' });
     });
@@ -77,7 +77,7 @@ describe('ScopeExternalIdMigrationService', () => {
         scope('s1', null, `spc:${ROOT_SITE_ID}/site`),
       ]);
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({ status: 'no_migration_needed' });
     });
@@ -86,7 +86,7 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({ status: 'migration_completed', migratedCount: 3 });
     });
@@ -96,7 +96,7 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, newFormatScope]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({ status: 'migration_completed', migratedCount: 2 });
       expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
@@ -107,7 +107,7 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, nullScope]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({ status: 'migration_completed', migratedCount: 1 });
       expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
@@ -117,16 +117,30 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
       updateScopeExternalIdMock
         .mockRejectedValueOnce(new Error('API error'))
-        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' })
-        .mockResolvedValueOnce({ id: 'root-1', externalId: 'new' });
+        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' });
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({
         status: 'migration_failed',
-        migratedCount: 2,
+        migratedCount: 1,
         failedCount: 1,
       });
+    });
+
+    it('does not migrate root scope when any child migration fails', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
+      updateScopeExternalIdMock
+        .mockRejectedValueOnce(new Error('API error'))
+        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' });
+
+      await service.migrateIfNeeded(ROOT_SITE_ID);
+
+      // Root is never attempted so the next sync still sees a legacy root and
+      // retries the stranded legacy children.
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
+      const calledScopeIds = updateScopeExternalIdMock.mock.calls.map((c) => c[0]);
+      expect(calledScopeIds).not.toContain(rootScope.id);
     });
 
     it('returns migration_failed when root scope update fails', async () => {
@@ -135,7 +149,7 @@ describe('ScopeExternalIdMigrationService', () => {
         .mockResolvedValueOnce({ id: 'drive-1', externalId: 'new' })
         .mockRejectedValueOnce(new Error('Root update error'));
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({
         status: 'migration_failed',
@@ -152,7 +166,7 @@ describe('ScopeExternalIdMigrationService', () => {
         return Promise.resolve({ id: scopeId, externalId: 'new' });
       });
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(updateOrder).toHaveLength(3);
       expect(updateOrder[updateOrder.length - 1]).toBe(rootScope.id);
@@ -168,7 +182,7 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'root-1', externalId: 'new' });
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
       const [scopeId, smearedArg] = updateScopeExternalIdMock.mock.calls[0] ?? [];
@@ -181,18 +195,18 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, folderScope]);
       updateScopeExternalIdMock
         .mockRejectedValueOnce(new Error('API error'))
-        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' })
-        .mockResolvedValueOnce({ id: 'root-1', externalId: 'new' });
+        .mockResolvedValueOnce({ id: 'folder-1', externalId: 'new' });
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
 
-      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(3);
+      // Both children are attempted before short-circuiting on the root.
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
     });
 
     it('returns migration_failed with zero counts when fetch fails', async () => {
       listScopesByExternalIdPrefixMock.mockRejectedValue(new Error('Network error'));
 
-      const result = await service.migrateSiteScopes(ROOT_SITE_ID);
+      const result = await service.migrateIfNeeded(ROOT_SITE_ID);
 
       expect(result).toEqual({
         status: 'migration_failed',
@@ -208,8 +222,8 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, rootB]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
-      await service.migrateSiteScopes(siteB);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
+      await service.migrateIfNeeded(siteB);
 
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
     });
@@ -221,30 +235,42 @@ describe('ScopeExternalIdMigrationService', () => {
       listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, driveScope, rootB]);
       updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
 
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
 
       // Site B's cache entry still valid — no re-fetch needed
-      await service.migrateSiteScopes(siteB);
+      await service.migrateIfNeeded(siteB);
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
 
       // Requesting ROOT_SITE_ID again triggers re-fetch (evicted after migration)
       listScopesByExternalIdPrefixMock.mockResolvedValue([]);
-      await service.migrateSiteScopes(ROOT_SITE_ID);
+      await service.migrateIfNeeded(ROOT_SITE_ID);
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(2);
     });
 
     it('re-fetches when cache entry has expired', async () => {
       vi.useFakeTimers();
       try {
-        listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+        // A non-legacy site B is used here so its cache entry survives the
+        // post-migration eviction of ROOT_SITE_ID — we then age it past the TTL
+        // and assert it gets re-fetched.
+        const siteB = 'site-xyz';
+        const newFormatRootB = scope('root-b', null, `spc:${siteB}/site`);
 
-        await service.migrateSiteScopes(ROOT_SITE_ID);
+        listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope, newFormatRootB]);
+        updateScopeExternalIdMock.mockResolvedValue({ id: 'any', externalId: 'any' });
+
+        await service.migrateIfNeeded(siteB);
         expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
 
-        vi.advanceTimersByTime(2 * 60 * 60 * 1000 + 1);
+        // Still cached — no re-fetch just before TTL
+        vi.advanceTimersByTime(2 * 60 * 60 * 1000 - 1);
+        await service.migrateIfNeeded(siteB);
+        expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
 
-        await service.migrateSiteScopes(ROOT_SITE_ID);
+        // Past TTL — triggers a re-fetch
+        vi.advanceTimersByTime(2);
+        await service.migrateIfNeeded(siteB);
         expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(2);
       } finally {
         vi.useRealTimers();

--- a/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.ts
@@ -35,7 +35,7 @@ export class ScopeExternalIdMigrationService {
 
   public constructor(private readonly uniqueScopesService: UniqueScopesService) {}
 
-  public async migrateSiteScopes(rootSiteId: string): Promise<ExternalIdMigrationResult> {
+  public async migrateIfNeeded(rootSiteId: string): Promise<ExternalIdMigrationResult> {
     const logPrefix = `[ExternalId Migration: ${createSmeared(rootSiteId)}]`;
 
     try {
@@ -58,8 +58,10 @@ export class ScopeExternalIdMigrationService {
       let migratedCount = 0;
       let failedCount = 0;
 
-      // Migrate children first — the root externalId is the definitive marker
-      // that migration for this site is complete, so it must be updated last.
+      // Migrate children first. The root externalId is the definitive marker
+      // that migration for this site is complete, so it must stay in legacy
+      // format until every child succeeds — otherwise the next sync would see
+      // a new-format root and skip retrying the stranded legacy children.
       for (const scope of children) {
         if (!scope.externalId || !isLegacyExternalId(scope.externalId)) {
           continue;
@@ -81,7 +83,13 @@ export class ScopeExternalIdMigrationService {
         }
       }
 
-      // Root scope migrated last — its updated externalId signals completion.
+      if (failedCount > 0) {
+        // Leave the root in legacy format so the next sync retries the failed
+        // children. Evict the cache since at least one child's externalId changed.
+        this.siteCache.delete(rootSiteId);
+        return { status: 'migration_failed', migratedCount, failedCount };
+      }
+
       try {
         const newRootExternalId = migrateLegacyExternalId(
           rootSiteId,
@@ -97,7 +105,6 @@ export class ScopeExternalIdMigrationService {
         failedCount++;
       }
 
-      // Evict this site's cached data since its externalIds have changed.
       this.siteCache.delete(rootSiteId);
 
       if (failedCount > 0) {

--- a/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.ts
+++ b/services/sharepoint-connector/src/scope-external-id-migration/scope-external-id-migration.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
+import { Scope } from '../unique-api/unique-scopes/unique-scopes.types';
+import { sanitizeError } from '../utils/normalize-error';
+import {
+  EXTERNAL_ID_PREFIX,
+  isLegacyExternalId,
+  migrateLegacyExternalId,
+  parseLegacyExternalId,
+} from '../utils/scope-external-id';
+import { createSmeared } from '../utils/smeared';
+import { groupScopesByRootSiteId } from './group-scopes-by-root-site-id';
+
+export type ExternalIdMigrationResult =
+  | { status: 'no_migration_needed' }
+  | { status: 'migration_completed'; migratedCount: number }
+  | { status: 'migration_failed'; migratedCount: number; failedCount: number };
+
+const CACHE_TTL_MS = 2 * 60 * 60 * 1000;
+
+interface CacheEntry {
+  readonly scopes: Scope[];
+  readonly populatedAt: number;
+}
+
+@Injectable()
+export class ScopeExternalIdMigrationService {
+  private readonly logger = new Logger(ScopeExternalIdMigrationService.name);
+
+  // Per-site cache of grouped scopes. When a site is missing from the cache,
+  // all scopes are fetched and grouped — populating entries for every site at
+  // once. After a successful migration, only the migrated site's entry is
+  // evicted (the data changed), while other sites' entries remain valid.
+  private readonly siteCache = new Map<string, CacheEntry>();
+
+  public constructor(private readonly uniqueScopesService: UniqueScopesService) {}
+
+  public async migrateSiteScopes(rootSiteId: string): Promise<ExternalIdMigrationResult> {
+    const logPrefix = `[ExternalId Migration: ${createSmeared(rootSiteId)}]`;
+
+    try {
+      const siteScopes = await this.getScopesForSite(rootSiteId);
+
+      const rootScope = siteScopes.find(
+        (s): s is Scope & { externalId: string } =>
+          s.externalId !== null && parseLegacyExternalId(s.externalId)?.type === 'root',
+      );
+
+      if (!rootScope) {
+        this.logger.debug(`${logPrefix} No legacy root scope found, no migration needed`);
+        return { status: 'no_migration_needed' };
+      }
+
+      const children = siteScopes.filter((s) => s.id !== rootScope.id);
+
+      this.logger.log(`${logPrefix} Found ${children.length} children and 1 root scope to migrate`);
+
+      let migratedCount = 0;
+      let failedCount = 0;
+
+      // Migrate children first — the root externalId is the definitive marker
+      // that migration for this site is complete, so it must be updated last.
+      for (const scope of children) {
+        if (!scope.externalId || !isLegacyExternalId(scope.externalId)) {
+          continue;
+        }
+
+        try {
+          const newExternalId = migrateLegacyExternalId(
+            rootSiteId,
+            createSmeared(scope.externalId),
+          );
+          await this.uniqueScopesService.updateScopeExternalId(scope.id, newExternalId);
+          migratedCount++;
+        } catch (error) {
+          this.logger.warn({
+            msg: `${logPrefix} Failed to migrate scope ${scope.id}`,
+            error: sanitizeError(error),
+          });
+          failedCount++;
+        }
+      }
+
+      // Root scope migrated last — its updated externalId signals completion.
+      try {
+        const newRootExternalId = migrateLegacyExternalId(
+          rootSiteId,
+          createSmeared(rootScope.externalId),
+        );
+        await this.uniqueScopesService.updateScopeExternalId(rootScope.id, newRootExternalId);
+        migratedCount++;
+      } catch (error) {
+        this.logger.warn({
+          msg: `${logPrefix} Failed to migrate root scope ${rootScope.id}`,
+          error: sanitizeError(error),
+        });
+        failedCount++;
+      }
+
+      // Evict this site's cached data since its externalIds have changed.
+      this.siteCache.delete(rootSiteId);
+
+      if (failedCount > 0) {
+        return { status: 'migration_failed', migratedCount, failedCount };
+      }
+
+      this.logger.log(`${logPrefix} Migration completed, ${migratedCount} scopes migrated`);
+      return { status: 'migration_completed', migratedCount };
+    } catch (error) {
+      this.logger.error({
+        msg: `${logPrefix} Migration failed`,
+        error: sanitizeError(error),
+      });
+      return { status: 'migration_failed', migratedCount: 0, failedCount: 0 };
+    }
+  }
+
+  private async getScopesForSite(rootSiteId: string): Promise<Scope[]> {
+    const cached = this.siteCache.get(rootSiteId);
+    if (cached && Date.now() - cached.populatedAt < CACHE_TTL_MS) {
+      return cached.scopes;
+    }
+
+    const allScopes = await this.uniqueScopesService.listScopesByExternalIdPrefix(
+      createSmeared(EXTERNAL_ID_PREFIX),
+    );
+
+    const grouped = groupScopesByRootSiteId(allScopes);
+    const now = Date.now();
+
+    for (const [siteId, scopes] of grouped) {
+      this.siteCache.set(siteId, { scopes, populatedAt: now });
+    }
+
+    return grouped.get(rootSiteId) ?? [];
+  }
+}

--- a/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.spec.ts
@@ -58,6 +58,80 @@ describe('RootScopeMigrationService', () => {
 
         expect(result).toEqual({ status: 'no_migration_needed' });
         expect(getScopeByExternalIdMock).toHaveBeenCalledWith('spc:site:site-456');
+        expect(getScopeByExternalIdMock).toHaveBeenCalledWith('spc:site-456/site');
+        expect(listChildrenScopesMock).not.toHaveBeenCalled();
+      });
+
+      it('falls back to new-format lookup when legacy lookup misses', async () => {
+        // After ScopeExternalIdMigrationService has run, the old root no longer carries the
+        // legacy `spc:site:{id}` externalId. RootScopeMigrationService must still find it via
+        // the new-format `spc:{id}/site` lookup so the root-reconfiguration path keeps working.
+        getScopeByExternalIdMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
+          id: 'old-root-123',
+          name: 'OldSiteRoot',
+          externalId: 'spc:site-456/site',
+          parentId: null,
+        });
+        listChildrenScopesMock.mockResolvedValue([
+          { id: 'child-1', name: 'Folder1', parentId: 'old-root-123' },
+        ]);
+        updateScopeParentMock.mockResolvedValue({ id: 'child-1', parentId: 'new-root-123' });
+        deleteScopeMock.mockResolvedValue({
+          successFolders: [{ id: 'old-root-123', name: 'OldSiteRoot', path: '/OldSiteRoot' }],
+          failedFolders: [],
+        });
+
+        const result = await service.migrateIfNeeded(
+          'new-root-123',
+          new Smeared('site-456', false),
+        );
+
+        expect(result).toEqual({ status: 'migration_completed' });
+        expect(getScopeByExternalIdMock).toHaveBeenNthCalledWith(1, 'spc:site:site-456');
+        expect(getScopeByExternalIdMock).toHaveBeenNthCalledWith(2, 'spc:site-456/site');
+        expect(updateScopeParentMock).toHaveBeenCalledWith('child-1', 'new-root-123');
+        expect(deleteScopeMock).toHaveBeenCalledWith('old-root-123');
+      });
+
+      it('skips fallback lookup when legacy lookup hits', async () => {
+        // Backwards-compatibility: tenants whose externalId migration has not yet run (or has
+        // partially failed) still keep the legacy root externalId and must be picked up on the
+        // first call without an extra round-trip.
+        getScopeByExternalIdMock.mockResolvedValueOnce({
+          id: 'old-root-123',
+          name: 'OldSiteRoot',
+          externalId: 'spc:site:site-456',
+          parentId: null,
+        });
+        listChildrenScopesMock.mockResolvedValue([]);
+        deleteScopeMock.mockResolvedValue({
+          successFolders: [{ id: 'old-root-123', name: 'OldSiteRoot', path: '/OldSiteRoot' }],
+          failedFolders: [],
+        });
+
+        await service.migrateIfNeeded('new-root-123', new Smeared('site-456', false));
+
+        expect(getScopeByExternalIdMock).toHaveBeenCalledTimes(1);
+        expect(getScopeByExternalIdMock).toHaveBeenCalledWith('spc:site:site-456');
+      });
+
+      it('returns no_migration_needed when new-format lookup finds the configured root itself', async () => {
+        // Steady-state safety net: if the legacy lookup misses and the new-format lookup returns
+        // the currently-configured root (because it was claimed in a previous sync), the
+        // existing same-root guard must still prevent self-migration.
+        getScopeByExternalIdMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
+          id: 'same-root-123',
+          name: 'SiteRoot',
+          externalId: 'spc:site-456/site',
+          parentId: null,
+        });
+
+        const result = await service.migrateIfNeeded(
+          'same-root-123',
+          new Smeared('site-456', false),
+        );
+
+        expect(result).toEqual({ status: 'no_migration_needed' });
         expect(listChildrenScopesMock).not.toHaveBeenCalled();
       });
 

--- a/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
-import { EXTERNAL_ID_PREFIX } from '../utils/logging.util';
+import { EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
 import { sanitizeError } from '../utils/normalize-error';
 import { createSmeared, Smeared, smearPath } from '../utils/smeared';
 

--- a/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
 import { sanitizeError } from '../utils/normalize-error';
-import { EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
+import { buildRootExternalId, EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
 import { createSmeared, Smeared, smearPath } from '../utils/smeared';
 
 export type MigrationResult =
@@ -16,11 +16,20 @@ export class RootScopeMigrationService {
   public constructor(private readonly uniqueScopesService: UniqueScopesService) {}
 
   public async migrateIfNeeded(newRootScopeId: string, siteId: Smeared): Promise<MigrationResult> {
-    const externalId = `${EXTERNAL_ID_PREFIX}site:${siteId.value}`;
+    const legacyExternalId = `${EXTERNAL_ID_PREFIX}site:${siteId.value}`;
+    const newFormatExternalId = buildRootExternalId(siteId.value).value;
     const logPrefix = `[Migration: ${siteId}]`;
 
     try {
-      const oldRoot = await this.uniqueScopesService.getScopeByExternalId(externalId);
+      // Try the legacy format first, then fall back to the new format. The fallback is required
+      // because `ScopeExternalIdMigrationService` runs earlier in `initializeRootScope` and
+      // rewrites any legacy `spc:site:{id}` root to `spc:{id}/site` before this service is
+      // called. Without the fallback, a user who reconfigures `rootScopeId` after the externalId
+      // migration has run would leave children stranded under the old root because the legacy
+      // lookup would always miss.
+      const oldRoot =
+        (await this.uniqueScopesService.getScopeByExternalId(legacyExternalId)) ??
+        (await this.uniqueScopesService.getScopeByExternalId(newFormatExternalId));
 
       if (!oldRoot) {
         this.logger.debug(`${logPrefix} No previous root scope found`);

--- a/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/root-scope-migration.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
-import { EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
 import { sanitizeError } from '../utils/normalize-error';
+import { EXTERNAL_ID_PREFIX } from '../utils/scope-external-id';
 import { createSmeared, Smeared, smearPath } from '../utils/smeared';
 
 export type MigrationResult =

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
@@ -5,6 +5,7 @@ import type {
   SharepointContentItem,
   SharepointDirectoryItem,
 } from '../microsoft-apis/graph/types/sharepoint-content-item.interface';
+import { ScopeExternalIdMigrationService } from '../scope-external-id-migration/scope-external-id-migration.service';
 import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
 import type { Scope, ScopeWithPath } from '../unique-api/unique-scopes/unique-scopes.types';
 import { UniqueUsersService } from '../unique-api/unique-users/unique-users.service';
@@ -163,6 +164,7 @@ describe('ScopeManagementService', () => {
     let getCurrentUserIdMock: ReturnType<typeof vi.fn>;
     let updateScopeExternalIdMock: ReturnType<typeof vi.fn>;
     let migrateIfNeededMock: ReturnType<typeof vi.fn>;
+    let migrateSiteScopesMock: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
       getScopeByIdMock = vi.fn();
@@ -170,6 +172,7 @@ describe('ScopeManagementService', () => {
       getCurrentUserIdMock = vi.fn().mockResolvedValue('user-123');
       updateScopeExternalIdMock = vi.fn().mockResolvedValue({ externalId: 'updated-external-id' });
       migrateIfNeededMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
+      migrateSiteScopesMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
 
       const { unit } = await TestBed.solitary(ScopeManagementService)
         .mock<UniqueScopesService>(UniqueScopesService)
@@ -188,6 +191,11 @@ describe('ScopeManagementService', () => {
         .impl((stubFn) => ({
           ...stubFn(),
           migrateIfNeeded: migrateIfNeededMock,
+        }))
+        .mock<ScopeExternalIdMigrationService>(ScopeExternalIdMigrationService)
+        .impl((stubFn) => ({
+          ...stubFn(),
+          migrateSiteScopes: migrateSiteScopesMock,
         }))
         .compile();
 
@@ -216,7 +224,7 @@ describe('ScopeManagementService', () => {
 
       const siteId = new Smeared('site-123', false);
       // As we do not patch env variable, Smeared external id constructed inside will be active.
-      const externalId = new Smeared(`spc:site:${siteId.value}`, true);
+      const externalId = new Smeared(`spc:${siteId.value}/site`, true);
       await service.initializeRootScope('root-scope-123', siteId, IngestionMode.Flat);
 
       expect(migrateIfNeededMock).toHaveBeenCalledWith('root-scope-123', siteId);
@@ -318,6 +326,99 @@ describe('ScopeManagementService', () => {
       expect(createScopeAccessesMock).toHaveBeenCalledWith('parent-1', [
         { type: 'READ', entityId: 'user-123', entityType: 'USER' },
       ]);
+    });
+
+    it('accepts new-format root externalId as valid ownership', async () => {
+      getScopeByIdMock.mockResolvedValueOnce({
+        id: 'root-scope-123',
+        name: 'test1',
+        externalId: 'spc:site-123/site',
+        parentId: null,
+      });
+
+      const result = await service.initializeRootScope(
+        'root-scope-123',
+        new Smeared('site-123', false),
+        IngestionMode.Flat,
+      );
+
+      expect(result.isInitialSync).toBe(false);
+      expect(updateScopeExternalIdMock).not.toHaveBeenCalled();
+    });
+
+    describe('scope externalId migration', () => {
+      it('calls migrateSiteScopes when root scope has legacy externalId', async () => {
+        getScopeByIdMock.mockResolvedValueOnce({
+          id: 'root-scope-123',
+          name: 'test1',
+          externalId: 'spc:site:site-123',
+          parentId: null,
+        });
+
+        await service.initializeRootScope(
+          'root-scope-123',
+          new Smeared('site-123', false),
+          IngestionMode.Flat,
+        );
+
+        expect(migrateSiteScopesMock).toHaveBeenCalledWith('site-123');
+      });
+
+      it('does not call migrateSiteScopes when root scope has new-format externalId', async () => {
+        getScopeByIdMock.mockResolvedValueOnce({
+          id: 'root-scope-123',
+          name: 'test1',
+          externalId: 'spc:site-123/site',
+          parentId: null,
+        });
+
+        await service.initializeRootScope(
+          'root-scope-123',
+          new Smeared('site-123', false),
+          IngestionMode.Flat,
+        );
+
+        expect(migrateSiteScopesMock).not.toHaveBeenCalled();
+      });
+
+      it('does not call migrateSiteScopes when root scope has no externalId', async () => {
+        getScopeByIdMock.mockResolvedValueOnce({
+          id: 'root-scope-123',
+          name: 'test1',
+          externalId: null,
+          parentId: null,
+        });
+
+        await service.initializeRootScope(
+          'root-scope-123',
+          new Smeared('site-123', false),
+          IngestionMode.Flat,
+        );
+
+        expect(migrateSiteScopesMock).not.toHaveBeenCalled();
+      });
+
+      it('throws and aborts sync when migration reports failure', async () => {
+        getScopeByIdMock.mockResolvedValueOnce({
+          id: 'root-scope-123',
+          name: 'test1',
+          externalId: 'spc:site:site-123',
+          parentId: null,
+        });
+        migrateSiteScopesMock.mockResolvedValueOnce({
+          status: 'migration_failed',
+          migratedCount: 3,
+          failedCount: 2,
+        });
+
+        await expect(
+          service.initializeRootScope(
+            'root-scope-123',
+            new Smeared('site-123', false),
+            IngestionMode.Flat,
+          ),
+        ).rejects.toThrow(/Scope externalId migration failed.*migrated=3.*failed=2/);
+      });
     });
   });
 
@@ -554,15 +655,15 @@ describe('ScopeManagementService', () => {
 
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:subsite:${subASiteId}` }),
+          expect.objectContaining({ value: `spc:site-123/subsite:${subASiteId}` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:drive:${subASiteId}/sub-drive` }),
+          expect.objectContaining({ value: `spc:site-123/drive:${subASiteId}/sub-drive` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:folder:${subASiteId}/sub-folder` }),
+          expect.objectContaining({ value: `spc:site-123/folder:${subASiteId}/sub-folder` }),
         );
       });
 
@@ -588,15 +689,15 @@ describe('ScopeManagementService', () => {
 
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:subsite:${subASiteId}` }),
+          expect.objectContaining({ value: `spc:site-123/subsite:${subASiteId}` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:subsite:${subBSiteId}` }),
+          expect.objectContaining({ value: `spc:site-123/subsite:${subBSiteId}` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:drive:${subBSiteId}/nested-drive` }),
+          expect.objectContaining({ value: `spc:site-123/drive:${subBSiteId}/nested-drive` }),
         );
       });
 
@@ -612,11 +713,11 @@ describe('ScopeManagementService', () => {
 
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:subsite:${subASiteId}` }),
+          expect.objectContaining({ value: `spc:site-123/subsite:${subASiteId}` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:drive:${subASiteId}/drive-1` }),
+          expect.objectContaining({ value: `spc:site-123/drive:${subASiteId}/drive-1` }),
         );
       });
 
@@ -655,23 +756,23 @@ describe('ScopeManagementService', () => {
 
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: 'spc:drive:site-123/root-drive' }),
+          expect.objectContaining({ value: 'spc:site-123/drive:site-123/root-drive' }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: 'spc:folder:site-123/root-folder' }),
+          expect.objectContaining({ value: 'spc:site-123/folder:site-123/root-folder' }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:subsite:${subASiteId}` }),
+          expect.objectContaining({ value: `spc:site-123/subsite:${subASiteId}` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:drive:${subASiteId}/sub-drive` }),
+          expect.objectContaining({ value: `spc:site-123/drive:${subASiteId}/sub-drive` }),
         );
         expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
           expect.any(String),
-          expect.objectContaining({ value: `spc:folder:${subASiteId}/sub-folder` }),
+          expect.objectContaining({ value: `spc:site-123/folder:${subASiteId}/sub-folder` }),
         );
       });
     });
@@ -842,7 +943,7 @@ describe('ScopeManagementService', () => {
       expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
       expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
         'scope-1',
-        expect.objectContaining({ value: 'spc:drive:site-123/drive-1' }),
+        expect.objectContaining({ value: 'spc:site-123/drive:site-123/drive-1' }),
       );
     });
 
@@ -874,7 +975,7 @@ describe('ScopeManagementService', () => {
 
       expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
       const [, externalId] = updateScopeExternalIdMock.mock.calls[0] as [string, Smeared];
-      expect(externalId.value).toMatch(/^spc:unknown:site-123::\/test1\/SubA\/UnknownLib-/);
+      expect(externalId.value).toMatch(/^spc:site-123\/unknown:\/test1\/SubA\/UnknownLib-/);
     });
 
     describe('conflict marking', () => {
@@ -940,7 +1041,7 @@ describe('ScopeManagementService', () => {
         expect(renameId).toBe('old-scope-id');
         expect(renameExternalId).toBeInstanceOf(Smeared);
         expect(renameExternalId.value).toMatch(
-          /^spc:pending-delete:site-123\/unknown:site-123::\/test1\/TestScope-/,
+          /^spc:pending-delete:site-123\/site-123\/unknown:\/test1\/TestScope-/,
         );
 
         expect(updateScopeExternalIdMock).toHaveBeenNthCalledWith(

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
@@ -1326,6 +1326,28 @@ describe('ScopeManagementService', () => {
       expect(deleteScopeMock).toHaveBeenCalledTimes(2);
       expect(deleteScopeMock).toHaveBeenNthCalledWith(2, 'parent-scope');
     });
+
+    it('does nothing when no stale scopes are found', async () => {
+      listScopesByExternalIdPrefixMock.mockResolvedValue([]);
+
+      await service.deleteStaleScopes(new Smeared('site-123', false));
+
+      expect(deleteScopeMock).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning and skips cleanup when listing stale scopes fails', async () => {
+      listScopesByExternalIdPrefixMock.mockRejectedValue(new Error('API unavailable'));
+
+      await service.deleteStaleScopes(new Smeared('site-123', false));
+
+      expect(deleteScopeMock).not.toHaveBeenCalled();
+      // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
+      expect(service['logger'].warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('Failed to query stale scopes'),
+        }),
+      );
+    });
   });
 
   describe('resetRootScope', () => {

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
@@ -163,16 +163,16 @@ describe('ScopeManagementService', () => {
     let createScopeAccessesMock: ReturnType<typeof vi.fn>;
     let getCurrentUserIdMock: ReturnType<typeof vi.fn>;
     let updateScopeExternalIdMock: ReturnType<typeof vi.fn>;
-    let migrateIfNeededMock: ReturnType<typeof vi.fn>;
-    let migrateSiteScopesMock: ReturnType<typeof vi.fn>;
+    let rootMigrationMock: ReturnType<typeof vi.fn>;
+    let externalIdMigrationMock: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
       getScopeByIdMock = vi.fn();
       createScopeAccessesMock = vi.fn();
       getCurrentUserIdMock = vi.fn().mockResolvedValue('user-123');
       updateScopeExternalIdMock = vi.fn().mockResolvedValue({ externalId: 'updated-external-id' });
-      migrateIfNeededMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
-      migrateSiteScopesMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
+      rootMigrationMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
+      externalIdMigrationMock = vi.fn().mockResolvedValue({ status: 'no_migration_needed' });
 
       const { unit } = await TestBed.solitary(ScopeManagementService)
         .mock<UniqueScopesService>(UniqueScopesService)
@@ -190,12 +190,12 @@ describe('ScopeManagementService', () => {
         .mock<RootScopeMigrationService>(RootScopeMigrationService)
         .impl((stubFn) => ({
           ...stubFn(),
-          migrateIfNeeded: migrateIfNeededMock,
+          migrateIfNeeded: rootMigrationMock,
         }))
         .mock<ScopeExternalIdMigrationService>(ScopeExternalIdMigrationService)
         .impl((stubFn) => ({
           ...stubFn(),
-          migrateSiteScopes: migrateSiteScopesMock,
+          migrateIfNeeded: externalIdMigrationMock,
         }))
         .compile();
 
@@ -227,7 +227,7 @@ describe('ScopeManagementService', () => {
       const externalId = new Smeared(`spc:${siteId.value}/site`, true);
       await service.initializeRootScope('root-scope-123', siteId, IngestionMode.Flat);
 
-      expect(migrateIfNeededMock).toHaveBeenCalledWith('root-scope-123', siteId);
+      expect(rootMigrationMock).toHaveBeenCalledWith('root-scope-123', siteId);
       expect(updateScopeExternalIdMock).toHaveBeenCalledWith('root-scope-123', externalId);
       // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
       expect(service['logger'].debug).toHaveBeenCalledWith(
@@ -242,7 +242,7 @@ describe('ScopeManagementService', () => {
         externalId: null,
         parentId: null,
       });
-      migrateIfNeededMock.mockResolvedValueOnce({
+      rootMigrationMock.mockResolvedValueOnce({
         status: 'migration_failed',
         error: 'Failed to move child scopes',
       });
@@ -347,7 +347,7 @@ describe('ScopeManagementService', () => {
     });
 
     describe('scope externalId migration', () => {
-      it('calls migrateSiteScopes when root scope has legacy externalId', async () => {
+      it('delegates the migration decision to the migration service', async () => {
         getScopeByIdMock.mockResolvedValueOnce({
           id: 'root-scope-123',
           name: 'test1',
@@ -361,41 +361,7 @@ describe('ScopeManagementService', () => {
           IngestionMode.Flat,
         );
 
-        expect(migrateSiteScopesMock).toHaveBeenCalledWith('site-123');
-      });
-
-      it('does not call migrateSiteScopes when root scope has new-format externalId', async () => {
-        getScopeByIdMock.mockResolvedValueOnce({
-          id: 'root-scope-123',
-          name: 'test1',
-          externalId: 'spc:site-123/site',
-          parentId: null,
-        });
-
-        await service.initializeRootScope(
-          'root-scope-123',
-          new Smeared('site-123', false),
-          IngestionMode.Flat,
-        );
-
-        expect(migrateSiteScopesMock).not.toHaveBeenCalled();
-      });
-
-      it('does not call migrateSiteScopes when root scope has no externalId', async () => {
-        getScopeByIdMock.mockResolvedValueOnce({
-          id: 'root-scope-123',
-          name: 'test1',
-          externalId: null,
-          parentId: null,
-        });
-
-        await service.initializeRootScope(
-          'root-scope-123',
-          new Smeared('site-123', false),
-          IngestionMode.Flat,
-        );
-
-        expect(migrateSiteScopesMock).not.toHaveBeenCalled();
+        expect(externalIdMigrationMock).toHaveBeenCalledWith('site-123');
       });
 
       it('throws and aborts sync when migration reports failure', async () => {
@@ -405,7 +371,7 @@ describe('ScopeManagementService', () => {
           externalId: 'spc:site:site-123',
           parentId: null,
         });
-        migrateSiteScopesMock.mockResolvedValueOnce({
+        externalIdMigrationMock.mockResolvedValueOnce({
           status: 'migration_failed',
           migratedCount: 3,
           failedCount: 2,
@@ -1041,7 +1007,7 @@ describe('ScopeManagementService', () => {
         expect(renameId).toBe('old-scope-id');
         expect(renameExternalId).toBeInstanceOf(Smeared);
         expect(renameExternalId.value).toMatch(
-          /^spc:pending-delete:site-123\/site-123\/unknown:\/test1\/TestScope-/,
+          /^spc:pending-delete:site-123\/unknown:\/test1\/TestScope-/,
         );
 
         expect(updateScopeExternalIdMock).toHaveBeenNthCalledWith(

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.spec.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { TestBed } from '@suites/unit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IngestionMode } from '../constants/ingestion.constants';
@@ -136,6 +137,7 @@ describe('ScopeManagementService', () => {
       .impl((stubFn) => ({
         ...stubFn(),
         createScopesBasedOnPaths: createScopesMock,
+        listScopesByExternalIdPrefix: vi.fn().mockResolvedValue([]),
       }))
       .compile();
 
@@ -586,6 +588,7 @@ describe('ScopeManagementService', () => {
               })),
             ),
             updateScopeExternalId: updateScopeExternalIdMock,
+            listScopesByExternalIdPrefix: vi.fn().mockResolvedValue([]),
           }))
           .compile();
 
@@ -943,164 +946,300 @@ describe('ScopeManagementService', () => {
       const [, externalId] = updateScopeExternalIdMock.mock.calls[0] as [string, Smeared];
       expect(externalId.value).toMatch(/^spc:site-123\/unknown:\/test1\/SubA\/UnknownLib-/);
     });
+  });
 
-    describe('conflict marking', () => {
-      let getScopeByExternalIdMock: ReturnType<typeof vi.fn>;
+  describe('markStaleScopesForDeletion', () => {
+    let listScopesByExternalIdPrefixMock: ReturnType<typeof vi.fn>;
+    let updateScopeExternalIdMock: ReturnType<typeof vi.fn>;
 
-      beforeEach(async () => {
-        getScopeByExternalIdMock = vi.fn().mockResolvedValue(null);
-        updateScopeExternalIdMock = vi
-          .fn()
-          .mockResolvedValue({ externalId: 'updated-external-id' });
+    beforeEach(async () => {
+      listScopesByExternalIdPrefixMock = vi.fn().mockResolvedValue([]);
+      updateScopeExternalIdMock = vi.fn().mockResolvedValue({ externalId: 'updated' });
 
-        const { unit } = await TestBed.solitary(ScopeManagementService)
-          .mock<UniqueScopesService>(UniqueScopesService)
-          .impl((stubFn) => ({
-            ...stubFn(),
-            updateScopeExternalId: updateScopeExternalIdMock,
-            getScopeByExternalId: getScopeByExternalIdMock,
-          }))
-          .compile();
+      const { unit } = await TestBed.solitary(ScopeManagementService)
+        .mock<UniqueScopesService>(UniqueScopesService)
+        .impl((stubFn) => ({
+          ...stubFn(),
+          listScopesByExternalIdPrefix: listScopesByExternalIdPrefixMock,
+          updateScopeExternalId: updateScopeExternalIdMock,
+        }))
+        .compile();
 
-        service = unit;
+      service = unit;
 
-        Object.defineProperty(service, 'logger', {
-          value: {
-            log: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            debug: vi.fn(),
-            verbose: vi.fn(),
-          },
-          writable: true,
-        });
+      Object.defineProperty(service, 'logger', {
+        value: {
+          log: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn(),
+          verbose: vi.fn(),
+        },
+        writable: true,
       });
+    });
 
-      it('marks conflicting scope with pending-delete prefix and assigns externalId to new scope', async () => {
-        getScopeByExternalIdMock.mockResolvedValue({
-          id: 'old-scope-id',
-          name: 'OldScope',
-          parentId: null,
-          externalId: 'spc:folder:site-123/folder-1',
-        });
+    it('queries existing scopes using the active root-site prefix', async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
 
-        const scopes = [{ id: 'new-scope-id', name: 'TestScope', externalId: null }];
-        const paths = ['/test1/TestScope'];
-        const items: SharepointContentItem[] = [];
-        const directories: SharepointDirectoryItem[] = [];
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledTimes(1);
+      expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'spc:site-123/' }),
+      );
+    });
 
-        // biome-ignore lint/suspicious/noExplicitAny: Testing private method
-        await (service as any).updateNewlyCreatedScopesWithExternalId(
-          scopes,
-          paths,
-          items,
-          directories,
-          mockContext,
-        );
+    it('marks scopes not present in the current sync with pending-delete prefix', async () => {
+      const staleScope: Scope = {
+        id: 'stale-scope',
+        name: 'Stale',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/folder-abc',
+      };
+      const activeScope: Scope = {
+        id: 'active-scope',
+        name: 'Active',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/folder-xyz',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([staleScope, activeScope]);
 
-        expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([activeScope], mockContext);
 
-        const [renameId, renameExternalId] = updateScopeExternalIdMock.mock.calls[0] as [
-          string,
-          Smeared,
-        ];
-        expect(renameId).toBe('old-scope-id');
-        expect(renameExternalId).toBeInstanceOf(Smeared);
-        expect(renameExternalId.value).toMatch(
-          /^spc:pending-delete:site-123\/unknown:\/test1\/TestScope-/,
-        );
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
+      expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
+        'stale-scope',
+        expect.objectContaining({
+          value: 'spc:pending-delete:site-123/folder:site-123/folder-abc',
+        }),
+      );
+    });
 
-        expect(updateScopeExternalIdMock).toHaveBeenNthCalledWith(
-          2,
-          'new-scope-id',
-          expect.any(Smeared),
-        );
-      });
+    it('does not mark anything when every existing scope is still current', async () => {
+      const scope: Scope = {
+        id: 'scope-a',
+        name: 'A',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/item-a',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([scope]);
 
-      it('proceeds without marking when no conflicting scope exists', async () => {
-        getScopeByExternalIdMock.mockResolvedValue(null);
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([scope], mockContext);
 
-        const scopes = [{ id: 'new-scope-id', name: 'TestScope', externalId: null }];
-        const paths = ['/test1/TestScope'];
-        const items: SharepointContentItem[] = [];
-        const directories: SharepointDirectoryItem[] = [];
+      expect(updateScopeExternalIdMock).not.toHaveBeenCalled();
+    });
 
-        // biome-ignore lint/suspicious/noExplicitAny: Testing private method
-        await (service as any).updateNewlyCreatedScopesWithExternalId(
-          scopes,
-          paths,
-          items,
-          directories,
-          mockContext,
-        );
+    it('preserves the original externalId suffix when producing the pending-delete marker', async () => {
+      const staleScope: Scope = {
+        id: 'stale-unknown',
+        name: 'Unknown',
+        parentId: null,
+        externalId: 'spc:site-123/unknown:/test1/Old-uuid-abc',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([staleScope]);
 
-        expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
-        expect(updateScopeExternalIdMock).toHaveBeenCalledWith('new-scope-id', expect.any(Smeared));
-      });
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
 
-      it('logs warning and still updates new scope when marking conflicting scope fails', async () => {
-        getScopeByExternalIdMock.mockResolvedValue({
-          id: 'old-scope-id',
-          name: 'OldScope',
-          parentId: null,
-          externalId: 'spc:folder:site-123/folder-1',
-        });
+      expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
+        'stale-unknown',
+        expect.objectContaining({
+          value: 'spc:pending-delete:site-123/unknown:/test1/Old-uuid-abc',
+        }),
+      );
+    });
 
-        updateScopeExternalIdMock
-          .mockRejectedValueOnce(new Error('Rename failed'))
-          .mockResolvedValue({ externalId: 'updated-external-id' });
+    it('never marks the configured root scope even when it is missing from current scopes', async () => {
+      const rootScope: Scope = {
+        id: 'root-scope-123',
+        name: 'test1',
+        parentId: null,
+        externalId: 'spc:site-123/site',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([rootScope]);
 
-        const scopes = [{ id: 'new-scope-id', name: 'TestScope', externalId: null }];
-        const paths = ['/test1/TestScope'];
-        const items: SharepointContentItem[] = [];
-        const directories: SharepointDirectoryItem[] = [];
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
 
-        // biome-ignore lint/suspicious/noExplicitAny: Testing private method
-        await (service as any).updateNewlyCreatedScopesWithExternalId(
-          scopes,
-          paths,
-          items,
-          directories,
-          mockContext,
-        );
+      expect(updateScopeExternalIdMock).not.toHaveBeenCalled();
+    });
 
-        // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
-        expect(service['logger'].warn).toHaveBeenCalledWith(
-          expect.objectContaining({
-            msg: expect.stringContaining('Failed to mark conflicting scope'),
-          }),
-        );
-        expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
-        expect(updateScopeExternalIdMock).toHaveBeenLastCalledWith(
-          'new-scope-id',
-          expect.any(Smeared),
-        );
-      });
+    it('skips scopes that have no externalId', async () => {
+      const scopeWithoutExternalId: Scope = {
+        id: 'scope-no-ext',
+        name: 'NoExt',
+        parentId: null,
+        externalId: null,
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([scopeWithoutExternalId]);
 
-      it('skips conflict marking during initial sync', async () => {
-        const initialSyncContext = { ...mockContext, isInitialSync: true };
-        const scopes = [{ id: 'new-scope-id', name: 'TestScope', externalId: null }];
-        const paths = ['/test1/TestScope'];
-        const items: SharepointContentItem[] = [];
-        const directories: SharepointDirectoryItem[] = [];
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
 
-        // biome-ignore lint/suspicious/noExplicitAny: Testing private method
-        await (service as any).updateNewlyCreatedScopesWithExternalId(
-          scopes,
-          paths,
-          items,
-          directories,
-          initialSyncContext,
-        );
+      expect(updateScopeExternalIdMock).not.toHaveBeenCalled();
+    });
 
-        expect(getScopeByExternalIdMock).not.toHaveBeenCalled();
-        expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(1);
-        expect(updateScopeExternalIdMock).toHaveBeenCalledWith('new-scope-id', expect.any(Smeared));
-      });
+    it('continues marking remaining scopes when one mark call fails', async () => {
+      const staleA: Scope = {
+        id: 'scope-a',
+        name: 'A',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/a',
+      };
+      const staleB: Scope = {
+        id: 'scope-b',
+        name: 'B',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/b',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([staleA, staleB]);
+      updateScopeExternalIdMock
+        .mockRejectedValueOnce(new Error('Mark failed'))
+        .mockResolvedValue({ externalId: 'updated' });
+
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
+
+      expect(updateScopeExternalIdMock).toHaveBeenCalledTimes(2);
+      // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
+      expect(service['logger'].warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('Failed to mark stale scope scope-a for deletion'),
+        }),
+      );
+    });
+
+    it('logs a warning and stops when listing existing scopes fails', async () => {
+      listScopesByExternalIdPrefixMock.mockRejectedValue(new Error('API unavailable'));
+
+      // biome-ignore lint/suspicious/noExplicitAny: Testing private method
+      await (service as any).markStaleScopesForDeletion([], mockContext);
+
+      expect(updateScopeExternalIdMock).not.toHaveBeenCalled();
+      // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
+      expect(service['logger'].warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: expect.stringContaining('Failed to list existing scopes'),
+        }),
+      );
     });
   });
 
-  describe('deleteOrphanedScopes', () => {
+  describe('batchCreateScopes stale marking', () => {
+    let listScopesByExternalIdPrefixMock: ReturnType<typeof vi.fn>;
+    let updateScopeExternalIdMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      listScopesByExternalIdPrefixMock = vi.fn().mockResolvedValue([]);
+      updateScopeExternalIdMock = vi.fn().mockResolvedValue({ externalId: 'updated' });
+
+      const { unit } = await TestBed.solitary(ScopeManagementService)
+        .mock<UniqueScopesService>(UniqueScopesService)
+        .impl((stubFn) => ({
+          ...stubFn(),
+          createScopesBasedOnPaths: vi.fn().mockResolvedValue(
+            mockScopes.map(({ id, name, parentId, externalId }) => ({
+              id,
+              name,
+              parentId,
+              externalId,
+            })),
+          ),
+          listScopesByExternalIdPrefix: listScopesByExternalIdPrefixMock,
+          updateScopeExternalId: updateScopeExternalIdMock,
+        }))
+        .compile();
+
+      service = unit;
+
+      Object.defineProperty(service, 'logger', {
+        value: {
+          log: vi.fn(),
+          error: vi.fn(),
+          warn: vi.fn(),
+          debug: vi.fn(),
+          verbose: vi.fn(),
+        },
+        writable: true,
+      });
+    });
+
+    it('marks stale scopes before assigning externalIds to newly created scopes', async () => {
+      const stale: Scope = {
+        id: 'stale-scope',
+        name: 'OldFolder',
+        parentId: 'scope_2',
+        externalId: 'spc:site-123/folder:site-123/old-folder-id',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([
+        stale,
+        ...mockScopes.map(({ id, name, parentId, externalId }) => ({
+          id,
+          name,
+          parentId,
+          externalId,
+        })),
+      ]);
+
+      await service.batchCreateScopes(
+        [createDriveContentItem('UniqueAG/SitePages')],
+        [],
+        mockContext,
+      );
+
+      const staleCallIndex = updateScopeExternalIdMock.mock.calls.findIndex(
+        ([scopeId]) => scopeId === 'stale-scope',
+      );
+      const firstNewAssignmentIndex = updateScopeExternalIdMock.mock.calls.findIndex(
+        ([scopeId]) => scopeId !== 'stale-scope',
+      );
+      expect(staleCallIndex).toBeGreaterThanOrEqual(0);
+      expect(firstNewAssignmentIndex).toBeGreaterThanOrEqual(0);
+
+      const staleCallOrder = updateScopeExternalIdMock.mock.invocationCallOrder[staleCallIndex];
+      const firstNewAssignmentOrder =
+        updateScopeExternalIdMock.mock.invocationCallOrder[firstNewAssignmentIndex];
+      assert.ok(staleCallOrder !== undefined && firstNewAssignmentOrder !== undefined);
+
+      expect(updateScopeExternalIdMock).toHaveBeenCalledWith(
+        'stale-scope',
+        expect.objectContaining({
+          value: 'spc:pending-delete:site-123/folder:site-123/old-folder-id',
+        }),
+      );
+      expect(staleCallOrder).toBeLessThan(firstNewAssignmentOrder);
+    });
+
+    it('continues assigning externalIds to new scopes when stale-mark call fails', async () => {
+      const stale: Scope = {
+        id: 'stale-scope',
+        name: 'OldFolder',
+        parentId: null,
+        externalId: 'spc:site-123/folder:site-123/old',
+      };
+      listScopesByExternalIdPrefixMock.mockResolvedValue([stale]);
+      updateScopeExternalIdMock.mockImplementation((scopeId: string) =>
+        scopeId === 'stale-scope'
+          ? Promise.reject(new Error('Mark failed'))
+          : Promise.resolve({ externalId: 'updated' }),
+      );
+
+      await service.batchCreateScopes(
+        [createDriveContentItem('UniqueAG/SitePages')],
+        [],
+        mockContext,
+      );
+
+      const newScopeAssignments = updateScopeExternalIdMock.mock.calls.filter(
+        ([scopeId]) => scopeId !== 'stale-scope',
+      );
+      expect(newScopeAssignments.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('deleteStaleScopes', () => {
     let listScopesByExternalIdPrefixMock: ReturnType<typeof vi.fn>;
     let deleteScopeMock: ReturnType<typeof vi.fn>;
 
@@ -1131,7 +1270,7 @@ describe('ScopeManagementService', () => {
       });
     });
 
-    it('deletes orphaned scopes children-first', async () => {
+    it('deletes stale scopes children-first', async () => {
       const parentScope: Scope = {
         id: 'parent-scope',
         name: 'Parent',
@@ -1146,7 +1285,7 @@ describe('ScopeManagementService', () => {
       };
       listScopesByExternalIdPrefixMock.mockResolvedValue([parentScope, childScope]);
 
-      await service.deleteOrphanedScopes(new Smeared('site-123', false));
+      await service.deleteStaleScopes(new Smeared('site-123', false));
 
       expect(listScopesByExternalIdPrefixMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1176,12 +1315,12 @@ describe('ScopeManagementService', () => {
         .mockRejectedValueOnce(new Error('Delete failed'))
         .mockResolvedValue(undefined);
 
-      await service.deleteOrphanedScopes(new Smeared('site-123', false));
+      await service.deleteStaleScopes(new Smeared('site-123', false));
 
       // biome-ignore lint/complexity/useLiteralKeys: Accessing private logger for testing
       expect(service['logger'].warn).toHaveBeenCalledWith(
         expect.objectContaining({
-          msg: expect.stringContaining('Failed to delete orphaned scope child-scope'),
+          msg: expect.stringContaining('Failed to delete stale scope child-scope'),
         }),
       );
       expect(deleteScopeMock).toHaveBeenCalledTimes(2);

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -74,16 +74,15 @@ export class ScopeManagementService {
     );
 
     // Check if the root scope has a legacy externalId and migrate it if needed.
-    if (rootScope.externalId && parseLegacyExternalId(rootScope.externalId)?.type === 'root') {
-      const migrationResult = await this.scopeExternalIdMigrationService.migrateSiteScopes(
-        siteId.value,
+    const externalIdMigrationResult = await this.scopeExternalIdMigrationService.migrateIfNeeded(
+      siteId.value,
+    );
+    if (externalIdMigrationResult.status === 'migration_failed') {
+      throw new Error(
+        `${logPrefix} Scope externalId migration failed: ` +
+          `migrated=${externalIdMigrationResult.migratedCount}, ` +
+          `failed=${externalIdMigrationResult.failedCount}`,
       );
-      if (migrationResult.status === 'migration_failed') {
-        throw new Error(
-          `${logPrefix} Scope externalId migration failed: ` +
-            `migrated=${migrationResult.migratedCount}, failed=${migrationResult.failedCount}`,
-        );
-      }
     }
 
     const isInitialSync = !rootScope.externalId;
@@ -264,9 +263,11 @@ export class ScopeManagementService {
 
     // Accept both legacy (spc:site:{id}) and new (spc:{id}/site) formats during
     // the transition period while existing scopes are being migrated.
-    const newExternalId = buildRootExternalId(siteId.value).value;
-    const legacyExternalId = `${EXTERNAL_ID_PREFIX}site:${siteId.value}`;
-    return rootScope.externalId === newExternalId || rootScope.externalId === legacyExternalId;
+    const legacy = parseLegacyExternalId(rootScope.externalId);
+    if (legacy?.type === 'root' && legacy.siteId === siteId.value) {
+      return true;
+    }
+    return rootScope.externalId === buildRootExternalId(siteId.value).value;
   }
 
   /**
@@ -394,7 +395,7 @@ export class ScopeManagementService {
       }
 
       if (!context.isInitialSync) {
-        await this.markConflictingScope(scope.id, externalId, context.siteConfig.siteId, logPrefix);
+        await this.markConflictingScope(scope.id, externalId, logPrefix);
       }
 
       try {
@@ -420,7 +421,6 @@ export class ScopeManagementService {
   private async markConflictingScope(
     newScopeId: string,
     externalId: Smeared,
-    siteId: Smeared,
     logPrefix: string,
   ): Promise<void> {
     try {
@@ -430,8 +430,11 @@ export class ScopeManagementService {
         return;
       }
 
+      // New-format externalIds already embed the rootSiteId after `spc:`, so
+      // replacing the `spc:` prefix with `spc:pending-delete:` produces a
+      // prefix-matchable pending-delete marker without duplicating the site id.
       const pendingDeleteExternalId = externalId.transform((value) =>
-        value.replace(EXTERNAL_ID_PREFIX, `${PENDING_DELETE_PREFIX}${siteId.value}/`),
+        value.replace(EXTERNAL_ID_PREFIX, PENDING_DELETE_PREFIX),
       );
       this.logger.log(
         `${logPrefix} Marking conflicting scope ${existingScope.id} with pending-delete prefix`,

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -8,19 +8,27 @@ import type {
   SharepointContentItem,
   SharepointDirectoryItem,
 } from '../microsoft-apis/graph/types/sharepoint-content-item.interface';
+import { ScopeExternalIdMigrationService } from '../scope-external-id-migration/scope-external-id-migration.service';
 import { UniqueScopesService } from '../unique-api/unique-scopes/unique-scopes.service';
 import type { Scope, ScopeWithPath } from '../unique-api/unique-scopes/unique-scopes.types';
 import { UniqueUsersService } from '../unique-api/unique-users/unique-users.service';
-import { EXTERNAL_ID_PREFIX, PENDING_DELETE_PREFIX } from '../utils/logging.util';
 import { sanitizeError } from '../utils/normalize-error';
 import { isAncestorOfRootPath } from '../utils/paths.util';
+import {
+  buildDriveExternalId,
+  buildFolderExternalId,
+  buildRootExternalId,
+  buildSitePagesExternalId,
+  buildSubsiteExternalId,
+  buildUnknownExternalId,
+  EXTERNAL_ID_PREFIX,
+  PENDING_DELETE_PREFIX,
+  parseLegacyExternalId,
+} from '../utils/scope-external-id';
 import { getUniqueParentPathFromItem, getUniquePathFromItem } from '../utils/sharepoint.util';
 import { createSmeared, Smeared, smearPath } from '../utils/smeared';
 import { RootScopeMigrationService } from './root-scope-migration.service';
 import type { SharepointSyncContext } from './sharepoint-sync-context.interface';
-
-const buildSiteExternalId = (siteId: Smeared) =>
-  createSmeared(`${EXTERNAL_ID_PREFIX}site:${siteId.value}`);
 
 export interface RootScopeInfo {
   serviceUserId: string;
@@ -36,6 +44,7 @@ export class ScopeManagementService {
     private readonly uniqueScopesService: UniqueScopesService,
     private readonly uniqueUsersService: UniqueUsersService,
     private readonly rootScopeMigrationService: RootScopeMigrationService,
+    private readonly scopeExternalIdMigrationService: ScopeExternalIdMigrationService,
   ) {}
 
   public async initializeRootScope(
@@ -64,6 +73,19 @@ export class ScopeManagementService {
       `Root scope ${rootScopeId} is owned by a different site. This scope cannot be synced by this site.`,
     );
 
+    // Check if the root scope has a legacy externalId and migrate it if needed.
+    if (rootScope.externalId && parseLegacyExternalId(rootScope.externalId)?.type === 'root') {
+      const migrationResult = await this.scopeExternalIdMigrationService.migrateSiteScopes(
+        siteId.value,
+      );
+      if (migrationResult.status === 'migration_failed') {
+        throw new Error(
+          `${logPrefix} Scope externalId migration failed: ` +
+            `migrated=${migrationResult.migratedCount}, failed=${migrationResult.failedCount}`,
+        );
+      }
+    }
+
     const isInitialSync = !rootScope.externalId;
 
     if (isInitialSync) {
@@ -75,7 +97,7 @@ export class ScopeManagementService {
         throw new Error(`Root scope migration failed: ${migrationResult.error}`);
       }
 
-      const externalId = buildSiteExternalId(siteId);
+      const externalId = buildRootExternalId(siteId.value);
       try {
         const updatedScope = await this.uniqueScopesService.updateScopeExternalId(
           rootScopeId,
@@ -240,8 +262,11 @@ export class ScopeManagementService {
       return true;
     }
 
-    const expectedExternalId = buildSiteExternalId(siteId);
-    return rootScope.externalId === expectedExternalId.value;
+    // Accept both legacy (spc:site:{id}) and new (spc:{id}/site) formats during
+    // the transition period while existing scopes are being migrated.
+    const newExternalId = buildRootExternalId(siteId.value).value;
+    const legacyExternalId = `${EXTERNAL_ID_PREFIX}site:${siteId.value}`;
+    return rootScope.externalId === newExternalId || rootScope.externalId === legacyExternalId;
   }
 
   /**
@@ -358,14 +383,13 @@ export class ScopeManagementService {
         continue;
       }
 
-      let externalId = pathToExternalIdMap[path]
-        ? createSmeared(pathToExternalIdMap[path])
-        : undefined;
+      let externalId = pathToExternalIdMap[path];
 
       if (isNullish(externalId)) {
         this.logger.warn(`${logPrefix} No external ID found for path ${createSmeared(path)}`);
-        externalId = createSmeared(
-          `${EXTERNAL_ID_PREFIX}unknown:${context.siteConfig.siteId.value}::${path}-${randomUUID()}`,
+        externalId = buildUnknownExternalId(
+          context.siteConfig.siteId.value,
+          `${path}-${randomUUID()}`,
         );
       }
 
@@ -428,23 +452,24 @@ export class ScopeManagementService {
     items: SharepointContentItem[],
     directories: SharepointDirectoryItem[],
     context: SharepointSyncContext,
-  ): Record<string, string> {
+  ): Record<string, Smeared> {
     const { rootPath, siteName, siteConfig, discoveredSubsites } = context;
-    const pathToExternalIdMap: Record<string, string> = {};
+    const pathToExternalIdMap: Record<string, Smeared> = {};
 
+    const rootSiteId = siteConfig.siteId.value;
     const siteIdToPrefix = new Map<string, string>();
     for (const subsite of discoveredSubsites) {
       siteIdToPrefix.set(subsite.siteId.value, subsite.relativePath.value);
       pathToExternalIdMap[`${rootPath.value}/${subsite.relativePath.value}`] ??=
-        `${EXTERNAL_ID_PREFIX}subsite:${subsite.siteId.value}`;
-      // Site pages is a special collection we fetch for ASPX pages, but has no folders.
+        buildSubsiteExternalId(rootSiteId, subsite.siteId.value);
       pathToExternalIdMap[`${rootPath.value}/${subsite.relativePath.value}/SitePages`] =
-        `${EXTERNAL_ID_PREFIX}${subsite.siteId.value}/sitePages`;
+        buildSitePagesExternalId(rootSiteId, subsite.siteId.value);
     }
 
-    // Site pages is a special collection we fetch for ASPX pages, but has no folders.
-    pathToExternalIdMap[`${rootPath.value}/SitePages`] =
-      `${EXTERNAL_ID_PREFIX}${siteConfig.siteId.value}/sitePages`;
+    pathToExternalIdMap[`${rootPath.value}/SitePages`] = buildSitePagesExternalId(
+      rootSiteId,
+      rootSiteId,
+    );
 
     const registeredDrives = new Set<string>();
 
@@ -454,8 +479,11 @@ export class ScopeManagementService {
         continue;
       }
 
-      pathToExternalIdMap[path.value] ??=
-        `${EXTERNAL_ID_PREFIX}folder:${directory.siteId.value}/${directory.item.id}`;
+      pathToExternalIdMap[path.value] ??= buildFolderExternalId(
+        rootSiteId,
+        directory.siteId.value,
+        directory.item.id,
+      );
 
       const sitePrefix = siteIdToPrefix.get(directory.siteId.value);
       const siteScopePath = sitePrefix ? `${rootPath.value}/${sitePrefix}` : rootPath.value;
@@ -464,8 +492,11 @@ export class ScopeManagementService {
       // Segments can be empty when a directory resolves to exactly the site scope path.
       if (segments[0]) {
         registeredDrives.add(`${directory.siteId.value}/${directory.driveId}`);
-        pathToExternalIdMap[`${siteScopePath}/${segments[0]}`] ??=
-          `${EXTERNAL_ID_PREFIX}drive:${directory.siteId.value}/${directory.driveId}`;
+        pathToExternalIdMap[`${siteScopePath}/${segments[0]}`] ??= buildDriveExternalId(
+          rootSiteId,
+          directory.siteId.value,
+          directory.driveId,
+        );
       }
     }
 
@@ -495,8 +526,11 @@ export class ScopeManagementService {
       const driveRelative = parentPath.value.substring(siteScopePath.length);
       const segments = driveRelative.split('/').filter(Boolean);
       if (segments[0]) {
-        pathToExternalIdMap[`${siteScopePath}/${segments[0]}`] ??=
-          `${EXTERNAL_ID_PREFIX}drive:${item.siteId.value}/${item.driveId}`;
+        pathToExternalIdMap[`${siteScopePath}/${segments[0]}`] ??= buildDriveExternalId(
+          rootSiteId,
+          item.siteId.value,
+          item.driveId,
+        );
       }
     }
 

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -446,7 +446,7 @@ export class ScopeManagementService {
     const currentScopeIds = new Set(currentScopes.map((scope) => scope.id));
     const configuredRootScopeId = context.siteConfig.scopeId;
     const staleScopes = existingScopes.filter(
-      (scope) =>
+      (scope): scope is Scope & { externalId: string } =>
         isNonNullish(scope.externalId) &&
         !currentScopeIds.has(scope.id) &&
         // Paranoid guard: the configured root scope is managed by `initializeRootScope` and must
@@ -468,7 +468,6 @@ export class ScopeManagementService {
     });
 
     for (const scope of staleScopes) {
-      assert.ok(scope.externalId, `Stale scope ${scope.id} unexpectedly has null externalId`);
       const pendingDeleteExternalId = toPendingDeleteExternalId(scope.externalId);
 
       try {

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -15,15 +15,16 @@ import { UniqueUsersService } from '../unique-api/unique-users/unique-users.serv
 import { sanitizeError } from '../utils/normalize-error';
 import { isAncestorOfRootPath } from '../utils/paths.util';
 import {
+  buildActiveScopesPrefix,
   buildDriveExternalId,
   buildFolderExternalId,
   buildRootExternalId,
   buildSitePagesExternalId,
+  buildStaleScopesPrefix,
   buildSubsiteExternalId,
   buildUnknownExternalId,
-  EXTERNAL_ID_PREFIX,
-  PENDING_DELETE_PREFIX,
   parseLegacyExternalId,
+  toPendingDeleteExternalId,
 } from '../utils/scope-external-id';
 import { getUniqueParentPathFromItem, getUniquePathFromItem } from '../utils/sharepoint.util';
 import { createSmeared, Smeared, smearPath } from '../utils/smeared';
@@ -186,70 +187,69 @@ export class ScopeManagementService {
     }
   }
 
-  public async deleteOrphanedScopes(siteId: Smeared): Promise<void> {
+  public async deleteStaleScopes(siteId: Smeared): Promise<void> {
     const logPrefix = `[Site: ${siteId}]`;
 
-    // Note: When subsites are enabled, we do not need to iterate over all discovered subsite IDs.
-    // This is because `markConflictingScope` (which marks scopes for deletion) constructs the
-    // pending-delete prefix using the root site's ID for all items, including those from subsites.
-    // Therefore, querying by the root site's ID prefix is sufficient to find all orphaned scopes
-    // for the entire site tree.
-    let orphanedScopes: Scope[];
+    // When subsites are enabled, querying by the root site's ID prefix is sufficient because
+    // `markStaleScopesForDeletion` constructs pending-delete externalIds using the root site's ID
+    // for all scopes, including those from subsites.
+    let staleScopes: Scope[];
     try {
-      orphanedScopes = await this.uniqueScopesService.listScopesByExternalIdPrefix(
-        siteId.transform((value) => `${PENDING_DELETE_PREFIX}${value}/`),
+      staleScopes = await this.uniqueScopesService.listScopesByExternalIdPrefix(
+        siteId.transform((value) => buildStaleScopesPrefix(value).value),
       );
     } catch (error) {
       this.logger.warn({
-        msg: `${logPrefix} Failed to query orphaned scopes, skipping cleanup`,
+        msg: `${logPrefix} Failed to query stale scopes, skipping cleanup`,
         error: sanitizeError(error),
       });
       return;
     }
 
-    if (orphanedScopes.length === 0) {
+    if (staleScopes.length === 0) {
       return;
     }
 
-    // We sort the orphans by depth to delete the deepest scopes first to avoid deleting scopes that
-    // have children. This way we can delete without recursive to be sure we're not accidentally
-    // deleting some content.
-
-    const orphanById = new Map(orphanedScopes.map((s) => [s.id, s]));
+    // Delete deepest scopes first so every `deleteScope` call can run non-recursive, preventing
+    // accidental removal of child content that was not itself flagged as stale.
+    const staleById = new Map(staleScopes.map((s) => [s.id, s]));
     const depthById = new Map<string, number>();
 
-    const setOrphanDepth = (scope: Scope): number => {
+    const setStaleDepth = (scope: Scope): number => {
       const cached = depthById.get(scope.id);
       if (isNonNullish(cached)) {
         return cached;
       }
 
       let depth = 0;
-      const parent = scope.parentId ? orphanById.get(scope.parentId) : undefined;
+      const parent = scope.parentId ? staleById.get(scope.parentId) : undefined;
       if (parent) {
-        depth = 1 + setOrphanDepth(parent);
+        depth = 1 + setStaleDepth(parent);
       }
       depthById.set(scope.id, depth);
       return depth;
     };
 
-    for (const scope of orphanedScopes) {
-      setOrphanDepth(scope);
+    for (const scope of staleScopes) {
+      setStaleDepth(scope);
     }
 
-    const sortedOrphans = sortBy(orphanedScopes, [(scope) => depthById.get(scope.id) ?? 0, 'desc']);
+    const sortedStaleScopes = sortBy(staleScopes, [
+      (scope) => depthById.get(scope.id) ?? 0,
+      'desc',
+    ]);
 
     this.logger.log(
-      `${logPrefix} Deleting ${orphanedScopes.length} orphaned scopes marked with pending-delete prefix`,
+      `${logPrefix} Deleting ${staleScopes.length} stale scopes marked with pending-delete prefix`,
     );
 
-    for (const scope of sortedOrphans) {
+    for (const scope of sortedStaleScopes) {
       try {
         await this.uniqueScopesService.deleteScope(scope.id);
-        this.logger.debug(`${logPrefix} Deleted orphaned scope ${scope.id}`);
+        this.logger.debug(`${logPrefix} Deleted stale scope ${scope.id}`);
       } catch (error) {
         this.logger.warn({
-          msg: `${logPrefix} Failed to delete orphaned scope ${scope.id}`,
+          msg: `${logPrefix} Failed to delete stale scope ${scope.id}`,
           error: sanitizeError(error),
         });
       }
@@ -336,7 +336,8 @@ export class ScopeManagementService {
     });
     this.logger.log(`${logPrefix} Created ${scopes.length} scopes`);
 
-    // Update newly created scopes with externalId
+    await this.markStaleScopesForDeletion(scopes, context);
+
     await this.updateNewlyCreatedScopesWithExternalId(
       scopes,
       allPathsWithParents,
@@ -394,10 +395,6 @@ export class ScopeManagementService {
         );
       }
 
-      if (!context.isInitialSync) {
-        await this.markConflictingScope(scope.id, externalId, logPrefix);
-      }
-
       try {
         const updatedScope = await this.uniqueScopesService.updateScopeExternalId(
           scope.id,
@@ -414,40 +411,75 @@ export class ScopeManagementService {
     }
   }
 
-  // When folder was moved in SharePoint, we will recreate it at a new location because we create
-  // scopes by path and not by id. Therefore if we find a scope with the same externalId, we mark it
-  // for deletion. It will happen after content sync, because we have to move files from old scopes
-  // to new ones.
-  private async markConflictingScope(
-    newScopeId: string,
-    externalId: Smeared,
-    logPrefix: string,
+  // Finds scopes owned by this site that are no longer referenced by any SharePoint item and marks
+  // them for deletion. Covers two cases at once:
+  //   1. Folders emptied or deleted in SharePoint — no new scope ID matches their externalId.
+  //   2. Folders moved in SharePoint — `createScopesBasedOnPaths` returned a different scope ID for
+  //      the new path, so the original scope ends up stale and gets renamed to free its externalId
+  //      before the new scope claims it.
+  //
+  // Actual deletion is deferred to `deleteStaleScopes` (runs after content sync) so that any
+  // files still attached to the stale scope get moved or removed first.
+  private async markStaleScopesForDeletion(
+    currentScopes: Scope[],
+    context: SharepointSyncContext,
   ): Promise<void> {
+    const logPrefix = `[Site: ${context.siteConfig.siteId}]`;
+
+    // All scopes for a given root site share the prefix `spc:{rootSiteId}/` — pending-delete scopes
+    // are excluded automatically because they live under `spc:pending-delete:{rootSiteId}/`.
+    const activePrefix = context.siteConfig.siteId.transform(
+      (value) => buildActiveScopesPrefix(value).value,
+    );
+
+    let existingScopes: Scope[];
     try {
-      const existingScope = await this.uniqueScopesService.getScopeByExternalId(externalId.value);
-
-      if (!existingScope || existingScope.id === newScopeId) {
-        return;
-      }
-
-      // New-format externalIds already embed the rootSiteId after `spc:`, so
-      // replacing the `spc:` prefix with `spc:pending-delete:` produces a
-      // prefix-matchable pending-delete marker without duplicating the site id.
-      const pendingDeleteExternalId = externalId.transform((value) =>
-        value.replace(EXTERNAL_ID_PREFIX, PENDING_DELETE_PREFIX),
-      );
-      this.logger.log(
-        `${logPrefix} Marking conflicting scope ${existingScope.id} with pending-delete prefix`,
-      );
-      await this.uniqueScopesService.updateScopeExternalId(
-        existingScope.id,
-        pendingDeleteExternalId,
-      );
+      existingScopes = await this.uniqueScopesService.listScopesByExternalIdPrefix(activePrefix);
     } catch (error) {
       this.logger.warn({
-        msg: `${logPrefix} Failed to mark conflicting scope for externalId ${externalId}`,
+        msg: `${logPrefix} Failed to list existing scopes, skipping stale-scope marking`,
         error: sanitizeError(error),
       });
+      return;
+    }
+
+    const currentScopeIds = new Set(currentScopes.map((scope) => scope.id));
+    const configuredRootScopeId = context.siteConfig.scopeId;
+    const staleScopes = existingScopes.filter(
+      (scope) =>
+        isNonNullish(scope.externalId) &&
+        !currentScopeIds.has(scope.id) &&
+        // Paranoid guard: the configured root scope is managed by `initializeRootScope` and must
+        // never be renamed here, even if it somehow failed to appear in `currentScopes`.
+        scope.id !== configuredRootScopeId,
+    );
+
+    if (staleScopes.length === 0) {
+      return;
+    }
+
+    this.logger.log(`${logPrefix} Marking ${staleScopes.length} stale scopes for deletion`);
+    this.logger.debug({
+      msg: `${logPrefix} Stale scope details`,
+      staleScopes: staleScopes.map((scope) => ({
+        id: scope.id,
+        externalId: scope.externalId,
+      })),
+    });
+
+    for (const scope of staleScopes) {
+      assert.ok(scope.externalId, `Stale scope ${scope.id} unexpectedly has null externalId`);
+      const pendingDeleteExternalId = toPendingDeleteExternalId(scope.externalId);
+
+      try {
+        await this.uniqueScopesService.updateScopeExternalId(scope.id, pendingDeleteExternalId);
+        this.logger.debug(`${logPrefix} Marked stale scope ${scope.id} for deletion`);
+      } catch (error) {
+        this.logger.warn({
+          msg: `${logPrefix} Failed to mark stale scope ${scope.id} for deletion`,
+          error: sanitizeError(error),
+        });
+      }
     }
   }
 

--- a/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.module.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.module.ts
@@ -4,6 +4,7 @@ import { MetricsModule } from '../metrics/metrics.module';
 import { MicrosoftApisModule } from '../microsoft-apis/microsoft-apis.module';
 import { PermissionsSyncModule } from '../permissions-sync/permissions-sync.module';
 import { ProcessingPipelineModule } from '../processing-pipeline/processing-pipeline.module';
+import { ScopeExternalIdMigrationModule } from '../scope-external-id-migration/scope-external-id-migration.module';
 import { UniqueApiModule } from '../unique-api/unique-api.module';
 import { ContentSyncService } from './content-sync.service';
 import { FileMoveProcessor } from './file-move-processor.service';
@@ -20,6 +21,7 @@ import { SubsiteDiscoveryService } from './subsite-discovery.service';
     UniqueApiModule,
     ProcessingPipelineModule,
     PermissionsSyncModule,
+    ScopeExternalIdMigrationModule,
   ],
   providers: [
     SharepointSynchronizationService,

--- a/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.service.spec.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.service.spec.ts
@@ -27,7 +27,7 @@ describe('SharepointSynchronizationService', () => {
     initializeRootScope: ReturnType<typeof vi.fn>;
     batchCreateScopes: ReturnType<typeof vi.fn>;
     resetRootScope: ReturnType<typeof vi.fn>;
-    deleteOrphanedScopes: ReturnType<typeof vi.fn>;
+    deleteStaleScopes: ReturnType<typeof vi.fn>;
   };
   let mockSubsiteDiscoveryService: {
     discoverAllSubsites: ReturnType<typeof vi.fn>;
@@ -136,7 +136,7 @@ describe('SharepointSynchronizationService', () => {
       }),
       batchCreateScopes: vi.fn().mockResolvedValue([]),
       resetRootScope: vi.fn().mockResolvedValue(undefined),
-      deleteOrphanedScopes: vi.fn().mockResolvedValue(undefined),
+      deleteStaleScopes: vi.fn().mockResolvedValue(undefined),
     };
 
     mockSubsiteDiscoveryService = {
@@ -337,27 +337,25 @@ describe('SharepointSynchronizationService', () => {
     expect(mockPermissionsSyncService.syncPermissionsForSite).not.toHaveBeenCalled();
   });
 
-  it('calls orphan scope cleanup after content sync', async () => {
+  it('calls stale scope cleanup after content sync', async () => {
     await service.synchronize();
 
     expect(mockContentSyncService.syncContentForSite).toHaveBeenCalledTimes(1);
-    expect(mockScopeManagementService.deleteOrphanedScopes).toHaveBeenCalledTimes(1);
-    expect(mockScopeManagementService.deleteOrphanedScopes).toHaveBeenCalledWith(
+    expect(mockScopeManagementService.deleteStaleScopes).toHaveBeenCalledTimes(1);
+    expect(mockScopeManagementService.deleteStaleScopes).toHaveBeenCalledWith(
       expect.objectContaining({
         value: 'bd9c85ee-998f-4665-9c44-577cf5a08a66',
       }),
     );
   });
 
-  it('continues global synchronization when orphan scope cleanup fails for a site', async () => {
-    mockScopeManagementService.deleteOrphanedScopes.mockRejectedValueOnce(
-      new Error('Cleanup failed'),
-    );
+  it('continues global synchronization when stale scope cleanup fails for a site', async () => {
+    mockScopeManagementService.deleteStaleScopes.mockRejectedValueOnce(new Error('Cleanup failed'));
 
     const result = await service.synchronize();
 
     expect(mockContentSyncService.syncContentForSite).toHaveBeenCalledTimes(1);
-    expect(mockScopeManagementService.deleteOrphanedScopes).toHaveBeenCalledTimes(1);
+    expect(mockScopeManagementService.deleteStaleScopes).toHaveBeenCalledTimes(1);
     expect(result.fullResult.status).toBe('success');
   });
 
@@ -1036,7 +1034,7 @@ describe('SharepointSynchronizationService', () => {
     );
   });
 
-  it('cleans up orphaned scopes using parent site ID when subsites are enabled', async () => {
+  it('cleans up stale scopes using parent site ID when subsites are enabled', async () => {
     const siteConfig = createMockSiteConfig({
       siteId: new Smeared('bd9c85ee-998f-4665-9c44-577cf5a08a66', false),
       subsitesScan: 'enabled',
@@ -1062,8 +1060,8 @@ describe('SharepointSynchronizationService', () => {
 
     await service.synchronize();
 
-    expect(mockScopeManagementService.deleteOrphanedScopes).toHaveBeenCalledTimes(1);
-    expect(mockScopeManagementService.deleteOrphanedScopes).toHaveBeenCalledWith(siteConfig.siteId);
+    expect(mockScopeManagementService.deleteStaleScopes).toHaveBeenCalledTimes(1);
+    expect(mockScopeManagementService.deleteStaleScopes).toHaveBeenCalledWith(siteConfig.siteId);
   });
 
   it('does not initialize root scope when getSiteInfo fails', async () => {

--- a/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/sharepoint-synchronization.service.ts
@@ -387,13 +387,13 @@ export class SharepointSynchronizationService {
     }
 
     try {
-      await this.scopeManagementService.deleteOrphanedScopes(siteConfig.siteId);
+      await this.scopeManagementService.deleteStaleScopes(siteConfig.siteId);
     } catch (error) {
       this.logger.warn({
-        msg: `${logPrefix} Failed to clean up orphaned scopes`,
+        msg: `${logPrefix} Failed to clean up stale scopes`,
         error: sanitizeError(error),
       });
-      return { status: 'failure', step: SiteSyncStep.OrphanScopeCleanup };
+      return { status: 'failure', step: SiteSyncStep.StaleScopeCleanup };
     }
 
     return { status: 'success' };

--- a/services/sharepoint-connector/src/utils/logging.util.ts
+++ b/services/sharepoint-connector/src/utils/logging.util.ts
@@ -2,8 +2,6 @@ import { ConfigService } from '@nestjs/config';
 import { regexes } from 'zod';
 import type { Config } from '../config';
 import { LogsDiagnosticDataPolicy } from '../config/app.config';
-export const EXTERNAL_ID_PREFIX = 'spc:' as const;
-export const PENDING_DELETE_PREFIX = 'spc:pending-delete:' as const;
 
 // SharePoint reserved virtual directories that appear after the site/subsite path. Used as
 // terminators to distinguish multi-segment subsite names from library/folder segments.

--- a/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDriveExternalId,
+  buildFolderExternalId,
+  buildRootExternalId,
+  buildSitePagesExternalId,
+  buildSubsiteExternalId,
+  buildUnknownExternalId,
+  isLegacyExternalId,
+  migrateLegacyExternalId,
+  parseLegacyExternalId,
+} from './scope-external-id';
+import { createSmeared } from './smeared';
+
+const ROOT_SITE_ID = 'root-site-id-123';
+
+const LEGACY_IDS = {
+  root: 'spc:site:site-id-abc',
+  subsite: 'spc:subsite:subsite-id-def',
+  drive: 'spc:drive:site-id-abc/drive-id-456',
+  folder: 'spc:folder:site-id-abc/item-id-789',
+  sitePages: 'spc:site-id-abc/sitePages',
+  unknown: 'spc:unknown:site-id-abc::/some/path-0123abcd',
+};
+
+const NEW_IDS = {
+  root: `spc:${ROOT_SITE_ID}/site`,
+  subsite: `spc:${ROOT_SITE_ID}/subsite:subsite-id-def`,
+  drive: `spc:${ROOT_SITE_ID}/drive:site-id-abc/drive-id-456`,
+  folder: `spc:${ROOT_SITE_ID}/folder:site-id-abc/item-id-789`,
+  sitePages: `spc:${ROOT_SITE_ID}/sitePages:site-id-abc`,
+  unknown: `spc:${ROOT_SITE_ID}/unknown:/some/path-0123abcd`,
+};
+
+describe('isLegacyExternalId', () => {
+  it.each([
+    ['root', LEGACY_IDS.root],
+    ['subsite', LEGACY_IDS.subsite],
+    ['drive', LEGACY_IDS.drive],
+    ['folder', LEGACY_IDS.folder],
+    ['sitePages', LEGACY_IDS.sitePages],
+    ['unknown', LEGACY_IDS.unknown],
+  ])('returns true for legacy %s format', (_type, id) => {
+    expect(isLegacyExternalId(id)).toBe(true);
+  });
+
+  it.each([
+    ['root', NEW_IDS.root],
+    ['subsite', NEW_IDS.subsite],
+    ['drive', NEW_IDS.drive],
+    ['folder', NEW_IDS.folder],
+    ['sitePages', NEW_IDS.sitePages],
+    ['unknown', NEW_IDS.unknown],
+  ])('returns false for new %s format', (_type, id) => {
+    expect(isLegacyExternalId(id)).toBe(false);
+  });
+
+  it('returns false for pending-delete format', () => {
+    expect(isLegacyExternalId(`spc:pending-delete:${ROOT_SITE_ID}/site`)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isLegacyExternalId('')).toBe(false);
+  });
+
+  it('returns false for non-spc prefix', () => {
+    expect(isLegacyExternalId('other:site:abc')).toBe(false);
+  });
+});
+
+describe('parseLegacyExternalId', () => {
+  it('parses root format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.root)).toEqual({
+      type: 'root',
+      siteId: 'site-id-abc',
+    });
+  });
+
+  it('parses subsite format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.subsite)).toEqual({
+      type: 'subsite',
+      subsiteId: 'subsite-id-def',
+    });
+  });
+
+  it('parses drive format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.drive)).toEqual({
+      type: 'drive',
+      siteId: 'site-id-abc',
+      driveId: 'drive-id-456',
+    });
+  });
+
+  it('parses folder format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.folder)).toEqual({
+      type: 'folder',
+      siteId: 'site-id-abc',
+      itemId: 'item-id-789',
+    });
+  });
+
+  it('parses sitePages format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.sitePages)).toEqual({
+      type: 'sitePages',
+      siteId: 'site-id-abc',
+    });
+  });
+
+  it('parses unknown format', () => {
+    expect(parseLegacyExternalId(LEGACY_IDS.unknown)).toEqual({
+      type: 'unknown',
+      suffix: '/some/path-0123abcd',
+    });
+  });
+
+  it('returns null for new-format externalIds', () => {
+    expect(parseLegacyExternalId(NEW_IDS.root)).toBeNull();
+  });
+
+  it('returns null for pending-delete format', () => {
+    expect(parseLegacyExternalId(`spc:pending-delete:${ROOT_SITE_ID}/site`)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseLegacyExternalId('')).toBeNull();
+  });
+
+  it('returns null for drive format missing separator', () => {
+    expect(parseLegacyExternalId('spc:drive:no-slash-here')).toBeNull();
+  });
+
+  it('returns null for folder format missing separator', () => {
+    expect(parseLegacyExternalId('spc:folder:no-slash-here')).toBeNull();
+  });
+
+  it('returns null for unknown format missing separator', () => {
+    expect(parseLegacyExternalId('spc:unknown:no-double-colon')).toBeNull();
+  });
+
+  it('returns null for root format with slash in siteId', () => {
+    expect(parseLegacyExternalId('spc:site:abc/xyz')).toBeNull();
+  });
+});
+
+describe('migrateLegacyExternalId', () => {
+  it.each([
+    ['root', LEGACY_IDS.root, NEW_IDS.root],
+    ['subsite', LEGACY_IDS.subsite, NEW_IDS.subsite],
+    ['drive', LEGACY_IDS.drive, NEW_IDS.drive],
+    ['folder', LEGACY_IDS.folder, NEW_IDS.folder],
+    ['sitePages', LEGACY_IDS.sitePages, NEW_IDS.sitePages],
+    ['unknown', LEGACY_IDS.unknown, NEW_IDS.unknown],
+  ])('converts legacy %s to new format', (_type, legacy, expected) => {
+    const result = migrateLegacyExternalId(ROOT_SITE_ID, createSmeared(legacy));
+    expect(result.value).toBe(expected);
+  });
+
+  it('returns a Smeared preserving the active flag', () => {
+    const inactive = migrateLegacyExternalId(ROOT_SITE_ID, createSmeared(LEGACY_IDS.root));
+    expect(inactive).toHaveProperty('value');
+    expect(inactive).toHaveProperty('active');
+  });
+
+  it('throws for unrecognized format', () => {
+    expect(() => migrateLegacyExternalId(ROOT_SITE_ID, createSmeared('garbage'))).toThrow(
+      'Unrecognized legacy externalId format: garbage',
+    );
+  });
+
+  it('throws for new-format input (not idempotent by design)', () => {
+    expect(() => migrateLegacyExternalId(ROOT_SITE_ID, createSmeared(NEW_IDS.root))).toThrow(
+      'Unrecognized legacy externalId format',
+    );
+  });
+
+  it('throws for pending-delete format', () => {
+    expect(() =>
+      migrateLegacyExternalId(
+        ROOT_SITE_ID,
+        createSmeared(`spc:pending-delete:${ROOT_SITE_ID}/site`),
+      ),
+    ).toThrow('Unrecognized legacy externalId format');
+  });
+
+  it('throws for drive format missing separator', () => {
+    expect(() =>
+      migrateLegacyExternalId(ROOT_SITE_ID, createSmeared('spc:drive:no-slash-here')),
+    ).toThrow('Unrecognized legacy externalId format');
+  });
+});
+
+describe('buildRootExternalId', () => {
+  it('builds new-format root externalId', () => {
+    expect(buildRootExternalId('site-abc').value).toBe('spc:site-abc/site');
+  });
+});
+
+describe('buildSubsiteExternalId', () => {
+  it('builds new-format subsite externalId', () => {
+    expect(buildSubsiteExternalId('root-abc', 'subsite-def').value).toBe(
+      'spc:root-abc/subsite:subsite-def',
+    );
+  });
+});
+
+describe('buildDriveExternalId', () => {
+  it('builds new-format drive externalId', () => {
+    expect(buildDriveExternalId('root-abc', 'site-abc', 'drive-456').value).toBe(
+      'spc:root-abc/drive:site-abc/drive-456',
+    );
+  });
+});
+
+describe('buildFolderExternalId', () => {
+  it('builds new-format folder externalId', () => {
+    expect(buildFolderExternalId('root-abc', 'site-abc', 'item-789').value).toBe(
+      'spc:root-abc/folder:site-abc/item-789',
+    );
+  });
+});
+
+describe('buildSitePagesExternalId', () => {
+  it('builds new-format sitePages externalId', () => {
+    expect(buildSitePagesExternalId('root-abc', 'site-abc').value).toBe(
+      'spc:root-abc/sitePages:site-abc',
+    );
+  });
+});
+
+describe('buildUnknownExternalId', () => {
+  it('builds new-format unknown externalId with arbitrary suffix', () => {
+    expect(buildUnknownExternalId('root-abc', '/some/path-fixed-suffix').value).toBe(
+      'spc:root-abc/unknown:/some/path-fixed-suffix',
+    );
+  });
+});

--- a/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
@@ -101,6 +101,16 @@ describe('extractRootSiteId', () => {
     expect(extractRootSiteId('')).toBeNull();
     expect(extractRootSiteId('other:site:abc')).toBeNull();
   });
+
+  it('returns null for pending-delete root externalId', () => {
+    expect(extractRootSiteId(`spc:pending-delete:${ROOT_SITE_ID}/site`)).toBeNull();
+  });
+
+  it('returns null for pending-delete non-root externalId', () => {
+    expect(
+      extractRootSiteId(`spc:pending-delete:${ROOT_SITE_ID}/drive:site-id-abc/drive-id-456`),
+    ).toBeNull();
+  });
 });
 
 describe('parseLegacyExternalId', () => {

--- a/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.spec.ts
@@ -6,6 +6,7 @@ import {
   buildSitePagesExternalId,
   buildSubsiteExternalId,
   buildUnknownExternalId,
+  extractRootSiteId,
   isLegacyExternalId,
   migrateLegacyExternalId,
   parseLegacyExternalId,
@@ -65,6 +66,40 @@ describe('isLegacyExternalId', () => {
 
   it('returns false for non-spc prefix', () => {
     expect(isLegacyExternalId('other:site:abc')).toBe(false);
+  });
+
+  // `isLegacyExternalId` must only return true when the id is fully parseable.
+  // Otherwise a malformed legacy id would satisfy the detection check, the
+  // migration step would then throw on parse, and a single corrupt row would
+  // block the whole site's sync.
+  it.each([
+    ['drive missing slash', 'spc:drive:no-slash-here'],
+    ['folder missing slash', 'spc:folder:no-slash-here'],
+    ['unknown missing separator', 'spc:unknown:no-double-colon'],
+    ['root with slash in siteId', 'spc:site:abc/xyz'],
+  ])('returns false for malformed legacy-like id (%s)', (_desc, id) => {
+    expect(isLegacyExternalId(id)).toBe(false);
+  });
+});
+
+describe('extractRootSiteId', () => {
+  it('extracts siteId from legacy root externalId', () => {
+    expect(extractRootSiteId('spc:site:site-id-abc')).toBe('site-id-abc');
+  });
+
+  it('extracts siteId from new-format root externalId', () => {
+    expect(extractRootSiteId('spc:site-id-abc/site')).toBe('site-id-abc');
+  });
+
+  it('returns null for non-root externalIds', () => {
+    expect(extractRootSiteId(LEGACY_IDS.drive)).toBeNull();
+    expect(extractRootSiteId(NEW_IDS.drive)).toBeNull();
+    expect(extractRootSiteId('spc:site-id-abc/subsite:foo')).toBeNull();
+  });
+
+  it('returns null for empty or unrelated strings', () => {
+    expect(extractRootSiteId('')).toBeNull();
+    expect(extractRootSiteId('other:site:abc')).toBeNull();
   });
 });
 

--- a/services/sharepoint-connector/src/utils/scope-external-id.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.ts
@@ -1,0 +1,193 @@
+import { createSmeared, Smeared } from './smeared';
+
+export const EXTERNAL_ID_PREFIX = 'spc:' as const;
+export const PENDING_DELETE_PREFIX = 'spc:pending-delete:' as const;
+
+const LEGACY_TYPE_PREFIXES = ['site:', 'subsite:', 'drive:', 'folder:', 'unknown:'] as const;
+
+const LEGACY_SITE_PAGES_REGEX = new RegExp(`^${EXTERNAL_ID_PREFIX}[^/]+/sitePages$`);
+
+// --- Legacy format types ---
+
+interface LegacyRootId {
+  type: 'root';
+  siteId: string;
+}
+
+interface LegacySubsiteId {
+  type: 'subsite';
+  subsiteId: string;
+}
+
+interface LegacyDriveId {
+  type: 'drive';
+  siteId: string;
+  driveId: string;
+}
+
+interface LegacyFolderId {
+  type: 'folder';
+  siteId: string;
+  itemId: string;
+}
+
+interface LegacySitePagesId {
+  type: 'sitePages';
+  siteId: string;
+}
+
+interface LegacyUnknownId {
+  type: 'unknown';
+  // The opaque blob after `::` in the legacy format — originally `{path}-{uuid}`.
+  // Treated as a single identifier during migration since the new format does
+  // not require splitting it back apart.
+  suffix: string;
+}
+
+export type ParsedLegacyExternalId =
+  | LegacyRootId
+  | LegacySubsiteId
+  | LegacyDriveId
+  | LegacyFolderId
+  | LegacySitePagesId
+  | LegacyUnknownId;
+
+// --- Legacy format detection and parsing ---
+
+export function isLegacyExternalId(externalId: string): boolean {
+  if (!externalId.startsWith(EXTERNAL_ID_PREFIX)) {
+    return false;
+  }
+
+  const afterPrefix = externalId.slice(EXTERNAL_ID_PREFIX.length);
+
+  if (afterPrefix.startsWith('pending-delete:')) {
+    return false;
+  }
+
+  for (const typePrefix of LEGACY_TYPE_PREFIXES) {
+    if (afterPrefix.startsWith(typePrefix)) {
+      return true;
+    }
+  }
+
+  return LEGACY_SITE_PAGES_REGEX.test(externalId);
+}
+
+export function parseLegacyExternalId(externalId: string): ParsedLegacyExternalId | null {
+  if (!isLegacyExternalId(externalId)) {
+    return null;
+  }
+
+  const afterPrefix = externalId.slice(EXTERNAL_ID_PREFIX.length);
+
+  if (afterPrefix.startsWith('site:')) {
+    const siteId = afterPrefix.slice('site:'.length);
+    if (siteId.includes('/')) {
+      return null;
+    }
+    return { type: 'root', siteId };
+  }
+
+  if (afterPrefix.startsWith('subsite:')) {
+    return { type: 'subsite', subsiteId: afterPrefix.slice('subsite:'.length) };
+  }
+
+  if (afterPrefix.startsWith('drive:')) {
+    const rest = afterPrefix.slice('drive:'.length);
+    const slashIndex = rest.indexOf('/');
+    if (slashIndex === -1) {
+      return null;
+    }
+    return {
+      type: 'drive',
+      siteId: rest.slice(0, slashIndex),
+      driveId: rest.slice(slashIndex + 1),
+    };
+  }
+
+  if (afterPrefix.startsWith('folder:')) {
+    const rest = afterPrefix.slice('folder:'.length);
+    const slashIndex = rest.indexOf('/');
+    if (slashIndex === -1) {
+      return null;
+    }
+    return {
+      type: 'folder',
+      siteId: rest.slice(0, slashIndex),
+      itemId: rest.slice(slashIndex + 1),
+    };
+  }
+
+  if (afterPrefix.startsWith('unknown:')) {
+    const rest = afterPrefix.slice('unknown:'.length);
+    const separatorIndex = rest.indexOf('::');
+    if (separatorIndex === -1) {
+      return null;
+    }
+    return { type: 'unknown', suffix: rest.slice(separatorIndex + 2) };
+  }
+
+  if (LEGACY_SITE_PAGES_REGEX.test(externalId)) {
+    const siteId = afterPrefix.slice(0, afterPrefix.indexOf('/'));
+    return { type: 'sitePages', siteId };
+  }
+
+  return null;
+}
+
+// --- New format builders ---
+
+export function buildRootExternalId(rootSiteId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/site`);
+}
+
+export function buildSubsiteExternalId(rootSiteId: string, subsiteId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/subsite:${subsiteId}`);
+}
+
+export function buildDriveExternalId(rootSiteId: string, siteId: string, driveId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/drive:${siteId}/${driveId}`);
+}
+
+export function buildFolderExternalId(rootSiteId: string, siteId: string, itemId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/folder:${siteId}/${itemId}`);
+}
+
+export function buildSitePagesExternalId(rootSiteId: string, siteId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/sitePages:${siteId}`);
+}
+
+// Takes an arbitrary suffix (caller is responsible for uniqueness — typically
+// `${path}-${randomUUID()}`). Keeping the suffix opaque lets migration reuse
+// the existing legacy suffix verbatim without reconstructing it.
+export function buildUnknownExternalId(rootSiteId: string, suffix: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/unknown:${suffix}`);
+}
+
+// --- Migration helper (legacy -> new) ---
+
+export function migrateLegacyExternalId(rootSiteId: string, legacyExternalId: Smeared): Smeared {
+  return legacyExternalId.transform((value) => {
+    const parsed = parseLegacyExternalId(value);
+
+    if (!parsed) {
+      throw new Error(`Unrecognized legacy externalId format: ${value}`);
+    }
+
+    switch (parsed.type) {
+      case 'root':
+        return buildRootExternalId(rootSiteId).value;
+      case 'subsite':
+        return buildSubsiteExternalId(rootSiteId, parsed.subsiteId).value;
+      case 'drive':
+        return buildDriveExternalId(rootSiteId, parsed.siteId, parsed.driveId).value;
+      case 'folder':
+        return buildFolderExternalId(rootSiteId, parsed.siteId, parsed.itemId).value;
+      case 'sitePages':
+        return buildSitePagesExternalId(rootSiteId, parsed.siteId).value;
+      case 'unknown':
+        return buildUnknownExternalId(rootSiteId, parsed.suffix).value;
+    }
+  });
+}

--- a/services/sharepoint-connector/src/utils/scope-external-id.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.ts
@@ -3,9 +3,9 @@ import { createSmeared, Smeared } from './smeared';
 export const EXTERNAL_ID_PREFIX = 'spc:' as const;
 export const PENDING_DELETE_PREFIX = 'spc:pending-delete:' as const;
 
-const LEGACY_TYPE_PREFIXES = ['site:', 'subsite:', 'drive:', 'folder:', 'unknown:'] as const;
-
 const LEGACY_SITE_PAGES_REGEX = new RegExp(`^${EXTERNAL_ID_PREFIX}[^/]+/sitePages$`);
+
+const NEW_ROOT_REGEX = new RegExp(`^${EXTERNAL_ID_PREFIX}([^/]+)/site$`);
 
 // --- Legacy format types ---
 
@@ -54,32 +54,36 @@ export type ParsedLegacyExternalId =
 
 // --- Legacy format detection and parsing ---
 
+// Returns true only when the externalId is a fully-parseable legacy format.
+// Strings that merely start with a legacy type prefix but cannot be parsed
+// (e.g. `spc:drive:no-slash`) return false so callers don't misclassify them
+// as migratable.
 export function isLegacyExternalId(externalId: string): boolean {
+  return parseLegacyExternalId(externalId) !== null;
+}
+
+// Extracts the rootSiteId from a root scope externalId in either legacy
+// (`spc:site:{id}`) or new (`spc:{id}/site`) format. Used to anchor scope
+// grouping during migration so that partially-migrated sites still resolve
+// their children under the same root.
+export function extractRootSiteId(externalId: string): string | null {
+  const legacy = parseLegacyExternalId(externalId);
+  if (legacy?.type === 'root') {
+    return legacy.siteId;
+  }
+  return externalId.match(NEW_ROOT_REGEX)?.[1] ?? null;
+}
+
+export function parseLegacyExternalId(externalId: string): ParsedLegacyExternalId | null {
   if (!externalId.startsWith(EXTERNAL_ID_PREFIX)) {
-    return false;
+    return null;
   }
 
   const afterPrefix = externalId.slice(EXTERNAL_ID_PREFIX.length);
 
   if (afterPrefix.startsWith('pending-delete:')) {
-    return false;
-  }
-
-  for (const typePrefix of LEGACY_TYPE_PREFIXES) {
-    if (afterPrefix.startsWith(typePrefix)) {
-      return true;
-    }
-  }
-
-  return LEGACY_SITE_PAGES_REGEX.test(externalId);
-}
-
-export function parseLegacyExternalId(externalId: string): ParsedLegacyExternalId | null {
-  if (!isLegacyExternalId(externalId)) {
     return null;
   }
-
-  const afterPrefix = externalId.slice(EXTERNAL_ID_PREFIX.length);
 
   if (afterPrefix.startsWith('site:')) {
     const siteId = afterPrefix.slice('site:'.length);

--- a/services/sharepoint-connector/src/utils/scope-external-id.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.ts
@@ -67,6 +67,11 @@ export function isLegacyExternalId(externalId: string): boolean {
 // grouping during migration so that partially-migrated sites still resolve
 // their children under the same root.
 export function extractRootSiteId(externalId: string): string | null {
+  // Pending-delete ids (`spc:pending-delete:...`) are rejected explicitly because without this
+  // guard `spc:pending-delete:{siteId}/site` would match NEW_ROOT_REGEX and yield a bogus root key.
+  if (externalId.startsWith(PENDING_DELETE_PREFIX)) {
+    return null;
+  }
   const legacy = parseLegacyExternalId(externalId);
   if (legacy?.type === 'root') {
     return legacy.siteId;

--- a/services/sharepoint-connector/src/utils/scope-external-id.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.ts
@@ -169,6 +169,22 @@ export function buildUnknownExternalId(rootSiteId: string, suffix: string): Smea
   return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/unknown:${suffix}`);
 }
 
+// Prefix that matches every active (non-pending-delete) scope for a given root site.
+export function buildActiveScopesPrefix(rootSiteId: string): Smeared {
+  return createSmeared(`${EXTERNAL_ID_PREFIX}${rootSiteId}/`);
+}
+
+// Prefix that matches every stale (pending-delete) scope for a given root site.
+export function buildStaleScopesPrefix(rootSiteId: string): Smeared {
+  return createSmeared(`${PENDING_DELETE_PREFIX}${rootSiteId}/`);
+}
+
+// Moves an active externalId into the pending-delete namespace. Suffix is is preserved verbatim so
+// operators can still identify the original scope type/site from the marker.
+export function toPendingDeleteExternalId(activeExternalId: string): Smeared {
+  return createSmeared(activeExternalId.replace(EXTERNAL_ID_PREFIX, PENDING_DELETE_PREFIX));
+}
+
 // --- Migration helper (legacy -> new) ---
 
 export function migrateLegacyExternalId(rootSiteId: string, legacyExternalId: Smeared): Smeared {

--- a/services/sharepoint-connector/src/utils/scope-external-id.ts
+++ b/services/sharepoint-connector/src/utils/scope-external-id.ts
@@ -179,8 +179,8 @@ export function buildStaleScopesPrefix(rootSiteId: string): Smeared {
   return createSmeared(`${PENDING_DELETE_PREFIX}${rootSiteId}/`);
 }
 
-// Moves an active externalId into the pending-delete namespace. Suffix is is preserved verbatim so
-// operators can still identify the original scope type/site from the marker.
+// Moves an active externalId into the pending-delete namespace. The suffix is preserved verbatim
+// so operators can still identify the original scope type/site from the marker.
 export function toPendingDeleteExternalId(activeExternalId: string): Smeared {
   return createSmeared(activeExternalId.replace(EXTERNAL_ID_PREFIX, PENDING_DELETE_PREFIX));
 }


### PR DESCRIPTION
## Summary

Closes [UN-18224](https://unique-ch.atlassian.net/browse/UN-18224). Before this change, scopes in Unique were never removed when the corresponding SharePoint folder was moved, emptied, or deleted — only per-scope *conflict* detection existed (which caught folder *moves* via `getScopeByExternalId` but nothing else). This PR makes stale-scope cleanup part of every sync by bulk-querying all scopes under a site's external-ID prefix and diffing against the live tree.

Delivering that efficiently required a migration of the externalId format first, so the feature ships in two stages on this branch:

1. **ExternalId format migration** (prework) — rewrites legacy `spc:folder:{siteId}/{itemId}`, `spc:site:{siteId}`, etc. to a unified `spc:{rootSiteId}/{type}:...` shape, so one paginated prefix query can enumerate all scopes for a root site.
2. **Stale scope detection + deletion** — diffs current vs. existing, renames the delta to `spc:pending-delete:{rootSiteId}/...`, then removes them after content sync via the existing cleanup step.

### Part 1 — ExternalId format migration

- New `ScopeExternalIdMigrationService` rewrites legacy externalIds to the new root-site-prefixed format. Children migrated first, root last, so interruption is safe (next run resumes).
- Grouping is done via memoized `parentId`-chain traversal, so partial migrations still resolve children to the same root via a new `extractRootSiteId` helper.
- Format logic (legacy detection/parsing, new-format builders) lives in a single `src/utils/scope-external-id.ts` module as the source of truth.
- `ScopeManagementService.initializeRootScope` runs the migration best-effort when the root has a legacy externalId.
- `isValidScopeOwnership` accepts both legacy and new format during the transition.
- Short-circuit before root migration if any child fails, preserving the legacy-root retry invariant so stranded legacy children migrate on the next sync instead of being permanently orphaned.
- Pending-delete prefix construction dropped the redundant `rootSiteId` since the new externalIds already embed it after `spc:`.

### Part 2 — Stale scope detection and deletion

- Added `ScopeManagementService.markStaleScopesForDeletion`: one paginated `listScopesByExternalIdPrefix('spc:{rootSiteId}/')`, diff against scope IDs returned by `createScopesBasedOnPaths`, rename the delta to `spc:pending-delete:{rootSiteId}/...`.
- Wired into `batchCreateScopes` right after `createScopesBasedOnPaths` and before `updateNewlyCreatedScopesWithExternalId` so moved folders' new scopes can reuse freed externalIds.
- Runs on every sync (including initial) — on a fresh root the active prefix is empty (apart from the claimed root, which is filtered out), so the extra list call is effectively a no-op.
- Paranoid guard: `context.siteConfig.scopeId` is explicitly excluded from stale marking even if it somehow failed to appear in `currentScopes`.
- Removed the old per-scope `markConflictingScope` (subsumed by the bulk diff, which now catches *both* moves and orphaned empties in one pass).
- Actual deletion stays in the existing post-sync step (now renamed `deleteStaleScopes`), deepest-first to allow non-recursive deletes.
- Terminology swept from `orphan`/`orphaned` to `stale` across the public method, `SiteSyncStep.StaleScopeCleanup` enum value, log strings, tests, and the subsite flow diagram in `docs/technical/flows.md`.
- Centralized helpers in `scope-external-id.ts`: `buildActiveScopesPrefix`, `buildStaleScopesPrefix`, `toPendingDeleteExternalId`.
- Post-review polish: type-predicate `filter` replaces a runtime `assert.ok`, empty-list and list-failure paths of `deleteStaleScopes` got dedicated tests.

### Ticket guardrails addressed

- **API call volume**: one paginated list per site per sync for marking plus one for deletion. Replaces the previous per-scope `getScopeByExternalId`.
- **Race conditions**: the mark step runs on a single snapshot of Graph items; actual deletion is deferred until after content + permission sync, so content sync can move files off old scopes before their IDs disappear. Failures at any stage skip the later cleanup for that cycle.

## Follow-ups worth tracking (not blocking)

- **Observability**: no dedicated metric/alert for "scopes marked" / "scopes deleted" counts — currently log-only.
- **Flat-mode leftovers**: tenants that previously ran in `Recursive` and switched to `Flat` keep their pre-existing child scopes — not touched by this PR since `batchCreateScopes` isn't called in `Flat`.

[UN-18224]: https://unique-ch.atlassian.net/browse/UN-18224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ