### PR TITLE
fix(teams-mcp): remove inline networkPolicy chart defaults

### DIFF
--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
@@ -27,27 +27,6 @@ server:
   ports:
     application: 51345
     metrics: 51346
-  networkPolicy:
-    enabled: true
-    policyTypes:
-      # - Egress # We can not yet leverage egress policies as Kubernetes flavor policies do not support FQDN and MS Graph IP-Addresses are not easily deterministic
-      - Ingress
-    egress: null
-    ingress:
-      - from:
-          - podSelector:
-              matchLabels:
-                app.kubernetes.io/managed-by: prometheus-operator
-            namespaceSelector:
-              matchLabels:
-                kubernetes.io/metadata.name: system
-          - podSelector:
-              matchLabels:
-                app.kubernetes.io/name: gateway
-                app.kubernetes.io/instance: kong
-            namespaceSelector:
-              matchLabels:
-                kubernetes.io/metadata.name: system
   resources:
     # Resources are granted generously as the service for now is a singleton
     limits:


### PR DESCRIPTION
## Summary

Remove the `server.networkPolicy` block from teams-mcp's chart default values. NetworkPolicy is now defined entirely in cluster overlays (matching the outlook-semantic-mcp pattern).

## Why

The backend-service chart enforces strict separation between `kubernetes` and `cilium` flavors. The current chart defaults set `policyTypes: [Ingress]` (a k8s-only field), which conflicts with any cluster overlay attempting `flavor: cilium`. Helm value overlays cannot delete keys, so the only fix is to remove the defaults from the chart.

## Context

Follow-up to [Unique-AG/monorepo#24704](https://github.com/Unique-AG/monorepo/pull/24704), which added a Cilium ephemeral-port ingress fix to outlook-semantic-mcp. The same fix is needed for teams-mcp — see the monorepo follow-up PR. That follow-up requires this chart cleanup to land first so it can apply a `flavor: cilium` overlay without hitting the conflicting defaults.

The QA pods will continue running with their existing rendered NetworkPolicy until the new chart version is pulled in by the monorepo PR; no immediate cluster impact.

## Test plan

- [x] No existing teams-mcp cluster overlay references the removed chart defaults — verified via grep across `gitops-resources/argocd/clusters/unique/{qa,prod}/application-specs/mcp/teams/`.
- [ ] Helm renders cleanly after merge (release-please cuts `teams-mcp@0.2.12`).
- [ ] Monorepo follow-up PR applies the new chart version and adds the cilium-flavor `network-policy.values.yaml`.