### PR TITLE
feat(charts): add imagePullSecrets support to tiny-postgres chart

### DIFF
--- a/charts/library/tiny-postgres/templates/statefulset.yaml
+++ b/charts/library/tiny-postgres/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"

--- a/charts/library/tiny-postgres/values.yaml
+++ b/charts/library/tiny-postgres/values.yaml
@@ -1,6 +1,7 @@
 image:
   registry: docker.io
   repository: postgres
+imagePullSecrets: []
 port: 5432
 secretRef: override, must contain POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
 annotations: {}


### PR DESCRIPTION
## Context

The tiny-postgres library chart is used by MCP server apps (factset, outlook) to deploy a PostgreSQL sidecar with images pulled from the ACR pull-through cache. The chart had no mechanism to pass imagePullSecrets to the StatefulSet pod spec, causing image pull failures after the v2026.05 secret rotation.

## Changes

- Add imagePullSecrets value (defaulting to empty list) to values.yaml
- Add conditional imagePullSecrets block to the StatefulSet pod spec template

Refs: UN-19741