### PR TITLE
fix(teams-mcp): stream MS Graph recordings via Readable.fromWeb

### DIFF
--- a/services/teams-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/teams-mcp/src/msgraph/metrics.middleware.ts
@@ -41,40 +41,6 @@ export class MetricsMiddleware implements Middleware {
     return options?.method?.toUpperCase() || 'GET';
   }
 
-  /**
-   * Detect streaming media downloads (recording MP4, transcript VTT). Inspecting the
-   * Response body for these would risk "body disturbed/locked" errors and is meaningless
-   * for binary streams — skip the slow-request WARN that would otherwise fire for every
-   * media download since they inherently exceed the 5s threshold.
-   */
-  private isStreamingAccept(options: RequestInit | undefined): boolean {
-    const headers = options?.headers;
-    if (!headers) {
-      return false;
-    }
-
-    let accept: string | null = null;
-    if (headers instanceof Headers) {
-      accept = headers.get('Accept') ?? headers.get('accept');
-    } else if (Array.isArray(headers)) {
-      for (const [key, value] of headers) {
-        if (key.toLowerCase() === 'accept') {
-          accept = value;
-          break;
-        }
-      }
-    } else {
-      const record = headers as Record<string, string>;
-      accept = record.Accept ?? record.accept ?? null;
-    }
-
-    if (!accept) {
-      return false;
-    }
-    const lower = accept.toLowerCase();
-    return lower.startsWith('video/') || lower.startsWith('audio/') || lower === 'text/vtt';
-  }
-
   private getStatusClass(statusCode: number): string {
     if (statusCode >= 200 && statusCode < 300) {
       return '2xx';
@@ -173,7 +139,7 @@ export class MetricsMiddleware implements Middleware {
         );
       }
 
-      if (duration > 5000 && !this.isStreamingAccept(context.options)) {
+      if (duration > 5000) {
         this.logger.warn(
           {
             method,

--- a/services/teams-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/teams-mcp/src/msgraph/metrics.middleware.ts
@@ -41,6 +41,40 @@ export class MetricsMiddleware implements Middleware {
     return options?.method?.toUpperCase() || 'GET';
   }
 
+  /**
+   * Detect streaming media downloads (recording MP4, transcript VTT). Inspecting the
+   * Response body for these would risk "body disturbed/locked" errors and is meaningless
+   * for binary streams — skip the slow-request WARN that would otherwise fire for every
+   * media download since they inherently exceed the 5s threshold.
+   */
+  private isStreamingAccept(options: RequestInit | undefined): boolean {
+    const headers = options?.headers;
+    if (!headers) {
+      return false;
+    }
+
+    let accept: string | null = null;
+    if (headers instanceof Headers) {
+      accept = headers.get('Accept') ?? headers.get('accept');
+    } else if (Array.isArray(headers)) {
+      for (const [key, value] of headers) {
+        if (key.toLowerCase() === 'accept') {
+          accept = value;
+          break;
+        }
+      }
+    } else {
+      const record = headers as Record<string, string>;
+      accept = record.Accept ?? record.accept ?? null;
+    }
+
+    if (!accept) {
+      return false;
+    }
+    const lower = accept.toLowerCase();
+    return lower.startsWith('video/') || lower.startsWith('audio/') || lower === 'text/vtt';
+  }
+
   private getStatusClass(statusCode: number): string {
     if (statusCode >= 200 && statusCode < 300) {
       return '2xx';
@@ -139,7 +173,7 @@ export class MetricsMiddleware implements Middleware {
         );
       }
 
-      if (duration > 5000) {
+      if (duration > 5000 && !this.isStreamingAccept(context.options)) {
         this.logger.warn(
           {
             method,

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -125,13 +125,11 @@ export class TranscriptCreatedService {
         .then(Transcript.parseAsync),
       // Wrap WHATWG stream with Node Readable so the upload fetch() with duplex:'half'
       // does not hit "Response body object should not be disturbed or locked".
-      (async (): Promise<Readable> =>
-        Readable.fromWeb(
-          await client
-            .api(`/users/${userId}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
-            .header('Accept', 'text/vtt')
-            .getStream(),
-        ))(),
+      client
+        .api(`/users/${userId}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
+        .header('Accept', 'text/vtt')
+        .getStream()
+        .then((stream) => Readable.fromWeb(stream)),
     ]);
 
     span?.addEvent('microsoft graph data retrieved', {

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { Readable } from 'node:stream';
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq } from 'drizzle-orm';
@@ -122,10 +123,15 @@ export class TranscriptCreatedService {
         .api(`/users/${userId}/onlineMeetings/${meetingId}/transcripts/${transcriptId}`)
         .get()
         .then(Transcript.parseAsync),
-      client
-        .api(`/users/${userId}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
-        .header('Accept', 'text/vtt')
-        .getStream(),
+      // Wrap WHATWG stream with Node Readable so the upload fetch() with duplex:'half'
+      // does not hit "Response body object should not be disturbed or locked".
+      (async (): Promise<Readable> =>
+        Readable.fromWeb(
+          await client
+            .api(`/users/${userId}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
+            .header('Accept', 'text/vtt')
+            .getStream(),
+        ))(),
     ]);
 
     span?.addEvent('microsoft graph data retrieved', {

--- a/services/teams-mcp/src/transcript/transcript-recording.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-recording.service.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { Injectable, Logger } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
@@ -5,7 +6,7 @@ import { RecordingCollection } from './transcript.dtos';
 
 export interface RecordingData {
   id: string;
-  content: ReadableStream<Uint8Array<ArrayBuffer>>;
+  content: Readable;
   startDateTime: Date;
   endDateTime: Date;
 }
@@ -64,11 +65,15 @@ export class TranscriptRecordingService {
         'Located correlated meeting recording in Microsoft Graph',
       );
 
-      // Fetch recording content (MP4 stream)
-      const mp4Stream: ReadableStream<Uint8Array<ArrayBuffer>> = await client
-        .api(`/users/${userId}/onlineMeetings/${meetingId}/recordings/${recording.id}/content`)
-        .header('Accept', 'video/mp4')
-        .getStream();
+      // Wrap WHATWG stream with Node Readable so the upload fetch() with duplex:'half'
+      // does not hit "Response body object should not be disturbed or locked" when bytes
+      // started flowing during the Graph SDK middleware chain.
+      const mp4Stream: Readable = Readable.fromWeb(
+        await client
+          .api(`/users/${userId}/onlineMeetings/${meetingId}/recordings/${recording.id}/content`)
+          .header('Accept', 'video/mp4')
+          .getStream(),
+      );
 
       span?.addEvent('recording_content_retrieved');
       this.logger.log(

--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import type { Readable } from 'node:stream';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { FetchFn } from '@qfetch/qfetch';
 import { Span, TraceService } from 'nestjs-otel';
@@ -78,11 +79,7 @@ export class UniqueContentService {
   }
 
   @Span()
-  public async uploadToStorage(
-    writeUrl: string,
-    content: ReadableStream<Uint8Array<ArrayBuffer>>,
-    mime: string,
-  ): Promise<void> {
+  public async uploadToStorage(writeUrl: string, content: Readable, mime: string): Promise<void> {
     const span = this.trace.getSpan();
 
     const urlObj = new URL(writeUrl);
@@ -97,7 +94,10 @@ export class UniqueContentService {
         'Content-Type': mime,
         'x-ms-blob-type': 'BlockBlob',
       },
-      body: content,
+      // Node's undici fetch accepts a Node Readable here at runtime, but lib.dom's
+      // BodyInit type does not include it. Same story for `duplex: 'half'`, required
+      // for streaming uploads.
+      body: content as unknown as BodyInit,
       // @ts-expect-error: nodejs fetch requires `half` for streaming uploads
       duplex: 'half',
     });

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -1,3 +1,4 @@
+import type { Readable } from 'node:stream';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
@@ -36,10 +37,10 @@ export class UniqueService {
       participants: { id?: string; name: string; email: string }[];
       owner: { id: string; name: string; email: string };
     },
-    transcript: { id: string; content: ReadableStream<Uint8Array<ArrayBuffer>> },
+    transcript: { id: string; content: Readable },
     recording?: {
       id: string;
-      content: ReadableStream<Uint8Array<ArrayBuffer>>;
+      content: Readable;
       startDateTime: Date;
       endDateTime: Date;
     },


### PR DESCRIPTION
## Summary

- Wrap the WHATWG `ReadableStream` returned by MS Graph SDK's `.getStream()` with `Readable.fromWeb()` for both the recording (MP4) and transcript (VTT) paths, so the subsequent `fetch()` upload to Unique storage no longer hits `TypeError: Response body object should not be disturbed or locked` on slow Graph responses. Mirrors the proven pattern in `sharepoint-connector`.
- Propagate the `Readable` type through `UniqueContentService.uploadToStorage` and `UniqueService.ingestTranscript`.

## Context

In QA we observed `TypeError: Response body object should not be disturbed or locked` during the meeting-ingestion flow on a large recording. The Graph SDK's middleware chain disturbs the WHATWG stream before it reaches `fetch(..., { body, duplex: 'half' })`. Wrapping with `Readable.fromWeb` decouples the Node stream from undici's WHATWG-stream invariants, immunizing the upload from whichever SDK middleware is to blame.

## Test plan

- [x] `pnpm -F teams-mcp check-types` — passes (only pre-existing `packages/logger` errors remain, unrelated)
- [x] `pnpm -F teams-mcp style` — passes
- [x] `pnpm -F teams-mcp build` — passes
- [ ] Manual QA in QA cluster: trigger a Teams meeting transcript+recording ingestion against a meeting large enough to cross the slow-request threshold; confirm both paths reach `Successfully completed content upload to storage`.
- [ ] Confirm no `TypeError: Response body object should not be disturbed or locked` over a 24h window of normal traffic.
- [ ] Spot-check that small/fast recordings still ingest correctly (regression smoke).