### PR TITLE
fix(confluence-connector): improve observability during long syncs

### DIFF
--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -141,6 +141,144 @@
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "id": 70,
+      "title": "Sync progress",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Current sync phase per tenant. Shows what the connector is doing right now: scanning, diffing, ingesting pages, ingesting attachments, deleting, cleaning up, or idle.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "text", "value": null }]
+          },
+          "mappings": [
+            { "options": { "idle": { "text": "Idle", "color": "gray", "index": 0 } }, "type": "value" },
+            { "options": { "scanning": { "text": "Scanning", "color": "blue", "index": 1 } }, "type": "value" },
+            { "options": { "diffing": { "text": "Diffing", "color": "purple", "index": 2 } }, "type": "value" },
+            { "options": { "ingesting_pages": { "text": "Ingesting pages", "color": "green", "index": 3 } }, "type": "value" },
+            { "options": { "ingesting_attachments": { "text": "Ingesting attachments", "color": "orange", "index": 4 } }, "type": "value" },
+            { "options": { "deleting": { "text": "Deleting", "color": "red", "index": 5 } }, "type": "value" },
+            { "options": { "cleaning_up": { "text": "Cleaning up", "color": "yellow", "index": 6 } }, "type": "value" }
+          ]
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 7 },
+      "id": 71,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "topk(1, cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"}) by (tenant, phase) * on(tenant, phase) group_left cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"} == 1",
+          "legendFormat": "{{tenant}} — {{phase}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": { "reducers": ["lastNotNull"] }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [{ "fieldName": "Last *", "config": { "id": "equal", "options": { "value": 1 } } }],
+            "type": "include",
+            "match": "any"
+          }
+        }
+      ],
+      "title": "Current sync phase",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Pages processed vs total pages to process. Shows ingestion progress during a long sync.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "noValue": "0"
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 7 },
+      "id": 72,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cfc_pages_processed_total{job=~\"$job\", tenant=~\"$tenant\", result=\"success\"}) or vector(0)",
+          "legendFormat": "Processed",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cfc_sync_pages_total{job=~\"$job\", tenant=~\"$tenant\"}) or vector(0)",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Pages: processed / total",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Attachments processed vs total attachments to process. Shows ingestion progress during a long sync.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "noValue": "0"
+        }
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 7 },
+      "id": 73,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cfc_attachments_processed_total{job=~\"$job\", tenant=~\"$tenant\", result=\"success\"}) or vector(0)",
+          "legendFormat": "Processed",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(cfc_sync_attachments_total{job=~\"$job\", tenant=~\"$tenant\"}) or vector(0)",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Attachments: processed / total",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 12 },
       "id": 1,
       "title": "Sync pipeline",
       "type": "row"

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -176,7 +176,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Pages processed vs total pages to process in the current sync. Processed includes successful + failed + skipped.",
+      "description": "Pages processed vs total pages to process in the current sync. Processed includes successful + failed + skipped. Processed is summed over the dashboard time range ($__range) so widen the range to cover the full sync for long initial syncs (e.g. 24h). Total is a point-in-time gauge for the current or most recent sync that had work. It persists across no-change syncs.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -214,7 +214,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Attachments processed vs total attachments to process in the current sync. Processed includes successful + failed.",
+      "description": "Attachments processed vs total attachments to process in the current sync. Processed includes successful + failed. Processed is summed over the dashboard time range ($__range) so widen the range to cover the full sync for long initial syncs (e.g. 24h). Total is a point-in-time gauge for the current or most recent sync that had work. It persists across no-change syncs.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -147,23 +147,11 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Current sync phase per tenant. Shows what the connector is doing right now: scanning, diffing, ingesting pages, ingesting attachments, deleting, cleaning up, or idle.",
+      "description": "Current sync phase per tenant. Shows what the connector is doing right now.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "text", "value": null }]
-          },
-          "mappings": [
-            { "options": { "idle": { "text": "Idle", "color": "gray", "index": 0 } }, "type": "value" },
-            { "options": { "scanning": { "text": "Scanning", "color": "blue", "index": 1 } }, "type": "value" },
-            { "options": { "diffing": { "text": "Diffing", "color": "purple", "index": 2 } }, "type": "value" },
-            { "options": { "ingesting_pages": { "text": "Ingesting pages", "color": "green", "index": 3 } }, "type": "value" },
-            { "options": { "ingesting_attachments": { "text": "Ingesting attachments", "color": "orange", "index": 4 } }, "type": "value" },
-            { "options": { "deleting": { "text": "Deleting", "color": "red", "index": 5 } }, "type": "value" },
-            { "options": { "cleaning_up": { "text": "Cleaning up", "color": "yellow", "index": 6 } }, "type": "value" }
-          ]
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "noValue": "Idle"
         }
       },
       "gridPos": { "h": 5, "w": 8, "x": 0, "y": 7 },
@@ -172,29 +160,15 @@
         "colorMode": "background_solid",
         "graphMode": "none",
         "reduceOptions": { "calcs": ["lastNotNull"] },
