### PR TITLE
fix(teams-mcp): propagate Microsoft invalid_grant as McpError for proper client re-auth signal

### DIFF
--- a/services/teams-mcp/src/msgraph/token-refresh.middleware.ts
+++ b/services/teams-mcp/src/msgraph/token-refresh.middleware.ts
@@ -1,5 +1,6 @@
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { Logger } from '@nestjs/common';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { serializeError } from 'serialize-error-cjs';
 import { normalizeError } from '../utils/normalize-error';
 import { TokenProvider } from './token.provider';
@@ -133,6 +134,12 @@ export class TokenRefreshMiddleware implements Middleware {
         );
       }
     } catch (error) {
+      // McpErrors (e.g. MicrosoftReauthRequiredException) must propagate so the tool
+      // handler can re-throw them as a JSON-RPC error rather than isError:true.
+      if (error instanceof McpError) {
+        throw error;
+      }
+
       this.logger.error(
         {
           error: serializeError(normalizeError(error)),

--- a/services/teams-mcp/src/msgraph/token-refresh.middleware.ts
+++ b/services/teams-mcp/src/msgraph/token-refresh.middleware.ts
@@ -1,6 +1,6 @@
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
-import { Logger } from '@nestjs/common';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { Logger } from '@nestjs/common';
 import { serializeError } from 'serialize-error-cjs';
 import { normalizeError } from '../utils/normalize-error';
 import { TokenProvider } from './token.provider';
@@ -134,8 +134,6 @@ export class TokenRefreshMiddleware implements Middleware {
         );
       }
     } catch (error) {
-      // McpErrors (e.g. MicrosoftReauthRequiredException) must propagate so the tool
-      // handler can re-throw them as a JSON-RPC error rather than isError:true.
       if (error instanceof McpError) {
         throw error;
       }

--- a/services/teams-mcp/src/msgraph/token.provider.ts
+++ b/services/teams-mcp/src/msgraph/token.provider.ts
@@ -10,6 +10,7 @@ import { serializeError } from 'serialize-error-cjs';
 import { DrizzleDatabase } from '../drizzle/drizzle.module';
 import { userProfiles } from '../drizzle/schema';
 import { normalizeError } from '../utils/normalize-error';
+import { MicrosoftReauthRequiredException } from '../utils/microsoft-reauth.exception';
 
 export class TokenProvider implements AuthenticationProvider {
   private readonly logger = new Logger(TokenProvider.name);
@@ -103,6 +104,27 @@ export class TokenProvider implements AuthenticationProvider {
           },
           'Microsoft Graph API rejected token refresh request',
         );
+
+        let parsedError: { error?: string; error_description?: string } = {};
+        try {
+          parsedError = JSON.parse(errorText);
+        } catch {
+          // not JSON, fall through to generic error
+        }
+
+        if (parsedError.error === 'invalid_grant') {
+          // The refresh token is permanently invalid (expired, revoked, device removed,
+          // Conditional Access policy changed, etc.). Clear the dead tokens so subsequent
+          // requests don't keep retrying, then surface a typed McpError so the tool
+          // handler propagates a JSON-RPC error instead of an isError:true result.
+          await this.drizzle
+            .update(userProfiles)
+            .set({ accessToken: null, refreshToken: null })
+            .where(eq(userProfiles.id, userProfileId));
+
+          throw new MicrosoftReauthRequiredException(parsedError.error_description);
+        }
+
         assert.fail(`Token refresh failed: ${response.statusText}`);
       }
 

--- a/services/teams-mcp/src/msgraph/token.provider.ts
+++ b/services/teams-mcp/src/msgraph/token.provider.ts
@@ -9,8 +9,8 @@ import { eq } from 'drizzle-orm';
 import { serializeError } from 'serialize-error-cjs';
 import { DrizzleDatabase } from '../drizzle/drizzle.module';
 import { userProfiles } from '../drizzle/schema';
-import { normalizeError } from '../utils/normalize-error';
 import { MicrosoftReauthRequiredException } from '../utils/microsoft-reauth.exception';
+import { normalizeError } from '../utils/normalize-error';
 
 export class TokenProvider implements AuthenticationProvider {
   private readonly logger = new Logger(TokenProvider.name);
@@ -94,29 +94,28 @@ export class TokenProvider implements AuthenticationProvider {
 
       if (!response.ok) {
         const errorText = await response.text();
+        let parsedError: { error?: string; error_description?: string } = {};
+        try {
+          parsedError = JSON.parse(errorText);
+        } catch {
+          // not JSON
+        }
+
         this.logger.error(
           {
             status: response.status,
-            errorText,
-            userProfileId: this.userProfileId,
+            errorText: parsedError,
+            userProfileId,
             tokenRefreshFailed: true,
             errorSource: 'microsoft_graph_api',
           },
           'Microsoft Graph API rejected token refresh request',
         );
 
-        let parsedError: { error?: string; error_description?: string } = {};
-        try {
-          parsedError = JSON.parse(errorText);
-        } catch {
-          // not JSON, fall through to generic error
-        }
-
         if (parsedError.error === 'invalid_grant') {
-          // The refresh token is permanently invalid (expired, revoked, device removed,
-          // Conditional Access policy changed, etc.). Clear the dead tokens so subsequent
-          // requests don't keep retrying, then surface a typed McpError so the tool
-          // handler propagates a JSON-RPC error instead of an isError:true result.
+          // Permanently invalid — expired, revoked, device removed from tenant, CAP changed.
+          // Clear the dead tokens and surface a typed McpError so the tool handler
+          // propagates a JSON-RPC error instead of isError:true.
           await this.drizzle
             .update(userProfiles)
             .set({ accessToken: null, refreshToken: null })
@@ -147,7 +146,7 @@ export class TokenProvider implements AuthenticationProvider {
 
       this.logger.debug(
         {
-          userProfileId: this.userProfileId,
+          userProfileId,
           tokenRefreshSuccess: true,
           action: 'token_refresh_completed',
         },
@@ -155,14 +154,12 @@ export class TokenProvider implements AuthenticationProvider {
       );
       return tokenData.access_token;
     } catch (error) {
-      // MicrosoftReauthRequiredException (McpError) must propagate unwrapped so the
-      // middleware and tool handler can re-throw it as a JSON-RPC error response.
       if (error instanceof MicrosoftReauthRequiredException) {
         throw error;
       }
       this.logger.error(
         {
-          userProfileId: this.userProfileId,
+          userProfileId,
           error: serializeError(normalizeError(error)),
           tokenRefreshFailed: true,
           errorSource: 'microsoft_graph_api',

--- a/services/teams-mcp/src/msgraph/token.provider.ts
+++ b/services/teams-mcp/src/msgraph/token.provider.ts
@@ -155,6 +155,11 @@ export class TokenProvider implements AuthenticationProvider {
       );
       return tokenData.access_token;
     } catch (error) {
+      // MicrosoftReauthRequiredException (McpError) must propagate unwrapped so the
+      // middleware and tool handler can re-throw it as a JSON-RPC error response.
+      if (error instanceof MicrosoftReauthRequiredException) {
+        throw error;
+      }
       this.logger.error(
         {
           userProfileId: this.userProfileId,

--- a/services/teams-mcp/src/msgraph/token.provider.ts
+++ b/services/teams-mcp/src/msgraph/token.provider.ts
@@ -104,7 +104,7 @@ export class TokenProvider implements AuthenticationProvider {
         this.logger.error(
           {
             status: response.status,
-            errorText: parsedError,
+            errorText,
             userProfileId,
             tokenRefreshFailed: true,
             errorSource: 'microsoft_graph_api',

--- a/services/teams-mcp/src/utils/microsoft-reauth.exception.ts
+++ b/services/teams-mcp/src/utils/microsoft-reauth.exception.ts
@@ -1,5 +1,4 @@
-import { McpError } from '@modelcontextprotocol/sdk/types.js';
-import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
 /**
  * Thrown when the Microsoft Graph refresh token is permanently invalid —
@@ -11,7 +10,7 @@ import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
  * signal that the user must re-authenticate rather than just a failed tool call.
  */
 export class MicrosoftReauthRequiredException extends McpError {
-  constructor(cause?: string) {
+  public constructor(cause?: string) {
     const message = cause
       ? `Microsoft re-authentication required: ${cause}`
       : 'Microsoft re-authentication required. Please reconnect your Microsoft account.';

--- a/services/teams-mcp/src/utils/microsoft-reauth.exception.ts
+++ b/services/teams-mcp/src/utils/microsoft-reauth.exception.ts
@@ -1,0 +1,21 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Thrown when the Microsoft Graph refresh token is permanently invalid —
+ * e.g. `invalid_grant`, device removed from tenant, Conditional Access policy changed.
+ *
+ * Extends McpError so the tool handler re-throws it as a JSON-RPC error response
+ * (code -32603) instead of wrapping it in `{ isError: true }`. The client SDK
+ * converts the JSON-RPC error into a thrown McpError, giving the client a clear
+ * signal that the user must re-authenticate rather than just a failed tool call.
+ */
+export class MicrosoftReauthRequiredException extends McpError {
+  constructor(cause?: string) {
+    const message = cause
+      ? `Microsoft re-authentication required: ${cause}`
+      : 'Microsoft re-authentication required. Please reconnect your Microsoft account.';
+    super(ErrorCode.InternalError, message);
+    this.name = 'MicrosoftReauthRequiredException';
+  }
+}


### PR DESCRIPTION
## Problem

When Microsoft rejects a token refresh with `invalid_grant` (refresh token expired/revoked, device removed from Entra ID tenant, Conditional Access policy changed), the tool was returning:

```json
{ "jsonrpc": "2.0", "id": 2, "result": { "content": [{ "type": "text", "text": "Lifetime validation failed, the token is expired." }], "isError": true } }
```

This is a JSON-RPC **success** response. The `isError: true` flag is visible to the LLM but the client SDK has no way to treat it as an authentication signal — it cannot trigger re-authentication.

The real error (`invalid_grant` from Microsoft) was being swallowed by `TokenRefreshMiddleware`'s catch block, which left the original Graph 401 in `context.response`, causing the tool to surface a misleading "Lifetime validation failed" message.

## Fix

Three changes:

1. **`MicrosoftReauthRequiredException`** (new) — extends `McpError` with `ErrorCode.InternalError`. By extending `McpError`, the existing `instanceof McpError` check in `McpToolsHandler` re-throws it as a JSON-RPC error response instead of an `isError: true` result.

2. **`TokenProvider.refreshAccessToken()`** — parses the Microsoft error body, detects `error === 'invalid_grant'`, clears the dead tokens from `user_profiles` (so subsequent requests don't loop retrying), and throws `MicrosoftReauthRequiredException`.

3. **`TokenRefreshMiddleware`** — re-throws `McpError` instances instead of swallowing all errors. Other non-McpError failures continue to fall back to the original 401 response as before.

## Result

The client SDK at `protocol.js` now receives:

```json
{ "jsonrpc": "2.0", "id": 2, "error": { "code": -32603, "message": "Microsoft re-authentication required: AADSTS700003: Device object was not found..." } }
```

And converts it to a thrown `McpError` on the client side — a clear signal to prompt the user to re-authenticate, rather than treating it as a recoverable tool failure.