### PR TITLE
fix(teams-mcp): skip inaccessible recordings without dangling KB records

### DIFF
--- a/services/teams-mcp/src/unique/unique-content.service.ts
+++ b/services/teams-mcp/src/unique/unique-content.service.ts
@@ -32,6 +32,20 @@ import {
 } from './unique.dtos';
 import type { UniqueIdentity } from './unique-identity.types';
 
+/**
+ * A download streamed to a local temp file, ready to upload with an authoritative `Content-Length`.
+ * Produced by {@link UniqueContentService.spoolContent}; the caller owns the file and must call
+ * {@link cleanup} once the upload has finished (or failed).
+ */
+export interface SpooledContent {
+  /** Absolute path of the temp file the content was streamed to. */
+  path: string;
+  /** Authoritative byte size from `fstat`, used as the upload `Content-Length`. */
+  size: number;
+  /** Removes the temp file. Safe to call more than once (`force` no-ops if already gone). */
+  cleanup: () => Promise<void>;
+}
+
 @Injectable()
 export class UniqueContentService {
   private readonly logger = new Logger(UniqueContentService.name);
@@ -87,67 +101,77 @@ export class UniqueContentService {
     return result;
   }
 
+  /**
+   * Streams a content download to a temp file at constant memory and returns its path plus an
+   * authoritative byte size (`fstat`). Call this *before* opening a Unique content record
+   * ({@link upsertContent}) so a failed download (e.g. a 403 on a recording the caller can't read)
+   * never leaves a dangling, empty record behind. The caller must {@link SpooledContent.cleanup}
+   * the returned file once the upload has finished or failed.
+   */
+  @Span()
+  public async spoolContent(
+    content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>,
+  ): Promise<SpooledContent> {
+    const span = this.trace.getSpan();
+    const tmpPath = join(tmpdir(), `teams-upload-${randomUUID()}`);
+
+    try {
+      // The MS Graph body is a web stream; Readable.fromWeb adapts it to a Node stream so the
+      // pipeline can write it to disk with backpressure (constant memory).
+      await pipeline(Readable.fromWeb(await content()), createWriteStream(tmpPath));
+      const { size } = await stat(tmpPath);
+      span?.setAttribute('content_length', size);
+      return { path: tmpPath, size, cleanup: () => rm(tmpPath, { force: true }) };
+    } catch (error) {
+      // Remove any partial spool before propagating, so a download failure leaves nothing behind.
+      await rm(tmpPath, { force: true });
+      throw error;
+    }
+  }
+
   @Span()
   public async uploadToStorage(
     writeUrl: string,
-    content: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>,
+    spooled: SpooledContent,
     mime: string,
   ): Promise<void> {
     const span = this.trace.getSpan();
 
     const uploadUrl = this.correctWriteUrl(writeUrl);
-    const urlObj = new URL(uploadUrl);
-    const storageEndpoint = urlObj.origin;
+    const storageEndpoint = new URL(uploadUrl).origin;
     span?.setAttribute('storage_endpoint', storageEndpoint);
+    span?.setAttribute('content_length', spooled.size);
 
     this.logger.debug({ storageEndpoint }, 'Beginning content upload to Unique storage system');
 
     // Azure Blob's single `PUT Blob` rejects `Transfer-Encoding: chunked` (400 UnsupportedHeader)
-    // and requires a `Content-Length`. The MS Graph `/content` response header is unreliable for
-    // recordings (its `/content` 302-redirects and the response can carry the redirect hop's
-    // length, not the video's), so instead of trusting it we spool the decoded download to a temp
-    // file at constant memory, `fstat` it for an authoritative size, then stream the file back with
-    // that explicit Content-Length — undici then sends a sized, non-chunked body.
-    const tmpPath = join(tmpdir(), `teams-upload-${randomUUID()}`);
-    span?.setAttribute('spooled', true);
+    // and requires a `Content-Length`. The spooled file gives us an authoritative size, and undici
+    // sends a sized, non-chunked body when an explicit Content-Length is set.
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': mime,
+        'Content-Length': String(spooled.size),
+        'x-ms-blob-type': 'BlockBlob',
+      },
+      // Stream the spooled file back as the request body. `duplex: 'half'` is required for a
+      // streaming request body.
+      body: Readable.toWeb(createReadStream(spooled.path)),
+      duplex: 'half',
+    });
 
