### PR TITLE
fix(confluence-connector): add typeid-js dependency required by @unique-ag/utils/zod

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       serialize-error-cjs:
         specifier: 0.2.0
         version: 0.2.0
+      typeid-js:
+        specifier: 1.2.0
+        version: 1.2.0
       undici:
         specifier: 7.24.4
         version: 7.24.4

--- a/services/confluence-connector/package.json
+++ b/services/confluence-connector/package.json
@@ -51,6 +51,7 @@
     "remeda": "2.32.0",
     "rxjs": "7.8.2",
     "serialize-error-cjs": "0.2.0",
+    "typeid-js": "1.2.0",
     "undici": "7.24.4",
     "zod": "4.1.5"
   },


### PR DESCRIPTION
## Summary

Add `typeid-js` as a dependency of confluence-connector.

## Problem

The `@unique-ag/utils/zod` module imports `typeid-js` at the top level. Node evaluates all top-level imports when loading a module, even if the consumer only uses `json` from it. The confluence-connector was missing `typeid-js` in its dependencies, causing a `MODULE_NOT_FOUND` crash on startup in QA.

## Test plan

- [x] `pnpm --filter confluence-connector run build` passes
- [x] `node -e "require('./dist/config/proxy.config.js')"` loads without crash
- [x] `pnpm --filter confluence-connector run test` passes (301 tests)