### PR TITLE
fix(confluence-connector): include release name in ConfigMap names

### DIFF
--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/proxy-configmap.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/proxy-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: confluence-connector-proxy-config
+  name: {{ include "chart.fullname" . }}-proxy-config
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 data:

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/tenant-config.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/tenant-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: confluence-connector-tenant-config
+  name: {{ include "chart.fullname" . }}-tenant-config
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 data:

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/values.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/values.yaml
@@ -39,7 +39,10 @@ connector:
   #           key: PROXY_PASSWORD
   # See https://artifacthub.io/packages/helm/unique/backend-service?modal=values&path=envVars for more options.
   envVars: []
-  # -- List of ConfigMaps to load as environment variables
+  # -- List of ConfigMaps to load as environment variables.
+  # The default assumes releaseName=confluence-connector. For multi-instance deployments
+  # with a different release name, override to match the rendered ConfigMap name
+  # (<releaseName>-proxy-config).
   extraEnvCM:
     - confluence-connector-proxy-config
   image:
@@ -65,7 +68,10 @@ connector:
   volumes:
     - name: tmp
       emptyDir: {}
-    # -- Tenant configuration YAML file mounted from ConfigMap
+    # -- Tenant configuration YAML file mounted from ConfigMap.
+    # The default assumes releaseName=confluence-connector. For multi-instance deployments
+    # with a different release name, override to match the rendered ConfigMap name
+    # (<releaseName>-tenant-config).
     - name: tenant-config
       configMap:
         name: confluence-connector-tenant-config


### PR DESCRIPTION
## Summary
- Use `chart.fullname` for `tenant-config` and `proxy-config` ConfigMaps so multi-instance deployments don't collide on a static name.
- Mirrors the pattern already used by `sharepoint-connector`.
- Multi-instance releases must override `connector.volumes` and `connector.extraEnvCM` to reference the rendered `<releaseName>-*` names. Monorepo gitops PR follows.

Ticket: UN-21495

## Test plan
- [x] `helm template confluence-connector .` renders unchanged ConfigMap names (default release name).
- [x] `helm template confluence-connector-v2 .` renders `confluence-connector-v2-{tenant,proxy}-config` ConfigMaps, with deployment refs matching once overrides are applied.