-    try {
-      // The MS Graph body is a web stream; Readable.fromWeb adapts it to a Node stream so the
-      // pipeline can write it to disk with backpressure.
-      await pipeline(Readable.fromWeb(await content()), createWriteStream(tmpPath));
-
-      const { size } = await stat(tmpPath);
-      span?.setAttribute('content_length', size);
-
-      const response = await fetch(uploadUrl, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': mime,
-          'Content-Length': String(size),
-          'x-ms-blob-type': 'BlockBlob',
-        },
-        // Stream the spooled file back as the request body. With an explicit Content-Length undici
-        // sends a sized, non-chunked PUT; `duplex: 'half'` is required for a streaming request body.
-        body: Readable.toWeb(createReadStream(tmpPath)),
-        duplex: 'half',
-      });
-
-      if (!response.ok) {
-        span?.setAttribute('error', true);
-        span?.setAttribute('http_status', response.status);
-        this.logger.error(
-          { status: response.status, storageEndpoint },
-          'Unique storage system rejected content upload with error',
-        );
-        assert.fail(`Unique storage upload failed: ${response.status}`);
-      }
-
+    if (!response.ok) {
+      span?.setAttribute('error', true);
       span?.setAttribute('http_status', response.status);
-      this.logger.debug({ storageEndpoint }, 'Successfully completed content upload to storage');
-    } finally {
-      // Remove the spool on success, download error, and upload error (`force` no-ops if absent).
-      await rm(tmpPath, { force: true });
+      this.logger.error(
+        { status: response.status, storageEndpoint },
+        'Unique storage system rejected content upload with error',
+      );
+      assert.fail(`Unique storage upload failed: ${response.status}`);
     }
+
+    span?.setAttribute('http_status', response.status);
+    this.logger.debug({ storageEndpoint }, 'Successfully completed content upload to storage');
   }
 
   // HACK (mirrors outlook-semantic-mcp): in cluster_local mode the storeInternally

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { GraphError } from '@microsoft/microsoft-graph-client';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
@@ -13,7 +14,7 @@ import {
   SourceOwnerType,
   UniqueIngestionMode,
 } from './unique.dtos';
-import { UniqueContentService } from './unique-content.service';
+import { type SpooledContent, UniqueContentService } from './unique-content.service';
 import { UniqueScopeService } from './unique-scope.service';
 import { UniqueUserService } from './unique-user.service';
 
@@ -151,40 +152,47 @@ export class UniqueService {
       'Beginning transcript upload to Unique system',
     );
 
