### PR TITLE
docs(sharepoint-connector): document siteDefaults configuration

### DIFF
--- a/services/sharepoint-connector/docs/faq.md
+++ b/services/sharepoint-connector/docs/faq.md
@@ -196,7 +196,7 @@ The same migration path covers transitions between the two `scopeId` variants:
 
 ### When should I use `in_parent:` instead of a fixed scope ID?
 
-**Answer:** Use `in_parent:scope_<parentId>` when you want the connector to find-or-create a per-site root scope under a shared parent automatically, instead of pre-creating one scope per site. It's useful when many sites need to be onboarded quickly and you don't want operators to materialise a scope before each ingestion request. The auto-created scope is named after the SharePoint site's URL slug. Removing the site (via `syncStatus: deleted`) removes the auto-created scope; the parent stays operator-managed and is never claimed by the connector.
+**Answer:** Use `in_parent:scope_<parentId>` when you want the connector to find-or-create a per-site root scope under a shared parent automatically, instead of pre-creating one scope per site. It's useful when many sites need to be onboarded quickly and you don't want operators to materialise a scope before each ingestion request. The auto-created scope is named after the SharePoint site's URL slug. Removing the site (via `syncStatus: deleted`) removes the auto-created scope.
 
 ### What happens if I unflag a document?
 

--- a/services/sharepoint-connector/docs/faq.md
+++ b/services/sharepoint-connector/docs/faq.md
@@ -110,16 +110,16 @@ sharepoint:
 
 ### What columns are needed for the SharePoint configuration list?
 
