### PR TITLE
fix(confluence-connector): downgrade noisy skip logs to debug level

### DIFF
--- a/services/confluence-connector/src/synchronization/__tests__/confluence-content-fetcher.spec.ts
+++ b/services/confluence-connector/src/synchronization/__tests__/confluence-content-fetcher.spec.ts
@@ -156,7 +156,7 @@ describe('ConfluenceContentFetcher', () => {
     const result = await fetcher.fetchPageContent(discoveredPage);
 
     expect(result).toBeNull();
-    expect(mockLogger.log).toHaveBeenCalledWith({
+    expect(mockLogger.debug).toHaveBeenCalledWith({
       pageId: 'empty',
       title: new Smeared('Page empty', false),
       msg: 'Page has no body, skipping',

--- a/services/confluence-connector/src/synchronization/confluence-content-fetcher.ts
+++ b/services/confluence-connector/src/synchronization/confluence-content-fetcher.ts
@@ -36,7 +36,7 @@ export class ConfluenceContentFetcher {
 
     const body = fullPage.body?.storage?.value || '';
     if (!body) {
-      this.logger.log({
+      this.logger.debug({
         pageId: page.id,
         title: page.title,
         msg: 'Page has no body, skipping',


### PR DESCRIPTION
## Summary

Change "Page has no body, skipping" log from `info` to `debug` level. These messages create excessive noise in prod logs when many pages have empty bodies.

"Attachment extension not allowed" was already at `debug` level.

## Test plan

- [x] 301 tests pass