### PR TITLE
fix(ci): add manual release re-run dispatch workflow

### DIFF
--- a/.github/workflows/outlook-semantic-mcp.dispatch.yaml
+++ b/.github/workflows/outlook-semantic-mcp.dispatch.yaml
@@ -1,0 +1,23 @@
+name: "[outlook-semantic-mcp] Manual Release Re-Run"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      existing-version:
+        description: "Existing version of the service"
+        required: true
+        type: string
+
+jobs:
+  manual-release:
+    uses: ./.github/workflows/_template-cd.yaml
+    secrets: inherit
+    with:
+      service-name: outlook-semantic-mcp
+      service-version: ${{ inputs.existing-version }}
+      dockerfile: services/outlook-semantic-mcp/deploy/Dockerfile


### PR DESCRIPTION
## Why

The `outlook-semantic-mcp@0.3.2` release-please run created the GitHub release but `releases_created` was reported as `false` (release was created mid-run on attempt 1, attempt 2 saw it already existed), so the `release-outlook-semantic-mcp` CD job was skipped. As a result, no Docker image and no Helm chart were published for 0.3.2:

- https://github.com/Unique-AG/connectors/pkgs/container/connectors%2Fservices%2Foutlook-semantic-mcp
- https://github.com/Unique-AG/connectors/pkgs/container/connectors%2Fhelm%2Foutlook-semantic-mcp

There is no recovery path today for this service. `confluence-connector` and `sharepoint-connector` already have manual re-run dispatch workflows for exactly this case; this PR adds the missing one for `outlook-semantic-mcp`.

Note: unlike the existing dispatch files, this one declares `packages: write` and `id-token: write` at the top level. Reusable workflows cannot escalate beyond the caller's `GITHUB_TOKEN` permissions, so the existing `confluence-connector.dispatch.yaml` and `sharepoint-connector.dispatch.yaml` would actually fail to push to ghcr.io if anyone tried to use them. (Sharepoint's single attempt did fail; logs are now expired.) Those should be patched in a follow-up.

## What 0.3.2 contains (from CHANGELOG)

### Features

* **outlook-semantic-mcp:** un-19787 implement search powered by ms graph ([#492](https://github.com/Unique-AG/connectors/issues/492)) ([c7c630f](https://github.com/Unique-AG/connectors/commit/c7c630f5b5aede312ddfe0c227577a099f0f5aee))

### Bug Fixes

* **outlook-mcp,outlook-semantic-mcp:** reduce metrics cardinality by sanitizing endpoint IDs ([#497](https://github.com/Unique-AG/connectors/issues/497)) ([38ee132](https://github.com/Unique-AG/connectors/commit/38ee1327439d030fdccd42713bf63d76a9653e09))

## Test plan

- [ ] After merge, trigger: `gh workflow run outlook-semantic-mcp.dispatch.yaml --ref main -R Unique-AG/connectors -f existing-version=0.3.2`
- [ ] `containerize` job builds and pushes to `ghcr.io/unique-ag/connectors/services/outlook-semantic-mcp:0.3.2` and `uniquecr.azurecr.io/connectors/services/outlook-semantic-mcp:0.3.2`
- [ ] Helm chart `outlook-semantic-mcp` 0.3.2 pushed to both OCI registries
- [ ] cosign signing succeeds (identity matches `refs/heads/main`)
- [ ] Monorepo PR Unique-AG/monorepo#23479 can then be merged to deploy 0.3.2