### PR TITLE
fix(confluence-connector): release as 2.0.0

### DIFF
--- a/services/confluence-connector/src/main.ts
+++ b/services/confluence-connector/src/main.ts
@@ -23,7 +23,6 @@ async function bootstrap() {
   });
 
   const port = configService.get('app.port', { infer: true });
-
   await app.listen(port);
   logger.log({ msg: `Server is running on http://localhost:${port}` });
 }


### PR DESCRIPTION
Release-please generated \`2.0.1-alpha.8\` instead of \`2.0.0\` because the default versioning strategy (which we switched to in #550) does not drop the prerelease suffix when the source version (\`2.0.0-alpha.8\`) has one. It just bumps the patch: \`2.0.0-alpha.8\` → \`2.0.1-alpha.8\`.

## What this PR does

- Reverts the cosmetic blank line added in #551 (it was only there to trigger release-please)
- Uses the documented \`Release-As: 2.0.0\` commit footer to force the next release to exactly \`2.0.0\`

## What happens after merging

1. Release-please re-runs on \`main\`
2. The existing release PR #552 gets updated (or closed and replaced) with \`chore(main): release confluence-connector 2.0.0\`
3. Merging that release PR creates the \`confluence-connector@2.0.0\` GitHub release and triggers the CD pipeline
4. The monorepo GitOps app specs then need to be bumped to \`confluence-connector@2.0.0\` (separate PR)