### PR TITLE
fix(ci): hardcode Azure OIDC client/tenant/subscription IDs in CD template

### DIFF
--- a/.github/workflows/_template-cd.yaml
+++ b/.github/workflows/_template-cd.yaml
@@ -26,7 +26,6 @@ jobs:
     permissions:
       packages: write
       id-token: write
-    environment: uniquecr-github-oidc
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/_template-cd.yaml
+++ b/.github/workflows/_template-cd.yaml
@@ -68,9 +68,9 @@ jobs:
       - name: Login to Azure with OIDC
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # Azure Login Action v3.0.0
         with:
-          client-id: ${{ vars.CLIENT_ID }}
-          tenant-id: ${{ vars.TENANT_ID }}
-          subscription-id: ${{ vars.SUBSCRIPTION_ID }}
+          client-id: daa88f8d-0943-459c-890a-17b1a018d11e
+          tenant-id: 99330c76-81d2-460e-861e-35af8e2a4266
+          subscription-id: fb8bce09-908a-459f-b200-a578005bfeb2
 
       - name: Get ACR access token
         id: acr-token


### PR DESCRIPTION
## What

Replaces the `${{ vars.CLIENT_ID }}` / `${{ vars.TENANT_ID }}` / `${{ vars.SUBSCRIPTION_ID }}` repository variable references in the first `azure/login` step of `_template-cd.yaml` with hardcoded values:

- `client-id`: `daa88f8d-0943-459c-890a-17b1a018d11e`
- `tenant-id`: `99330c76-81d2-460e-861e-35af8e2a4266`
- `subscription-id`: `fb8bce09-908a-459f-b200-a578005bfeb2`

## Why

These match the IDs already hardcoded in the getunique token-issuer login step further down in the same workflow, removing the dependency on repository-level variables.

Note: these are Azure tenant/subscription/app registration identifiers, not secrets.