-**Answer:** When using `sharepoint_list` as the sites source, create a list with these columns:
+**Answer:** When using `sharepoint_list` as the sites source, create a list with these columns. Only `siteId` must be present as a column on the list — every other column marked `Yes*` can instead be supplied via `sharepoint.siteDefaults` in the tenant config, in which case the column can be omitted from the list entirely. See [Site Defaults](./operator/configuration.md#Site-Defaults).
 
 | Column Display Name          | Type             | Required | Description                                   |
 | ---------------------------- | ---------------- | -------- | --------------------------------------------- |
 | `siteId`                     | Single line text | Yes      | SharePoint site ID (UUID)                     |
-| `syncColumnName`             | Single line text | Yes      | Column marking files for sync                 |
-| `ingestionMode`              | Choice           | Yes      | `flat` or `recursive`                         |
-| `uniqueScopeId`              | Single line text | Yes      | Unique scope ID                               |
-| `syncStatus`                 | Choice           | Yes      | `active`, `inactive`, or `deleted`            |
-| `syncMode`                   | Choice           | Yes      | `content_only` or `content_and_permissions`   |
+| `syncColumnName`             | Single line text | Yes\*    | Column marking files for sync                 |
+| `ingestionMode`              | Choice           | Yes\*    | `flat` or `recursive`                         |
+| `uniqueScopeId`              | Single line text | Yes\*    | Unique scope ID                               |
+| `syncStatus`                 | Choice           | Yes\*    | `active`, `inactive`, or `deleted`            |
+| `syncMode`                   | Choice           | Yes\*    | `content_only` or `content_and_permissions`   |
 | `maxFilesToIngest`           | Number           | No       | Optional limit                                |
 | `storeInternally`            | Choice           | No       | `enabled` or `disabled`                       |
 | `permissionsInheritanceMode` | Choice           | No       | Inheritance settings                          |

--- a/services/sharepoint-connector/docs/operator/configuration.md
+++ b/services/sharepoint-connector/docs/operator/configuration.md
@@ -50,24 +50,28 @@ Sites can be configured in two ways:
 sharepoint:
   # ... auth and base configuration ...
 
+  # Deployment-wide defaults applied to every site below; per-site values
+  # win when set. See "Site Defaults" further down for full semantics.
+  siteDefaults:
+    syncColumnName: FinanceGPTKnowledge
+    storeInternally: enabled
+    syncStatus: active
+    syncMode: content_only
+    permissionsInheritanceMode: inherit_scopes_and_files
+
   sitesSource: config_file
   sites:
+    # Overrides syncMode for this site; everything else inherits from siteDefaults.
     - siteId: 12345678-1234-1234-1234-123456789abc
-      syncColumnName: FinanceGPTKnowledge
       ingestionMode: recursive
       scopeId: scope_bu4gokr0atzj0kfiuaaaaaaa
       maxFilesToIngest: 1000
-      storeInternally: enabled
-      syncStatus: active
       syncMode: content_and_permissions
+    # Overrides syncColumnName for this site; everything else inherits from siteDefaults.
     - siteId: 87654321-4321-4321-4321-cba987654321
       syncColumnName: HRKnowledge
       ingestionMode: flat
       scopeId: scope_bu4gokr0atzj0kfiubbbbbb
-      storeInternally: enabled
-      syncStatus: active
-      syncMode: content_only
-      permissionsInheritanceMode: inherit_scopes_and_files
 ```
 
 ### Dynamic Sites Configuration (sharepoint_list)
@@ -198,7 +202,7 @@ The connector supports HTTP/HTTPS proxy for environments where internet access i
 
 ## SharePoint List Configuration
 
-When using `sharepoint_list` as the sites source, create a SharePoint list with the following columns:
+When using `sharepoint_list` as the sites source, create a SharePoint list with the following columns. Only `siteId` is strictly required as a column on the list — any other column whose value is set via [Site Defaults](#Site-Defaults) can be omitted from the list entirely, and rows will inherit the deployment-wide value.
 
 | Column Display Name          | Type             | Description                                                                                                       |
 | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |

--- a/services/sharepoint-connector/docs/operator/configuration.md
+++ b/services/sharepoint-connector/docs/operator/configuration.md
@@ -102,12 +102,13 @@ sharepoint:
     thumbprintSha1: AB12CD34EF56...
 ```
 
-| Option                                | Required | Default | Description                                                                                      |
-| ------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------ |
-| `tenantId`                            | Yes      | —       | Azure AD tenant ID                                                                               |
-| `baseUrl`                             | Yes      | —       | Company SharePoint URL (e.g., `https://acme.sharepoint.com`). Must not end with a trailing slash |
-| `graphApiRateLimitPerMinuteThousands` | No       | `780`   | Microsoft Graph API rate limit in thousands of requests per minute                               |
-| `auth`                                | Yes      | —       | Authentication configuration (see below)                                                         |
+| Option                                | Required | Default | Description                                                                                       |
+| ------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `tenantId`                            | Yes      | —       | Azure AD tenant ID                                                                                |
+| `baseUrl`                             | Yes      | —       | Company SharePoint URL (e.g., `https://acme.sharepoint.com`). Must not end with a trailing slash  |
+| `graphApiRateLimitPerMinuteThousands` | No       | `780`   | Microsoft Graph API rate limit in thousands of requests per minute                                |
+| `auth`                                | Yes      | —       | Authentication configuration (see [Authentication](#Authentication))                              |
+| `siteDefaults`                        | No       | `{}`    | Deployment-level fallbacks applied to every per-site config (see [Site Defaults](#Site-Defaults)) |
 
 ### Authentication
 
@@ -199,18 +200,18 @@ The connector supports HTTP/HTTPS proxy for environments where internet access i
 
 When using `sharepoint_list` as the sites source, create a SharePoint list with the following columns:
 
-| Column Display Name          | Type             | Description                                                                                  |
-| ---------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
-| `siteId`                     | Single line text | SharePoint site ID (UUID or compound format: `hostname,siteCollectionId,webId` for subsites) |
-| `syncColumnName`             | Single line text | Column that marks files for sync                                                             |
-| `ingestionMode`              | Choice           | `flat` or `recursive`                                                                        |
+| Column Display Name          | Type             | Description                                                                                                       |
+| ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `siteId`                     | Single line text | SharePoint site ID (UUID or compound format: `hostname,siteCollectionId,webId` for subsites)                      |
+| `syncColumnName`             | Single line text | Column that marks files for sync                                                                                  |
+| `ingestionMode`              | Choice           | `flat` or `recursive`                                                                                             |
 | `uniqueScopeId`              | Single line text | Unique scope ID. Either `scope_<id>` (existing root) or `in_parent:scope_<parentId>` (auto-resolve under parent). |
-| `maxFilesToIngest`           | Number           | Maximum new + updated files per sync cycle; sync fails for the site if exceeded              |
-| `storeInternally`            | Choice           | `enabled` or `disabled`                                                                      |
-| `syncStatus`                 | Choice           | `active`, `inactive`, or `deleted`                                                           |
-| `syncMode`                   | Choice           | `content_only` or `content_and_permissions`                                                  |
-| `permissionsInheritanceMode` | Choice           | Optional inheritance mode                                                                    |
-| `subsitesScan`               | Choice           | `enabled` or `disabled` (default: `disabled`)                                                |
+| `maxFilesToIngest`           | Number           | Maximum new + updated files per sync cycle; sync fails for the site if exceeded                                   |
+| `storeInternally`            | Choice           | `enabled` or `disabled`                                                                                           |
+| `syncStatus`                 | Choice           | `active`, `inactive`, or `deleted`                                                                                |
+| `syncMode`                   | Choice           | `content_only` or `content_and_permissions`                                                                       |
+| `permissionsInheritanceMode` | Choice           | Optional inheritance mode                                                                                         |
+| `subsitesScan`               | Choice           | `enabled` or `disabled` (default: `disabled`)                                                                     |
 
 ### Benefits of SharePoint List Configuration
 
@@ -223,24 +224,24 @@ When using `sharepoint_list` as the sites source, create a SharePoint list with 
 
 **Important:** The connector is a singleton — each SharePoint site must be configured in at most one connector process per Unique instance. Configuring the same site in multiple processes leads to conflicting state and unexpected behavior of the connector.
 
-| Option                       | Values                                          | Default                    | Description                                                                                                                                                                                                                                                                                                                                                                |
-| ---------------------------- | ----------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `siteId`                     | UUID or compound ID                             | — (required)               | SharePoint site ID. Subsites use compound format: `hostname,siteCollectionId,webId`                                                                                                                                                                                                                                                                                        |
-| `syncColumnName`             | String                                          | `FinanceGPTKnowledge`      | Display name or internal name of the sync flag column (display name takes priority)                                                                                                                                                                                                                                                                                        |
-| `ingestionMode`              | `flat`, `recursive`                             | — (required)               | Flat ingests all to one scope; recursive maintains hierarchy                                                                                                                                                                                                                                                                                                               |
-| `scopeId`                    | `scope_<id>` or `in_parent:scope_<parentId>`    | — (required)               | Where to mount this site's content. `scope_<id>` uses an existing scope as the site root (operator must have created it). `in_parent:scope_<parentId>` finds-or-creates a child scope under the given parent automatically — useful when many sites share a single parent and the operator doesn't want to pre-create a scope per site.                                    |
-| `maxFilesToIngest`           | Number                                          | — (unlimited)              | Maximum new + updated files per sync cycle; sync fails for the site if exceeded                                                                                                                                                                                                                                                                                            |
-| `storeInternally`            | `enabled`, `disabled`                           | `enabled`                  | Whether to store content in Unique                                                                                                                                                                                                                                                                                                                                         |
-| `syncStatus`                 | `active`, `inactive`, `deleted`                 | `active`                   | Control sync behavior                                                                                                                                                                                                                                                                                                                                                      |
-| `syncMode`                   | `content_only`, `content_and_permissions`       | — (required)               | What to sync                                                                                                                                                                                                                                                                                                                                                               |
-| `permissionsInheritanceMode` | See below                                       | `inherit_scopes_and_files` | Inheritance settings for content_only mode                                                                                                                                                                                                                                                                                                                                 |
-| `subsitesScan`               | `enabled`, `disabled`                           | `disabled`                 | Recursively discover and sync content from subsites                                                                                                                                                                                                                                                                                                                        |
+| Option                       | Values                                                                | Default                    | Description                                                                                                                                                    |
+| ---------------------------- | --------------------------------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `siteId`                     | UUID or compound ID                                                   | — (required)               | SharePoint site ID. Subsites use compound format: `hostname,siteCollectionId,webId`                                                                            |
+| `syncColumnName`             | String                                                                | `FinanceGPTKnowledge`      | Display name or internal name of the sync flag column (display name takes priority)                                                                            |
+| `ingestionMode`              | `flat`, `recursive`                                                   | — (required)               | Flat ingests all to one scope; recursive maintains hierarchy                                                                                                   |
+| `scopeId`                    | `scope_<id>` or `in_parent:scope_<parentId>`                          | — (required)               | Where to mount this site's content, see [Choosing between fixed scope and `in_parent:` auto-resolve](#Choosing-between-fixed-scope-and-in_parent-auto-resolve) |
+| `maxFilesToIngest`           | Number                                                                | — (unlimited)              | Maximum new + updated files per sync cycle; sync fails for the site if exceeded                                                                                |
+| `storeInternally`            | `enabled`, `disabled`                                                 | `enabled`                  | Whether to store content in Unique                                                                                                                             |
+| `syncStatus`                 | `active`, `inactive`, `deleted`                                       | `active`                   | Control sync behavior                                                                                                                                          |
+| `syncMode`                   | `content_only`, `content_and_permissions`                             | — (required)               | What to sync                                                                                                                                                   |
+| `permissionsInheritanceMode` | `none`, `inherit_files`, `inherit_scopes`, `inherit_scopes_and_files` | `inherit_scopes_and_files` | Inheritance settings for content_only, see [Permissions Inheritance Modes](#Permissions-Inheritance-Modes) mode                                                |
+| `subsitesScan`               | `enabled`, `disabled`                                                 | `disabled`                 | Recursively discover and sync content from subsites                                                                                                            |
 
 ### Choosing between fixed scope and `in_parent:` auto-resolve
 
 **Fixed (`scope_<id>`)** — each site needs its own scope, pre-created by the operator before the site is configured. Best when scopes are managed centrally and named or permissioned individually, since the operator stays in full control of the scope's identity, ACLs, and lifecycle.
 
-**Auto (`in_parent:scope_<parentId>`)** — the connector finds-or-creates a child scope under the parent on every sync, named after the SharePoint site's URL slug. Multiple sites can legitimately share the same parent — the connector intentionally does not dedup by parent. Removing a site (via `syncStatus: deleted`) removes the auto-created scope; removing the parent itself stays the operator's responsibility, since the parent's externalId is never written by the connector. If a sibling scope under the parent already has the same site name and isn't claimed by us, the connector aborts the sync with a typed error rather than guessing — the four codes are `unclaimed_name_match` (orphan with no externalId), `foreign_name_match` (claimed by a different site), `ambiguous_name_match` (multiple siblings share the name), and `claim_failed` (creation succeeded but the externalId update didn't — the connector rolls back the create).
+**Auto (`in_parent:scope_<parentId>`)** — the connector finds-or-creates a child scope under the parent on every sync, named after the SharePoint site's URL slug. Removing a site (via `syncStatus: deleted`) removes the auto-created scope. If a sibling scope under the parent already has the same site name and isn't claimed by us, the connector aborts the sync with a typed error rather than guessing to stay on the safe side and not sync a site into a user folder.
 
 ### Permissions Inheritance Modes
 
@@ -252,6 +253,86 @@ Only used when `syncMode` is `content_only`. It controls whether newly created s
 | `inherit_scopes`           | Yes            | No            |
 | `inherit_files`            | No             | Yes           |
 | `none`                     | No             | No            |
+
+## Site Defaults
+
+`sharepoint.siteDefaults` lets you set deployment-level fallbacks for any per-site option except `siteId`. Each site (whether sourced from `config_file` or from a `sharepoint_list` row) is merged with the defaults: if the per-site value is set, it wins; otherwise the default is used. This keeps individual site entries terse and makes it easy to change a policy across an entire deployment in one place.
+
+### With `config_file`
+
+```yaml
+sharepoint:
+  # ... auth and base configuration ...
+
+  siteDefaults:
+    syncColumnName: FinanceGPTKnowledge
+    ingestionMode: recursive
+    storeInternally: enabled
+    syncStatus: active
+    syncMode: content_only
+    permissionsInheritanceMode: inherit_scopes_and_files
+    subsitesScan: disabled
+
+  sitesSource: config_file
+  sites:
+    # Inherits everything from siteDefaults except scopeId / maxFilesToIngest
+    - siteId: 12345678-1234-1234-1234-123456789abc
+      scopeId: scope_bu4gokr0atzj0kfiuaaaaaaa
+      maxFilesToIngest: 1000
+    # Overrides syncColumnName and ingestionMode for this site
+    - siteId: 87654321-4321-4321-4321-cba987654321
+      syncColumnName: HRKnowledge
+      ingestionMode: flat
+      scopeId: scope_bu4gokr0atzj0kfiubbbbbb
+```
+
+### With `sharepoint_list`
+
+`siteDefaults` works identically for `sharepoint_list`: any column whose value is set on a row wins; any column that is blank (or whose mapped field is `undefined` because the column is not present on the list at all) falls back to the default. This means **columns covered by `siteDefaults` can be omitted from the SharePoint list entirely** — only the columns you want to vary per row need to exist. At minimum, the list must carry `siteId`; everything else can live in `siteDefaults`.
+
+```yaml
+sharepoint:
+  # ... auth and base configuration ...
+
+  siteDefaults:
+    syncColumnName: FinanceGPTKnowledge
+    ingestionMode: recursive
+    storeInternally: enabled
+    syncStatus: active
+    syncMode: content_only
+    permissionsInheritanceMode: inherit_scopes_and_files
+    subsitesScan: disabled
+    # Common pattern: every site auto-creates a child under one shared parent scope,
+    # so the list does not need a `uniqueScopeId` column at all.
+    scopeId: in_parent:scope_bu4gokr0atzj0kfiucccccc
+
+  sitesSource: sharepoint_list
+  sharepointList:
+    siteId: your-config-site-id-here
+    listId: 00000000-0000-0000-0000-000000000000
+```
+
+With the example above, the SharePoint list can be reduced to a single `siteId` column — every other per-site field is supplied by `siteDefaults`. Add columns back to the list only when you need per-site overrides for those fields.
+
+### Merge Rules
+
+- **Per-site value wins when "set".** For string-typed fields (including `siteId`, `scopeId`, `syncColumnName`), "set" means non-`undefined` and non-empty after trim — so a blank cell in a SharePoint list row falls back to the default. For numeric/enum fields, any non-`undefined` value counts as set.
+- **Required-after-merge.** `ingestionMode`, `scopeId`, and `syncMode` are required on the final merged config. If a per-site entry omits them and `siteDefaults` does not supply them either, the merger throws — and because sites are merged eagerly at the start of every sync cycle (for both `config_file` and `sharepoint_list`), a single unmergeable row aborts the **entire sync cycle**, not just that site. The service stays running and retries on the next scheduled cycle; the failure is recorded as a full-sync failure with step `SitesConfigLoading`.
+- **`siteId` cannot be defaulted.** It must always be set per site.
+
+### Schema Defaults
+
+The fields below have schema-level defaults applied even when you do not provide a `siteDefaults` block. Listing them in `siteDefaults` is still allowed if you want to make them explicit, but it is optional.
+
+| Field                        | Schema Default             |
+| ---------------------------- | -------------------------- |
+| `syncColumnName`             | `FinanceGPTKnowledge`      |
+| `storeInternally`            | `enabled`                  |
+| `syncStatus`                 | `active`                   |
+| `permissionsInheritanceMode` | `inherit_scopes_and_files` |
+| `subsitesScan`               | `disabled`                 |
+
+The remaining defaultable fields (`ingestionMode`, `scopeId`, `maxFilesToIngest`, `syncMode`) have no schema default — they take effect only if you set them under `siteDefaults` or per site.
 
 ## SharePoint Site Configuration
 


### PR DESCRIPTION
- Adds a dedicated **Site Defaults** section to the SharePoint Connector operator configuration guide. The `sharepoint.siteDefaults` block was previously undocumented despite being shipped in the example tenant configs.
- Documents merge semantics (per-site value wins when "set"; required-after-merge fields — `ingestionMode`, `scopeId`, `syncMode` — abort the entire sync cycle on the next tick if unresolved, not at startup and not isolated to a single site), schema-level defaults, and gives separate examples for `config_file` and `sharepoint_list`. Notes that columns covered by `siteDefaults` can be omitted from the SharePoint list entirely.
- Drive-by cleanup: replaces "see below" pointers with explicit `#Section-Name` Confluence-style anchors, and shortens the per-site `scopeId` description in favor of a link to the existing "Choosing between fixed scope and `in_parent:` auto-resolve" subsection (mirroring how `permissionsInheritanceMode` is handled).