### PR TITLE
fix(confluence-connector): namespace dashboard configmap key to avoid sidecar file collision

### DIFF
--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/grafana-dashboard.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/grafana-dashboard.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     grafana_folder: {{ .Values.grafana.dashboard.folder | quote }}
 data:
-  dashboard.json: {{ .Files.Get "files/grafana-dashboard.json" | quote }}
+  {{ include "chart.fullname" . }}.json: {{ .Files.Get "files/grafana-dashboard.json" | quote }}
 {{- end }}


### PR DESCRIPTION
The QA dashboard is not the one privisioned by us in this file.... After looking at this for quite some time now with opus it seems that Grafana sidecar writes each `grafana_dashboard=1` ConfigMap to `<folder>/<data-key>`. Our key was `dashboard.json`, same as sharepoint-connector's, in the same `connectors` folder. Both ConfigMaps land at `/tmp/dashboards/connectors/dashboard.json` and overwrite each other every minute.

Fix: template the key with `chart.fullname` so each release writes a unique filename (`confluence-connector-v2.json`). UID unchanged.