### PR TITLE
fix(teams-mcp): send Content-Length on storage upload to avoid chunked rejection

### DIFF
--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -9,6 +9,7 @@ import { MAIN_EXCHANGE } from '~/amqp/amqp.constants';
 import { DRIZZLE, type DrizzleDatabase, subscriptions } from '~/drizzle';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import { UniqueService } from '~/unique/unique.service';
+import { readSizedContent } from '~/utils/sized-content';
 import {
   CreatedEventDto,
   IngestRequestedEventDto,
@@ -275,12 +276,14 @@ export class TranscriptCreatedService {
       },
       {
         id: transcript.id,
-        content: () =>
-          client
-            .api(`${ownerPath}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
-            .header('Accept', 'text/vtt')
-            .responseType(ResponseType.RAW)
-            .get(),
+        content: async () =>
+          readSizedContent(
+            await client
+              .api(`${ownerPath}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
+              .header('Accept', 'text/vtt')
+              .responseType(ResponseType.RAW)
+              .get(),
+          ),
       },
       recording ?? undefined,
     );

--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq } from 'drizzle-orm';
 import { Span, TraceService } from 'nestjs-otel';
@@ -278,7 +279,8 @@ export class TranscriptCreatedService {
           client
             .api(`${ownerPath}/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`)
             .header('Accept', 'text/vtt')
-            .getStream(),
+            .responseType(ResponseType.RAW)
+            .get(),
       },
       recording ?? undefined,
     );

--- a/services/teams-mcp/src/transcript/transcript-recording.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-recording.service.ts
@@ -2,13 +2,14 @@ import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { Injectable, Logger } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
+import { readSizedContent, type SizedContent } from '~/utils/sized-content';
 import { RecordingCollection } from './transcript.dtos';
 
 export interface RecordingData {
   id: string;
-  // Opens the recording as a raw MS Graph download response. The upload layer reads the body
-  // stream and `Content-Length` from it (Azure Blob requires a known Content-Length).
-  content: () => Promise<Response>;
+  // Opens the recording for upload as a stream paired with its byte size (Azure Blob requires a
+  // known Content-Length).
+  content: () => Promise<SizedContent>;
   startDateTime: Date;
   endDateTime: Date;
 }
