### PR TITLE
fix(outlook-mcp,outlook-semantic-mcp): reduce metrics cardinality by sanitizing endpoint IDs

### DIFF
--- a/services/outlook-mcp/src/msgraph/metrics.middleware.spec.ts
+++ b/services/outlook-mcp/src/msgraph/metrics.middleware.spec.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetricsMiddleware } from './metrics.middleware';
+
+const mockCounter = { add: vi.fn() };
+const mockHistogram = { record: vi.fn() };
+const mockMetricService = {
+  getCounter: vi.fn().mockReturnValue(mockCounter),
+  getHistogram: vi.fn().mockReturnValue(mockHistogram),
+};
+
+describe('MetricsMiddleware', () => {
+  let unit: MetricsMiddleware;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unit = new MetricsMiddleware(mockMetricService as any);
+  });
+
+  describe('extractEndpoint', () => {
+    it('strips v1.0 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
+        '/me/messages',
+      );
+    });
+
+    it('strips v1 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
+        '/me/messages',
+      );
+    });
+
+    it('strips v2.0 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe(
+        '/users',
+      );
+    });
+
+    it('extracts endpoint from a Request object', () => {
+      const request = new Request('https://graph.microsoft.com/v1.0/me/mailFolders');
+      expect((unit as any).extractEndpoint(request)).toBe('/me/mailFolders');
+    });
+
+    it('returns / for root path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
+    });
+
+    it('returns unknown for an invalid URL', () => {
+      expect((unit as any).extractEndpoint('not-a-url')).toBe('unknown');
+    });
+  });
+
+  describe('sanitizeEndpointForMetrics', () => {
+    it('leaves clean resource names unchanged', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
+    });
+
+    it('leaves childFolders unchanged (12 chars, no digit)', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
+        '/me/mailFolders/childFolders',
+      );
+    });
+
+    it('replaces a UUID segment', () => {
+      expect(
+        (unit as any).sanitizeEndpointForMetrics(
+          '/users/550e8400-e29b-41d4-a716-446655440000/mailFolders',
+        ),
+      ).toBe('/users/:id/mailFolders');
+    });
+
+    it('replaces a long Outlook base64 ID segment containing a digit', () => {
+      const outlookId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
+      expect((unit as any).sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
+        '/me/messages/:id',
+      );
+    });
+
+    it('replaces multiple ID segments in one path', () => {
+      const folderId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
+      const messageId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGBBBBBBB1';
+      expect(
+        (unit as any).sanitizeEndpointForMetrics(`/me/mailFolders/${folderId}/messages/${messageId}`),
+      ).toBe('/me/mailFolders/:id/messages/:id');
+    });
+
+    it('does not replace short alphanumeric segment without digit', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
+    });
+
+    it('preserves empty segments from leading slash', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
+    });
+  });
+});

--- a/services/outlook-mcp/src/msgraph/metrics.middleware.spec.ts
+++ b/services/outlook-mcp/src/msgraph/metrics.middleware.spec.ts
@@ -1,68 +1,74 @@
+import type { MetricService } from 'nestjs-otel';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MetricsMiddleware } from './metrics.middleware';
 
 const mockCounter = { add: vi.fn() };
 const mockHistogram = { record: vi.fn() };
