### PR TITLE
fix(sharepoint-connector): log partial failures when deleting stale scopes

### DIFF
--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -245,8 +245,18 @@ export class ScopeManagementService {
 
     for (const scope of sortedStaleScopes) {
       try {
-        await this.uniqueScopesService.deleteScope(scope.id);
-        this.logger.debug(`${logPrefix} Deleted stale scope ${scope.id}`);
+        const result = await this.uniqueScopesService.deleteScope(scope.id);
+        if (result.failedFolders.length > 0) {
+          this.logger.warn({
+            msg: `${logPrefix} Failed to delete stale scope ${scope.id}`,
+            failedFolders: result.failedFolders.map((f) => ({
+              id: f.id,
+              reason: f.failReason,
+            })),
+          });
+        } else {
+          this.logger.debug(`${logPrefix} Deleted stale scope ${scope.id}`);
+        }
       } catch (error) {
         this.logger.warn({
           msg: `${logPrefix} Failed to delete stale scope ${scope.id}`,

--- a/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
+++ b/services/sharepoint-connector/src/sharepoint-synchronization/scope-management.service.ts
@@ -254,8 +254,6 @@ export class ScopeManagementService {
               reason: f.failReason,
             })),
           });
-        } else {
-          this.logger.debug(`${logPrefix} Deleted stale scope ${scope.id}`);
         }
       } catch (error) {
         this.logger.warn({


### PR DESCRIPTION
## Summary
- When a stale scope deletion completes but some folders fail to delete, surface those failures via a structured warning log so they're visible in observability tooling. Previously a partial failure was silently logged at debug level as a successful deletion.

## Test plan
- [ ] Verify warning log appears when `deleteScope` returns a non-empty `failedFolders` array
- [ ] Verify debug log still appears on full success