### PR TITLE
fix(deps,teams-mcp): argo sync

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1454,6 +1454,9 @@ importers:
       cache-manager:
         specifier: 7.2.0
         version: 7.2.0
+      drizzle-kit:
+        specifier: 0.31.4
+        version: 0.31.4
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.0)(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.2))(typescript@5.9.2))(@types/pg@8.15.5)(pg@8.16.3)(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.2))
@@ -1554,9 +1557,6 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@22.16.5)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))
-      drizzle-kit:
-        specifier: 0.31.4
-        version: 0.31.4
       globals:
         specifier: 16.3.0
         version: 16.3.0
@@ -10032,14 +10032,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.16.5)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.16.5)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.4.0)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -13627,7 +13619,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.16.5)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.4.0)(jiti@2.6.1)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/services/teams-mcp/package.json
+++ b/services/teams-mcp/package.json
@@ -49,6 +49,7 @@
     "@unique-ag/probe": "workspace:*",
     "amqplib": "0.10.9",
     "cache-manager": "7.2.0",
+    "drizzle-kit": "0.31.4",
     "drizzle-orm": "0.45.2",
     "drizzle-zod": "0.8.3",
     "jsonwebtoken": "9.0.3",
@@ -84,7 +85,6 @@
     "@types/pg": "8.15.5",
     "@types/supertest": "6.0.3",
     "@vitest/coverage-istanbul": "3.2.4",
-    "drizzle-kit": "0.31.4",
     "globals": "16.3.0",
     "istanbul-badges-readme": "1.9.0",
     "source-map-support": "0.5.21",
@@ -93,5 +93,6 @@
     "typescript": "5.9.2",
     "unplugin-swc": "1.5.7",
     "vitest": "3.2.4"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }


### PR DESCRIPTION
## Summary
- Move `drizzle-kit` from `devDependencies` to `dependencies` in `services/teams-mcp/package.json` so it survives `pnpm deploy out` (which prunes devDeps) and is present in the runner image.
- Add `"packageManager": "pnpm@10.28.1"` so corepack at runtime resolves the pinned version from the deployed manifest instead of its bundled default (currently pnpm 11.x).

## Why
The teams-mcp Argo `migration` job was failing with:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.1.2.tgz
[EROFS] EROFS: read-only file system, open '/app/_tmp_19_...'
```

Without `drizzle-kit` in runtime `dependencies`, the migration job fell back to running `pnpm install` at startup. The deployed `package.json` (from `pnpm deploy out`) had no `packageManager` field, so corepack used its bundled default (pnpm 11.1.2), tried to fetch it, and hit EROFS on the read-only container filesystem.

Same fix as #529 (outlook-semantic-mcp).

## Test plan
- [ ] Image builds (`docker build -f services/teams-mcp/deploy/Dockerfile .`)
- [ ] `node_modules/.bin/drizzle-kit` is present in the runner stage
- [ ] Argo `migration` job succeeds on next deploy without pnpm download attempts