-const mockMetricService = {
+const mockMetricService: Pick<MetricService, 'getCounter' | 'getHistogram'> = {
   getCounter: vi.fn().mockReturnValue(mockCounter),
   getHistogram: vi.fn().mockReturnValue(mockHistogram),
 };
 
+interface MetricsMiddlewareInternals {
+  extractEndpoint(request: RequestInfo): string;
+  sanitizeEndpointForMetrics(endpoint: string): string;
+}
+
 describe('MetricsMiddleware', () => {
   let unit: MetricsMiddleware;
+  let internals: MetricsMiddlewareInternals;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    unit = new MetricsMiddleware(mockMetricService as any);
+    unit = new MetricsMiddleware(mockMetricService as MetricService);
+    internals = unit as unknown as MetricsMiddlewareInternals;
   });
 
   describe('extractEndpoint', () => {
     it('strips v1.0 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
         '/me/messages',
       );
     });
 
     it('strips v1 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
         '/me/messages',
       );
     });
 
     it('strips v2.0 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe(
-        '/users',
-      );
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe('/users');
     });
 
     it('extracts endpoint from a Request object', () => {
       const request = new Request('https://graph.microsoft.com/v1.0/me/mailFolders');
-      expect((unit as any).extractEndpoint(request)).toBe('/me/mailFolders');
+      expect(internals.extractEndpoint(request)).toBe('/me/mailFolders');
     });
 
     it('returns / for root path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
     });
 
     it('returns unknown for an invalid URL', () => {
-      expect((unit as any).extractEndpoint('not-a-url')).toBe('unknown');
+      expect(internals.extractEndpoint('not-a-url')).toBe('unknown');
     });
   });
 
   describe('sanitizeEndpointForMetrics', () => {
     it('leaves clean resource names unchanged', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
+      expect(internals.sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
     });
 
     it('leaves childFolders unchanged (12 chars, no digit)', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
+      expect(internals.sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
         '/me/mailFolders/childFolders',
       );
     });
 
     it('replaces a UUID segment', () => {
       expect(
-        (unit as any).sanitizeEndpointForMetrics(
+        internals.sanitizeEndpointForMetrics(
           '/users/550e8400-e29b-41d4-a716-446655440000/mailFolders',
         ),
       ).toBe('/users/:id/mailFolders');
@@ -70,7 +76,7 @@ describe('MetricsMiddleware', () => {
 
     it('replaces a long Outlook base64 ID segment containing a digit', () => {
       const outlookId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
-      expect((unit as any).sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
+      expect(internals.sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
         '/me/messages/:id',
       );
     });
@@ -79,16 +85,16 @@ describe('MetricsMiddleware', () => {
       const folderId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
       const messageId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGBBBBBBB1';
       expect(
-        (unit as any).sanitizeEndpointForMetrics(`/me/mailFolders/${folderId}/messages/${messageId}`),
+        internals.sanitizeEndpointForMetrics(`/me/mailFolders/${folderId}/messages/${messageId}`),
       ).toBe('/me/mailFolders/:id/messages/:id');
     });
 
     it('does not replace short alphanumeric segment without digit', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
+      expect(internals.sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
     });
 
     it('preserves empty segments from leading slash', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
+      expect(internals.sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
     });
   });
 });

--- a/services/outlook-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/outlook-mcp/src/msgraph/metrics.middleware.ts
@@ -43,7 +43,7 @@ export class MetricsMiddleware implements Middleware {
 
     return endpoint
       .split('/')
-      .map(segment => (isId(segment) ? ':id' : segment))
+      .map((segment) => (isId(segment) ? ':id' : segment))
       .join('/');
   }
 

--- a/services/outlook-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/outlook-mcp/src/msgraph/metrics.middleware.ts
@@ -2,6 +2,7 @@ import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { Logger } from '@nestjs/common';
 import type { Counter, Histogram } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
+import { z } from 'zod';
 
 export class MetricsMiddleware implements Middleware {
   private readonly logger = new Logger(this.constructor.name);
@@ -33,6 +34,17 @@ export class MetricsMiddleware implements Middleware {
     } catch {
       return 'unknown';
     }
+  }
+
+  private sanitizeEndpointForMetrics(endpoint: string): string {
+    const uuid = z.string().uuid();
+    const isId = (segment: string) =>
+      uuid.safeParse(segment).success || (segment.length > 15 && /\d/.test(segment));
+
+    return endpoint
+      .split('/')
+      .map(segment => (isId(segment) ? ':id' : segment))
+      .join('/');
   }
 
   private extractMethod(options: RequestInit | undefined): string {
@@ -99,6 +111,7 @@ export class MetricsMiddleware implements Middleware {
     }
 
     const endpoint = this.extractEndpoint(context.request);
+    const metricEndpoint = this.sanitizeEndpointForMetrics(endpoint);
     const method = this.extractMethod(context.options);
     const startTime = Date.now();
 
@@ -110,13 +123,13 @@ export class MetricsMiddleware implements Middleware {
       const statusClass = this.getStatusClass(statusCode);
 
       this.msgraphRequestCounter.add(1, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
         status_class: statusClass,
       });
 
       this.msgraphRequestDuration.record(duration / 1000, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
       });
 
@@ -136,13 +149,13 @@ export class MetricsMiddleware implements Middleware {
       const duration = Date.now() - startTime;
 
       this.msgraphRequestCounter.add(1, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
         status_class: '5xx',
       });
 
       this.msgraphRequestDuration.record(duration / 1000, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
       });
 

--- a/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.spec.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetricsMiddleware } from './metrics.middleware';
+
+const mockCounter = { add: vi.fn() };
+const mockHistogram = { record: vi.fn() };
+const mockMetricService = {
+  getCounter: vi.fn().mockReturnValue(mockCounter),
+  getHistogram: vi.fn().mockReturnValue(mockHistogram),
+};
+
+describe('MetricsMiddleware', () => {
+  let unit: MetricsMiddleware;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unit = new MetricsMiddleware(mockMetricService as any);
+  });
+
+  describe('extractEndpoint', () => {
+    it('strips v1.0 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
+        '/me/messages',
+      );
+    });
+
+    it('strips v1 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
+        '/me/messages',
+      );
+    });
+
+    it('strips v2.0 version prefix from path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe(
+        '/users',
+      );
+    });
+
+    it('extracts endpoint from a Request object', () => {
+      const request = new Request('https://graph.microsoft.com/v1.0/me/mailFolders');
+      expect((unit as any).extractEndpoint(request)).toBe('/me/mailFolders');
+    });
+
+    it('returns / for root path', () => {
+      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
+    });
+
+    it('returns unknown for an invalid URL', () => {
+      expect((unit as any).extractEndpoint('not-a-url')).toBe('unknown');
+    });
+  });
+
+  describe('sanitizeEndpointForMetrics', () => {
+    it('leaves clean resource names unchanged', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
+    });
+
+    it('leaves childFolders unchanged (12 chars, no digit)', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
+        '/me/mailFolders/childFolders',
+      );
+    });
+
+    it('replaces a UUID segment', () => {
+      expect(
+        (unit as any).sanitizeEndpointForMetrics(
+          '/users/550e8400-e29b-41d4-a716-446655440000/mailFolders',
+        ),
+      ).toBe('/users/:id/mailFolders');
+    });
+
+    it('replaces a long Outlook base64 ID segment containing a digit', () => {
+      const outlookId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
+      expect((unit as any).sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
+        '/me/messages/:id',
+      );
+    });
+
+    it('replaces multiple ID segments in one path', () => {
+      const folderId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
+      const messageId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGBBBBBBB1';
+      expect(
+        (unit as any).sanitizeEndpointForMetrics(
+          `/me/mailFolders/${folderId}/messages/${messageId}`,
+        ),
+      ).toBe('/me/mailFolders/:id/messages/:id');
+    });
+
+    it('does not replace short alphanumeric segment without digit', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
+    });
+
+    it('preserves empty segments from leading slash', () => {
+      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
+    });
+  });
+});

