### PR TITLE
feat(confluence-connector): add HTTP Basic auth for data-center

### DIFF
--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/ci/data-center-basic-values.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/ci/data-center-basic-values.yaml
@@ -1,0 +1,30 @@
+connectorConfig:
+  enabled: true
+  tenants:
+    - name: default
+      confluence:
+        instanceType: data-center
+        baseUrl: https://confluence.acme.com
+        apiRateLimitPerMinute: 100
+        ingestSingleLabel: ai-ingest
+        ingestAllLabel: ai-ingest-all
+        auth:
+          mode: basic
+          username: confluence-bot
+          password: "os.environ/CONFLUENCE_PASSWORD"
+      unique:
+        authMode: cluster_local
+        ingestionServiceBaseUrl: http://node-ingestion.finance-gpt:8091
+        scopeManagementServiceBaseUrl: http://node-scope-management.finance-gpt:8094
+        apiRateLimitPerMinute: 100
+        serviceExtraHeaders:
+          x-company-id: "123456789101112131"
+          x-user-id: "123456789101112131"
+      processing:
+        concurrency: 1
+        scanIntervalCron: "0 */2 * * *"
+      ingestion:
+        ingestionMode: flat
+        scopeId: test-scope-id
+        storeInternally: enabled
+        useV1KeyFormat: disabled

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/tenant-config.yaml
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/templates/tenant-config.yaml
@@ -24,6 +24,10 @@ data:
         {{- if eq $tenant.confluence.auth.mode "pat" }}
         token: {{ $tenant.confluence.auth.token | quote }}
         {{- end }}
+        {{- if eq $tenant.confluence.auth.mode "basic" }}
+        username: {{ $tenant.confluence.auth.username | quote }}
+        password: {{ $tenant.confluence.auth.password | quote }}
+        {{- end }}
       apiRateLimitPerMinute: {{ $tenant.confluence.apiRateLimitPerMinute }}
       ingestSingleLabel: {{ $tenant.confluence.ingestSingleLabel | quote }}
       ingestAllLabel: {{ $tenant.confluence.ingestAllLabel | quote }}

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/values.schema.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/values.schema.json
@@ -203,6 +203,25 @@
                         },
                         "required": ["mode", "token"],
                         "additionalProperties": false
+                      },
+                      {
+                        "properties": {
+                          "mode": {
+                            "type": "string",
+                            "enum": ["basic"],
+                            "description": "HTTP Basic username/password (Data Center only)"
+                          },
+                          "username": {
+                            "type": "string",
+                            "description": "Confluence username for Basic auth"
+                          },
+                          "password": {
+                            "type": "string",
+                            "description": "Confluence password for Basic auth. Use \"os.environ/ENV_VAR_NAME\" to read from environment variable at runtime."
+                          }
+                        },
+                        "required": ["mode", "username", "password"],
+                        "additionalProperties": false
                       }
                     ]
                   },
@@ -228,7 +247,7 @@
                           "required": ["mode"],
                           "properties": {
                             "mode": {
-                              "const": "pat"
+                              "enum": ["pat", "basic"]
                             }
                           }
                         }

--- a/services/confluence-connector/src/auth/confluence-auth/__tests__/confluence-auth.factory.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/__tests__/confluence-auth.factory.spec.ts
@@ -7,18 +7,25 @@ import type { TenantContext } from '../../../tenant/tenant-context.interface';
 import { tenantStorage } from '../../../tenant/tenant-context.storage';
 import { Redacted } from '../../../utils/redacted';
 import { ConfluenceAuthFactory } from '../confluence-auth.factory';