-        "textMode": "auto"
+        "textMode": "name"
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "topk(1, cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"}) by (tenant, phase) * on(tenant, phase) group_left cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"} == 1",
-          "legendFormat": "{{tenant}} — {{phase}}",
+          "expr": "cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"} == 1",
+          "legendFormat": "{{tenant}}: {{phase}}",
           "refId": "A",
           "instant": true
-        }
-      ],
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": { "reducers": ["lastNotNull"] }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [{ "fieldName": "Last *", "config": { "id": "equal", "options": { "value": 1 } } }],
-            "type": "include",
-            "match": "any"
-          }
         }
       ],
       "title": "Current sync phase",
@@ -202,7 +176,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Pages processed vs total pages to process. Shows ingestion progress during a long sync.",
+      "description": "Pages processed vs total pages to process in the current sync. Processed includes successful + failed + skipped.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -224,7 +198,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(cfc_pages_processed_total{job=~\"$job\", tenant=~\"$tenant\", result=\"success\"}) or vector(0)",
+          "expr": "round(sum(increase(cfc_pages_processed_total{job=~\"$job\", tenant=~\"$tenant\"}[$__range]))) or vector(0)",
           "legendFormat": "Processed",
           "refId": "A"
         },
@@ -240,7 +214,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "description": "Attachments processed vs total attachments to process. Shows ingestion progress during a long sync.",
+      "description": "Attachments processed vs total attachments to process in the current sync. Processed includes successful + failed.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -262,7 +236,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(cfc_attachments_processed_total{job=~\"$job\", tenant=~\"$tenant\", result=\"success\"}) or vector(0)",
+          "expr": "round(sum(increase(cfc_attachments_processed_total{job=~\"$job\", tenant=~\"$tenant\"}[$__range]))) or vector(0)",
           "legendFormat": "Processed",
           "refId": "A"
         },

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -274,7 +274,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 7 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 13 },
       "id": 2,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -308,7 +308,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 7 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 13 },
       "id": 3,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -327,7 +327,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
       "id": 10,
       "title": "Content throughput",
       "type": "row"
@@ -347,7 +347,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 17 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 23 },
       "id": 11,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -385,7 +385,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 17 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 23 },
       "id": 12,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -416,7 +416,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 26 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
       "id": 60,
       "title": "Space cleanup",
       "type": "row"
@@ -436,7 +436,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 27 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 33 },
       "id": 61,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -474,7 +474,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 27 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 33 },
       "id": 62,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -493,7 +493,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 42 },
       "id": 20,
       "title": "Attachment uploads",
       "type": "row"
@@ -515,7 +515,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 37 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 43 },
       "id": 21,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -558,7 +558,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 46 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 52 },
       "id": 30,
       "title": "Confluence API performance",
       "type": "row"
@@ -580,7 +580,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 47 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 53 },
       "id": 31,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -612,7 +612,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 47 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 53 },
       "id": 32,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -637,7 +637,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 62 },
       "id": 35,
       "title": "Unique API performance",
       "type": "row"
@@ -659,7 +659,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 57 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 63 },
       "id": 36,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -691,7 +691,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 57 },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 63 },
       "id": 37,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
@@ -710,7 +710,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 72 },
       "id": 50,
       "panels": [],
       "title": "Node.js runtime",
@@ -732,7 +732,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 67 },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 73 },
       "id": 51,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -765,7 +765,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 67 },
+      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 73 },
       "id": 52,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -798,7 +798,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 67 },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 73 },
       "id": 53,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -165,7 +165,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\"} == 1",
+          "expr": "cfc_sync_phase{job=~\"$job\", tenant=~\"$tenant\", phase!=\"idle\"} == 1",
           "legendFormat": "{{tenant}}: {{phase}}",
           "refId": "A",
           "instant": true
@@ -274,7 +274,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 13 },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 13 },
       "id": 2,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -308,7 +308,7 @@
           "min": 0
         }
       },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 13 },
+      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 13 },
       "id": 3,
       "options": {
         "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
@@ -323,6 +323,44 @@
         }
       ],
       "title": "Confluence scan duration per tenant",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Sync completion outcomes per tenant, recorded when each sync cycle finishes. Failure spikes may indicate auth, Confluence API, or ingestion errors. Cross-check the 'API errors and throttling' panel and application logs for root cause.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "stacking": { "mode": "normal" }