--- a/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.spec.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.spec.ts
@@ -1,68 +1,74 @@
+import type { MetricService } from 'nestjs-otel';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MetricsMiddleware } from './metrics.middleware';
 
 const mockCounter = { add: vi.fn() };
 const mockHistogram = { record: vi.fn() };
-const mockMetricService = {
+const mockMetricService: Pick<MetricService, 'getCounter' | 'getHistogram'> = {
   getCounter: vi.fn().mockReturnValue(mockCounter),
   getHistogram: vi.fn().mockReturnValue(mockHistogram),
 };
 
+interface MetricsMiddlewareInternals {
+  extractEndpoint(request: RequestInfo): string;
+  sanitizeEndpointForMetrics(endpoint: string): string;
+}
+
 describe('MetricsMiddleware', () => {
   let unit: MetricsMiddleware;
+  let internals: MetricsMiddlewareInternals;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    unit = new MetricsMiddleware(mockMetricService as any);
+    unit = new MetricsMiddleware(mockMetricService as MetricService);
+    internals = unit as unknown as MetricsMiddlewareInternals;
   });
 
   describe('extractEndpoint', () => {
     it('strips v1.0 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1.0/me/messages')).toBe(
         '/me/messages',
       );
     });
 
     it('strips v1 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1/me/messages')).toBe(
         '/me/messages',
       );
     });
 
     it('strips v2.0 version prefix from path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe(
-        '/users',
-      );
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v2.0/users')).toBe('/users');
     });
 
     it('extracts endpoint from a Request object', () => {
       const request = new Request('https://graph.microsoft.com/v1.0/me/mailFolders');
-      expect((unit as any).extractEndpoint(request)).toBe('/me/mailFolders');
+      expect(internals.extractEndpoint(request)).toBe('/me/mailFolders');
     });
 
     it('returns / for root path', () => {
-      expect((unit as any).extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
+      expect(internals.extractEndpoint('https://graph.microsoft.com/v1.0/')).toBe('/');
     });
 
     it('returns unknown for an invalid URL', () => {
-      expect((unit as any).extractEndpoint('not-a-url')).toBe('unknown');
+      expect(internals.extractEndpoint('not-a-url')).toBe('unknown');
     });
   });
 
   describe('sanitizeEndpointForMetrics', () => {
     it('leaves clean resource names unchanged', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
+      expect(internals.sanitizeEndpointForMetrics('/me/messages')).toBe('/me/messages');
     });
 
     it('leaves childFolders unchanged (12 chars, no digit)', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
+      expect(internals.sanitizeEndpointForMetrics('/me/mailFolders/childFolders')).toBe(
         '/me/mailFolders/childFolders',
       );
     });
 
     it('replaces a UUID segment', () => {
       expect(
-        (unit as any).sanitizeEndpointForMetrics(
+        internals.sanitizeEndpointForMetrics(
           '/users/550e8400-e29b-41d4-a716-446655440000/mailFolders',
         ),
       ).toBe('/users/:id/mailFolders');
@@ -70,7 +76,7 @@ describe('MetricsMiddleware', () => {
 
     it('replaces a long Outlook base64 ID segment containing a digit', () => {
       const outlookId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
-      expect((unit as any).sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
+      expect(internals.sanitizeEndpointForMetrics(`/me/messages/${outlookId}`)).toBe(
         '/me/messages/:id',
       );
     });
@@ -79,18 +85,16 @@ describe('MetricsMiddleware', () => {
       const folderId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGAAAAAAB';
       const messageId = 'AAMkADc4ZTM3OWQ4LWJlOGEtNGVjZi1hMjFlLWI4NDE2ZWIyZGUyNgBGBBBBBBB1';
       expect(
-        (unit as any).sanitizeEndpointForMetrics(
-          `/me/mailFolders/${folderId}/messages/${messageId}`,
-        ),
+        internals.sanitizeEndpointForMetrics(`/me/mailFolders/${folderId}/messages/${messageId}`),
       ).toBe('/me/mailFolders/:id/messages/:id');
     });
 
     it('does not replace short alphanumeric segment without digit', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
+      expect(internals.sanitizeEndpointForMetrics('/me/drive/root')).toBe('/me/drive/root');
     });
 
     it('preserves empty segments from leading slash', () => {
-      expect((unit as any).sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
+      expect(internals.sanitizeEndpointForMetrics('/me/messages')).toMatch(/^\/me\/messages/);
     });
   });
 });

--- a/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.ts
@@ -43,7 +43,7 @@ export class MetricsMiddleware implements Middleware {
 
     return endpoint
       .split('/')
-      .map(segment => (isId(segment) ? ':id' : segment))
+      .map((segment) => (isId(segment) ? ':id' : segment))
       .join('/');
   }
 

--- a/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/metrics.middleware.ts
@@ -2,6 +2,7 @@ import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { Logger } from '@nestjs/common';
 import type { Counter, Histogram } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
+import { z } from 'zod';
 
 export class MetricsMiddleware implements Middleware {
   private readonly logger = new Logger(this.constructor.name);
@@ -33,6 +34,17 @@ export class MetricsMiddleware implements Middleware {
     } catch {
       return 'unknown';
     }
+  }
+
+  private sanitizeEndpointForMetrics(endpoint: string): string {
+    const uuid = z.string().uuid();
+    const isId = (segment: string) =>
+      uuid.safeParse(segment).success || (segment.length > 15 && /\d/.test(segment));
+
+    return endpoint
+      .split('/')
+      .map(segment => (isId(segment) ? ':id' : segment))
+      .join('/');
   }
 
   private extractMethod(options: RequestInit | undefined): string {
@@ -99,6 +111,7 @@ export class MetricsMiddleware implements Middleware {
     }
 
     const endpoint = this.extractEndpoint(context.request);
+    const metricEndpoint = this.sanitizeEndpointForMetrics(endpoint);
     const method = this.extractMethod(context.options);
     const startTime = Date.now();
 
@@ -110,13 +123,13 @@ export class MetricsMiddleware implements Middleware {
       const statusClass = this.getStatusClass(statusCode);
 
       this.msgraphRequestCounter.add(1, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
         status_class: statusClass,
       });
 
       this.msgraphRequestDuration.record(duration / 1000, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
       });
 
@@ -149,13 +162,13 @@ export class MetricsMiddleware implements Middleware {
       const duration = Date.now() - startTime;
 
       this.msgraphRequestCounter.add(1, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
         status_class: '5xx',
       });
 
       this.msgraphRequestDuration.record(duration / 1000, {
-        endpoint,
+        endpoint: metricEndpoint,
         method,
       });
 


### PR DESCRIPTION
Removes the id from URL metrics urls
<img width="3952" height="1682" alt="image (4)" src="https://github.com/user-attachments/assets/449700d6-32ec-419d-a51d-de10328ffe81" />
