### PR TITLE
fix(teams-mcp): restore per-occurrence date folder for transcript ingestion

### DIFF
--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -158,7 +158,10 @@ export class TranscriptCreatedService {
     await this.unique.ingestTranscript(
       {
         subject: meeting.subject ?? '',
-        date: meeting.startDateTime,
+        // onlineMeetings/{id}.startDateTime returns the master/scheduled time, which
+        // collapses every occurrence of a recurring meeting into one YYYY-MM-DD folder.
+        // Use the transcript time so each occurrence gets its own folder.
+        date: transcript.createdDateTime,
         startDateTime: transcript.createdDateTime,
         endDateTime: transcript.endDateTime,
         contentCorrelationId: transcript.contentCorrelationId,


### PR DESCRIPTION
## Summary

- PR #507 (0.2.8) added a `date` field on the ingest payload sourced from `onlineMeetings/{id}.startDateTime`. That endpoint returns the master/scheduled time, so every occurrence of a recurring meeting collapsed into the same `YYYY-MM-DD` child scope — re-introducing the bug that #235 originally fixed (UN-16557).
- This switches `date` back to `transcript.createdDateTime`, so folder path, `date` metadata, `start_datetime`, and `end_datetime` are all transcript times and per-occurrence-unique. Matches pre-0.2.8 behavior.
- Comment added at the call site to prevent re-regression.

## Test plan

- [x] `pnpm --filter teams-mcp run check-types`
- [ ] Trigger ingestion of a recurring Teams meeting series across two occurrences and confirm each lands in its own dated child scope under the subject parent scope
- [ ] Verify `date`, `start_datetime`, `end_datetime` metadata on ingested content match the transcript time

## Follow-up

For the original goal of #507 (`date` = actual scheduled meeting time), we need to re-introduce a `calendarView` lookup on `threadId` to get the per-occurrence event start — file as a separate ticket if consumers actually need scheduled time semantics.