+import { BasicAuthStrategy } from '../strategies/basic-auth.strategy';
 import { OAuth2LoAuthStrategy } from '../strategies/oauth2lo-auth.strategy';
 import { PatAuthStrategy } from '../strategies/pat-auth.strategy';
 
 vi.mock('../strategies/oauth2lo-auth.strategy', () => ({
   OAuth2LoAuthStrategy: vi.fn().mockImplementation(() => ({
-    acquireToken: vi.fn().mockResolvedValue('oauth-token'),
+    getAuthorizationHeader: vi.fn().mockResolvedValue('Bearer oauth-token'),
   })),
 }));
 
 vi.mock('../strategies/pat-auth.strategy', () => ({
   PatAuthStrategy: vi.fn().mockImplementation(() => ({
-    acquireToken: vi.fn().mockResolvedValue('pat-token'),
+    getAuthorizationHeader: vi.fn().mockResolvedValue('Bearer pat-token'),
+  })),
+}));
+
+vi.mock('../strategies/basic-auth.strategy', () => ({
+  BasicAuthStrategy: vi.fn().mockImplementation(() => ({
+    getAuthorizationHeader: vi.fn().mockResolvedValue('Basic dXNlcjpwYXNz'),
   })),
 }));
 
@@ -58,9 +65,9 @@ describe('ConfluenceAuthFactory', () => {
       };
 
       const auth = tenantStorage.run(mockTenant, () => factory.createAuthStrategy(config));
-      const token = await auth.acquireToken();
+      const header = await auth.getAuthorizationHeader();
 
-      expect(token).toBe('oauth-token');
+      expect(header).toBe('Bearer oauth-token');
       expect(OAuth2LoAuthStrategy).toHaveBeenCalledWith(config.auth, config, expect.anything());
     });
 
