### PR TITLE
fix(teams-mcp): fail loudly on non-media content downloads instead of uploading them

### DIFF
--- a/services/teams-mcp/src/utils/sized-content.spec.ts
+++ b/services/teams-mcp/src/utils/sized-content.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readSizedContent } from './sized-content';
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+describe('readSizedContent', () => {
+  it('streams an identity-encoded response using the advertised content-length', async () => {
+    const body = new Uint8Array(20_000).fill(7);
+    const response = new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'video/mp4', 'content-length': String(body.byteLength) },
+    });
+
+    const { stream, size } = await readSizedContent(response);
+
+    expect(size).toBe(20_000);
+    expect((await collect(stream)).byteLength).toBe(20_000);
+  });
+
+  it('buffers to measure the decompressed size when the body is content-encoded', async () => {
+    // gzip body whose content-length header (compressed) must NOT be trusted as the stream size.
+    const decompressed = new TextEncoder().encode('WEBVTT\n\n'.repeat(500));
+    const response = new Response(decompressed, {
+      status: 200,
+      headers: {
+        'content-type': 'text/vtt',
+        'content-encoding': 'gzip',
+        'content-length': '120',
+      },
+    });
+
+    const { stream, size } = await readSizedContent(response);
+
+    expect(size).toBe(decompressed.byteLength);
+    expect((await collect(stream)).byteLength).toBe(decompressed.byteLength);
+  });
+
+  it('throws (instead of uploading) when the download is not OK, surfacing the body', async () => {
+    const response = new Response('<Error><Code>AuthenticationFailed</Code></Error>', {
+      status: 403,
+      headers: { 'content-type': 'application/xml' },
+    });
+
+    await expect(readSizedContent(response)).rejects.toThrow(/status=403.*AuthenticationFailed/s);
+  });
+
+  it('throws when a 200 returns a non-media (JSON error) body rather than the content', async () => {
+    const response = new Response(JSON.stringify({ error: { code: 'NotFound' } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(readSizedContent(response)).rejects.toThrow(
+      /contentType=application\/json.*NotFound/s,
+    );
+  });
+});

--- a/services/teams-mcp/src/utils/sized-content.ts
+++ b/services/teams-mcp/src/utils/sized-content.ts
@@ -9,18 +9,46 @@ export interface SizedContent {
   size: number;
 }
 
+/** Max bytes of an unexpected/error body we read back into a thrown error for diagnosis. */
+const DIAGNOSTIC_BODY_LIMIT = 2048;
+
+/**
+ * Content types that indicate an error envelope or redirect/login page rather than the media we
+ * asked for. MS Graph errors are JSON, Azure Blob/SAS errors are XML, and auth interstitials are
+ * HTML — none of which should ever be uploaded as recording/transcript content.
+ */
+const NON_MEDIA_CONTENT_TYPES = ['application/json', 'application/xml', 'text/xml', 'text/html'];
+
 /**
  * Adapts an HTTP download `Response` (e.g. an MS Graph `/content` fetch) into a
  * {@link SizedContent} with a known byte size.
  *
- * The `Content-Length` header is trusted only for identity-encoded responses: Node's fetch
- * (undici) transparently decompresses a gzip/deflate/br `body` stream while the header keeps the
- * *compressed* size, so streaming it under that length would truncate the upload. When the length
- * cannot be trusted (content-encoded, or absent) the body is buffered in memory purely to measure
- * it — used for small, compressible payloads; large media is served uncompressed and takes the
+ * Per the Graph docs a healthy recording/transcript download is `200 OK` with the media bytes
+ * (e.g. `Content-Type: video/mp4`). A non-OK status — or a JSON/XML/HTML body — means we got an
+ * error envelope, SAS-expiry notice, or login page instead of the content; uploading that would
+ * silently store a tiny corrupt blob. We fail loudly in that case and include the (small) body in
+ * the error to surface the real cause.
+ *
+ * For a valid response the `Content-Length` header is trusted only when the body is not
+ * content-encoded: Node's fetch (undici) transparently decompresses a gzip/deflate/br `body`
+ * stream while the header keeps the *compressed* size, so streaming it under that length would
+ * truncate the upload. When the length cannot be trusted (content-encoded, or absent) the body is
+ * buffered in memory purely to measure it — large media is served uncompressed and takes the
  * zero-copy streaming path.
  */
 export async function readSizedContent(response: Response): Promise<SizedContent> {
+  const contentType = response.headers.get('content-type');
+
+  if (!response.ok || isNonMediaContentType(contentType)) {
+    const detail = await readBodyForDiagnostics(response);
+    const location = response.headers.get('location');
+    throw new Error(
+      `Content download did not return media: status=${response.status} ` +
+        `url=${response.url} contentType=${contentType ?? '<none>'} ` +
+        `location=${location ?? '<none>'} body=${detail}`,
+    );
+  }
+
   assert.ok(response.body, 'Content response has no body');
 
   const advertised = response.headers.get('content-length');
@@ -49,4 +77,23 @@ export async function readSizedContent(response: Response): Promise<SizedContent
     }),
     size: buffered.byteLength,
   };
+}
+
+function isNonMediaContentType(contentType: string | null): boolean {
+  if (contentType === null) {
+    return false;
+  }
+  const base = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+  return NON_MEDIA_CONTENT_TYPES.includes(base);
+}
+
+async function readBodyForDiagnostics(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.length > DIAGNOSTIC_BODY_LIMIT
+      ? `${text.slice(0, DIAGNOSTIC_BODY_LIMIT)}…(truncated)`
+      : text;
+  } catch {
+    return '<unreadable body>';
+  }
 }


### PR DESCRIPTION
## Problem

After #614 fixed the chunked-upload rejection, recording (`video/mp4`) uploads were producing a tiny **~214-byte** blob (empty/corrupt), while transcript (`text/vtt`) uploads worked correctly.

Investigation (incl. the [Graph `callRecording` content docs](https://learn.microsoft.com/en-us/graph/api/callrecording-get?view=graph-rest-1.0&tabs=http)):

- A healthy `GET .../recordings/{id}/content` returns `200 OK` + `Content-Type: video/mp4` + the media bytes (it may 302 internally to storage; the SDK's `RedirectHandler` follows it). Our endpoint/approach is correct.
- At the SDK level, `.getStream()` and `.responseType(RAW).get()` return the **same** `rawResponse.body`, so this isn't a regression from #614 — the recording download itself is yielding ~214 bytes.
- A 214-byte payload is almost certainly a **non-media error/redirect body** — a Graph JSON error, an Azure SAS-expiry XML, or an auth/redirect HTML page — that we were uploading verbatim, because `readSizedContent` never checked `response.ok` or the content type.

## Change

`readSizedContent` now rejects non-media downloads instead of silently storing them:

- Throws when the response is **not OK** or the content type is **JSON/XML/HTML**.
- The error includes `status`, final `url`, `content-type`, `Location` header, and the (capped) response body — so the real cause is visible in logs.
- Recording upload is already wrapped in try/catch in `ingestTranscript`, so this only fails the recording (logged as a warning) and leaves transcript ingestion intact.

This is both a **correctness guard** (no more corrupt 214-byte recordings) and a **diagnostic**: the next recording attempt will surface the actual error response so we can fix the root cause (e.g. permissions, SAS expiry, or an unfollowed redirect).

Adds unit coverage for the stream / buffered / non-OK / non-media paths.

## Verification

- `tsc --noEmit`, `biome check`, and all 53 unit tests pass (4 new).

## Follow-up

Once the captured error reveals why the recording `/content` returns a non-media body, apply the targeted fix.