### PR TITLE
fix(outlook-semantic-mcp): load users from the same tenant

### DIFF
--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.spec.ts
@@ -306,7 +306,7 @@ describe('SharedMailboxSyncService', () => {
       vi.clearAllMocks();
     });
 
-    it('returns null from factory → logs warning, no DB operations, no cache update', async () => {
+    it('returns null from factory → logs warning, cleans up stale rows, no cache update', async () => {
       const { service, db, graphClientFactory, persistentCacheService } = createService({
         config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [null],
@@ -315,7 +315,9 @@ describe('SharedMailboxSyncService', () => {
       await (service as any).runSyncWithRetries();
 
       expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenCalledOnce();
-      expect(db.delete).not.toHaveBeenCalled();
+      // Cleanup always runs; with no matched users the delete has no NOT IN clause
+      expect(db.delete).toHaveBeenCalledOnce();
+      expect(db.insert).not.toHaveBeenCalled();
       expect(persistentCacheService.set).not.toHaveBeenCalled();
     });
   });

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.spec.ts
@@ -255,7 +255,10 @@ describe('SharedMailboxSyncService', () => {
         resolveFactory = resolve;
       });
 
-      const { service, graphClientFactory } = createService({ cacheResult: null });
+      const { service, graphClientFactory } = createService({
+        cacheResult: null,
+        config: { sharedMailboxEmails: ['shared@example.com'] },
+      });
       graphClientFactory.createClientForAnyAuthorizedUser.mockReturnValue(delayedFactory);
 
       const first = (service as any).runSyncWithRetries();
@@ -280,6 +283,7 @@ describe('SharedMailboxSyncService', () => {
     it('syncIsRunning is reset after a run, allowing a subsequent call to proceed', async () => {
       const mockClient = makeGraphClient([{ value: [] }, { value: [] }]);
       const { service, graphClientFactory } = createService({
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [
           { client: mockClient, userId: 'user1' },
           { client: mockClient, userId: 'user1' },
@@ -335,7 +339,7 @@ describe('SharedMailboxSyncService', () => {
       // factoryResults: [] keeps the Once queue empty so our mockImplementationOnce
       // calls below are the first entries and aren't shadowed by pre-queued values.
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [],
       });
       graphClientFactory.createClientForAnyAuthorizedUser
@@ -360,7 +364,7 @@ describe('SharedMailboxSyncService', () => {
       const clientSuccess = makeGraphClient([{ value: [] }]);
 
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [
           { client: client401, userId: 'user1' },
           { client: clientSuccess, userId: 'user2' },
@@ -370,9 +374,11 @@ describe('SharedMailboxSyncService', () => {
       await (service as any).runSyncWithRetries();
 
       expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenCalledTimes(2);
-      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(2, [
-        'user1',
-      ]);
+      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(
+        2,
+        ['user1'],
+        'example.com',
+      );
     });
 
     it('429 from Graph → retries with same user (no exclusion)', async () => {
@@ -380,7 +386,7 @@ describe('SharedMailboxSyncService', () => {
       const clientSuccess = makeGraphClient([{ value: [] }]);
 
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [
           { client: client429, userId: 'user1' },
           { client: clientSuccess, userId: 'user1' },
@@ -391,8 +397,16 @@ describe('SharedMailboxSyncService', () => {
 
       expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenCalledTimes(2);
       // Both calls exclude nothing extra — excludedUserIds stays empty on 429
-      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(1, []);
-      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(2, []);
+      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(
+        1,
+        [],
+        'example.com',
+      );
+      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(
+        2,
+        [],
+        'example.com',
+      );
     });
 
     it('500 from Graph → retries with same user (transient error)', async () => {
@@ -400,7 +414,7 @@ describe('SharedMailboxSyncService', () => {
       const clientSuccess = makeGraphClient([{ value: [] }]);
 
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [
           { client: client500, userId: 'user1' },
           { client: clientSuccess, userId: 'user1' },
@@ -410,14 +424,18 @@ describe('SharedMailboxSyncService', () => {
       await (service as any).runSyncWithRetries();
 
       expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenCalledTimes(2);
-      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(2, []);
+      expect(graphClientFactory.createClientForAnyAuthorizedUser).toHaveBeenNthCalledWith(
+        2,
+        [],
+        'example.com',
+      );
     });
 
     it('non-retryable GraphError (e.g. 404) → stops after first attempt, no retry', async () => {
       const client404 = makeGraphClient([makeGraphError(404)]);
 
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [{ client: client404, userId: 'user1' }],
       });
 
@@ -431,7 +449,7 @@ describe('SharedMailboxSyncService', () => {
       const clientPlainError = makeGraphClient([new Error('unexpected')]);
 
       const { service, graphClientFactory } = createService({
-        config: { sharedMailboxEmails: [] },
+        config: { sharedMailboxEmails: ['shared@example.com'] },
         factoryResults: [{ client: clientPlainError, userId: 'user1' }],
       });
 

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -4,7 +4,7 @@ import { Client, GraphError } from '@microsoft/microsoft-graph-client';
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
-import { and, eq, ilike, inArray, not, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, not, sql } from 'drizzle-orm';
 import { DelegatedAccessConfig, delegatedAccessConfig } from '~/config';
 import { DRIZZLE, DrizzleDatabase, userProfiles } from '~/db';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
@@ -206,22 +206,19 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     // Delete source='shared-mailbox' rows that belong to a synced domain but are no longer matched.
     // We only delete for successfully synced domains so that rows for domains with no authorized
     // user are left untouched until a future run can verify them.
-    if (syncedDomains.length > 0) {
-      await this.db.delete(userProfiles).where(
-        and(
-          eq(userProfiles.source, 'shared-mailbox'),
-          or(...syncedDomains.map((d) => ilike(userProfiles.email, `%@${d}`))),
-          allMatchedUsers.length > 0
-            ? not(
-                inArray(
-                  sql`lower(${userProfiles.email})`,
-                  allMatchedUsers.map((item) => item.mail),
-                ),
-              )
-            : undefined,
-        ),
-      );
-    }
+    await this.db.delete(userProfiles).where(
+      and(
+        eq(userProfiles.source, 'shared-mailbox'),
+        allMatchedUsers.length > 0
+          ? not(
+              inArray(
+                sql`lower(${userProfiles.email})`,
+                allMatchedUsers.map((item) => item.mail),
+              ),
+            )
+          : undefined,
+      ),
+    );
 
     // Upsert matched users
     if (allMatchedUsers.length > 0) {

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -1,25 +1,19 @@
-import { createHash } from "node:crypto";
-import { OAuthUserProfile } from "@unique-ag/mcp-oauth";
-import { Client, GraphError } from "@microsoft/microsoft-graph-client";
-import {
-  Inject,
-  Injectable,
-  Logger,
-  OnModuleDestroy,
-  OnModuleInit,
-} from "@nestjs/common";
-import { SchedulerRegistry } from "@nestjs/schedule";
-import { CronJob } from "cron";
-import { and, eq, ilike, inArray, not, or, sql } from "drizzle-orm";
-import { DelegatedAccessConfig, delegatedAccessConfig } from "~/config";
-import { DRIZZLE, DrizzleDatabase, userProfiles } from "~/db";
-import { GraphClientFactory } from "~/msgraph/graph-client.factory";
-import { NonNullishProps } from "~/utils/non-nullish-props";
-import { sleep } from "~/utils/sleep";
-import { PersistentCacheService } from "../persistent-cache/persistent-cache.service";
+import { createHash } from 'node:crypto';
+import { OAuthUserProfile } from '@unique-ag/mcp-oauth';
+import { Client, GraphError } from '@microsoft/microsoft-graph-client';
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import { and, eq, ilike, inArray, not, or, sql } from 'drizzle-orm';
+import { DelegatedAccessConfig, delegatedAccessConfig } from '~/config';
+import { DRIZZLE, DrizzleDatabase, userProfiles } from '~/db';
+import { GraphClientFactory } from '~/msgraph/graph-client.factory';
+import { NonNullishProps } from '~/utils/non-nullish-props';
+import { sleep } from '~/utils/sleep';
+import { PersistentCacheService } from '../persistent-cache/persistent-cache.service';
 
-export const SHARED_MAILBOX_SYNC_CACHE_KEY = "SharedMailboxSync";
-const CRON_JOB_NAME = "shared-mailbox-sync";
+export const SHARED_MAILBOX_SYNC_CACHE_KEY = 'SharedMailboxSync';
+const CRON_JOB_NAME = 'shared-mailbox-sync';
 
 interface GraphUser {
   id: string;
@@ -53,7 +47,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   public async onModuleInit(): Promise<void> {
-    if (this.config.scan === "disabled") {
+    if (this.config.scan === 'disabled') {
       return;
     }
     // We only run the sync if the env var changed since our last run.
@@ -61,7 +55,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
       await this.runSyncWithRetries();
     } else {
       this.logger.log({
-        msg: "SharedMailboxSync: config unchanged since last sync, skipping startup sync",
+        msg: 'SharedMailboxSync: config unchanged since last sync, skipping startup sync',
       });
     }
     this.setupCronJob();
@@ -74,33 +68,30 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
       job.stop();
     } catch (err) {
       this.logger.error({
-        msg: "Error stopping shared-mailbox-sync cron job",
+        msg: 'Error stopping shared-mailbox-sync cron job',
         err,
       });
     }
   }
 
   private setupCronJob(): void {
-    if (this.config.scan === "disabled") {
+    if (this.config.scan === 'disabled') {
       return;
     }
     // We need a cron job because once the mcp is setup we have no active user and we cannot sync the shared
     // mailboxes to database and we have to eighter login and restart the mcp or we can tell the client that
     // it takes at most until the next cron runs and there is a user which can list their ms graph users.
     // Since the mcp has in SCOPES User.Read.All all uses should have the permission to do this sync.
-    const job = new CronJob(
-      this.config.sharedMailboxSyncCronSchedule,
-      async () => {
-        try {
-          await this.runSyncWithRetries();
-        } catch (err) {
-          this.logger.error({
-            msg: "Unexpected error during shared mailbox sync cron",
-            err,
-          });
-        }
-      },
-    );
+    const job = new CronJob(this.config.sharedMailboxSyncCronSchedule, async () => {
+      try {
+        await this.runSyncWithRetries();
+      } catch (err) {
+        this.logger.error({
+          msg: 'Unexpected error during shared mailbox sync cron',
+          err,
+        });
+      }
+    });
     this.schedulerRegistry.addCronJob(CRON_JOB_NAME, job);
     job.start();
   }
@@ -108,7 +99,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
   private async hasConfigChangedSinceLastSync(): Promise<boolean> {
     const cached = await this.persistentCacheService.get(
       SHARED_MAILBOX_SYNC_CACHE_KEY,
-      "SharedMailboxSync",
+      'SharedMailboxSync',
     );
     if (!cached) {
       return true;
@@ -132,10 +123,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
           await this.syncSharedMailboxesProfiles(excludedUserIds);
           break;
         } catch (err) {
-          const { shouldRetry, excludeUserId } = this.handleSyncError(
-            attempt,
-            err,
-          );
+          const { shouldRetry, excludeUserId } = this.handleSyncError(attempt, err);
           if (excludeUserId) {
             excludedUserIds.push(excludeUserId);
           }
@@ -152,37 +140,34 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
 
   // Sync shared mailboxes will read the mailboxes from the env var will cross reference
   // them with msGraph api and save the common result to database.
-  private async syncSharedMailboxesProfiles(
-    excludedUserIds: string[],
-  ): Promise<void> {
+  private async syncSharedMailboxesProfiles(excludedUserIds: string[]): Promise<void> {
     if (this.isShuttingDown) {
-      this.logger.log({ msg: "Skipping shared mailbox sync due to shutdown" });
+      this.logger.log({ msg: 'Skipping shared mailbox sync due to shutdown' });
       return;
     }
 
-    this.logger.log({ msg: "SharedMailboxSync: starting sync" });
+    this.logger.log({ msg: 'SharedMailboxSync: starting sync' });
 
     const envEmails = this.getSharedMailboxEmails();
     if (envEmails.length === 0) {
       this.logger.warn({
-        msg: "SharedMailboxSync: DELEGATED_ACCESS_SHARED_MAILBOX_EMAILS env var is empty or unset",
+        msg: 'SharedMailboxSync: DELEGATED_ACCESS_SHARED_MAILBOX_EMAILS env var is empty or unset',
       });
     }
 
     // We group by email because the mcp in our QA handles 2 tenants, the unique prod and the dogfood tenant.
     const emailsByDomain = this.groupEmailsByDomain(envEmails);
-    const allMatchedUsers: NonNullishProps<GraphUser, "mail">[] = [];
+    const allMatchedUsers: NonNullishProps<GraphUser, 'mail'>[] = [];
     const syncedDomains: string[] = [];
 
     for (const [domain, domainEmails] of emailsByDomain) {
-      const result =
-        await this.graphClientFactory.createClientForAnyAuthorizedUser(
-          excludedUserIds,
-          domain,
-        );
+      const result = await this.graphClientFactory.createClientForAnyAuthorizedUser(
+        excludedUserIds,
+        domain,
+      );
       if (!result) {
         this.logger.warn({
-          msg: "SharedMailboxSync: no authorized user profile found for domain, skipping",
+          msg: 'SharedMailboxSync: no authorized user profile found for domain, skipping',
           domain,
         });
         continue;
@@ -195,24 +180,21 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
         syncedDomains.push(domain);
       } catch (err) {
         if (err instanceof GraphError) {
-          throw new FetchUsersError(
-            userId,
-            `Failed to fetch users from ms graph`,
-            { cause: err },
-          );
+          throw new FetchUsersError(userId, `Failed to fetch users from ms graph`, { cause: err });
         }
         throw err;
       }
 
       const matched = graphUsers
         .map((u) => ({ ...u, mail: u.mail?.toLowerCase() }))
-        .filter(
-          (user) => user.mail && domainEmails.includes(user.mail),
-        ) as NonNullishProps<GraphUser, "mail">[];
+        .filter((user) => user.mail && domainEmails.includes(user.mail)) as NonNullishProps<
+        GraphUser,
+        'mail'
+      >[];
 
       if (matched.length === 0 && domainEmails.length > 0) {
         this.logger.warn({
-          msg: "SharedMailboxSync: no Graph users found for the configured shared mailbox emails",
+          msg: 'SharedMailboxSync: no Graph users found for the configured shared mailbox emails',
           domain,
           domainEmails,
         });
@@ -227,7 +209,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     if (syncedDomains.length > 0) {
       await this.db.delete(userProfiles).where(
         and(
-          eq(userProfiles.source, "shared-mailbox"),
+          eq(userProfiles.source, 'shared-mailbox'),
           or(...syncedDomains.map((d) => ilike(userProfiles.email, `%@${d}`))),
           allMatchedUsers.length > 0
             ? not(
@@ -244,29 +226,27 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     // Upsert matched users
     if (allMatchedUsers.length > 0) {
       type UserProfileInsert = typeof userProfiles.$inferInsert;
-      const mappedProfiles: UserProfileInsert[] = allMatchedUsers.map(
-        (user) => {
-          const rawData: OAuthUserProfile = {
-            id: user.id ?? undefined,
-            displayName: user.displayName ?? undefined,
-            username: user.mail ?? undefined,
-            email: user.mail ?? undefined,
-            avatarUrl: undefined,
-            raw: user,
-          };
-          return {
-            provider: "microsoft" as const,
-            providerUserId: user.id,
-            username: user.mail,
-            email: user.mail,
-            displayName: user.displayName ?? null,
-            source: "shared-mailbox" as const,
-            accessToken: null,
-            refreshToken: null,
-            raw: rawData,
-          };
-        },
-      );
+      const mappedProfiles: UserProfileInsert[] = allMatchedUsers.map((user) => {
+        const rawData: OAuthUserProfile = {
+          id: user.id ?? undefined,
+          displayName: user.displayName ?? undefined,
+          username: user.mail ?? undefined,
+          email: user.mail ?? undefined,
+          avatarUrl: undefined,
+          raw: user,
+        };
+        return {
+          provider: 'microsoft' as const,
+          providerUserId: user.id,
+          username: user.mail,
+          email: user.mail,
+          displayName: user.displayName ?? null,
+          source: 'shared-mailbox' as const,
+          accessToken: null,
+          refreshToken: null,
+          raw: rawData,
+        };
+      });
 
       // source is intentionally omitted from the conflict update: if an Entra identity
       // already exists as an OAuth row we leave it as oauth. Overwriting source would
@@ -286,26 +266,31 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
         });
     }
 
-    // Update cache with new hash and timestamp
-    const newHash = this.hashMailboxes(envEmails);
-    await this.persistentCacheService.set(SHARED_MAILBOX_SYNC_CACHE_KEY, {
-      dataType: "SharedMailboxSync",
-      payload: {
-        envarHash: newHash,
-        lastSyncedAt: Date.now(),
-      },
-    });
+    // Only update the cache when every configured domain was successfully queried.
+    // If some domains had no authorized user we leave the cache stale so the next
+    // cron run retries them once a matching user logs in.
+    if (syncedDomains.length === emailsByDomain.size) {
+      const newHash = this.hashMailboxes(envEmails);
+      await this.persistentCacheService.set(SHARED_MAILBOX_SYNC_CACHE_KEY, {
+        dataType: 'SharedMailboxSync',
+        payload: {
+          envarHash: newHash,
+          lastSyncedAt: Date.now(),
+        },
+      });
+    }
 
     this.logger.log({
-      msg: "SharedMailboxSync: sync complete",
+      msg: 'SharedMailboxSync: sync complete',
       upserted: allMatchedUsers.length,
+      syncedDomains,
     });
   }
 
   private groupEmailsByDomain(emails: string[]): Map<string, string[]> {
     const map = new Map<string, string[]>();
     for (const email of emails) {
-      const atIdx = email.lastIndexOf("@");
+      const atIdx = email.lastIndexOf('@');
       if (atIdx === -1) {
         continue;
       }
@@ -359,10 +344,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     }
 
     // This is a transient graph api error which we hope we can fix by waiting and retrying.
-    if (
-      cause.statusCode === 429 ||
-      (cause.statusCode >= 500 && cause.statusCode < 600)
-    ) {
+    if (cause.statusCode === 429 || (cause.statusCode >= 500 && cause.statusCode < 600)) {
       this.logger.log({
         msg: `${msgBase}. cause is GraphError, transient graph api error. Retrying with the same user`,
         statusCode: cause.statusCode,
@@ -381,24 +363,22 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     return { shouldRetry: false };
   }
 
-  private async fetchSharedMailboxCandidatesFromGraph(
-    client: Client,
-  ): Promise<GraphUser[]> {
+  private async fetchSharedMailboxCandidatesFromGraph(client: Client): Promise<GraphUser[]> {
     const users: GraphUser[] = [];
 
     // Shared mailboxes appear in Entra ID as accountEnabled=false accounts
     let response = (await client
-      .api("/users")
-      .filter("accountEnabled eq false")
-      .select("id,mail,displayName")
-      .get()) as { value: GraphUser[]; "@odata.nextLink"?: string };
+      .api('/users')
+      .filter('accountEnabled eq false')
+      .select('id,mail,displayName')
+      .get()) as { value: GraphUser[]; '@odata.nextLink'?: string };
 
     users.push(...response.value);
 
-    while (response["@odata.nextLink"]) {
-      response = (await client.api(response["@odata.nextLink"]).get()) as {
+    while (response['@odata.nextLink']) {
+      response = (await client.api(response['@odata.nextLink']).get()) as {
         value: GraphUser[];
-        "@odata.nextLink"?: string;
+        '@odata.nextLink'?: string;
       };
       users.push(...response.value);
     }
@@ -407,15 +387,15 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
   }
 
   private getSharedMailboxEmails(): string[] {
-    if (this.config.scan === "disabled") {
+    if (this.config.scan === 'disabled') {
       return [];
     }
     return this.config.sharedMailboxEmails;
   }
 
   private hashMailboxes(mailboxes: string[]): string {
-    return createHash("sha256")
-      .update([...mailboxes].sort().join(","))
-      .digest("hex");
+    return createHash('sha256')
+      .update([...mailboxes].sort().join(','))
+      .digest('hex');
   }
 }

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -1,19 +1,25 @@
-import { createHash } from 'node:crypto';
-import { OAuthUserProfile } from '@unique-ag/mcp-oauth';
-import { Client, GraphError } from '@microsoft/microsoft-graph-client';
-import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { SchedulerRegistry } from '@nestjs/schedule';
-import { CronJob } from 'cron';
-import { and, eq, inArray, not, sql } from 'drizzle-orm';
-import { DelegatedAccessConfig, delegatedAccessConfig } from '~/config';
-import { DRIZZLE, DrizzleDatabase, userProfiles } from '~/db';
-import { GraphClientFactory } from '~/msgraph/graph-client.factory';
-import { NonNullishProps } from '~/utils/non-nullish-props';
-import { sleep } from '~/utils/sleep';
-import { PersistentCacheService } from '../persistent-cache/persistent-cache.service';
+import { createHash } from "node:crypto";
+import { OAuthUserProfile } from "@unique-ag/mcp-oauth";
+import { Client, GraphError } from "@microsoft/microsoft-graph-client";
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from "@nestjs/common";
+import { SchedulerRegistry } from "@nestjs/schedule";
+import { CronJob } from "cron";
+import { and, eq, ilike, inArray, not, or, sql } from "drizzle-orm";
+import { DelegatedAccessConfig, delegatedAccessConfig } from "~/config";
+import { DRIZZLE, DrizzleDatabase, userProfiles } from "~/db";
+import { GraphClientFactory } from "~/msgraph/graph-client.factory";
+import { NonNullishProps } from "~/utils/non-nullish-props";
+import { sleep } from "~/utils/sleep";
+import { PersistentCacheService } from "../persistent-cache/persistent-cache.service";
 
-export const SHARED_MAILBOX_SYNC_CACHE_KEY = 'SharedMailboxSync';
-const CRON_JOB_NAME = 'shared-mailbox-sync';
+export const SHARED_MAILBOX_SYNC_CACHE_KEY = "SharedMailboxSync";
+const CRON_JOB_NAME = "shared-mailbox-sync";
 
 interface GraphUser {
   id: string;
@@ -39,14 +45,15 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
 
   public constructor(
     @Inject(DRIZZLE) private readonly db: DrizzleDatabase,
-    @Inject(delegatedAccessConfig.KEY) private readonly config: DelegatedAccessConfig,
+    @Inject(delegatedAccessConfig.KEY)
+    private readonly config: DelegatedAccessConfig,
     private readonly graphClientFactory: GraphClientFactory,
     private readonly persistentCacheService: PersistentCacheService,
     private readonly schedulerRegistry: SchedulerRegistry,
   ) {}
 
   public async onModuleInit(): Promise<void> {
-    if (this.config.scan === 'disabled') {
+    if (this.config.scan === "disabled") {
       return;
     }
     // We only run the sync if the env var changed since our last run.
@@ -54,7 +61,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
       await this.runSyncWithRetries();
     } else {
       this.logger.log({
-        msg: 'SharedMailboxSync: config unchanged since last sync, skipping startup sync',
+        msg: "SharedMailboxSync: config unchanged since last sync, skipping startup sync",
       });
     }
     this.setupCronJob();
@@ -66,25 +73,34 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
       const job = this.schedulerRegistry.getCronJob(CRON_JOB_NAME);
       job.stop();
     } catch (err) {
-      this.logger.error({ msg: 'Error stopping shared-mailbox-sync cron job', err });
+      this.logger.error({
+        msg: "Error stopping shared-mailbox-sync cron job",
+        err,
+      });
     }
   }
 
   private setupCronJob(): void {
-    if (this.config.scan === 'disabled') {
+    if (this.config.scan === "disabled") {
       return;
     }
     // We need a cron job because once the mcp is setup we have no active user and we cannot sync the shared
     // mailboxes to database and we have to eighter login and restart the mcp or we can tell the client that
     // it takes at most until the next cron runs and there is a user which can list their ms graph users.
     // Since the mcp has in SCOPES User.Read.All all uses should have the permission to do this sync.
-    const job = new CronJob(this.config.sharedMailboxSyncCronSchedule, async () => {
-      try {
-        await this.runSyncWithRetries();
-      } catch (err) {
-        this.logger.error({ msg: 'Unexpected error during shared mailbox sync cron', err });
-      }
-    });
+    const job = new CronJob(
+      this.config.sharedMailboxSyncCronSchedule,
+      async () => {
+        try {
+          await this.runSyncWithRetries();
+        } catch (err) {
+          this.logger.error({
+            msg: "Unexpected error during shared mailbox sync cron",
+            err,
+          });
+        }
+      },
+    );
     this.schedulerRegistry.addCronJob(CRON_JOB_NAME, job);
     job.start();
   }
@@ -92,7 +108,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
   private async hasConfigChangedSinceLastSync(): Promise<boolean> {
     const cached = await this.persistentCacheService.get(
       SHARED_MAILBOX_SYNC_CACHE_KEY,
-      'SharedMailboxSync',
+      "SharedMailboxSync",
     );
     if (!cached) {
       return true;
@@ -116,7 +132,10 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
           await this.syncSharedMailboxesProfiles(excludedUserIds);
           break;
         } catch (err) {
-          const { shouldRetry, excludeUserId } = this.handleSyncError(attempt, err);
+          const { shouldRetry, excludeUserId } = this.handleSyncError(
+            attempt,
+            err,
+          );
           if (excludeUserId) {
             excludedUserIds.push(excludeUserId);
           }
@@ -133,92 +152,121 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
 
   // Sync shared mailboxes will read the mailboxes from the env var will cross reference
   // them with msGraph api and save the common result to database.
-  private async syncSharedMailboxesProfiles(excludedUserIds: string[]): Promise<void> {
+  private async syncSharedMailboxesProfiles(
+    excludedUserIds: string[],
+  ): Promise<void> {
     if (this.isShuttingDown) {
-      this.logger.log({ msg: 'Skipping shared mailbox sync due to shutdown' });
+      this.logger.log({ msg: "Skipping shared mailbox sync due to shutdown" });
       return;
     }
 
-    this.logger.log({ msg: 'SharedMailboxSync: starting sync' });
+    this.logger.log({ msg: "SharedMailboxSync: starting sync" });
 
     const envEmails = this.getSharedMailboxEmails();
     if (envEmails.length === 0) {
       this.logger.warn({
-        msg: 'SharedMailboxSync: DELEGATED_ACCESS_SHARED_MAILBOX_EMAILS env var is empty or unset',
+        msg: "SharedMailboxSync: DELEGATED_ACCESS_SHARED_MAILBOX_EMAILS env var is empty or unset",
       });
     }
 
-    const result = await this.graphClientFactory.createClientForAnyAuthorizedUser(excludedUserIds);
-    if (!result) {
-      this.logger.warn({
-        msg: 'SharedMailboxSync: no authorized user profile found, skipping sync',
-      });
-      return;
-    }
-    const { client, userId } = result;
+    // We group by email because the mcp in our QA handles 2 tenants, the unique prod and the dogfood tenant.
+    const emailsByDomain = this.groupEmailsByDomain(envEmails);
+    const allMatchedUsers: NonNullishProps<GraphUser, "mail">[] = [];
+    const syncedDomains: string[] = [];
 
-    let graphUsers: GraphUser[] = [];
-    try {
-      graphUsers = await this.fetchSharedMailboxCandidatesFromGraph(client);
-    } catch (err) {
-      if (err instanceof GraphError) {
-        throw new FetchUsersError(userId, `Failed to fetch users from ms graph`, { cause: err });
+    for (const [domain, domainEmails] of emailsByDomain) {
+      const result =
+        await this.graphClientFactory.createClientForAnyAuthorizedUser(
+          excludedUserIds,
+          domain,
+        );
+      if (!result) {
+        this.logger.warn({
+          msg: "SharedMailboxSync: no authorized user profile found for domain, skipping",
+          domain,
+        });
+        continue;
       }
-      throw err;
+      const { client, userId } = result;
+
+      let graphUsers: GraphUser[] = [];
+      try {
+        graphUsers = await this.fetchSharedMailboxCandidatesFromGraph(client);
+        syncedDomains.push(domain);
+      } catch (err) {
+        if (err instanceof GraphError) {
+          throw new FetchUsersError(
+            userId,
+            `Failed to fetch users from ms graph`,
+            { cause: err },
+          );
+        }
+        throw err;
+      }
+
+      const matched = graphUsers
+        .map((u) => ({ ...u, mail: u.mail?.toLowerCase() }))
+        .filter(
+          (user) => user.mail && domainEmails.includes(user.mail),
+        ) as NonNullishProps<GraphUser, "mail">[];
+
+      if (matched.length === 0 && domainEmails.length > 0) {
+        this.logger.warn({
+          msg: "SharedMailboxSync: no Graph users found for the configured shared mailbox emails",
+          domain,
+          domainEmails,
+        });
+      }
+
+      allMatchedUsers.push(...matched);
     }
 
-    const matchedUsers = graphUsers
-      .map((u) => ({ ...u, mail: u.mail?.toLowerCase() }))
-      .filter((user) => user.mail && envEmails.includes(user.mail)) as NonNullishProps<
-      GraphUser,
-      'mail'
-    >[];
-
-    if (matchedUsers.length === 0 && envEmails.length > 0) {
-      this.logger.warn({
-        msg: 'SharedMailboxSync: no Graph users found for the configured shared mailbox emails',
-        envEmails,
-      });
+    // Delete source='shared-mailbox' rows that belong to a synced domain but are no longer matched.
+    // We only delete for successfully synced domains so that rows for domains with no authorized
+    // user are left untouched until a future run can verify them.
+    if (syncedDomains.length > 0) {
+      await this.db.delete(userProfiles).where(
+        and(
+          eq(userProfiles.source, "shared-mailbox"),
+          or(...syncedDomains.map((d) => ilike(userProfiles.email, `%@${d}`))),
+          allMatchedUsers.length > 0
+            ? not(
+                inArray(
+                  sql`lower(${userProfiles.email})`,
+                  allMatchedUsers.map((item) => item.mail),
+                ),
+              )
+            : undefined,
+        ),
+      );
     }
-    // Delete source='shared-mailbox' rows whose email is NOT in the intersection
-    await this.db.delete(userProfiles).where(
-      and(
-        eq(userProfiles.source, 'shared-mailbox'),
-        matchedUsers.length > 0
-          ? not(
-              inArray(
-                sql`lower(${userProfiles.email})`,
-                matchedUsers.map((item) => item.mail),
-              ),
-            )
-          : undefined,
-      ),
-    );
 
     // Upsert matched users
-    if (matchedUsers.length > 0) {
+    if (allMatchedUsers.length > 0) {
       type UserProfileInsert = typeof userProfiles.$inferInsert;
-      const mappedProfiles: UserProfileInsert[] = matchedUsers.map((user) => {
-        const rawData: OAuthUserProfile = {
-          id: user.id ?? undefined,
-          displayName: user.displayName ?? undefined,
-          username: user.mail ?? undefined,
-          email: user.mail ?? undefined,
-          avatarUrl: undefined,
-          raw: user,
-        };
-        return {
-          provider: 'microsoft' as const,
-          providerUserId: user.id,
-          username: user.mail,
-          email: user.mail,
-          displayName: user.displayName ?? null,
-          source: 'shared-mailbox' as const,
-          accessToken: null,
-          refreshToken: null,
-          raw: rawData,
-        };
-      });
+      const mappedProfiles: UserProfileInsert[] = allMatchedUsers.map(
+        (user) => {
+          const rawData: OAuthUserProfile = {
+            id: user.id ?? undefined,
+            displayName: user.displayName ?? undefined,
+            username: user.mail ?? undefined,
+            email: user.mail ?? undefined,
+            avatarUrl: undefined,
+            raw: user,
+          };
+          return {
+            provider: "microsoft" as const,
+            providerUserId: user.id,
+            username: user.mail,
+            email: user.mail,
+            displayName: user.displayName ?? null,
+            source: "shared-mailbox" as const,
+            accessToken: null,
+            refreshToken: null,
+            raw: rawData,
+          };
+        },
+      );
 
       // source is intentionally omitted from the conflict update: if an Entra identity
       // already exists as an OAuth row we leave it as oauth. Overwriting source would
@@ -241,7 +289,7 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     // Update cache with new hash and timestamp
     const newHash = this.hashMailboxes(envEmails);
     await this.persistentCacheService.set(SHARED_MAILBOX_SYNC_CACHE_KEY, {
-      dataType: 'SharedMailboxSync',
+      dataType: "SharedMailboxSync",
       payload: {
         envarHash: newHash,
         lastSyncedAt: Date.now(),
@@ -249,9 +297,27 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     });
 
     this.logger.log({
-      msg: 'SharedMailboxSync: sync complete',
-      upserted: matchedUsers.length,
+      msg: "SharedMailboxSync: sync complete",
+      upserted: allMatchedUsers.length,
     });
+  }
+
+  private groupEmailsByDomain(emails: string[]): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    for (const email of emails) {
+      const atIdx = email.lastIndexOf("@");
+      if (atIdx === -1) {
+        continue;
+      }
+      const domain = email.slice(atIdx + 1).toLowerCase();
+      const existing = map.get(domain);
+      if (existing) {
+        existing.push(email);
+      } else {
+        map.set(domain, [email]);
+      }
+    }
+    return map;
   }
 
   // The error handling here is very specific to the shared mailbox profile sync.
@@ -293,7 +359,10 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     }
 
     // This is a transient graph api error which we hope we can fix by waiting and retrying.
-    if (cause.statusCode === 429 || (cause.statusCode >= 500 && cause.statusCode < 600)) {
+    if (
+      cause.statusCode === 429 ||
+      (cause.statusCode >= 500 && cause.statusCode < 600)
+    ) {
       this.logger.log({
         msg: `${msgBase}. cause is GraphError, transient graph api error. Retrying with the same user`,
         statusCode: cause.statusCode,
@@ -312,22 +381,24 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     return { shouldRetry: false };
   }
 
-  private async fetchSharedMailboxCandidatesFromGraph(client: Client): Promise<GraphUser[]> {
+  private async fetchSharedMailboxCandidatesFromGraph(
+    client: Client,
+  ): Promise<GraphUser[]> {
     const users: GraphUser[] = [];
 
     // Shared mailboxes appear in Entra ID as accountEnabled=false accounts
     let response = (await client
-      .api('/users')
-      .filter('accountEnabled eq false')
-      .select('id,mail,displayName')
-      .get()) as { value: GraphUser[]; '@odata.nextLink'?: string };
+      .api("/users")
+      .filter("accountEnabled eq false")
+      .select("id,mail,displayName")
+      .get()) as { value: GraphUser[]; "@odata.nextLink"?: string };
 
     users.push(...response.value);
 
-    while (response['@odata.nextLink']) {
-      response = (await client.api(response['@odata.nextLink']).get()) as {
+    while (response["@odata.nextLink"]) {
+      response = (await client.api(response["@odata.nextLink"]).get()) as {
         value: GraphUser[];
-        '@odata.nextLink'?: string;
+        "@odata.nextLink"?: string;
       };
       users.push(...response.value);
     }
@@ -336,15 +407,15 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
   }
 
   private getSharedMailboxEmails(): string[] {
-    if (this.config.scan === 'disabled') {
+    if (this.config.scan === "disabled") {
       return [];
     }
     return this.config.sharedMailboxEmails;
   }
 
   private hashMailboxes(mailboxes: string[]): string {
-    return createHash('sha256')
-      .update([...mailboxes].sort().join(','))
-      .digest('hex');
+    return createHash("sha256")
+      .update([...mailboxes].sort().join(","))
+      .digest("hex");
   }
 }

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -203,9 +203,6 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
       allMatchedUsers.push(...matched);
     }
 
-    // Delete source='shared-mailbox' rows that belong to a synced domain but are no longer matched.
-    // We only delete for successfully synced domains so that rows for domains with no authorized
-    // user are left untouched until a future run can verify them.
     await this.db.delete(userProfiles).where(
       and(
         eq(userProfiles.source, 'shared-mailbox'),

--- a/services/outlook-semantic-mcp/src/msgraph/graph-client.factory.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/graph-client.factory.ts
@@ -13,7 +13,7 @@ import {
 } from '@microsoft/microsoft-graph-client';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { and, desc, eq, isNotNull, notInArray } from 'drizzle-orm';
+import { and, desc, eq, ilike, isNotNull, notInArray } from 'drizzle-orm';
 import { MetricService } from 'nestjs-otel';
 import type { AppConfigNamespaced, MicrosoftConfigNamespaced } from '~/config';
 import { SCOPES } from '../auth/microsoft.provider';
@@ -52,6 +52,7 @@ export class GraphClientFactory {
   // client scoped to a particular user via createClientForUser.
   public async createClientForAnyAuthorizedUser(
     excludeIds?: string[],
+    domain?: string,
   ): Promise<{ client: Client; userId: string } | null> {
     const profile = await this.drizzle.query.userProfiles.findFirst({
       where: and(
@@ -59,6 +60,7 @@ export class GraphClientFactory {
         eq(userProfiles.source, 'oauth'),
         isNotNull(userProfiles.accessToken),
         excludeIds && excludeIds.length > 0 ? notInArray(userProfiles.id, excludeIds) : undefined,
+        domain ? ilike(userProfiles.email, `%@${domain}`) : undefined,
       ),
       // We order by updatedAt descending so that we minize the chance of getting a deactivated user
       orderBy: (t) => desc(t.updatedAt),


### PR DESCRIPTION
1. Since qa has users from unique tenant and from dogfood tenant we need to load a user from dogfood tenant for the config check