### PR TITLE
fix(teams-mcp): parse folder update response as folder-info

### DIFF
--- a/services/teams-mcp/src/unique/unique-scope.service.ts
+++ b/services/teams-mcp/src/unique/unique-scope.service.ts
@@ -9,9 +9,10 @@ import {
   PublicCreateScopeRequestSchema,
   PublicCreateScopeResultSchema,
   PublicFolderUpdateRequestSchema,
+  type PublicFolderUpdateResult,
+  PublicFolderUpdateResultSchema,
   type PublicScopeAccessSchema,
   type Scope,
-  ScopeSchema,
 } from './unique.dtos';
 
 @Injectable()
@@ -107,7 +108,7 @@ export class UniqueScopeService {
   public async updateScope(
     scopeId: string,
     patch: { externalId?: string; name?: string; parentId?: string | null },
-  ): Promise<Scope> {
+  ): Promise<PublicFolderUpdateResult> {
     const span = this.trace.getSpan();
     span?.setAttribute('scope_id', scopeId);
     span?.setAttribute('has_external_id', patch.externalId !== undefined);
@@ -124,7 +125,7 @@ export class UniqueScopeService {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const result = ScopeSchema.parse(await response.json());
+    const result = PublicFolderUpdateResultSchema.parse(await response.json());
 
     this.logger.log({ scopeId, externalId: result.externalId }, 'Successfully updated scope');
 

--- a/services/teams-mcp/src/unique/unique.dtos.ts
+++ b/services/teams-mcp/src/unique/unique.dtos.ts
@@ -78,8 +78,15 @@ export const PublicFolderUpdateRequestSchema = z.object({
 });
 export type PublicFolderUpdateRequest = z.infer<typeof PublicFolderUpdateRequestSchema>;
 
-// The PATCH response reuses the same folder shape as create.
-export const PublicFolderUpdateResultSchema = ScopeSchema;
+// The PATCH folder/:scopeId endpoint returns a FolderInfoResultDto, which is a
+// richer shape than create's FolderDto and is tagged object="folder-info".
+export const PublicFolderUpdateResultSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  parentId: z.string().nullable().optional(),
+  externalId: z.string().nullable().optional(),
+  object: z.literal('folder-info'),
+});
 export type PublicFolderUpdateResult = z.infer<typeof PublicFolderUpdateResultSchema>;
 
 // !SECTION - FolderUpdate endpoint types


### PR DESCRIPTION
## Problem

Transcript ingestion crashed with a `ZodError` when stamping the meeting scope's `externalId`:

```
ZodError: [{ "code": "invalid_value", "values": ["folder"], "path": ["object"],
  "message": "Invalid input: expected \"folder\"" }]
    at UniqueScopeService.updateScope (unique-scope.service.ts:127)
    at UniqueService.ingestTranscript (unique.service.ts:114)
```

## Root cause

`updateScope` validated the `PATCH folder/:scopeId` response with `ScopeSchema`, which requires `object: "folder"`. The two Unique API folder endpoints return structurally-similar payloads under **different** `object` tags:

| Endpoint | Returns | `object` value |
|---|---|---|
| `POST folder` (create) | `FolderDto[]` | `"folder"` ✅ |
| `PATCH folder/:scopeId` (update) | `FolderInfoResultDto` | `"folder-info"` ❌ |

`createScope` worked because create returns `"folder"`; `updateScope` blew up because update returns `"folder-info"`. The old comment claiming "the PATCH response reuses the same folder shape as create" was incorrect.

## Fix

- `unique.dtos.ts` — `PublicFolderUpdateResultSchema` is now its own schema expecting `object: z.literal('folder-info')` instead of being aliased to `ScopeSchema`.
- `unique-scope.service.ts` — `updateScope` parses with `PublicFolderUpdateResultSchema`, returns `Promise<PublicFolderUpdateResult>`; dropped the now-unused `ScopeSchema` import.

The return value of `updateScope` is discarded at the call site, so this is purely about making the parse succeed against the real `folder-info` shape.

## Testing

- `tsc --noEmit` passes.
- No existing tests cover `UniqueScopeService`.