+          },
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 13 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "round(sum(increase(cfc_sync_duration_seconds_count{job=~\"$job\", tenant=~\"$tenant\", result=\"success\"}[1m])) by (tenant))",
+          "legendFormat": "{{tenant}} — success",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "round(sum(increase(cfc_sync_duration_seconds_count{job=~\"$job\", tenant=~\"$tenant\", result=\"failure\"}[1m])) by (tenant))",
+          "legendFormat": "{{tenant}} — failure",
+          "refId": "B"
+        }
+      ],
+      "title": "Sync outcomes per tenant (in 1 minute)",
       "type": "timeseries"
     },
     {
@@ -866,7 +904,7 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": { "from": "now-24h", "to": "now" },
   "timezone": "",
   "title": "Confluence Connector",
   "uid": "confluence-connector",

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/files/grafana-dashboard.json
@@ -726,12 +726,12 @@
       },
       {
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
-        "definition": "label_values(cfc_sync_duration_seconds_count, job)",
+        "definition": "label_values(cfc_pages_processed_total, job)",
         "includeAll": false,
         "label": "Job",
         "name": "job",
         "query": {
-          "query": "label_values(cfc_sync_duration_seconds_count, job)",
+          "query": "label_values(cfc_pages_processed_total, job)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -740,12 +740,12 @@
       },
       {
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
-        "definition": "label_values(cfc_sync_duration_seconds_count, tenant)",
+        "definition": "label_values(cfc_pages_processed_total, tenant)",
         "includeAll": true,
         "label": "Tenant",
         "name": "tenant",
         "query": {
-          "query": "label_values(cfc_sync_duration_seconds_count, tenant)",
+          "query": "label_values(cfc_pages_processed_total, tenant)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/services/confluence-connector/src/metrics/__mocks__/noop-metrics.ts
+++ b/services/confluence-connector/src/metrics/__mocks__/noop-metrics.ts
@@ -24,6 +24,8 @@ export function createNoopMetrics(): Metrics {
     recordApiThrottleEvent: noop,
     recordOrphanedScopesCleaned: noop,
     recordOrphanedFilesCleaned: noop,
+    setSyncPhase: noop,
+    recordSyncItemTotals: noop,
     initializeCounters: noop,
   };
 

--- a/services/confluence-connector/src/metrics/index.ts
+++ b/services/confluence-connector/src/metrics/index.ts
@@ -1,2 +1,2 @@
 export { MetricsModule } from './metrics.module';
-export { Metrics } from './metrics.service';
+export { Metrics, SyncPhase } from './metrics.service';

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -144,7 +144,7 @@ export class Metrics {
     this.scanDuration.record(durationSeconds, { tenant: this.tenantName });
   }
 
-  public recordPagesProcessed(count: number, result: 'success' | 'failure'): void {
+  public recordPagesProcessed(count: number, result: 'success' | 'failure' | 'skipped'): void {
     this.pagesProcessed.add(count, { tenant: this.tenantName, result });
   }
 
@@ -229,6 +229,7 @@ export class Metrics {
     const tenant = { tenant: this.tenantName };
     this.pagesProcessed.add(0, { ...tenant, result: 'success' });
     this.pagesProcessed.add(0, { ...tenant, result: 'failure' });
+    this.pagesProcessed.add(0, { ...tenant, result: 'skipped' });
     this.attachmentsProcessed.add(0, { ...tenant, result: 'success' });
     this.attachmentsProcessed.add(0, { ...tenant, result: 'failure' });
     this.contentDeleted.add(0, { ...tenant, result: 'success' });

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -1,6 +1,6 @@
 import { getHttpStatusCodeClass } from '@unique-ag/utils';
 import { Injectable } from '@nestjs/common';
-import type { Counter, Histogram, ObservableGauge } from '@opentelemetry/api';
+import type { Counter, Histogram } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
 import { getCurrentTenant } from '../tenant';
 

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -4,14 +4,15 @@ import type { Counter, Histogram, ObservableGauge } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
 import { getCurrentTenant } from '../tenant';
 
-export type SyncPhase =
-  | 'idle'
-  | 'scanning'
-  | 'diffing'
-  | 'ingesting_pages'
-  | 'ingesting_attachments'
-  | 'deleting'
-  | 'cleaning_up';
+export enum SyncPhase {
+  Idle = 'idle',
+  Scanning = 'scanning',
+  Diffing = 'diffing',
+  IngestingPages = 'ingesting_pages',
+  IngestingAttachments = 'ingesting_attachments',
+  Deleting = 'deleting',
+  CleaningUp = 'cleaning_up',
+}
 
 @Injectable()
 export class Metrics {

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -223,10 +223,12 @@ export class Metrics {
   /**
    * Initializes all counters for the current tenant by recording a zero value. This ensures
    * Prometheus scrapes a baseline before the first sync, so that `increase()` can compute a
-   * correct delta from 0 -> N on the first sync cycle after startup.
+   * correct delta from 0 -> N on the first sync cycle after startup. Also seeds the
+   * observable-gauge state maps so the sync-progress panels have data before the first sync.
    */
   public initializeCounters(): void {
-    const tenant = { tenant: this.tenantName };
+    const tenantName = this.tenantName;
+    const tenant = { tenant: tenantName };
     this.pagesProcessed.add(0, { ...tenant, result: 'success' });
     this.pagesProcessed.add(0, { ...tenant, result: 'failure' });
     this.pagesProcessed.add(0, { ...tenant, result: 'skipped' });
@@ -242,5 +244,7 @@ export class Metrics {
     this.orphanedScopesCleaned.add(0, { ...tenant, result: 'success' });
     this.orphanedScopesCleaned.add(0, { ...tenant, result: 'failure' });
     this.orphanedFilesCleaned.add(0, tenant);
+    this.syncPhaseState.set(tenantName, SyncPhase.Idle);
+    this.syncItemTotals.set(tenantName, { pages: 0, attachments: 0 });
   }
 }

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -28,10 +28,9 @@ export class Metrics {
   private readonly confluenceApiErrors: Counter;
   private readonly orphanedScopesCleaned: Counter;
   private readonly orphanedFilesCleaned: Counter;
-  private readonly syncPagesTotal: Counter;
-  private readonly syncAttachmentsTotal: Counter;
 
   private readonly syncPhaseState = new Map<string, SyncPhase>();
+  private readonly syncItemTotals = new Map<string, { pages: number; attachments: number }>();
 
   public constructor(metricService: MetricService) {
     this.syncDuration = metricService.getHistogram('cfc_sync_duration_seconds', {
@@ -97,21 +96,35 @@ export class Metrics {
       description: 'Number of files deleted during orphaned space cleanup',
     });
 
-    this.syncPagesTotal = metricService.getCounter('cfc_sync_pages_total', {
-      description: 'Total number of pages to process in the current sync cycle (set after diff)',
-    });
-
-    this.syncAttachmentsTotal = metricService.getCounter('cfc_sync_attachments_total', {
-      description:
-        'Total number of attachments to process in the current sync cycle (set after diff)',
-    });
-
     const syncPhaseGauge = metricService.getObservableGauge('cfc_sync_phase', {
-      description: 'Current sync phase (1 = active). Labels: tenant, phase',
+      description: 'Current sync phase (1 = active, 0 = inactive). Labels: tenant, phase',
     });
     syncPhaseGauge.addCallback((observable) => {
-      for (const [tenant, phase] of this.syncPhaseState) {
-        observable.observe(1, { tenant, phase });
+      for (const [tenant, currentPhase] of this.syncPhaseState) {
+        for (const phase of Object.values(SyncPhase)) {
+          observable.observe(phase === currentPhase ? 1 : 0, { tenant, phase });
+        }
+      }
+    });
+
+    const syncPagesTotalGauge = metricService.getObservableGauge('cfc_sync_pages_total', {
+      description: 'Number of pages to process in the current sync cycle',
+    });
+    syncPagesTotalGauge.addCallback((observable) => {
+      for (const [tenant, totals] of this.syncItemTotals) {
+        observable.observe(totals.pages, { tenant });
+      }
+    });
+
+    const syncAttachmentsTotalGauge = metricService.getObservableGauge(
+      'cfc_sync_attachments_total',
+      {
+        description: 'Number of attachments to process in the current sync cycle',
+      },
+    );
+    syncAttachmentsTotalGauge.addCallback((observable) => {
+      for (const [tenant, totals] of this.syncItemTotals) {
+        observable.observe(totals.attachments, { tenant });
       }
     });
   }
@@ -191,8 +204,7 @@ export class Metrics {
   }
 
   public recordSyncItemTotals(pages: number, attachments: number): void {
-    this.syncPagesTotal.add(pages, { tenant: this.tenantName });
-    this.syncAttachmentsTotal.add(attachments, { tenant: this.tenantName });
+    this.syncItemTotals.set(this.tenantName, { pages, attachments });
   }
 
   public recordApiThrottleEvent(): void {

--- a/services/confluence-connector/src/metrics/metrics.service.ts
+++ b/services/confluence-connector/src/metrics/metrics.service.ts
@@ -1,8 +1,17 @@
 import { getHttpStatusCodeClass } from '@unique-ag/utils';
 import { Injectable } from '@nestjs/common';
-import type { Counter, Histogram } from '@opentelemetry/api';
+import type { Counter, Histogram, ObservableGauge } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
 import { getCurrentTenant } from '../tenant';
+
+export type SyncPhase =
+  | 'idle'
+  | 'scanning'
+  | 'diffing'
+  | 'ingesting_pages'
+  | 'ingesting_attachments'
+  | 'deleting'
+  | 'cleaning_up';
 
 @Injectable()
 export class Metrics {
@@ -18,6 +27,10 @@ export class Metrics {
   private readonly confluenceApiErrors: Counter;
   private readonly orphanedScopesCleaned: Counter;
   private readonly orphanedFilesCleaned: Counter;
+  private readonly syncPagesTotal: Counter;
+  private readonly syncAttachmentsTotal: Counter;
+
+  private readonly syncPhaseState = new Map<string, SyncPhase>();
 
   public constructor(metricService: MetricService) {
     this.syncDuration = metricService.getHistogram('cfc_sync_duration_seconds', {
@@ -81,6 +94,24 @@ export class Metrics {
 
     this.orphanedFilesCleaned = metricService.getCounter('cfc_orphaned_files_cleaned_total', {
       description: 'Number of files deleted during orphaned space cleanup',
+    });
+
+    this.syncPagesTotal = metricService.getCounter('cfc_sync_pages_total', {
+      description: 'Total number of pages to process in the current sync cycle (set after diff)',
+    });
+
+    this.syncAttachmentsTotal = metricService.getCounter('cfc_sync_attachments_total', {
+      description:
+        'Total number of attachments to process in the current sync cycle (set after diff)',
+    });
+
+    const syncPhaseGauge = metricService.getObservableGauge('cfc_sync_phase', {
+      description: 'Current sync phase (1 = active). Labels: tenant, phase',
+    });
+    syncPhaseGauge.addCallback((observable) => {
+      for (const [tenant, phase] of this.syncPhaseState) {
+        observable.observe(1, { tenant, phase });
+      }
     });
   }
 
@@ -152,6 +183,15 @@ export class Metrics {
 
   public recordOrphanedFilesCleaned(count: number): void {
     this.orphanedFilesCleaned.add(count, { tenant: this.tenantName });
+  }
+
+  public setSyncPhase(phase: SyncPhase): void {
+    this.syncPhaseState.set(this.tenantName, phase);
+  }
+
+  public recordSyncItemTotals(pages: number, attachments: number): void {
+    this.syncPagesTotal.add(pages, { tenant: this.tenantName });
+    this.syncAttachmentsTotal.add(attachments, { tenant: this.tenantName });
   }
 
   public recordApiThrottleEvent(): void {

--- a/services/confluence-connector/src/synchronization/__tests__/confluence-synchronization.service.spec.ts
+++ b/services/confluence-connector/src/synchronization/__tests__/confluence-synchronization.service.spec.ts
@@ -170,6 +170,7 @@ describe('ConfluenceSynchronizationService', () => {
       expect(mockLogger.log).toHaveBeenCalledWith({
         total: 1,
         ingested: 0,
+        skipped: 0,
         failed: 1,
         msg: 'Page ingestion summary',
       });

--- a/services/confluence-connector/src/synchronization/__tests__/confluence-synchronization.service.spec.ts
+++ b/services/confluence-connector/src/synchronization/__tests__/confluence-synchronization.service.spec.ts
@@ -1,5 +1,6 @@
 import { Smeared } from '@unique-ag/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Metrics, SyncPhase } from '../../metrics';
 import { createNoopMetrics } from '../../metrics/__mocks__/noop-metrics';
 import type { TenantContext } from '../../tenant/tenant-context.interface';
 import { tenantStorage } from '../../tenant/tenant-context.storage';
@@ -47,6 +48,7 @@ function createService(
     IngestionService,
     'ingestPage' | 'ingestAttachment' | 'deleteContentByKeys'
   >,
+  metrics: Metrics = createNoopMetrics(),
 ): ConfluenceSynchronizationService {
   return new ConfluenceSynchronizationService(
     scanner as ConfluencePageScanner,
@@ -54,8 +56,17 @@ function createService(
     fileDiffService as FileDiffService,
     ingestionService as IngestionService,
     mockScopeManagementService,
-    createNoopMetrics(),
+    metrics,
   );
+}
+
+function createMetricsSpy(): Metrics {
+  const base = createNoopMetrics();
+  const spy = { ...base } as Record<string, unknown>;
+  for (const key of Object.keys(spy)) {
+    spy[key] = vi.fn();
+  }
+  return spy as unknown as Metrics;
 }
 
 describe('ConfluenceSynchronizationService', () => {
@@ -459,6 +470,199 @@ describe('ConfluenceSynchronizationService', () => {
         msg: 'Attachment ingestion summary',
       });
       expect(mockLogger.log).toHaveBeenCalledWith({ msg: 'Sync work done' });
+    });
+  });
+
+  describe('metrics', () => {
+    it('records pages per item with success, failure, and skipped results', async () => {
+      // biome-ignore lint/style/noNonNullAssertion: fixture has at least one entry by construction
+      const baseDiscovered = discoveredPagesFixture[0]!;
+      const discovered = [
+        { ...baseDiscovered, id: 'ok' },
+        { ...baseDiscovered, id: 'skip' },
+        { ...baseDiscovered, id: 'fail' },
+      ];
+      vi.mocked(mockScanner.discoverPages).mockResolvedValue({
+        pages: discovered,
+        attachments: [],
+      });
+      vi.mocked(mockFileDiffService.computeDiff).mockResolvedValue({
+        newItemIds: ['ok', 'skip', 'fail'],
+        updatedItemIds: [],
+        deletedItems: [],
+        movedItemIds: [],
+      });
+      // biome-ignore lint/style/noNonNullAssertion: fixture has at least one entry by construction
+      const baseFetched = fetchedPagesFixture[0]!;
+      vi.mocked(mockContentFetcher.fetchPageContent).mockImplementation((page: { id: string }) => {
+        if (page.id === 'skip') {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve({ ...baseFetched, id: page.id });
+      });
+      vi.mocked(mockIngestionService.ingestPage).mockImplementation(
+        ({ id }: { id: string }): Promise<void> => {
+          if (id === 'fail') {
+            return Promise.reject(new Error('boom'));
+          }
+          return Promise.resolve();
+        },
+      );
+
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      expect(metrics.recordPagesProcessed).toHaveBeenCalledWith(1, 'success');
+      expect(metrics.recordPagesProcessed).toHaveBeenCalledWith(1, 'skipped');
+      expect(metrics.recordPagesProcessed).toHaveBeenCalledWith(1, 'failure');
+      expect(vi.mocked(metrics.recordPagesProcessed).mock.calls).toHaveLength(3);
+    });
+
+    it('records attachments per item with success and failure results', async () => {
+      const mkAttachment = (id: string): DiscoveredAttachment => ({
+        id,
+        title: `${id}.pdf`,
+        mediaType: 'application/pdf',
+        fileSize: 1,
+        downloadPath: `/download/attachments/1/${id}.pdf`,
+        versionTimestamp: '2026-02-01T00:00:00.000Z',
+        pageId: '1',
+        spaceId: 'space-1',
+        spaceKey: 'SP',
+        spaceName: 'Space',
+        webUrl: `${CONFLUENCE_BASE_URL}/wiki/spaces/SP/pages/1/attachments/${id}`,
+      });
+      vi.mocked(mockScanner.discoverPages).mockResolvedValue({
+        pages: [],
+        attachments: [mkAttachment('ok'), mkAttachment('fail')],
+      });
+      vi.mocked(mockFileDiffService.computeDiff).mockResolvedValue({
+        newItemIds: ['1::ok', '1::fail'],
+        updatedItemIds: [],
+        deletedItems: [],
+        movedItemIds: [],
+      });
+      vi.mocked(mockIngestionService.ingestAttachment).mockImplementation(
+        (attachment: { id: string }): Promise<void> => {
+          if (attachment.id === 'fail') {
+            return Promise.reject(new Error('boom'));
+          }
+          return Promise.resolve();
+        },
+      );
+
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      expect(metrics.recordAttachmentsProcessed).toHaveBeenCalledWith(1, 'success');
+      expect(metrics.recordAttachmentsProcessed).toHaveBeenCalledWith(1, 'failure');
+      expect(vi.mocked(metrics.recordAttachmentsProcessed).mock.calls).toHaveLength(2);
+    });
+
+    it('walks through sync phases and ends on Idle', async () => {
+      vi.mocked(mockFileDiffService.computeDiff).mockResolvedValue({
+        newItemIds: ['1'],
+        updatedItemIds: [],
+        deletedItems: [{ id: '9', partialKey: 'test-tenant/space-1_SP' }],
+        movedItemIds: [],
+      });
+
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      const phaseCalls = vi
+        .mocked(metrics.setSyncPhase)
+        .mock.calls.map((args: unknown[]) => args[0]);
+      expect(phaseCalls).toEqual([
+        SyncPhase.Scanning,
+        SyncPhase.Diffing,
+        SyncPhase.IngestingPages,
+        SyncPhase.IngestingAttachments,
+        SyncPhase.Deleting,
+        SyncPhase.CleaningUp,
+        SyncPhase.Idle,
+      ]);
+    });
+
+    it('ends on Idle even when sync fails mid-way', async () => {
+      vi.mocked(mockFileDiffService.computeDiff).mockRejectedValue(new Error('diff boom'));
+
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      const phaseCalls = vi
+        .mocked(metrics.setSyncPhase)
+        .mock.calls.map((args: unknown[]) => args[0]);
+      expect(phaseCalls.at(-1)).toBe(SyncPhase.Idle);
+    });
+
+    it('records sync item totals when there is work to do', async () => {
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      expect(metrics.recordSyncItemTotals).toHaveBeenCalledWith(1, 0);
+    });
+
+    it('does not reset sync item totals on a no-change sync', async () => {
+      vi.mocked(mockFileDiffService.computeDiff).mockResolvedValue({
+        newItemIds: [],
+        updatedItemIds: [],
+        deletedItems: [],
+        movedItemIds: [],
+      });
+
+      const metrics = createMetricsSpy();
+      const svc = createService(
+        mockScanner,
+        mockContentFetcher,
+        mockFileDiffService,
+        mockIngestionService,
+        metrics,
+      );
+
+      await tenantStorage.run(tenant, () => svc.synchronize());
+
+      expect(metrics.recordSyncItemTotals).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -146,6 +146,7 @@ export class ConfluenceSynchronizationService {
 
           if (!fetched) {
             skipped++;
+            this.metrics.recordPagesProcessed(1, 'skipped');
             return;
           }
           const scopeId = spaceScopes.get(page.spaceKey);

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -43,6 +43,7 @@ export class ConfluenceSynchronizationService {
     try {
       this.logger.log({ tenantName: tenant.name, msg: 'Starting sync' });
 
+      this.metrics.setSyncPhase('scanning');
       const rootScopePath = await this.scopeManagementService.initialize();
 
       const scanStartTime = Date.now();
@@ -54,6 +55,7 @@ export class ConfluenceSynchronizationService {
         msg: 'Discovery completed',
       });
 
+      this.metrics.setSyncPhase('diffing');
       const allSpaceKeyToSpaceId = this.buildSpaceKeyToSpaceIdMap(
         discoveredPages,
         discoveredAttachments,
@@ -70,6 +72,8 @@ export class ConfluenceSynchronizationService {
         itemIdsToProcess.has(`${a.pageId}::${a.id}`),
       );
 
+      this.metrics.recordSyncItemTotals(pagesToFetch.length, attachmentsToIngest.length);
+
       if (pagesToFetch.length > 0 || attachmentsToIngest.length > 0) {
         const spaceKeys = [
           ...new Set([
@@ -85,11 +89,16 @@ export class ConfluenceSynchronizationService {
         );
 
         const concurrency = tenant.config.processing.concurrency;
+
+        this.metrics.setSyncPhase('ingesting_pages');
         await this.fetchAndIngestPages(pagesToFetch, spaceScopes, concurrency);
+
+        this.metrics.setSyncPhase('ingesting_attachments');
         await this.ingestAttachments(attachmentsToIngest, spaceScopes, concurrency);
       }
 
       if (diffResult.deletedItems.length > 0) {
+        this.metrics.setSyncPhase('deleting');
         const contentKeys = diffResult.deletedItems.map((item) => `${item.partialKey}/${item.id}`);
         const deletedCount = await this.ingestionService.deleteContentByKeys(contentKeys);
         this.logger.log({
@@ -99,6 +108,7 @@ export class ConfluenceSynchronizationService {
         });
       }
 
+      this.metrics.setSyncPhase('cleaning_up');
       await this.scopeManagementService.cleanupRemovedSpaces(new Set(allSpaceKeyToSpaceId.keys()));
 
       this.logger.log({ msg: 'Sync work done' });
@@ -107,6 +117,7 @@ export class ConfluenceSynchronizationService {
       this.logger.error({ err: error, msg: 'Sync failed' });
     } finally {
       tenant.isScanning = false;
+      this.metrics.setSyncPhase('idle');
       this.metrics.recordSyncDuration(elapsedSeconds(startTime), syncResult);
     }
   }

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -139,6 +139,10 @@ export class ConfluenceSynchronizationService {
           assert.ok(scopeId, `No scope resolved for space: ${page.spaceKey}`);
           await this.ingestionService.ingestPage(fetched, scopeId);
           ingested++;
+          this.metrics.recordPagesProcessed(1, 'success');
+        }).catch((err) => {
+          this.metrics.recordPagesProcessed(1, 'failure');
+          throw err;
         }).finally(() => {
           processed++;
           if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
@@ -153,9 +157,6 @@ export class ConfluenceSynchronizationService {
     );
 
     const failed = pages.length - ingested;
-
-    this.metrics.recordPagesProcessed(ingested, 'success');
-    this.metrics.recordPagesProcessed(failed, 'failure');
 
     this.logger.log({
       total: pages.length,
@@ -187,6 +188,10 @@ export class ConfluenceSynchronizationService {
           assert.ok(scopeId, `No scope resolved for space: ${attachment.spaceKey}`);
           await this.ingestionService.ingestAttachment(attachment, scopeId);
           ingested++;
+          this.metrics.recordAttachmentsProcessed(1, 'success');
+        }).catch((err) => {
+          this.metrics.recordAttachmentsProcessed(1, 'failure');
+          throw err;
         }).finally(() => {
           processed++;
           if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
@@ -201,8 +206,6 @@ export class ConfluenceSynchronizationService {
     );
 
     const failed = attachments.length - ingested;
-    this.metrics.recordAttachmentsProcessed(ingested, 'success');
-    this.metrics.recordAttachmentsProcessed(failed, 'failure');
 
     this.logger.log({
       total: attachments.length,

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { elapsedSeconds } from '@unique-ag/utils';
 import { Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
-import type { Metrics } from '../metrics';
+import { SyncPhase, type Metrics } from '../metrics';
 import { getCurrentTenant } from '../tenant';
 import type { ConfluenceContentFetcher } from './confluence-content-fetcher';
 import type { ConfluencePageScanner } from './confluence-page-scanner';
@@ -43,7 +43,7 @@ export class ConfluenceSynchronizationService {
     try {
       this.logger.log({ tenantName: tenant.name, msg: 'Starting sync' });
 
-      this.metrics.setSyncPhase('scanning');
+      this.metrics.setSyncPhase(SyncPhase.Scanning);
       const rootScopePath = await this.scopeManagementService.initialize();
 
       const scanStartTime = Date.now();
@@ -55,7 +55,7 @@ export class ConfluenceSynchronizationService {
         msg: 'Discovery completed',
       });
 
-      this.metrics.setSyncPhase('diffing');
+      this.metrics.setSyncPhase(SyncPhase.Diffing);
       const allSpaceKeyToSpaceId = this.buildSpaceKeyToSpaceIdMap(
         discoveredPages,
         discoveredAttachments,
@@ -90,15 +90,15 @@ export class ConfluenceSynchronizationService {
 
         const concurrency = tenant.config.processing.concurrency;
 
-        this.metrics.setSyncPhase('ingesting_pages');
+        this.metrics.setSyncPhase(SyncPhase.IngestingPages);
         await this.fetchAndIngestPages(pagesToFetch, spaceScopes, concurrency);
 
-        this.metrics.setSyncPhase('ingesting_attachments');
+        this.metrics.setSyncPhase(SyncPhase.IngestingAttachments);
         await this.ingestAttachments(attachmentsToIngest, spaceScopes, concurrency);
       }
 
       if (diffResult.deletedItems.length > 0) {
-        this.metrics.setSyncPhase('deleting');
+        this.metrics.setSyncPhase(SyncPhase.Deleting);
         const contentKeys = diffResult.deletedItems.map((item) => `${item.partialKey}/${item.id}`);
         const deletedCount = await this.ingestionService.deleteContentByKeys(contentKeys);
         this.logger.log({
@@ -108,7 +108,7 @@ export class ConfluenceSynchronizationService {
         });
       }
 
-      this.metrics.setSyncPhase('cleaning_up');
+      this.metrics.setSyncPhase(SyncPhase.CleaningUp);
       await this.scopeManagementService.cleanupRemovedSpaces(new Set(allSpaceKeyToSpaceId.keys()));
 
       this.logger.log({ msg: 'Sync work done' });
@@ -117,7 +117,7 @@ export class ConfluenceSynchronizationService {
       this.logger.error({ err: error, msg: 'Sync failed' });
     } finally {
       tenant.isScanning = false;
-      this.metrics.setSyncPhase('idle');
+      this.metrics.setSyncPhase(SyncPhase.Idle);
       this.metrics.recordSyncDuration(elapsedSeconds(startTime), syncResult);
     }
   }

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -125,6 +125,7 @@ export class ConfluenceSynchronizationService {
 
     let processed = 0;
     let ingested = 0;
+    let skipped = 0;
     const total = pages.length;
 
     await Promise.allSettled(
@@ -133,6 +134,7 @@ export class ConfluenceSynchronizationService {
           const fetched = await this.contentFetcher.fetchPageContent(page);
 
           if (!fetched) {
+            skipped++;
             return;
           }
           const scopeId = spaceScopes.get(page.spaceKey);
@@ -156,11 +158,12 @@ export class ConfluenceSynchronizationService {
       ),
     );
 
-    const failed = pages.length - ingested;
+    const failed = pages.length - ingested - skipped;
 
     this.logger.log({
       total: pages.length,
       ingested,
+      skipped,
       failed,
       msg: 'Page ingestion summary',
     });

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { elapsedSeconds } from '@unique-ag/utils';
 import { Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
-import { SyncPhase, type Metrics } from '../metrics';
+import { type Metrics, SyncPhase } from '../metrics';
 import { getCurrentTenant } from '../tenant';
 import type { ConfluenceContentFetcher } from './confluence-content-fetcher';
 import type { ConfluencePageScanner } from './confluence-page-scanner';
@@ -154,19 +154,21 @@ export class ConfluenceSynchronizationService {
           await this.ingestionService.ingestPage(fetched, scopeId);
           ingested++;
           this.metrics.recordPagesProcessed(1, 'success');
-        }).catch((err) => {
-          this.metrics.recordPagesProcessed(1, 'failure');
-          throw err;
-        }).finally(() => {
-          processed++;
-          if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
-            this.logger.log({
-              processed,
-              total,
-              msg: 'Page ingestion in progress',
-            });
-          }
-        }),
+        })
+          .catch((err) => {
+            this.metrics.recordPagesProcessed(1, 'failure');
+            throw err;
+          })
+          .finally(() => {
+            processed++;
+            if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
+              this.logger.log({
+                processed,
+                total,
+                msg: 'Page ingestion in progress',
+              });
+            }
+          }),
       ),
     );
 
@@ -204,19 +206,21 @@ export class ConfluenceSynchronizationService {
           await this.ingestionService.ingestAttachment(attachment, scopeId);
           ingested++;
           this.metrics.recordAttachmentsProcessed(1, 'success');
-        }).catch((err) => {
-          this.metrics.recordAttachmentsProcessed(1, 'failure');
-          throw err;
-        }).finally(() => {
-          processed++;
-          if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
-            this.logger.log({
-              processed,
-              total,
-              msg: 'Attachment ingestion in progress',
-            });
-          }
-        }),
+        })
+          .catch((err) => {
+            this.metrics.recordAttachmentsProcessed(1, 'failure');
+            throw err;
+          })
+          .finally(() => {
+            processed++;
+            if (processed % INGESTION_PROGRESS_LOG_INTERVAL === 0) {
+              this.logger.log({
+                processed,
+                total,
+                msg: 'Attachment ingestion in progress',
+              });
+            }
+          }),
       ),
     );
 

--- a/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
+++ b/services/confluence-connector/src/synchronization/confluence-synchronization.service.ts
@@ -72,9 +72,9 @@ export class ConfluenceSynchronizationService {
         itemIdsToProcess.has(`${a.pageId}::${a.id}`),
       );
 
-      this.metrics.recordSyncItemTotals(pagesToFetch.length, attachmentsToIngest.length);
-
       if (pagesToFetch.length > 0 || attachmentsToIngest.length > 0) {
+        this.metrics.recordSyncItemTotals(pagesToFetch.length, attachmentsToIngest.length);
+
         const spaceKeys = [
           ...new Set([
             ...pagesToFetch.map((p) => p.spaceKey),


### PR DESCRIPTION
## Summary

- Fix dashboard variables to use a metric that exists at startup (not after first sync completes)
- Record page/attachment metrics per-item instead of in bulk at end of sync
- Track skipped pages separately from failures
- Add sync progress panels: current phase, pages processed/total, attachments processed/total
- Add observable gauges for sync phase and item totals

## Problem

During a long initial sync (20+ hours), the Grafana dashboard was completely empty because all metrics were only recorded after the sync finished.

## Test plan

- [x] 301 tests pass
- [x] Type check passes