### PR TITLE
chore(ci): promote confluence-connector to stable 2.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -124,9 +124,6 @@
       ]
     },
     "services/confluence-connector": {
-      "prerelease": true,
-      "prerelease-type": "alpha",
-      "versioning": "prerelease",
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Summary

- Removes `prerelease: true`, `prerelease-type: alpha`, and `versioning: prerelease` from the `services/confluence-connector` entry in `release-please-config.json`
- After merging, release-please will update PR #517 (currently proposing `2.0.0-alpha.8`) to propose `2.0.0` instead
- Merging the updated release PR will create the `confluence-connector@2.0.0` GitHub release and trigger the CD pipeline

## Steps after merging

1. Close (or let release-please auto-update) PR #517
2. Release-please will open/update a `chore(main): release confluence-connector 2.0.0` PR
3. Merge that PR to publish the stable 2.0.0 release