### PR TITLE
fix(teams-mcp): route internal content upload through ingestion service

### DIFF
--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert';
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import type { FetchFn } from '@qfetch/qfetch';
 import { Span, TraceService } from 'nestjs-otel';
+import type { UniqueConfigNamespaced } from '~/config';
 import { UNIQUE_FETCH } from './unique.consts';
 import {
   type ContentInfoItem,
@@ -30,6 +32,7 @@ export class UniqueContentService {
   public constructor(
     @Inject(UNIQUE_FETCH) private readonly fetch: FetchFn,
     private readonly trace: TraceService,
+    private readonly config: ConfigService<UniqueConfigNamespaced, true>,
   ) {}
 
   @Span()
@@ -85,14 +88,15 @@ export class UniqueContentService {
   ): Promise<void> {
     const span = this.trace.getSpan();
 
-    const urlObj = new URL(writeUrl);
+    const uploadUrl = this.correctWriteUrl(writeUrl);
+    const urlObj = new URL(uploadUrl);
     const storageEndpoint = urlObj.origin;
     span?.setAttribute('storage_endpoint', storageEndpoint);
 
     this.logger.debug({ storageEndpoint }, 'Beginning content upload to Unique storage system');
 
     const stream = await content();
-    const response = await fetch(writeUrl, {
+    const response = await fetch(uploadUrl, {
       method: 'PUT',
       headers: {
         'Content-Type': mime,
@@ -115,6 +119,23 @@ export class UniqueContentService {
 
     span?.setAttribute('http_status', response.status);
     this.logger.debug({ storageEndpoint }, 'Successfully completed content upload to storage');
+  }
+
+  // HACK (mirrors outlook-semantic-mcp): in cluster_local mode the storeInternally
+  // writeUrl points at the public, Kong-gateway-fronted storage endpoint, which
+  // in-cluster pods cannot reach (egress is policy-denied → connect timeout). Rewrite
+  // it to route through node-ingestion's scoped upload endpoint, reachable in-cluster.
+  // In external mode the public writeUrl is used as-is.
+  private correctWriteUrl(writeUrl: string): string {
+    const config = this.config.get('unique', { infer: true });
+    if (config.serviceAuthMode === 'external') {
+      return writeUrl;
+    }
+    const key = new URL(writeUrl).searchParams.get('key');
+    assert.ok(key, 'writeUrl is missing key parameter');
+    const target = new URL('/scoped/upload', config.ingestionServiceBaseUrl);
+    target.searchParams.set('key', key);
+    return target.toString();
   }
 
   @Span()


### PR DESCRIPTION
## What

In `cluster_local` auth mode, rewrite the storage `writeUrl` returned by the content upsert so the blob `PUT` goes through node-ingestion's `/scoped/upload` endpoint (via the already-configured `UNIQUE_INGESTION_SERVICE_BASE_URL`) instead of the public, Kong-gateway-fronted storage URL. `external` auth mode is unchanged.

## Why

After a transcript/recording is registered with `storeInternally: true`, the upsert returns a `writeUrl` pointing at the **public, Kong-gateway-fronted** storage endpoint. In-cluster pods can't reach that — the egress to `kong-gateway.system:8443` is **policy-denied** by Cilium, so `uploadToStorage`'s `fetch` failed with `TypeError: fetch failed` / `UND_ERR_CONNECT_TIMEOUT` and ingestion never completed.

This was latent until the `MICROSOFT_365_TEAMS` `SourceKind` enum fix let the flow finally reach the upload step.

`outlook-semantic-mcp` already solves this in `UploadFileForIngestionCommand.correctWriteUrl`; teams-mcp had `ingestionServiceBaseUrl` configured for exactly this but never consumed it. This change wires it in.

## How

- `UniqueContentService`: inject `ConfigService`, add `correctWriteUrl()`, and use it in `uploadToStorage`.
- `correctWriteUrl` extracts the `key` query param from the public `writeUrl` and rebuilds it as `${ingestionServiceBaseUrl}/scoped/upload?key=…`. Type-narrowed to the `cluster_local` config branch (the only one carrying `ingestionServiceBaseUrl`).
- No NetworkPolicy / infra change required — `node-ingestion:8091` is already reachable in-cluster.

## Testing

- `tsc --noEmit` — clean
- `biome check` — clean
- `vitest run` — 49/49 pass

Refs incident: Teams ingestion 500s in finance-gpt QA (SourceKind enum + storage hairpinning).