### PR TITLE
feat(teams-mcp): add start_datetime and end_datetime to meeting metadata (UN-20156)

### DIFF
--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -50,6 +50,8 @@ const TranscriptChunkSchema = z.object({
   text: z.string().describe('The relevant passage'),
   url: z.string().optional().describe('External URL if applicable'),
   meetingDate: z.string().optional().describe('Date of the meeting'),
+  startDatetime: z.string().optional().describe('Meeting start datetime (ISO 8601)'),
+  endDatetime: z.string().optional().describe('Meeting end datetime (ISO 8601)'),
   organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participants'),
 });
@@ -135,9 +137,8 @@ export class FindTranscriptsTool {
     const result = await this.contentService.scopedSearch(searchRequest, scopeContext);
 
     const results = result.data.map((item) => {
-      const { meetingDate, organizer, participants } = parseTranscriptMetadata(
-        item.metadata as Record<string, unknown> | null,
-      );
+      const { meetingDate, startDatetime, endDatetime, organizer, participants } =
+        parseTranscriptMetadata(item.metadata as Record<string, unknown> | null);
 
       return {
         id: item.id,
@@ -147,6 +148,8 @@ export class FindTranscriptsTool {
         text: item.text,
         url: `unique://content/${item.id}`,
         meetingDate,
+        startDatetime,
+        endDatetime,
         organizer,
         participants,
       };

--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -50,8 +50,8 @@ const TranscriptChunkSchema = z.object({
   text: z.string().describe('The relevant passage'),
   url: z.string().optional().describe('External URL if applicable'),
   meetingDate: z.string().optional().describe('Date of the meeting'),
-  startDatetime: z.string().optional().describe('Meeting start datetime (ISO 8601)'),
-  endDatetime: z.string().optional().describe('Meeting end datetime (ISO 8601)'),
+  startDatetime: z.string().optional().describe('Transcript recording start datetime (ISO 8601)'),
+  endDatetime: z.string().optional().describe('Transcript recording end datetime (ISO 8601)'),
   organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participants'),
 });

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -45,8 +45,8 @@ const MeetingItemSchema = z.object({
   id: z.string().describe('Content ID — use this to reference the meeting in other tools'),
   title: z.string().describe('Meeting subject / title'),
   meetingDate: z.string().optional().describe('Meeting start date (ISO 8601)'),
-  startDatetime: z.string().optional().describe('Meeting start datetime (ISO 8601)'),
-  endDatetime: z.string().optional().describe('Meeting end datetime (ISO 8601)'),
+  startDatetime: z.string().optional().describe('Transcript recording start datetime (ISO 8601)'),
+  endDatetime: z.string().optional().describe('Transcript recording end datetime (ISO 8601)'),
   organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participant names'),
 });

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -45,6 +45,8 @@ const MeetingItemSchema = z.object({
   id: z.string().describe('Content ID — use this to reference the meeting in other tools'),
   title: z.string().describe('Meeting subject / title'),
   meetingDate: z.string().optional().describe('Meeting start date (ISO 8601)'),
+  startDatetime: z.string().optional().describe('Meeting start datetime (ISO 8601)'),
+  endDatetime: z.string().optional().describe('Meeting end datetime (ISO 8601)'),
   organizer: z.string().optional().describe('Name of the meeting organizer'),
   participants: z.array(z.string()).optional().describe('List of participant names'),
 });
@@ -131,14 +133,15 @@ export class ListMeetingsTool {
     );
 
     const meetings = result.contents.map((item) => {
-      const { meetingDate, organizer, participants } = parseTranscriptMetadata(
-        item.metadata as Record<string, unknown> | null,
-      );
+      const { meetingDate, startDatetime, endDatetime, organizer, participants } =
+        parseTranscriptMetadata(item.metadata as Record<string, unknown> | null);
 
       return {
         id: item.id,
         title: item.title ?? 'Untitled Meeting',
         meetingDate,
+        startDatetime,
+        endDatetime,
         organizer,
         participants,
       };

--- a/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
+++ b/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
@@ -118,7 +118,8 @@ export function parseTranscriptMetadata(
 
   return {
     meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
-    startDatetime: typeof metadata?.start_datetime === 'string' ? metadata.start_datetime : undefined,
+    startDatetime:
+      typeof metadata?.start_datetime === 'string' ? metadata.start_datetime : undefined,
     endDatetime: typeof metadata?.end_datetime === 'string' ? metadata.end_datetime : undefined,
     organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
     participants: participants?.length ? participants : undefined,

--- a/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
+++ b/services/teams-mcp/src/transcript/tools/transcript-tools.helpers.ts
@@ -10,6 +10,8 @@ export interface TranscriptFilterInput {
 
 export interface ParsedTranscriptMetadata {
   meetingDate?: string;
+  startDatetime?: string;
+  endDatetime?: string;
   organizer?: string;
   participants?: string[];
 }
@@ -116,6 +118,8 @@ export function parseTranscriptMetadata(
 
   return {
     meetingDate: typeof metadata?.date === 'string' ? metadata.date : undefined,
+    startDatetime: typeof metadata?.start_datetime === 'string' ? metadata.start_datetime : undefined,
+    endDatetime: typeof metadata?.end_datetime === 'string' ? metadata.end_datetime : undefined,
     organizer: typeof metadata?.organizer_name === 'string' ? metadata.organizer_name : undefined,
     participants: participants?.length ? participants : undefined,
   };

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -160,8 +160,6 @@ export class TranscriptCreatedService {
         subject: meeting.subject ?? '',
         startDateTime: transcript.createdDateTime,
         endDateTime: transcript.endDateTime,
-        meetingStartDateTime: meeting.startDateTime,
-        meetingEndDateTime: meeting.endDateTime,
         contentCorrelationId: transcript.contentCorrelationId,
         owner: {
           id: meeting.participants.organizer.identity.user.id,

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -160,6 +160,8 @@ export class TranscriptCreatedService {
         subject: meeting.subject ?? '',
         startDateTime: transcript.createdDateTime,
         endDateTime: transcript.endDateTime,
+        meetingStartDateTime: meeting.startDateTime,
+        meetingEndDateTime: meeting.endDateTime,
         contentCorrelationId: transcript.contentCorrelationId,
         owner: {
           id: meeting.participants.organizer.identity.user.id,

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -158,6 +158,7 @@ export class TranscriptCreatedService {
     await this.unique.ingestTranscript(
       {
         subject: meeting.subject ?? '',
+        date: meeting.startDateTime,
         startDateTime: transcript.createdDateTime,
         endDateTime: transcript.endDateTime,
         contentCorrelationId: transcript.contentCorrelationId,

--- a/services/teams-mcp/src/transcript/transcript-recording.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-recording.service.ts
@@ -6,6 +6,8 @@ import { RecordingCollection } from './transcript.dtos';
 export interface RecordingData {
   id: string;
   content: ReadableStream<Uint8Array<ArrayBuffer>>;
+  startDateTime: Date;
+  endDateTime: Date;
 }
 
 @Injectable()
@@ -74,7 +76,12 @@ export class TranscriptRecordingService {
         'Successfully fetched recording from MS Graph',
       );
 
-      return { id: recording.id, content: mp4Stream };
+      return {
+        id: recording.id,
+        content: mp4Stream,
+        startDateTime: recording.createdDateTime,
+        endDateTime: recording.endDateTime,
+      };
     } catch (error) {
       span?.addEvent('failed_to_retrieve_recording', {
         error: error instanceof Error ? error.message : String(error),

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -29,6 +29,7 @@ export class UniqueService {
   public async ingestTranscript(
     meeting: {
       subject: string;
+      date: Date;
       startDateTime: Date;
       endDateTime: Date;
       contentCorrelationId: string;
@@ -46,7 +47,7 @@ export class UniqueService {
     const span = this.trace.getSpan();
     span?.setAttribute('transcript_id', transcript.id);
     span?.setAttribute('participant_count', meeting.participants.length);
-    span?.setAttribute('meeting_date', meeting.startDateTime.toISOString());
+    span?.setAttribute('meeting_date', meeting.date.toISOString());
     span?.setAttribute('owner_id', meeting.owner.id);
     if (recording) {
       span?.setAttribute('recording_id', recording.id);
@@ -57,7 +58,7 @@ export class UniqueService {
         transcriptId: transcript.id,
         recordingId: recording?.id,
         participantCount: meeting.participants.length,
-        meetingDate: meeting.startDateTime.toISOString(),
+        meetingDate: meeting.date.toISOString(),
       },
       'Beginning processing of meeting transcript for ingestion',
     );
@@ -91,10 +92,7 @@ export class UniqueService {
     );
 
     const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
-    const { subjectPath, datePath } = this.mapMeetingToRelativePaths(
-      meeting.subject,
-      meeting.startDateTime,
-    );
+    const { subjectPath, datePath } = this.mapMeetingToRelativePaths(meeting.subject, meeting.date);
 
     const parentScope = await this.scopeService.createScope(rootScopeId, subjectPath, false);
     span?.setAttribute('parent_scope_id', parentScope.id);
@@ -246,6 +244,7 @@ export class UniqueService {
 
   private buildContentMetadata(
     meeting: {
+      date: Date;
       startDateTime: Date;
       endDateTime: Date;
       contentCorrelationId: string;
@@ -257,7 +256,7 @@ export class UniqueService {
     const startDateTime = datetimeOverride?.startDateTime ?? meeting.startDateTime;
     const endDateTime = datetimeOverride?.endDateTime ?? meeting.endDateTime;
     const metadata: Record<string, string> = {
-      date: meeting.startDateTime.toISOString(),
+      date: meeting.date.toISOString(),
       start_datetime: startDateTime.toISOString(),
       end_datetime: endDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -31,6 +31,8 @@ export class UniqueService {
       subject: string;
       startDateTime: Date;
       endDateTime: Date;
+      meetingStartDateTime: Date;
+      meetingEndDateTime: Date;
       contentCorrelationId: string;
       participants: { id?: string; name: string; email: string }[];
       owner: { id: string; name: string; email: string };
@@ -241,12 +243,16 @@ export class UniqueService {
 
   private buildContentMetadata(meeting: {
     startDateTime: Date;
+    meetingStartDateTime: Date;
+    meetingEndDateTime: Date;
     contentCorrelationId: string;
     owner: { name: string; email: string };
     participants: { name: string; email: string }[];
   }): Record<string, string> {
     const metadata: Record<string, string> = {
       date: meeting.startDateTime.toISOString(),
+      start_datetime: meeting.meetingStartDateTime.toISOString(),
+      end_datetime: meeting.meetingEndDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,
       organizer_email: meeting.owner.email.toLowerCase(),
     };

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -36,7 +36,12 @@ export class UniqueService {
       owner: { id: string; name: string; email: string };
     },
     transcript: { id: string; content: ReadableStream<Uint8Array<ArrayBuffer>> },
-    recording?: { id: string; content: ReadableStream<Uint8Array<ArrayBuffer>> },
+    recording?: {
+      id: string;
+      content: ReadableStream<Uint8Array<ArrayBuffer>>;
+      startDateTime: Date;
+      endDateTime: Date;
+    },
   ): Promise<void> {
     const span = this.trace.getSpan();
     span?.setAttribute('transcript_id', transcript.id);
@@ -179,7 +184,7 @@ export class UniqueService {
             ingestionConfig: {
               uniqueIngestionMode: UniqueIngestionMode.SKIP_INGESTION,
             },
-            metadata: this.buildContentMetadata(meeting),
+            metadata: this.buildContentMetadata(meeting, recording),
           },
         });
         await this.contentService.uploadToStorage(
@@ -239,17 +244,22 @@ export class UniqueService {
     return { subjectPath, datePath: formattedDate };
   }
 
-  private buildContentMetadata(meeting: {
-    startDateTime: Date;
-    endDateTime: Date;
-    contentCorrelationId: string;
-    owner: { name: string; email: string };
-    participants: { name: string; email: string }[];
-  }): Record<string, string> {
+  private buildContentMetadata(
+    meeting: {
+      startDateTime: Date;
+      endDateTime: Date;
+      contentCorrelationId: string;
+      owner: { name: string; email: string };
+      participants: { name: string; email: string }[];
+    },
+    datetimeOverride?: { startDateTime: Date; endDateTime: Date },
+  ): Record<string, string> {
+    const startDateTime = datetimeOverride?.startDateTime ?? meeting.startDateTime;
+    const endDateTime = datetimeOverride?.endDateTime ?? meeting.endDateTime;
     const metadata: Record<string, string> = {
       date: meeting.startDateTime.toISOString(),
-      start_datetime: meeting.startDateTime.toISOString(),
-      end_datetime: meeting.endDateTime.toISOString(),
+      start_datetime: startDateTime.toISOString(),
+      end_datetime: endDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,
       organizer_email: meeting.owner.email.toLowerCase(),
     };

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -31,8 +31,6 @@ export class UniqueService {
       subject: string;
       startDateTime: Date;
       endDateTime: Date;
-      meetingStartDateTime: Date;
-      meetingEndDateTime: Date;
       contentCorrelationId: string;
       participants: { id?: string; name: string; email: string }[];
       owner: { id: string; name: string; email: string };
@@ -243,16 +241,15 @@ export class UniqueService {
 
   private buildContentMetadata(meeting: {
     startDateTime: Date;
-    meetingStartDateTime: Date;
-    meetingEndDateTime: Date;
+    endDateTime: Date;
     contentCorrelationId: string;
     owner: { name: string; email: string };
     participants: { name: string; email: string }[];
   }): Record<string, string> {
     const metadata: Record<string, string> = {
       date: meeting.startDateTime.toISOString(),
-      start_datetime: meeting.meetingStartDateTime.toISOString(),
-      end_datetime: meeting.meetingEndDateTime.toISOString(),
+      start_datetime: meeting.startDateTime.toISOString(),
+      end_datetime: meeting.endDateTime.toISOString(),
       content_correlation_id: meeting.contentCorrelationId,
       organizer_email: meeting.owner.email.toLowerCase(),
     };


### PR DESCRIPTION
## Summary

Adds `start_datetime` and `end_datetime` metadata fields to Teams MCP meeting content, and fixes `date` to reflect the actual scheduled meeting time.

**Metadata per artifact:**

| Field | Transcript | Recording |
|---|---|---|
| `date` | `onlineMeeting.startDateTime` (scheduled) | `onlineMeeting.startDateTime` (scheduled) |
| `start_datetime` | `transcript.createdDateTime` | `recording.createdDateTime` |
| `end_datetime` | `transcript.endDateTime` | `recording.endDateTime` |

**Exposed via MCP tools:** `list_meetings` and `find_transcripts` both return `startDatetime` and `endDatetime` fields.

Closes [UN-20156](https://unique-ch.atlassian.net/browse/UN-20156)

## Test plan

- [ ] Ingest a new meeting transcript and verify `date`, `start_datetime`, `end_datetime` appear correctly in stored transcript metadata
- [ ] Ingest a meeting with a recording and verify recording metadata has its own `start_datetime`/`end_datetime` (distinct from transcript times)
- [ ] Call `list_meetings` and confirm `startDatetime`/`endDatetime` are returned per meeting item
- [ ] Call `find_transcripts` and confirm `startDatetime`/`endDatetime` appear in search results
- [ ] Verify `date` field matches the scheduled meeting start (not transcript creation time)

[UN-20156]: https://unique-ch.atlassian.net/browse/UN-20156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