### PR TITLE
feat(teams-mcp): tag Teams content with shared source + lock scopes via externalId [UN-20155]

### DIFF
--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -150,6 +150,7 @@ export class TranscriptCreatedService {
 
     await this.unique.ingestTranscript(
       {
+        meetingId,
         subject: meeting.subject ?? '',
         // onlineMeetings/{id}.startDateTime returns the master/scheduled time, which
         // collapses every occurrence of a recurring meeting into one YYYY-MM-DD folder.

--- a/services/teams-mcp/src/unique/scope-external-id.ts
+++ b/services/teams-mcp/src/unique/scope-external-id.ts
@@ -1,0 +1,23 @@
+export const EXTERNAL_ID_PREFIX = 'teams:' as const;
+
+/**
+ * Builds the deterministic externalId for a meeting (subject) scope.
+ *
+ * Anchored on the Graph onlineMeeting id so recurring meetings share the same
+ * parent scope. `encodeURIComponent` is required because Graph ids are base64-ish
+ * and can contain `/`, `+`, `=`, which would collide with the `/` delimiter.
+ */
+export function buildMeetingExternalId(meetingId: string): string {
+  return `${EXTERNAL_ID_PREFIX}${encodeURIComponent(meetingId)}/meeting`;
+}
+
+/**
+ * Builds the deterministic externalId for an occurrence (session) scope.
+ *
+ * Anchored on the transcript id so each recording session gets its own child
+ * scope, even for multiple meetings on the same day. Re-ingesting re-stamps the
+ * same externalId (idempotent).
+ */
+export function buildOccurrenceExternalId(meetingId: string, transcriptId: string): string {
+  return `${EXTERNAL_ID_PREFIX}${encodeURIComponent(meetingId)}/occurrence:${encodeURIComponent(transcriptId)}`;
+}

--- a/services/teams-mcp/src/unique/unique-scope.service.ts
+++ b/services/teams-mcp/src/unique/unique-scope.service.ts
@@ -8,8 +8,10 @@ import {
   PublicAddScopeAccessResultSchema,
   PublicCreateScopeRequestSchema,
   PublicCreateScopeResultSchema,
+  PublicFolderUpdateRequestSchema,
   type PublicScopeAccessSchema,
   type Scope,
+  ScopeSchema,
 } from './unique.dtos';
 
 @Injectable()
@@ -97,6 +99,34 @@ export class UniqueScopeService {
       { scopeId, accessesAdded: accesses.length },
       'Successfully configured user access permissions for scope',
     );
+
+    return result;
+  }
+
+  @Span()
+  public async updateScope(
+    scopeId: string,
+    patch: { externalId?: string; name?: string; parentId?: string | null },
+  ): Promise<Scope> {
+    const span = this.trace.getSpan();
+    span?.setAttribute('scope_id', scopeId);
+    span?.setAttribute('has_external_id', patch.externalId !== undefined);
+
+    const payload = PublicFolderUpdateRequestSchema.encode(patch);
+
+    this.logger.debug(
+      { scopeId, externalId: patch.externalId },
+      'Updating organizational scope in Unique API',
+    );
+
+    const response = await this.fetch(`folder/${scopeId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const result = ScopeSchema.parse(await response.json());
+
+    this.logger.log({ scopeId, externalId: result.externalId }, 'Successfully updated scope');
 
     return result;
   }

--- a/services/teams-mcp/src/unique/unique.consts.ts
+++ b/services/teams-mcp/src/unique/unique.consts.ts
@@ -1,1 +1,9 @@
 export const UNIQUE_FETCH = Symbol('UNIQUE_FETCH');
+
+/**
+ * Source identity for Teams-ingested content. Hardcoded as a fixed platform
+ * contract: every transcript/recording is attributed to a single shared
+ * org-level "Microsoft Teams" source (mirrors SharePoint).
+ */
+export const TEAMS_SOURCE_KIND = 'MICROSOFT_365_TEAMS' as const;
+export const TEAMS_SOURCE_NAME = 'Microsoft Teams' as const;

--- a/services/teams-mcp/src/unique/unique.dtos.ts
+++ b/services/teams-mcp/src/unique/unique.dtos.ts
@@ -57,6 +57,7 @@ export const ScopeSchema = z.object({
   id: z.string(),
   name: z.string(),
   parentId: z.string().nullable().optional(),
+  externalId: z.string().nullable().optional(),
   object: z.literal('folder'),
 });
 export type Scope = z.infer<typeof ScopeSchema>;
@@ -67,6 +68,21 @@ export const PublicCreateScopeResultSchema = z.object({
 export type PublicCreateScopeResult = z.infer<typeof PublicCreateScopeResultSchema>;
 
 // !SECTION - CreateScope endpoint types
+
+// SECTION - FolderUpdate endpoint types
+
+export const PublicFolderUpdateRequestSchema = z.object({
+  externalId: z.string().nullable().optional(),
+  name: z.string().optional(),
+  parentId: z.string().nullable().optional(),
+});
+export type PublicFolderUpdateRequest = z.infer<typeof PublicFolderUpdateRequestSchema>;
+
+// The PATCH response reuses the same folder shape as create.
+export const PublicFolderUpdateResultSchema = ScopeSchema;
+export type PublicFolderUpdateResult = z.infer<typeof PublicFolderUpdateResultSchema>;
+
+// !SECTION - FolderUpdate endpoint types
 
 // SECTION - AddScopeAccess endpoint types
 
@@ -168,12 +184,22 @@ export const ContentUpsertInputSchema = z.object({
 });
 export type ContentUpsertInput = z.infer<typeof ContentUpsertInputSchema>;
 
+// Matches the platform's `OwnerType` (node-chat).
+export enum SourceOwnerType {
+  User = 'USER',
+  Company = 'COMPANY',
+  Chat = 'CHAT',
+}
+
 export const PublicContentUpsertRequestSchema = z.object({
   input: ContentUpsertInputSchema,
   scopeId: z.string().optional(),
   chatId: z.string().optional(),
   storeInternally: z.boolean().default(true),
   fileUrl: z.string().optional(),
+  sourceKind: z.string().optional(),
+  sourceName: z.string().optional(),
+  sourceOwnerType: z.enum(SourceOwnerType).optional(),
 });
 export type PublicContentUpsertRequest = z.infer<typeof PublicContentUpsertRequestSchema>;
 

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -3,10 +3,13 @@ import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import pLimit from 'p-limit';
 import type { UniqueConfigNamespaced } from '~/config';
+import { buildMeetingExternalId, buildOccurrenceExternalId } from './scope-external-id';
+import { TEAMS_SOURCE_KIND, TEAMS_SOURCE_NAME } from './unique.consts';
 import {
   type PublicScopeAccessSchema,
   ScopeAccessEntityType,
   ScopeAccessType,
+  SourceOwnerType,
   UniqueIngestionMode,
 } from './unique.dtos';
 import { UniqueContentService } from './unique-content.service';
@@ -28,6 +31,7 @@ export class UniqueService {
   @Span()
   public async ingestTranscript(
     meeting: {
+      meetingId: string;
       subject: string;
       date: Date;
       startDateTime: Date;
@@ -100,6 +104,12 @@ export class UniqueService {
     const parentScope = await this.scopeService.createScope(rootScopeId, subjectPath, false);
     span?.setAttribute('parent_scope_id', parentScope.id);
 
+    // Stamp the meeting (subject) scope with a deterministic externalId so it is
+    // externally managed (locked in the UI) and idempotently re-stampable.
+    await this.scopeService.updateScope(parentScope.id, {
+      externalId: buildMeetingExternalId(meeting.meetingId),
+    });
+
     const accesses = participants.map<PublicScopeAccessSchema>((p) => ({
       entityId: p.id,
       entityType: ScopeAccessEntityType.User,
@@ -125,6 +135,12 @@ export class UniqueService {
     const childScope = await this.scopeService.createScope(parentScope.id, datePath, true);
     span?.setAttribute('child_scope_id', childScope.id);
 
+    // Stamp the occurrence (session) scope, anchored on the transcript id so each
+    // recording session gets a unique externalId even for same-day meetings.
+    await this.scopeService.updateScope(childScope.id, {
+      externalId: buildOccurrenceExternalId(meeting.meetingId, transcript.id),
+    });
+
     this.logger.log(
       { transcriptId: transcript.id, scopeId: childScope.id },
       'Beginning transcript upload to Unique system',
@@ -133,6 +149,9 @@ export class UniqueService {
     const transcriptUpload = await this.contentService.upsertContent({
       storeInternally: true,
       scopeId: childScope.id,
+      sourceKind: TEAMS_SOURCE_KIND,
+      sourceName: TEAMS_SOURCE_NAME,
+      sourceOwnerType: SourceOwnerType.Company,
       input: {
         key: transcript.id,
         mimeType: 'text/vtt',
@@ -151,6 +170,9 @@ export class UniqueService {
     await this.contentService.upsertContent({
       storeInternally: true,
       scopeId: childScope.id,
+      sourceKind: TEAMS_SOURCE_KIND,
+      sourceName: TEAMS_SOURCE_NAME,
+      sourceOwnerType: SourceOwnerType.Company,
       fileUrl: transcriptUpload.readUrl,
       input: {
         key: transcript.id,
@@ -177,6 +199,9 @@ export class UniqueService {
         const recordingUpload = await this.contentService.upsertContent({
           storeInternally: true,
           scopeId: childScope.id,
+          sourceKind: TEAMS_SOURCE_KIND,
+          sourceName: TEAMS_SOURCE_NAME,
+          sourceOwnerType: SourceOwnerType.Company,
           input: {
             key: recording.id,
             mimeType: 'video/mp4',
@@ -196,6 +221,9 @@ export class UniqueService {
         await this.contentService.upsertContent({
           storeInternally: true,
           scopeId: childScope.id,
+          sourceKind: TEAMS_SOURCE_KIND,
+          sourceName: TEAMS_SOURCE_NAME,
+          sourceOwnerType: SourceOwnerType.Company,
           fileUrl: recordingUpload.readUrl,
           input: {
             key: recording.id,

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
@@ -99,7 +100,11 @@ export class UniqueService {
     );
 
     const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
-    const { subjectPath, datePath } = this.mapMeetingToRelativePaths(meeting.subject, meeting.date);
+    const { subjectPath, datePath } = this.mapMeetingToRelativePaths(
+      meeting.subject,
+      meeting.meetingId,
+      meeting.date,
+    );
 
     const parentScope = await this.scopeService.createScope(rootScopeId, subjectPath, false);
     span?.setAttribute('parent_scope_id', parentScope.id);
@@ -265,18 +270,37 @@ export class UniqueService {
 
   private mapMeetingToRelativePaths(
     subject: string,
+    meetingId: string,
     happenedAt: Date,
   ): { subjectPath: string; datePath: string } {
-    // Second-precision UTC timestamp (not just the calendar date) so multiple
-    // transcripts/recordings on the same day each get their own folder.
-    // `happenedAt` is the transcript's createdDateTime — the onlineMeeting
-    // startDateTime is the recurring series' master time and is identical for
-    // every occurrence, so it cannot be used here. ':' -> '-' keeps the path
-    // segment safe (the folder API treats ':' specially and splits on '/').
-    // e.g. "2024-01-15 14-30-45"
+    // Parent (subject) folder: human-readable subject plus a stable, path-safe
+    // suffix derived from the meetingId. Recurring occurrences of one series
+    // share the same meetingId (and subject) so they collapse into one folder
+    // as intended; two *different* meetings that happen to share a title get
+    // distinct folders, so their `meeting` externalIds no longer overwrite each
+    // other. e.g. "Weekly Sync (a1b2c3d4)"
+    const subjectPath = `${subject || 'Untitled Meeting'} (${this.shortHash(meetingId)})`;
+
+    // Child (session) folder: second-precision UTC timestamp (not just the
+    // calendar date) so multiple transcripts/recordings on the same day each
+    // get their own folder. `happenedAt` is the transcript's createdDateTime —
+    // the onlineMeeting startDateTime is the recurring series' master time and
+    // is identical for every occurrence, so it cannot be used here. ':' -> '-'
+    // keeps the segment path-safe (the folder API splits on '/'). e.g.
+    // "2024-01-15 14-30-45"
     const datePath = happenedAt.toISOString().slice(0, 19).replace('T', ' ').replaceAll(':', '-');
-    const subjectPath = subject || 'Untitled Meeting';
+
     return { subjectPath, datePath };
+  }
+
+  /**
+   * Short, stable, path-safe digest of an id — used to disambiguate folder
+   * names without leaking the raw Graph id (which can contain '/', '+', '='
+   * that would break folder paths). Deterministic, so re-ingestion re-uses the
+   * same folder.
+   */
+  private shortHash(value: string): string {
+    return createHash('sha256').update(value).digest('hex').slice(0, 8);
   }
 
   private buildContentMetadata(

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -267,10 +267,16 @@ export class UniqueService {
     subject: string,
     happenedAt: Date,
   ): { subjectPath: string; datePath: string } {
-    // biome-ignore lint/style/noNonNullAssertion: iso string is always with T
-    const formattedDate = happenedAt.toISOString().split('T').at(0)!;
+    // Second-precision UTC timestamp (not just the calendar date) so multiple
+    // transcripts/recordings on the same day each get their own folder.
+    // `happenedAt` is the transcript's createdDateTime — the onlineMeeting
+    // startDateTime is the recurring series' master time and is identical for
+    // every occurrence, so it cannot be used here. ':' -> '-' keeps the path
+    // segment safe (the folder API treats ':' specially and splits on '/').
+    // e.g. "2024-01-15 14-30-45"
+    const datePath = happenedAt.toISOString().slice(0, 19).replace('T', ' ').replaceAll(':', '-');
     const subjectPath = subject || 'Untitled Meeting';
-    return { subjectPath, datePath: formattedDate };
+    return { subjectPath, datePath };
   }
 
   private buildContentMetadata(


### PR DESCRIPTION
## What

PR3 of the 3-PR Teams source-tagging chain (UN-20155) — the consumer end in `teams-mcp`. After PR1 (node-ingestion `MICROSOFT_365_TEAMS` source kind) and PR2 (node-chat public REST accepts `sourceKind`/`sourceName`/`sourceOwnerType` on upsert + `externalId` on folder PATCH), this PR makes teams-mcp actually use them.

Three things:

1. **Source tagging** — every uploaded transcript/recording is now attributed to a shared org-level **"Microsoft Teams"** source (`sourceOwnerType: COMPANY`, mirroring SharePoint), instead of the per-user `USER` default.
2. **Scope lock/freeze** — the meeting (subject) and occurrence (session) scopes are stamped with a deterministic `externalId`, making them externally-managed (read-only/locked in the UI) and idempotently re-stampable on re-ingestion.
3. **Unique folders** — folder paths are keyed so that each meeting series and each session map 1:1 to their `externalId` (see below).

## externalId scheme (mirrors SharePoint `spc:`)

```
parent (subject) scope:   teams:{enc(meetingId)}/meeting
child  (session) scope:   teams:{enc(meetingId)}/occurrence:{enc(transcriptId)}
```

`enc()` = `encodeURIComponent` — required because Graph onlineMeeting/transcript ids are base64-ish and can contain `/`, `+`, `=`. Recurring meetings share the same parent `meeting` scope; each session gets its own `occurrence` child anchored on `transcript.id`.

## Folder structure

```
<root>/<subject> (a1b2c3d4)/2024-01-15 14-30-45/<transcript + recording>
```

`createScope` is an idempotent upsert by path, so a folder path must be as unique as the `externalId` stamped on it — otherwise a later ingest reuses an existing folder and overwrites its `externalId`. Both levels are now keyed to match:

- **Parent (subject):** human-readable subject + a stable, path-safe short hash of the `meetingId`. Recurring occurrences of one series share the same `meetingId` + subject so they collapse into one folder as intended; two *different* meetings that happen to share a title get distinct folders.
- **Child (session):** a **second-precision UTC timestamp** from `transcript.createdDateTime` (not `onlineMeeting.startDateTime`, which is the recurring series' master time and identical for every occurrence). Previously multiple transcripts on the same day collapsed into one `YYYY-MM-DD` folder and the occurrence `externalId` overwrote whichever was ingested last.

Both keys are deterministic (stable Graph properties, UTC, no wall-clock, hash), so re-ingesting the same transcript re-uses the same folders and re-stamps the same `externalId`s. Folder ↔ externalId are 1:1 at both levels.

## Changes (`services/teams-mcp/src`)

- **NEW** `unique/scope-external-id.ts` — pure `buildMeetingExternalId()` / `buildOccurrenceExternalId()` builders.
- `unique/unique.consts.ts` — `TEAMS_SOURCE_KIND` / `TEAMS_SOURCE_NAME` constants.
- `unique/unique.dtos.ts` — `SourceOwnerType` enum (matches platform `OwnerType`); `sourceKind`/`sourceName`/`sourceOwnerType` on the upsert schema; `externalId` on `ScopeSchema`; new folder PATCH request/result schemas.
- `unique/unique-scope.service.ts` — `updateScope()` PATCHing `folder/:scopeId`.
- `unique/unique.service.ts` — thread `meetingId`, stamp both scopes, tag all 4 upserts (transcript + recording, create + finalize); meetingId-disambiguated subject folder + second-precision session folder.
- `transcript/transcript-created.service.ts` — pass `meetingId`.

Verified: `biome check` clean, `pnpm build` green.

## Out of scope
- **Scope dedup by externalId** (find-existing-before-create, SharePoint-style) — not needed now that folder paths are 1:1 with externalIds; the path-unique keying makes create-by-path idempotent per entity.
- No pending-delete / stale-scope lifecycle.

## Sequencing
**Hard dependency:** deploy order PR1 → PR2 → PR3. teams-mcp must run against an env where node-ingestion accepts the source kind and node-chat REST accepts the new fields.

---
Jira: [UN-20155](https://unique-ch.atlassian.net/browse/UN-20155)
Parent PRs (monorepo): Unique-AG/monorepo#24778 (PR1), Unique-AG/monorepo#24780 (PR2)


[UN-20155]: https://unique-ch.atlassian.net/browse/UN-20155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