### PR TITLE
fix(confluence-connector): request JSON from DC applinks manifest endpoint

### DIFF
--- a/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
+++ b/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
@@ -47,7 +47,7 @@ describe('DataCenterConfluenceApiClient', () => {
   });
 
   describe('resolveInstanceIdentifier', () => {
-    it('calls the applinks manifest endpoint with empty auth headers', async () => {
+    it('calls the applinks manifest endpoint with Accept: application/json and no auth header', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce({
         id: 'dc-instance-uuid',
         name: 'My Confluence',
@@ -57,7 +57,7 @@ describe('DataCenterConfluenceApiClient', () => {
 
       expect(mockHttpClient.rateLimitedRequest).toHaveBeenCalledWith(
         `${BASE_URL}/rest/applinks/1.0/manifest`,
-        {},
+        { Accept: 'application/json' },
       );
     });
 

--- a/services/confluence-connector/src/confluence-api/data-center-api-client.ts
+++ b/services/confluence-connector/src/confluence-api/data-center-api-client.ts
@@ -37,9 +37,12 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
 
   public async resolveInstanceIdentifier(): Promise<InstanceIdentifier> {
     // The manifest endpoint is public and does not require authentication, so we
-    // pass empty headers intentionally (no Authorization header needed).
+    // omit the Authorization header intentionally. Accept must be set explicitly
+    // because the endpoint returns XML by default on Confluence 10.x.
     const url = `${this.config.baseUrl}/rest/applinks/1.0/manifest`;
-    const response = await this.httpClient.rateLimitedRequest(url, {});
+    const response = await this.httpClient.rateLimitedRequest(url, {
+      Accept: 'application/json',
+    });
 
     const manifest = z.object({ id: z.string().min(1) }).safeParse(response);
     assert.ok(


### PR DESCRIPTION
## Summary

On Confluence 10.x, `GET /rest/applinks/1.0/manifest` returns XML by default and only returns JSON when `Accept: application/json` is sent. The DC client passed empty headers, so `body.json()` threw and sync failed before any pages were fetched.

Fix: pass `Accept: application/json` on the manifest request.

## Observed error (dogfood-data-center, QA)

```
SyntaxError: Unexpected token '<', "<?xml vers"... is not valid JSON
  at JSON.parse (<anonymous>)
  at consumeEnd (undici/lib/api/readable.js:527:20)
```

## Reproduction against `confluence.qa.unique.app` (Confluence 10.2.2)

**Before** — `curl https://confluence.qa.unique.app/rest/applinks/1.0/manifest`

```
HTTP/2 200
content-type: application/xml

<?xml version="1.0" encoding="UTF-8" standalone="yes"?><manifest><id>92b23664-...</id><name>Confluence</name>...
```

**After** — same URL with `-H "Accept: application/json"`

```
HTTP/2 200
content-type: application/json

{"id":"92b23664-16d8-3ab3-9ba5-f3a45b057487","name":"Confluence","typeId":"confluence","version":"10.2.2","buildNumber":23509,...}
```

Cloud and other DC endpoints return JSON by default, so this is the only call path affected.

## Test plan

- [x] biome / tsc / vitest (33/33 DC client tests pass)
- [ ] Deploy to QA and confirm `dogfood-data-center` sync proceeds past `resolveInstanceIdentifier`