@@ -76,10 +83,29 @@ describe('ConfluenceAuthFactory', () => {
       };
 
       const auth = tenantStorage.run(mockTenant, () => factory.createAuthStrategy(config));
-      const token = await auth.acquireToken();
+      const header = await auth.getAuthorizationHeader();
 
-      expect(token).toBe('pat-token');
+      expect(header).toBe('Bearer pat-token');
       expect(PatAuthStrategy).toHaveBeenCalledWith(config.auth);
+    });
+
+    it('creates auth for HTTP Basic data-center config', async () => {
+      const factory = createFactory();
+      const config: ConfluenceConfig = {
+        ...baseFields,
+        instanceType: 'data-center',
+        auth: {
+          mode: AuthMode.Basic,
+          username: 'alice',
+          password: new Redacted('s3cret'),
+        },
+      };
+
+      const auth = tenantStorage.run(mockTenant, () => factory.createAuthStrategy(config));
+      const header = await auth.getAuthorizationHeader();
+
+      expect(header).toBe('Basic dXNlcjpwYXNz');
+      expect(BasicAuthStrategy).toHaveBeenCalledWith(config.auth);
     });
 
     it('throws for unsupported auth mode', () => {

--- a/services/confluence-connector/src/auth/confluence-auth/confluence-auth.abstract.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/confluence-auth.abstract.ts
@@ -1,4 +1,4 @@
 //We use abstract classes as service tokens because interfaces are erased at runtime and cannot be used as ServiceRegistry keys.
 export abstract class ConfluenceAuth {
-  public abstract acquireToken(): Promise<string>;
+  public abstract getAuthorizationHeader(): Promise<string>;
 }

--- a/services/confluence-connector/src/auth/confluence-auth/confluence-auth.factory.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/confluence-auth.factory.ts
@@ -5,6 +5,7 @@ import { AuthMode, type ConfluenceConfig } from '../../config';
 import { ProxyService } from '../../proxy';
 import { getCurrentTenant } from '../../tenant/tenant-context.storage';
 import { ConfluenceAuth } from './confluence-auth.abstract';
+import { BasicAuthStrategy } from './strategies/basic-auth.strategy';
 import { OAuth2LoAuthStrategy } from './strategies/oauth2lo-auth.strategy';
 import { PatAuthStrategy } from './strategies/pat-auth.strategy';
 
@@ -33,6 +34,13 @@ export class ConfluenceAuthFactory {
       case AuthMode.Pat: {
         this.logger.log({ tenantName, msg: 'Using PAT authentication for data-center instance' });
         return new PatAuthStrategy(config.auth);
+      }
+      case AuthMode.Basic: {
+        this.logger.log({
+          tenantName,
+          msg: 'Using HTTP Basic authentication for data-center instance',
+        });
+        return new BasicAuthStrategy(config.auth);
       }
       default: {
         assert.fail(`Unsupported Confluence auth mode`);

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/basic-auth.strategy.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/basic-auth.strategy.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { AuthMode } from '../../../../config/confluence.schema';
+import type { TenantContext } from '../../../../tenant/tenant-context.interface';
+import { tenantStorage } from '../../../../tenant/tenant-context.storage';
+import { Redacted } from '../../../../utils/redacted';
+import { BasicAuthStrategy } from '../basic-auth.strategy';
+
+const mockTenant: TenantContext = {
+  name: 'test-tenant',
+  config: {} as TenantContext['config'],
+  status: 'active',
+  isScanning: false,
+};
+
+describe('BasicAuthStrategy', () => {
+  it('returns a Basic authorization header with base64(user:password)', async () => {
+    const strategy = new BasicAuthStrategy({
+      mode: AuthMode.Basic,
+      username: 'alice',
+      password: new Redacted('s3cret'),
+    });
+
+    const result = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
+
+    expect(result).toBe(`Basic ${Buffer.from('alice:s3cret', 'utf8').toString('base64')}`);
+  });
+
+  it('returns the same header on multiple calls', async () => {
+    const strategy = new BasicAuthStrategy({
+      mode: AuthMode.Basic,
+      username: 'bob',
+      password: new Redacted('p@ssw0rd'),
+    });
+
+    const first = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
+    const second = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
+
+    expect(first).toBe(second);
+  });
+
+  it('correctly encodes credentials containing non-ASCII characters', async () => {
+    const strategy = new BasicAuthStrategy({
+      mode: AuthMode.Basic,
+      username: 'üser',
+      password: new Redacted('päss:wörd'),
+    });
+
+    const result = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
+
+    const expected = Buffer.from('üser:päss:wörd', 'utf8').toString('base64');
+    expect(result).toBe(`Basic ${expected}`);
+  });
+});

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/oauth2lo-auth.strategy.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/oauth2lo-auth.strategy.spec.ts
@@ -73,7 +73,7 @@ describe('OAuth2LoAuthStrategy', () => {
       mockTokenResponse(200, successBody);
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
-      await strategy.acquireToken();
+      await strategy.getAuthorizationHeader();
 
       expect(mockRequest).toHaveBeenCalledOnce();
       // biome-ignore lint/style/noNonNullAssertion: Asserted above with toHaveBeenCalledOnce
@@ -90,24 +90,24 @@ describe('OAuth2LoAuthStrategy', () => {
       });
     });
 
-    it('returns access token for cloud', async () => {
+    it('returns a Bearer authorization header for cloud', async () => {
       mockTokenResponse(200, successBody);
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
-      const token = await strategy.acquireToken();
+      const header = await strategy.getAuthorizationHeader();
 
-      expect(token).toBe('returned-access-token');
+      expect(header).toBe('Bearer returned-access-token');
     });
 
     it('caches token across sequential calls', async () => {
       mockTokenResponse(200, successBody);
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      const tokenA = await strategy.acquireToken();
-      const tokenB = await strategy.acquireToken();
+      const headerA = await strategy.getAuthorizationHeader();
+      const headerB = await strategy.getAuthorizationHeader();
 
-      expect(tokenA).toBe('returned-access-token');
-      expect(tokenB).toBe('returned-access-token');
+      expect(headerA).toBe('Bearer returned-access-token');
+      expect(headerB).toBe('Bearer returned-access-token');
       expect(mockRequest).toHaveBeenCalledOnce();
     });
 
@@ -115,13 +115,13 @@ describe('OAuth2LoAuthStrategy', () => {
       mockTokenResponse(200, successBody);
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      const [tokenA, tokenB] = await Promise.all([
-        strategy.acquireToken(),
-        strategy.acquireToken(),
+      const [headerA, headerB] = await Promise.all([
+        strategy.getAuthorizationHeader(),
+        strategy.getAuthorizationHeader(),
       ]);
 
-      expect(tokenA).toBe('returned-access-token');
-      expect(tokenB).toBe('returned-access-token');
+      expect(headerA).toBe('Bearer returned-access-token');
+      expect(headerB).toBe('Bearer returned-access-token');
       expect(mockRequest).toHaveBeenCalledOnce();
     });
 
@@ -129,7 +129,7 @@ describe('OAuth2LoAuthStrategy', () => {
       mockTokenResponse(200, successBody);
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
-      await strategy.acquireToken();
+      await strategy.getAuthorizationHeader();
 
       expect(mockLogger.log).toHaveBeenCalledWith({
         msg: 'Acquiring Confluence cloud token via OAuth 2.0 2LO',
@@ -143,7 +143,7 @@ describe('OAuth2LoAuthStrategy', () => {
       mockTokenResponse(200, successBody);
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, dcConnection);
-      await strategy.acquireToken();
+      await strategy.getAuthorizationHeader();
 
       expect(mockRequest).toHaveBeenCalledOnce();
       // biome-ignore lint/style/noNonNullAssertion: Asserted above with toHaveBeenCalledOnce
@@ -159,13 +159,13 @@ describe('OAuth2LoAuthStrategy', () => {
       expect(params.get('scope')).toBe('READ');
     });
 
-    it('returns access token for DC', async () => {
+    it('returns a Bearer authorization header for DC', async () => {
       mockTokenResponse(200, successBody);
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, dcConnection);
-      const token = await strategy.acquireToken();
+      const header = await strategy.getAuthorizationHeader();
 
-      expect(token).toBe('returned-access-token');
+      expect(header).toBe('Bearer returned-access-token');
     });
   });
 
@@ -175,7 +175,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow();
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow();
 
       expect(mockLogger.error).toHaveBeenCalledOnce();
       // biome-ignore lint/style/noNonNullAssertion: Asserted above with toHaveBeenCalledOnce
@@ -192,7 +192,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(networkError);
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(networkError);
     });
 
     it('throws on HTTP 401 indicating invalid credentials', async () => {
@@ -200,7 +200,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(
         'Error response from https://api.atlassian.com/oauth/token: 401 Unauthorized',
       );
     });
@@ -210,7 +210,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, dcConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(
         'Error response from https://confluence.corp.example.com/rest/oauth2/latest/token: 403 Forbidden',
       );
     });
@@ -220,7 +220,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(
         'Error response from https://api.atlassian.com/oauth/token: 500 Internal Server Error',
       );
     });
@@ -236,7 +236,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(
         'Error response from https://api.atlassian.com/oauth/token: 500 No response body',
       );
     });
@@ -246,7 +246,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(/access_token/);
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(/access_token/);
     });
 
     it('throws ZodError on malformed response missing expires_in', async () => {
@@ -254,7 +254,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(/expires_in/);
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(/expires_in/);
     });
 
     it('throws ZodError on malformed response missing both fields', async () => {
@@ -262,7 +262,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow(/access_token/);
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow(/access_token/);
     });
 
     it('throws on non-JSON response body', async () => {
@@ -276,7 +276,7 @@ describe('OAuth2LoAuthStrategy', () => {
 
       const strategy = new OAuth2LoAuthStrategy(authConfig, cloudConnection);
 
-      await expect(strategy.acquireToken()).rejects.toThrow('invalid json');
+      await expect(strategy.getAuthorizationHeader()).rejects.toThrow('invalid json');
     });
   });
 });

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/pat-auth.strategy.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/pat-auth.strategy.spec.ts
@@ -18,21 +18,21 @@ describe('PatAuthStrategy', () => {
     token: new Redacted('my-personal-access-token'),
   };
 
-  it('returns the unwrapped token value as accessToken', async () => {
+  it('returns a Bearer authorization header with the unwrapped token', async () => {
     const strategy = new PatAuthStrategy(authConfig);
 
-    const result = await tenantStorage.run(mockTenant, () => strategy.acquireToken());
+    const result = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
 
-    expect(result).toBe('my-personal-access-token');
+    expect(result).toBe('Bearer my-personal-access-token');
   });
 
-  it('returns the same token on multiple calls', async () => {
+  it('returns the same header on multiple calls', async () => {
     const strategy = new PatAuthStrategy(authConfig);
 
-    const first = await tenantStorage.run(mockTenant, () => strategy.acquireToken());
-    const second = await tenantStorage.run(mockTenant, () => strategy.acquireToken());
+    const first = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
+    const second = await tenantStorage.run(mockTenant, () => strategy.getAuthorizationHeader());
 
     expect(first).toBe(second);
-    expect(first).toBe('my-personal-access-token');
+    expect(first).toBe('Bearer my-personal-access-token');
   });
 });

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/basic-auth.strategy.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/basic-auth.strategy.ts
@@ -1,0 +1,18 @@
+import { AuthMode, ConfluenceConfig } from '../../../config/confluence.schema';
+import { ConfluenceAuth } from '../confluence-auth.abstract';
+
+type BasicAuthConfig = Extract<ConfluenceConfig['auth'], { mode: typeof AuthMode.Basic }>;
+
+export class BasicAuthStrategy extends ConfluenceAuth {
+  private readonly header: string;
+
+  public constructor(authConfig: BasicAuthConfig) {
+    super();
+    const credentials = `${authConfig.username}:${authConfig.password.value}`;
+    this.header = `Basic ${Buffer.from(credentials, 'utf8').toString('base64')}`;
+  }
+
+  public async getAuthorizationHeader(): Promise<string> {
+    return this.header;
+  }
+}

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/oauth2lo-auth.strategy.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/oauth2lo-auth.strategy.ts
@@ -49,8 +49,9 @@ export class OAuth2LoAuthStrategy extends ConfluenceAuth {
     this.dispatcher = dispatcher;
   }
 
-  public async acquireToken(): Promise<string> {
-    return this.tokenCache.getToken(() => this.fetchToken());
+  public async getAuthorizationHeader(): Promise<string> {
+    const token = await this.tokenCache.getToken(() => this.fetchToken());
+    return `Bearer ${token}`;
   }
 
   private async fetchToken(): Promise<TokenResult> {

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/pat-auth.strategy.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/pat-auth.strategy.ts
@@ -4,14 +4,14 @@ import { ConfluenceAuth } from '../confluence-auth.abstract';
 type PatAuthConfig = Extract<ConfluenceConfig['auth'], { mode: typeof AuthMode.Pat }>;
 
 export class PatAuthStrategy extends ConfluenceAuth {
-  private readonly token: string;
+  private readonly header: string;
 
   public constructor(authConfig: PatAuthConfig) {
     super();
-    this.token = authConfig.token.value;
+    this.header = `Bearer ${authConfig.token.value}`;
   }
 
-  public async acquireToken(): Promise<string> {
-    return this.token;
+  public async getAuthorizationHeader(): Promise<string> {
+    return this.header;
   }
 }

--- a/services/confluence-connector/src/config/confluence.schema.ts
+++ b/services/confluence-connector/src/config/confluence.schema.ts
@@ -9,6 +9,7 @@ import {
 export const AuthMode = {
   OAuth2Lo: 'oauth_2lo',
   Pat: 'pat',
+  Basic: 'basic',
 } as const;
 
 const oauth2loAuth = z.object({
@@ -20,6 +21,12 @@ const oauth2loAuth = z.object({
 const patAuth = z.object({
   mode: z.literal(AuthMode.Pat).describe('Personal Access Token (Data Center only)'),
   token: envRequiredSecretSchema,
+});
+
+const basicAuth = z.object({
+  mode: z.literal(AuthMode.Basic).describe('HTTP Basic username/password (Data Center only)'),
+  username: requiredStringSchema,
+  password: envRequiredSecretSchema,
 });
 
 const baseConfluenceFields = z.object({
@@ -42,7 +49,7 @@ export const ConfluenceConfigSchema = z.discriminatedUnion('instanceType', [
   }),
   baseConfluenceFields.extend({
     instanceType: z.literal('data-center'),
-    auth: z.discriminatedUnion('mode', [oauth2loAuth, patAuth]),
+    auth: z.discriminatedUnion('mode', [oauth2loAuth, patAuth, basicAuth]),
   }),
 ]);
 

--- a/services/confluence-connector/src/confluence-api/__tests__/cloud-api-client.spec.ts
+++ b/services/confluence-connector/src/confluence-api/__tests__/cloud-api-client.spec.ts
@@ -9,7 +9,7 @@ const BASE_URL = 'https://cloud.example.com';
 const CLOUD_ID = 'test-cloud-id';
 const API_BASE_URL = `https://api.atlassian.com/ex/confluence/${CLOUD_ID}`;
 
-const mockAuth = { acquireToken: vi.fn().mockResolvedValue('cloud-token') };
+const mockAuth = { getAuthorizationHeader: vi.fn().mockResolvedValue('Bearer cloud-token') };
 
 const mockHttpClient = {
   rateLimitedRequest: vi.fn(),

--- a/services/confluence-connector/src/confluence-api/__tests__/confluence-api-client.spec.ts
+++ b/services/confluence-connector/src/confluence-api/__tests__/confluence-api-client.spec.ts
@@ -5,9 +5,10 @@ import { DataCenterConfluenceApiClient } from '../data-center-api-client';
 import type { ConfluencePage } from '../types/confluence-api.types';
 
 const MOCK_TOKEN = 'test-bearer-token';
+const MOCK_AUTH_HEADER = `Bearer ${MOCK_TOKEN}`;
 const BASE_URL = 'https://dc.example.com';
 
-const mockAuth = { acquireToken: vi.fn().mockResolvedValue(MOCK_TOKEN) };
+const mockAuth = { getAuthorizationHeader: vi.fn().mockResolvedValue(MOCK_AUTH_HEADER) };
 
 const mockHttpClient = {
   rateLimitedRequest: vi.fn(),
@@ -40,24 +41,24 @@ describe('ConfluenceApiClient (auth integration)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAuth.acquireToken.mockResolvedValue(MOCK_TOKEN);
+    mockAuth.getAuthorizationHeader.mockResolvedValue(MOCK_AUTH_HEADER);
     client = new DataCenterConfluenceApiClient(mockConfig, mockAuth as never, mockHttpClient, {
       attachmentsEnabled: false,
     });
   });
 
   describe('auth header injection', () => {
-    it('includes Authorization Bearer header on every request', async () => {
+    it('includes the strategy-provided Authorization header on every request', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce(makePage());
 
       await client.getPageById('1');
 
       expect(mockHttpClient.rateLimitedRequest).toHaveBeenCalledWith(expect.any(String), {
-        Authorization: `Bearer ${MOCK_TOKEN}`,
+        Authorization: MOCK_AUTH_HEADER,
       });
     });
 
-    it('acquires a fresh token before each request', async () => {
+    it('acquires a fresh authorization header before each request', async () => {
       vi.mocked(mockHttpClient.rateLimitedRequest).mockResolvedValueOnce(
         makePage({ id: '1', title: 'P' }),
       );
@@ -68,7 +69,7 @@ describe('ConfluenceApiClient (auth integration)', () => {
       await client.getPageById('1');
       await client.getPageById('2');
 
-      expect(mockAuth.acquireToken).toHaveBeenCalledTimes(2);
+      expect(mockAuth.getAuthorizationHeader).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
+++ b/services/confluence-connector/src/confluence-api/__tests__/data-center-api-client.spec.ts
@@ -7,7 +7,7 @@ import { type ConfluencePage, ContentType } from '../types/confluence-api.types'
 
 const BASE_URL = 'https://dc.example.com';
 
-const mockAuth = { acquireToken: vi.fn().mockResolvedValue('dc-token') };
+const mockAuth = { getAuthorizationHeader: vi.fn().mockResolvedValue('Bearer dc-token') };
 
 const mockHttpClient = {
   rateLimitedRequest: vi.fn(),

--- a/services/confluence-connector/src/confluence-api/cloud-api-client.ts
+++ b/services/confluence-connector/src/confluence-api/cloud-api-client.ts
@@ -137,8 +137,8 @@ export class CloudConfluenceApiClient extends ConfluenceApiClient {
     _downloadPath: string,
   ): Promise<Readable> {
     const url = `${this.apiBaseUrl}/wiki/rest/api/content/${pageId}/child/attachment/${attachmentId}/download`;
-    const token = await this.confluenceAuth.acquireToken();
-    return this.httpClient.rateLimitedStreamRequest(url, { Authorization: `Bearer ${token}` });
+    const authorization = await this.confluenceAuth.getAuthorizationHeader();
+    return this.httpClient.rateLimitedStreamRequest(url, { Authorization: authorization });
   }
 
   // Confluence Cloud inlines up to 25 attachments per page via expand=children.attachment.
@@ -188,7 +188,7 @@ export class CloudConfluenceApiClient extends ConfluenceApiClient {
   }
 
   protected async makeAuthenticatedRequest(url: string): Promise<unknown> {
-    const token = await this.confluenceAuth.acquireToken();
-    return this.httpClient.rateLimitedRequest(url, { Authorization: `Bearer ${token}` });
+    const authorization = await this.confluenceAuth.getAuthorizationHeader();
+    return this.httpClient.rateLimitedRequest(url, { Authorization: authorization });
   }
 }

--- a/services/confluence-connector/src/confluence-api/data-center-api-client.ts
+++ b/services/confluence-connector/src/confluence-api/data-center-api-client.ts
@@ -141,8 +141,8 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
     downloadPath: string,
   ): Promise<Readable> {
     const url = `${this.config.baseUrl}${downloadPath}`;
-    const token = await this.confluenceAuth.acquireToken();
-    return this.httpClient.rateLimitedStreamRequest(url, { Authorization: `Bearer ${token}` });
+    const authorization = await this.confluenceAuth.getAuthorizationHeader();
+    return this.httpClient.rateLimitedStreamRequest(url, { Authorization: authorization });
   }
 
   // Data Center does not have a v2 REST API, so we follow the v1 _links.next
@@ -171,7 +171,7 @@ export class DataCenterConfluenceApiClient extends ConfluenceApiClient {
   }
 
   protected async makeAuthenticatedRequest(url: string): Promise<unknown> {
-    const token = await this.confluenceAuth.acquireToken();
-    return this.httpClient.rateLimitedRequest(url, { Authorization: `Bearer ${token}` });
+    const authorization = await this.confluenceAuth.getAuthorizationHeader();
+    return this.httpClient.rateLimitedRequest(url, { Authorization: authorization });
   }
 }

--- a/services/confluence-connector/src/tenant/__tests__/tenant-registry.spec.ts
+++ b/services/confluence-connector/src/tenant/__tests__/tenant-registry.spec.ts
@@ -73,7 +73,7 @@ function createMockTenantConfig(): TenantConfig {
 }
 
 function createMockAuth(): ConfluenceAuth {
-  return { acquireToken: vi.fn().mockResolvedValue('mock-token') };
+  return { getAuthorizationHeader: vi.fn().mockResolvedValue('Bearer mock-token') };
 }
 
 function createMockUniqueApiClient() {


### PR DESCRIPTION
## Summary
- Adds `basic` auth mode (username + password → HTTP Basic) for Confluence Data Center. Cloud is rejected at the schema layer.
- Refactors `ConfluenceAuth.acquireToken()` → `getAuthorizationHeader()` so each strategy owns its scheme (`Bearer` vs `Basic`).
- Helm: template + `values.schema.json` updated; new CI values file.

Unblocks the release. Ports the v1 (monorepo) auth strategy to v2.

Ticket: UN-21496

## Test plan
- [x] `pnpm check-types`, `pnpm style`, `pnpm exec vitest run` (398 tests pass).
- [x] `helm template` with `data-center` + `basic` renders correctly; `cloud` + `basic` is rejected.
- [ ] Manual smoke against a real Data Center instance post-deploy.