-    const transcriptUpload = await this.contentService.upsertContent({
-      storeInternally: true,
-      scopeId: childScope.id,
-      sourceKind: TEAMS_SOURCE_KIND,
-      sourceName: TEAMS_SOURCE_NAME,
-      sourceOwnerType: SourceOwnerType.Company,
-      input: {
-        key: transcript.id,
-        mimeType: 'text/vtt',
-        title: meeting.subject || 'Untitled Meeting',
-        byteSize: 1,
-        metadata: this.buildContentMetadata(meeting),
-      },
-    });
+    // Download to disk BEFORE opening a content record, so a failed download never leaves a
+    // dangling, empty record behind. The temp file is removed once the upload finishes or fails.
+    const transcriptSpool = await this.contentService.spoolContent(transcript.content);
+    try {
+      const transcriptUpload = await this.contentService.upsertContent({
+        storeInternally: true,
+        scopeId: childScope.id,
+        sourceKind: TEAMS_SOURCE_KIND,
+        sourceName: TEAMS_SOURCE_NAME,
+        sourceOwnerType: SourceOwnerType.Company,
+        input: {
+          key: transcript.id,
+          mimeType: 'text/vtt',
+          title: meeting.subject || 'Untitled Meeting',
+          byteSize: 1,
+          metadata: this.buildContentMetadata(meeting),
+        },
+      });
 
-    await this.contentService.uploadToStorage(
-      transcriptUpload.writeUrl,
-      transcript.content,
-      'text/vtt',
-    );
+      await this.contentService.uploadToStorage(
+        transcriptUpload.writeUrl,
+        transcriptSpool,
+        'text/vtt',
+      );
 
-    await this.contentService.upsertContent({
-      storeInternally: true,
-      scopeId: childScope.id,
-      sourceKind: TEAMS_SOURCE_KIND,
-      sourceName: TEAMS_SOURCE_NAME,
-      sourceOwnerType: SourceOwnerType.Company,
-      fileUrl: transcriptUpload.readUrl,
-      input: {
-        key: transcript.id,
-        mimeType: 'text/vtt',
-        title: meeting.subject || 'Untitled Meeting',
-      },
-    });
+      await this.contentService.upsertContent({
+        storeInternally: true,
+        scopeId: childScope.id,
+        sourceKind: TEAMS_SOURCE_KIND,
+        sourceName: TEAMS_SOURCE_NAME,
+        sourceOwnerType: SourceOwnerType.Company,
+        fileUrl: transcriptUpload.readUrl,
+        input: {
+          key: transcript.id,
+          mimeType: 'text/vtt',
+          title: meeting.subject || 'Untitled Meeting',
+        },
+      });
+    } finally {
+      await transcriptSpool.cleanup();
+    }
 
     span?.addEvent('transcript_ingestion_completed', {
       transcriptId: transcript.id,
@@ -192,68 +200,101 @@ export class UniqueService {
       childScopeId: childScope.id,
     });
 
-    // Upload recording if provided (with SKIP_INGESTION)
-    // Wrapped in try-catch to ensure recording upload failures don't break transcript ingestion
+    // Upload recording if provided (with SKIP_INGESTION).
     if (recording) {
+      // Download the recording to disk FIRST, before opening any content record. Teams recordings
+      // live in the meeting owner's OneDrive, so a caller who isn't the owner (e.g. an invited
+      // attendee triggering on-demand ingest) gets a 403 here. Spooling first means that failure
+      // leaves no dangling, empty content record behind — we simply skip the recording and let the
+      // transcript ingestion (already done above) stand.
+      let recordingSpool: SpooledContent | undefined;
       try {
         this.logger.log(
           { recordingId: recording.id, scopeId: childScope.id },
-          'Beginning recording upload to Unique system (skip ingestion)',
+          'Downloading meeting recording before upload',
         );
-
-        const recordingUpload = await this.contentService.upsertContent({
-          storeInternally: true,
-          scopeId: childScope.id,
-          sourceKind: TEAMS_SOURCE_KIND,
-          sourceName: TEAMS_SOURCE_NAME,
-          sourceOwnerType: SourceOwnerType.Company,
-          input: {
-            key: recording.id,
-            mimeType: 'video/mp4',
-            title: meeting.subject || 'Untitled Meeting',
-            byteSize: 1,
-            ingestionConfig: {
-              uniqueIngestionMode: UniqueIngestionMode.SKIP_INGESTION,
-            },
-            metadata: this.buildContentMetadata(meeting, recording),
-          },
-        });
-        await this.contentService.uploadToStorage(
-          recordingUpload.writeUrl,
-          recording.content,
-          'video/mp4',
-        );
-        await this.contentService.upsertContent({
-          storeInternally: true,
-          scopeId: childScope.id,
-          sourceKind: TEAMS_SOURCE_KIND,
-          sourceName: TEAMS_SOURCE_NAME,
-          sourceOwnerType: SourceOwnerType.Company,
-          fileUrl: recordingUpload.readUrl,
-          input: {
-            key: recording.id,
-            mimeType: 'video/mp4',
-            title: meeting.subject || 'Untitled Meeting',
-            ingestionConfig: {
-              uniqueIngestionMode: UniqueIngestionMode.SKIP_INGESTION,
-            },
-          },
-        });
-
-        span?.addEvent('recording_stored', {
-          recordingId: recording.id,
-          parentScopeId: parentScope.id,
-          childScopeId: childScope.id,
-        });
+        recordingSpool = await this.contentService.spoolContent(recording.content);
       } catch (error) {
-        span?.addEvent('recording_upload_failed', {
+        const statusCode = error instanceof GraphError ? error.statusCode : undefined;
+        span?.addEvent('recording_download_failed', {
           recordingId: recording.id,
+          statusCode: statusCode ?? 'unknown',
           error: error instanceof Error ? error.message : String(error),
         });
         this.logger.warn(
-          { error, recordingId: recording.id },
-          'Failed to upload recording, transcript ingestion will continue',
+          { recordingId: recording.id, statusCode },
+          statusCode === 403
+            ? 'Recording skipped: the caller cannot access the recording file (only the meeting owner can). Transcript ingestion completed.'
+            : 'Recording download failed; skipping recording. Transcript ingestion completed.',
         );
+      }
+
+      if (recordingSpool) {
+        try {
+          this.logger.log(
+            { recordingId: recording.id, scopeId: childScope.id },
+            'Beginning recording upload to Unique system (skip ingestion)',
+          );
+
+          const recordingUpload = await this.contentService.upsertContent({
+            storeInternally: true,
+            scopeId: childScope.id,
+            sourceKind: TEAMS_SOURCE_KIND,
+            sourceName: TEAMS_SOURCE_NAME,
+            sourceOwnerType: SourceOwnerType.Company,
+            input: {
+              key: recording.id,
+              mimeType: 'video/mp4',
+              title: meeting.subject || 'Untitled Meeting',
+              byteSize: 1,
+              ingestionConfig: {
+                uniqueIngestionMode: UniqueIngestionMode.SKIP_INGESTION,
+              },
+              metadata: this.buildContentMetadata(meeting, recording),
+            },
+          });
+          await this.contentService.uploadToStorage(
+            recordingUpload.writeUrl,
+            recordingSpool,
+            'video/mp4',
+          );
+          await this.contentService.upsertContent({
+            storeInternally: true,
+            scopeId: childScope.id,
+            sourceKind: TEAMS_SOURCE_KIND,
+            sourceName: TEAMS_SOURCE_NAME,
+            sourceOwnerType: SourceOwnerType.Company,
+            fileUrl: recordingUpload.readUrl,
+            input: {
+              key: recording.id,
+              mimeType: 'video/mp4',
+              title: meeting.subject || 'Untitled Meeting',
+              ingestionConfig: {
+                uniqueIngestionMode: UniqueIngestionMode.SKIP_INGESTION,
+              },
+            },
+          });
+
+          span?.addEvent('recording_stored', {
+            recordingId: recording.id,
+            parentScopeId: parentScope.id,
+            childScopeId: childScope.id,
+          });
+        } catch (error) {
+          // The download succeeded but opening/uploading/finalizing the record failed (rare — e.g.
+          // a node-ingestion error). The empty record may linger; teams-mcp has no delete path.
+          // Don't let it break the already-completed transcript ingestion.
+          span?.addEvent('recording_upload_failed', {
+            recordingId: recording.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          this.logger.warn(
+            { error, recordingId: recording.id },
+            'Failed to upload recording after download, transcript ingestion will continue',
+          );
+        } finally {
+          await recordingSpool.cleanup();
+        }
       }
     }
 


### PR DESCRIPTION
## Context

Follow-up to #619 (disk-spool upload). Investigating a participant-triggered ingest on 0.2.16 (logs provided) showed the on-demand `ingest_meeting` path **only partially failed**, and in a way that left junk behind:

- Meeting lookup, transcript metadata, recording metadata, and the **transcript upload all succeeded** for an invited attendee.
- The **recording `/content` download from Graph returned 403**: `{"statusCode":403,"code":null,"requestId":null,"body":{}}` (a `GraphError`).

Why: Teams **recordings** live in the **meeting owner's OneDrive**; `/recordings/{id}/content` 302-redirects there and is governed by that file's ACL, so a non-owner (e.g. an invited attendee triggering on-demand ingest) gets 403. **Transcripts** live in the meeting/Stream service and *are* readable by attendees. (This is orthogonal to #619 — the 403 happens on download, before any upload/spooling.)

The bug: we called `upsertContent` (which **opens storage** and returns a `writeUrl`) **before** downloading. So the 403 left a **dangling, empty content record** in the knowledge base, and the failure was swallowed as a generic warning.

## Change

**Download-first ordering** — spool the Graph download to a temp file *before* opening any content record:

- Split `uploadToStorage(writeUrl, content, mime)` into:
  - `spoolContent(content) -> { path, size, cleanup }` — streams the download to a temp file (constant memory), `fstat`s for the authoritative size; cleans up its own partial temp on failure.
  - `uploadToStorage(writeUrl, spooled, mime)` — PUTs the spooled file with an explicit `Content-Length`.
- `ingestTranscript` now does, per artifact: **spool → upsert (open) → upload → upsert (finalize)**, with `cleanup()` in `finally`.
- **Recording**: if `spoolContent` throws (e.g. 403), we **skip the recording and never open a record** — nothing to clean up — and the transcript (already ingested) stands. The 403 is detected via `error instanceof GraphError` and logged explicitly. A failure *after* the download (rare node-ingestion error) is still caught so it can't break transcript ingestion (it could leave a record, noted in a comment — teams-mcp has no delete path).
- Applied the same download-first order to the **transcript** (so a transcript download failure also leaves no dangling record).

## Why not delete-on-failure?

teams-mcp has no delete capability — platform deletes (`files.deleteByIds`) are a **GraphQL ingestion-client** operation (`@unique-ag/unique-api`), which teams-mcp doesn't wire up (it uses the public REST `FetchFn` + node-ingestion's `/scoped/upload`). Reordering **prevents** the dangling record for the 403 case instead of creating-then-deleting it — cleaner, and needs no new client/dependency.

## Limitations / follow-ups

- The recording skip is surfaced via logs/telemetry only (the tool enqueues and returns before ingestion runs, so it can't synchronously report the recording outcome).
- Letting participants actually pull the recording via **app permissions on behalf of the organizer** (`OnlineMeetingRecording.Read.All` + application access policy) is a larger follow-up for its own ticket.

## Verification

- `check-types`, `style`, `build`, `test` (49/49) all pass.
- ⏳ Manual e2e: trigger `ingest_meeting` as a non-owner attendee → transcript ingests, recording is skipped (403 logged), and **no empty recording content record** is created.

Refs: UN-20155