### PR TITLE
chore(ci): force confluence-connector release as 2.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -124,6 +124,7 @@
       ]
     },
     "services/confluence-connector": {
+      "release-as": "2.0.0",
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Why this is needed

PR #552 still proposes \`2.0.1-alpha.8\`. Release-please's default versioning strategy preserves the prerelease suffix when bumping from \`2.0.0-alpha.8\`, producing \`2.0.1-alpha.8\` instead of graduating to \`2.0.0\`.

PR #553 attempted to use the \`Release-As: 2.0.0\` commit footer, but the footer ended up embedded in prose (with backticks) inside the squash-merge commit body, so the conventional-commits-parser did not recognize it.

## What this PR does

Adds the \`release-as: "2.0.0"\` field to \`release-please-config.json\` for \`services/confluence-connector\`. This is the documented, deterministic override and is not affected by squash-merge formatting.

## What happens after merging

1. Release-please re-runs, sees \`release-as: 2.0.0\` in config, ignores commit-derived version
2. PR #552 gets updated to \`chore(main): release confluence-connector 2.0.0\`
3. Merging PR #552 publishes \`confluence-connector@2.0.0\` and triggers CD

## Cleanup

The \`release-as\` setting is sticky. A follow-up PR (after 2.0.0 is published) must remove this field, otherwise every subsequent release-please run will keep proposing \`2.0.0\` again.