@@ -69,12 +70,14 @@ export class TranscriptRecordingService {
 
       return {
         id: recording.id,
-        content: () =>
-          client
-            .api(`${ownerPath}/onlineMeetings/${meetingId}/recordings/${recording.id}/content`)
-            .header('Accept', 'video/mp4')
-            .responseType(ResponseType.RAW)
-            .get(),
+        content: async () =>
+          readSizedContent(
+            await client
+              .api(`${ownerPath}/onlineMeetings/${meetingId}/recordings/${recording.id}/content`)
+              .header('Accept', 'video/mp4')
+              .responseType(ResponseType.RAW)
+              .get(),
+          ),
         startDateTime: recording.createdDateTime,
         endDateTime: recording.endDateTime,
       };

--- a/services/teams-mcp/src/transcript/transcript-recording.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-recording.service.ts
@@ -1,3 +1,4 @@
+import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { Injectable, Logger } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
@@ -5,7 +6,9 @@ import { RecordingCollection } from './transcript.dtos';
 
 export interface RecordingData {
   id: string;
-  content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>;
+  // Opens the recording as a raw MS Graph download response. The upload layer reads the body
+  // stream and `Content-Length` from it (Azure Blob requires a known Content-Length).
+  content: () => Promise<Response>;
   startDateTime: Date;
   endDateTime: Date;
 }
@@ -70,7 +73,8 @@ export class TranscriptRecordingService {
           client
             .api(`${ownerPath}/onlineMeetings/${meetingId}/recordings/${recording.id}/content`)
             .header('Accept', 'video/mp4')
-            .getStream(),
+            .responseType(ResponseType.RAW)
+            .get(),
         startDateTime: recording.createdDateTime,
         endDateTime: recording.endDateTime,
       };

--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -83,7 +83,7 @@ export class UniqueContentService {
   @Span()
   public async uploadToStorage(
     writeUrl: string,
-    content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>,
+    content: () => Promise<Response>,
     mime: string,
   ): Promise<void> {
     const span = this.trace.getSpan();
@@ -95,14 +95,53 @@ export class UniqueContentService {
 
     this.logger.debug({ storageEndpoint }, 'Beginning content upload to Unique storage system');
 
-    const stream = await content();
+    // Azure Blob's single `PUT Blob` rejects `Transfer-Encoding: chunked` (400
+    // UnsupportedHeader) and requires a `Content-Length`. Node's fetch only omits chunked
+    // framing for a streaming body when an explicit Content-Length is set, so the byte size
+    // must be known up-front. We stream with the size advertised by the source response when
+    // it can be trusted; otherwise we buffer the body in memory purely to measure it.
+    //
+    // The advertised `Content-Length` is only trustworthy when the body is not
+    // content-encoded: undici transparently decompresses the `body` stream (e.g. gzip) while
+    // the header still reflects the *compressed* size, so streaming it with that length would
+    // truncate the upload. Large media (video/mp4) is served uncompressed and always carries a
+    // length, so it streams without buffering; compressible payloads (small transcripts) fall
+    // back to the in-memory measure, which is cheap.
+    const source = await content();
+    const advertised = source.headers.get('content-length');
+    const encoding = source.headers.get('content-encoding');
+    const isIdentityEncoding = encoding === null || encoding === '' || encoding === 'identity';
+    const canStream =
+      isIdentityEncoding &&
+      advertised !== null &&
+      advertised !== '' &&
+      Number.isFinite(Number(advertised));
+
+    let body: ReadableStream<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>;
+    let byteSize: number;
+    if (canStream) {
+      assert.ok(source.body, 'Content source response has no body to upload');
+      body = source.body as ReadableStream<Uint8Array<ArrayBuffer>>;
+      byteSize = Number(advertised);
+    } else {
+      body = new Uint8Array(await source.arrayBuffer());
+      byteSize = body.byteLength;
+      this.logger.debug(
+        { storageEndpoint, byteSize, encoding },
+        'Content length not trustable from source; buffered upload body to determine its size',
+      );
+    }
+    span?.setAttribute('content_length', byteSize);
+    span?.setAttribute('content_buffered', !canStream);
+
     const response = await fetch(uploadUrl, {
       method: 'PUT',
       headers: {
         'Content-Type': mime,
+        'Content-Length': String(byteSize),
         'x-ms-blob-type': 'BlockBlob',
       },
-      body: stream,
+      body,
       // @ts-expect-error: nodejs fetch requires `half` for streaming uploads
       duplex: 'half',
     });

--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import type { FetchFn } from '@qfetch/qfetch';
 import { Span, TraceService } from 'nestjs-otel';
 import type { UniqueConfigNamespaced } from '~/config';
+import type { SizedContent } from '~/utils/sized-content';
 import { UNIQUE_FETCH } from './unique.consts';
 import {
   type ContentInfoItem,
@@ -83,7 +84,7 @@ export class UniqueContentService {
   @Span()
   public async uploadToStorage(
     writeUrl: string,
-    content: () => Promise<Response>,
+    content: () => Promise<SizedContent>,
     mime: string,
   ): Promise<void> {
     const span = this.trace.getSpan();
@@ -95,53 +96,20 @@ export class UniqueContentService {
 
     this.logger.debug({ storageEndpoint }, 'Beginning content upload to Unique storage system');
 
-    // Azure Blob's single `PUT Blob` rejects `Transfer-Encoding: chunked` (400
-    // UnsupportedHeader) and requires a `Content-Length`. Node's fetch only omits chunked
-    // framing for a streaming body when an explicit Content-Length is set, so the byte size
-    // must be known up-front. We stream with the size advertised by the source response when
-    // it can be trusted; otherwise we buffer the body in memory purely to measure it.
-    //
-    // The advertised `Content-Length` is only trustworthy when the body is not
-    // content-encoded: undici transparently decompresses the `body` stream (e.g. gzip) while
-    // the header still reflects the *compressed* size, so streaming it with that length would
-    // truncate the upload. Large media (video/mp4) is served uncompressed and always carries a
-    // length, so it streams without buffering; compressible payloads (small transcripts) fall
-    // back to the in-memory measure, which is cheap.
-    const source = await content();
-    const advertised = source.headers.get('content-length');
-    const encoding = source.headers.get('content-encoding');
-    const isIdentityEncoding = encoding === null || encoding === '' || encoding === 'identity';
-    const canStream =
-      isIdentityEncoding &&
-      advertised !== null &&
-      advertised !== '' &&
-      Number.isFinite(Number(advertised));
-
-    let body: ReadableStream<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>;
-    let byteSize: number;
-    if (canStream) {
-      assert.ok(source.body, 'Content source response has no body to upload');
-      body = source.body as ReadableStream<Uint8Array<ArrayBuffer>>;
-      byteSize = Number(advertised);
-    } else {
-      body = new Uint8Array(await source.arrayBuffer());
-      byteSize = body.byteLength;
-      this.logger.debug(
-        { storageEndpoint, byteSize, encoding },
-        'Content length not trustable from source; buffered upload body to determine its size',
-      );
-    }
-    span?.setAttribute('content_length', byteSize);
-    span?.setAttribute('content_buffered', !canStream);
+    // Azure Blob's single `PUT Blob` rejects `Transfer-Encoding: chunked` (400 UnsupportedHeader)
+    // and requires a `Content-Length`. Node's fetch only omits chunked framing for a streaming
+    // body when an explicit Content-Length is set, so we pass the pre-measured `size`.
+    const { stream, size } = await content();
+    span?.setAttribute('content_length', size);
 
     const response = await fetch(uploadUrl, {
       method: 'PUT',
       headers: {
         'Content-Type': mime,
-        'Content-Length': String(byteSize),
+        'Content-Length': String(size),
         'x-ms-blob-type': 'BlockBlob',
       },
-      body,
+      body: stream,
       // @ts-expect-error: nodejs fetch requires `half` for streaming uploads
       duplex: 'half',
     });

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import pLimit from 'p-limit';
 import type { UniqueConfigNamespaced } from '~/config';
+import type { SizedContent } from '~/utils/sized-content';
 import { buildMeetingExternalId, buildOccurrenceExternalId } from './scope-external-id';
 import { TEAMS_SOURCE_KIND, TEAMS_SOURCE_NAME } from './unique.consts';
 import {
@@ -43,11 +44,11 @@ export class UniqueService {
     },
     transcript: {
       id: string;
-      content: () => Promise<Response>;
+      content: () => Promise<SizedContent>;
     },
     recording?: {
       id: string;
-      content: () => Promise<Response>;
+      content: () => Promise<SizedContent>;
       startDateTime: Date;
       endDateTime: Date;
     },

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -43,11 +43,11 @@ export class UniqueService {
     },
     transcript: {
       id: string;
-      content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>;
+      content: () => Promise<Response>;
     },
     recording?: {
       id: string;
-      content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>;
+      content: () => Promise<Response>;
       startDateTime: Date;
       endDateTime: Date;
     },

--- a/services/teams-mcp/src/utils/sized-content.ts
+++ b/services/teams-mcp/src/utils/sized-content.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+
+/**
+ * A content payload paired with its exact byte size, ready to be uploaded with an explicit
+ * `Content-Length` header.
+ */
+export interface SizedContent {
+  stream: ReadableStream<Uint8Array<ArrayBuffer>>;
+  size: number;
+}
+
+/**
+ * Adapts an HTTP download `Response` (e.g. an MS Graph `/content` fetch) into a
+ * {@link SizedContent} with a known byte size.
+ *
+ * The `Content-Length` header is trusted only for identity-encoded responses: Node's fetch
+ * (undici) transparently decompresses a gzip/deflate/br `body` stream while the header keeps the
+ * *compressed* size, so streaming it under that length would truncate the upload. When the length
+ * cannot be trusted (content-encoded, or absent) the body is buffered in memory purely to measure
+ * it — used for small, compressible payloads; large media is served uncompressed and takes the
+ * zero-copy streaming path.
+ */
+export async function readSizedContent(response: Response): Promise<SizedContent> {
+  assert.ok(response.body, 'Content response has no body');
+
+  const advertised = response.headers.get('content-length');
+  const encoding = response.headers.get('content-encoding');
+  const isIdentityEncoding = encoding === null || encoding === '' || encoding === 'identity';
+
+  if (
+    isIdentityEncoding &&
+    advertised !== null &&
+    advertised !== '' &&
+    Number.isFinite(Number(advertised))
+  ) {
+    return {
+      stream: response.body as ReadableStream<Uint8Array<ArrayBuffer>>,
+      size: Number(advertised),
+    };
+  }
+
+  const buffered = new Uint8Array(await response.arrayBuffer());
+  return {
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue(buffered);
+        controller.close();
+      },
+    }),
+    size: buffered.byteLength,
+  };
+}


### PR DESCRIPTION
## Problem

Teams transcript/recording uploads to Unique storage were failing. The error surfaced as a `500` from `node-ingestion`'s `PUT /scoped/upload`, but the **real** error is a `400` from Azure Blob Storage:

```
x-ms-error-code: UnsupportedHeader   <HeaderName>Transfer-Encoding</HeaderName>
"One of the HTTP headers specified in the request is not supported."
```

Azure Blob's single `PUT Blob` **requires a `Content-Length` and rejects `Transfer-Encoding: chunked`.** The whole chain sent chunked:

1. `uploadToStorage` PUT a `ReadableStream` body via Node `fetch` + `duplex:'half'` → Node uses **chunked** (no `Content-Length`).
2. #608 routes in-cluster uploads through `node-ingestion`'s `/scoped/upload` proxy, which re-streams the body to Azure with `content-length: undefined` → still **chunked**.
3. Azure → `400 UnsupportedHeader`; node-ingestion rethrows as a generic `500`; teams-mcp `assert.fail('…500')`.

**Why it surfaced now:** in-cluster uploads previously failed earlier on a Kong-egress connect-timeout and never reached Azure. #608 fixed the egress, so the upload now reaches Azure and trips on the chunked rejection. (The multipart branch worked only because it buffers and sets an explicit `Content-Length`.)

## Fix

Set an explicit `Content-Length` on the PUT so `fetch` streams the body **without** chunked framing (verified on Node 24 — fetch honors a manual Content-Length on a stream body and drops chunked).

The upload content provider is modelled as a **sized stream**:

```ts
content: () => Promise<{ stream: ReadableStream<Uint8Array>; size: number }>
```

- New `src/utils/sized-content.ts` exports `SizedContent` and `readSizedContent(response)`, which adapts an MS Graph `/content` download `Response` into `{ stream, size }`. Providers switched from `.getStream()` to `.responseType(ResponseType.RAW).get()` so the helper can read the source `Content-Length`.
- `uploadToStorage` now just destructures `{ stream, size }` and sets `Content-Length: size`.
- **Video (uncompressed):** streams with the advertised length — no buffering, no OOM risk.
- **gzip edge case:** undici transparently decompresses gzipped bodies while `content-length` stays the *compressed* size. `readSizedContent` trusts the header only for identity-encoded responses; content-encoded payloads (small transcripts) fall back to an in-memory measure to avoid a truncated/corrupt upload.

Also fixes the latent `external`-mode path (direct-to-Azure was chunked too).

## Verification

- `tsc --noEmit`, `biome check`, and all 49 unit tests pass.
- End-to-end simulation against a chunked-rejecting (Azure-like) server confirms both the identity (stream) and gzip (buffered, wrapped-stream) paths upload the exact byte count.

## Follow-up (not in this PR)

`node-ingestion`'s `ScopedAPIController` swallows Azure's specific error into a generic `500`; surfacing `x-ms-error-code`/status would make this class of failure far faster to diagnose.