### PR TITLE
fix(outlook-semantic-mcp): fortify draft_email tool description for reply use case

### DIFF
--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -30,7 +30,12 @@ export const META = createMeta({
 
     ### Drafting Behavior
     When the user asks you to write, reply to, or draft an email:
-    1. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
+    1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
+       - Is there a retrieved email (with a \`msGraphMessageId\`) that the user is clearly reacting to?
+       - If yes → use \`type: "reply"\` with that \`msGraphMessageId\`. Do not ask for recipient or subject.
+       - If no → use \`type: "draft"\` and resolve the recipient as described below.
+       Default to \`type: "reply"\` whenever there is a plausible retrieved email in context. Only use \`type: "draft"\` when there is genuinely no prior email to reply to, or when the user explicitly wants to start a new thread.
+    2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
     2. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
     3. **Draft a single email right away** and present it using the format specified below.
     4. **The user will correct you if needed.** Trust that the user will tell you if something is wrong. Do not try to get it perfect on the first ask — getting it done fast is more important.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -31,14 +31,14 @@ export const META = createMeta({
     ### Drafting Behavior
     When the user asks you to write, reply to, or draft an email:
     1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
-       - Is there a retrieved email that the user is **directly reacting to** in this message?
-         - If it has a \`msGraphMessageId\` → use \`type: "reply"\` with that ID immediately. Do not ask for recipient or subject.
-         - If it was returned by semantic search only and **lacks** \`msGraphMessageId\` → re-fetch it using \`msGraphKeywordSearchQueries\` in \`search_emails\` (search by subject or sender) to obtain the Graph ID, then use \`type: "reply"\`.
-       - Does the user clearly want to reply to a specific email that is **not yet in context** (e.g. "draft a reply to Nick's email about payroll")?
-         - If yes → call \`search_emails\` with \`msGraphKeywordSearchQueries\` to find and retrieve that email (Graph results always include \`msGraphMessageId\`), then use \`type: "reply"\`.
+       - Is there a retrieved email that the user is **directly reacting to** in this message, and does it have a \`msGraphMessageId\`?
+         - If yes → use \`type: "reply"\` with that ID immediately. Do not ask for recipient or subject.
+       - Does the user refer to a specific email by subject, sender, or topic but it is **not yet in context**, or the in-context result **lacks** \`msGraphMessageId\`?
+         - If yes → call \`search_emails\` to find it. Present the matching emails to the user and ask them to confirm which one to reply to. Once confirmed, use \`type: "reply"\` with the confirmed email's \`msGraphMessageId\`. This confirmation step is required because replying to the wrong email is a hard-to-recover mistake.
        - Otherwise → use \`type: "draft"\` and resolve the recipient as described below.
-       Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific email. Do not default to reply just because some email happens to be in context from an earlier search — the user must be explicitly responding to it.
+       Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific, identified email. Do not default to reply just because some email happens to be in context from an earlier search.
     2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
+       Exception to "act immediately": when a \`search_emails\` call is needed to identify the email to reply to, always confirm the exact email with the user before drafting — do not silently pick the first result.
     3. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
     4. **Draft a single email right away** and present it using the format specified below.
     5. **The user will correct you if needed.** Trust that the user will tell you if something is wrong. Do not try to get it perfect on the first ask — getting it done fast is more important.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -35,14 +35,15 @@ export const META = createMeta({
          - If yes → use \`type: "reply"\` with that ID immediately. Do not ask for recipient or subject.
        - Does the user refer to a specific email by subject, sender, or topic but it is **not yet in context**, or the in-context result **lacks** \`msGraphMessageId\`?
          - If yes → call \`search_emails\` to find it. Present the matching emails to the user and ask them to confirm which one to reply to. Once confirmed, use \`type: "reply"\` with the confirmed email's \`msGraphMessageId\`. This confirmation step is required because replying to the wrong email is a hard-to-recover mistake.
-       - Otherwise → use \`type: "draft"\` and resolve the recipient as described below.
+       - Otherwise → use \`type: "draft"\` and resolve the recipient following the "Resolving Email Recipients" section above.
        Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific, identified email. Do not default to reply just because some email happens to be in context from an earlier search.
-    2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
-       Exception to "act immediately": when a \`search_emails\` call is needed to identify the email to reply to, always confirm the exact email with the user before drafting — do not silently pick the first result.
+    2. **Act immediately — with two exceptions where you must pause and confirm first:**
+       - When \`search_emails\` is needed to identify the email to reply to: present the results and ask the user to confirm the exact email before drafting.
+       - When the recipient address for a new draft cannot be resolved after searching with \`search_emails\` and \`lookup_contacts\`: ask the user to provide it.
+       For everything else: no clarifications, no confirmations, no plans. Just draft.
     3. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
     4. **Draft a single email right away** and present it using the format specified below.
     5. **The user will correct you if needed.** Trust that the user will tell you if something is wrong. Do not try to get it perfect on the first ask — getting it done fast is more important.
-    The **only** exception: if after searching with \`search_emails\` and \`lookup_contacts\` you still cannot determine the recipient's email address, ask the user for it. That is the only reason to pause and ask a question.
 
     ### What \`draft_email\` Does
     Creates a draft email in the user's Outlook mailbox. The draft is saved and can be reviewed or sent later.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -31,10 +31,11 @@ export const META = createMeta({
     ### Drafting Behavior
     When the user asks you to write, reply to, or draft an email:
     1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
-       - Is there a retrieved email (with a \`msGraphMessageId\`) that the user is **directly reacting to** in this message?
-         - If yes → use \`type: "reply"\` with that \`msGraphMessageId\`. Do not ask for recipient or subject.
+       - Is there a retrieved email that the user is **directly reacting to** in this message?
+         - If it has a \`msGraphMessageId\` → use \`type: "reply"\` with that ID immediately. Do not ask for recipient or subject.
+         - If it was returned by semantic search only and **lacks** \`msGraphMessageId\` → re-fetch it using \`msGraphKeywordSearchQueries\` in \`search_emails\` (search by subject or sender) to obtain the Graph ID, then use \`type: "reply"\`.
        - Does the user clearly want to reply to a specific email that is **not yet in context** (e.g. "draft a reply to Nick's email about payroll")?
-         - If yes → first call \`search_emails\` to find and retrieve that email, then use \`type: "reply"\` with its \`msGraphMessageId\`.
+         - If yes → call \`search_emails\` with \`msGraphKeywordSearchQueries\` to find and retrieve that email (Graph results always include \`msGraphMessageId\`), then use \`type: "reply"\`.
        - Otherwise → use \`type: "draft"\` and resolve the recipient as described below.
        Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific email. Do not default to reply just because some email happens to be in context from an earlier search — the user must be explicitly responding to it.
     2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -17,8 +17,10 @@ export const META = createMeta({
     If the user refers to a person and describes content they want communicated, treat it as an email drafting request. There is no "send email" tool — drafting is the final action.
 
     ### Resolving Email Recipients
+    This section applies to \`type: "draft"\` only. For \`type: "reply"\`, skip recipient resolution entirely — pass the \`msGraphMessageId\` directly as \`inReplyToMessageId\` and Graph pre-fills all recipients.
+
     **Do not ask the user for confirmation before searching.** Act immediately.
-    Before drafting, you **must** resolve the recipient's email address:
+    For new drafts (\`type: "draft"\`), you **must** resolve the recipient's email address before drafting:
     1. **Explicit address provided**: If the user gave you an email address directly, use it.
     2. **No address provided — search immediately**: If the user refers to a person by name, role, or organization but did not provide an email address, **immediately** call the \`search_emails\` tool. Do NOT ask the user whether you should search. Do NOT present a plan or options. Do NOT ask for confirmation. Just search.
     3. **Ambiguous results**: If \`search_emails\` returns multiple possible matches, present them to the user and ask which one to use.
@@ -35,7 +37,9 @@ export const META = createMeta({
     The **only** exception: if after searching with \`search_emails\` and \`lookup_contacts\` you still cannot determine the recipient's email address, ask the user for it. That is the only reason to pause and ask a question.
 
     ### What \`draft_email\` Does
-    Creates a draft email in the user's Outlook mailbox. Provide subject, body content (Markdown), and at least one recipient. Optionally include CC recipients and attachments. The draft is saved and can be reviewed or sent later.
+    Creates a draft email in the user's Outlook mailbox. The draft is saved and can be reviewed or sent later.
+    - For \`type: "draft"\`: provide subject, body content (Markdown), and at least one recipient. Optionally include CC recipients and attachments.
+    - For \`type: "reply"\`: provide only the body content (Markdown) and the \`inReplyToMessageId\`. Graph pre-fills all recipients and the subject — no need to specify them.
 
     ### Shared Mailbox and Reply Drafts
     \`draft_email\` requires a \`type\` field that selects the drafting mode:
@@ -146,7 +150,7 @@ export const META = createMeta({
   {message}
 
   Rules:
-  - **subject**: Use the subject from the tool input.
+  - **subject**: For \`type: "draft"\`, use the subject from the tool input. For \`type: "reply"\`, use the subject of the original email from the conversation context (Graph pre-fills it; the tool output does not return it).
   - **Open in Outlook link**: Include only when \`webLink\` is present in the tool output. Use the \`webLink\` value directly as the href — do not construct or modify it.
   - **message**: Display the \`message\` from the tool output (e.g. "Draft email created successfully.").
   - If \`attachmentsFailed\` is non-empty, list each failed attachment below the message.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -31,14 +31,14 @@ export const META = createMeta({
     ### Drafting Behavior
     When the user asks you to write, reply to, or draft an email:
     1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
-       - Is there a retrieved email (with a \`msGraphMessageId\`) that the user is clearly reacting to?
+       - Is there a retrieved email (with a \`msGraphMessageId\`) that the user is **directly reacting to** in this message?
        - If yes → use \`type: "reply"\` with that \`msGraphMessageId\`. Do not ask for recipient or subject.
        - If no → use \`type: "draft"\` and resolve the recipient as described below.
-       Default to \`type: "reply"\` whenever there is a plausible retrieved email in context. Only use \`type: "draft"\` when there is genuinely no prior email to reply to, or when the user explicitly wants to start a new thread.
+       Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific email just shown in the conversation. Do not default to reply just because some email happens to be in context from an earlier search — the user must be explicitly responding to it.
     2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
-    2. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
-    3. **Draft a single email right away** and present it using the format specified below.
-    4. **The user will correct you if needed.** Trust that the user will tell you if something is wrong. Do not try to get it perfect on the first ask — getting it done fast is more important.
+    3. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
+    4. **Draft a single email right away** and present it using the format specified below.
+    5. **The user will correct you if needed.** Trust that the user will tell you if something is wrong. Do not try to get it perfect on the first ask — getting it done fast is more important.
     The **only** exception: if after searching with \`search_emails\` and \`lookup_contacts\` you still cannot determine the recipient's email address, ask the user for it. That is the only reason to pause and ask a question.
 
     ### What \`draft_email\` Does
@@ -74,33 +74,33 @@ export const META = createMeta({
 
     Context: conversation contains an email with msGraphMessageId="AAMk123", from nick@example.com, subject "Payroll System Migration Plan"
     User: "Draft a reply to this email, tell him we need to reduce ADP cost to 76k max"
-    Action: type="reply", inReplyToMessageId="AAMk123", body addresses the cost constraint (Graph fills recipient and subject)
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk123" }, body addresses the cost constraint (Graph fills recipient and subject)
 
     Context: conversation contains an email with msGraphMessageId="AAMk456", from sarah@acme.com, subject "Re: Q2 Budget Review"
     User: "Respond to this — confirm the meeting is on Thursday"
-    Action: type="reply", inReplyToMessageId="AAMk456", body confirms the meeting (Graph fills recipient and subject as-is, no duplicate "Re:")
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk456" }, body confirms the meeting (Graph fills recipient and subject as-is, no duplicate "Re:")
 
     Context: conversation contains an email with msGraphMessageId="AAMk789", from investor@fund.com, subject "Due Diligence Update"
     User: "Get back to them — say we'll have the documents ready by Friday"
-    Action: type="reply", inReplyToMessageId="AAMk789", body states Friday deadline
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk789" }, body states Friday deadline
 
     Context: conversation contains an email with msGraphMessageId="AAMk321", from alex@partner.com, subject "Integration Timeline"
     User: "Respond to this and ask for more details about the timeline"
-    Action: type="reply", inReplyToMessageId="AAMk321", body requests timeline details
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk321" }, body requests timeline details
 
     #### Examples — when to use type: "draft" (new email, no prior email in context)
 
     Context: no prior email in conversation
     User: "Write an email to john@example.com about the upcoming product launch"
-    Action: type="draft", toRecipients=[john@example.com], subject inferred from content
+    Action: recipientsData={ type="draft", toRecipients=[john@example.com], subject inferred from content }
 
     Context: no prior email in conversation
     User: "Draft a message to the finance team asking for the Q1 numbers"
-    Action: type="draft", search for finance team address first, then toRecipients=[resolved address], subject inferred
+    Action: search for finance team address first, then recipientsData={ type="draft", toRecipients=[resolved address], subject inferred }
 
     Context: no prior email in conversation
     User: "Send a quick note to Maria letting her know the contract is signed"
-    Action: type="draft", search for Maria's email address first, then toRecipients=[resolved address], subject inferred
+    Action: search for Maria's email address first, then recipientsData={ type="draft", toRecipients=[resolved address], subject inferred }
 
     ### Body Formatting
     The \`content\` field is **Markdown**. It is converted to HTML on the server before being sent to Outlook, so use Markdown syntax for all formatting — do **not** write raw HTML tags (\`<br>\`, \`<p>\`, \`<strong>\`, etc.); they will be shown as literal text.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -32,9 +32,11 @@ export const META = createMeta({
     When the user asks you to write, reply to, or draft an email:
     1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
        - Is there a retrieved email (with a \`msGraphMessageId\`) that the user is **directly reacting to** in this message?
-       - If yes → use \`type: "reply"\` with that \`msGraphMessageId\`. Do not ask for recipient or subject.
-       - If no → use \`type: "draft"\` and resolve the recipient as described below.
-       Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific email just shown in the conversation. Do not default to reply just because some email happens to be in context from an earlier search — the user must be explicitly responding to it.
+         - If yes → use \`type: "reply"\` with that \`msGraphMessageId\`. Do not ask for recipient or subject.
+       - Does the user clearly want to reply to a specific email that is **not yet in context** (e.g. "draft a reply to Nick's email about payroll")?
+         - If yes → first call \`search_emails\` to find and retrieve that email, then use \`type: "reply"\` with its \`msGraphMessageId\`.
+       - Otherwise → use \`type: "draft"\` and resolve the recipient as described below.
+       Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific email. Do not default to reply just because some email happens to be in context from an earlier search — the user must be explicitly responding to it.
     2. **Act immediately. Do not ask any questions before drafting.** No clarifications, no confirmations, no options, no plans. Just do it.
     3. **Infer everything you can** from the user's message — tone, intent, level of formality, content. Use reasonable defaults for anything not specified.
     4. **Draft a single email right away** and present it using the format specified below.
@@ -92,15 +94,15 @@ export const META = createMeta({
 
     Context: no prior email in conversation
     User: "Write an email to john@example.com about the upcoming product launch"
-    Action: recipientsData={ type="draft", toRecipients=[john@example.com], subject inferred from content }
+    Action: recipientsData={ type="draft", toRecipients=[{email: "john@example.com"}], subject inferred from content }
 
     Context: no prior email in conversation
     User: "Draft a message to the finance team asking for the Q1 numbers"
-    Action: search for finance team address first, then recipientsData={ type="draft", toRecipients=[resolved address], subject inferred }
+    Action: search for finance team address first, then recipientsData={ type="draft", toRecipients=[{email: "resolved@address.com"}], subject inferred }
 
     Context: no prior email in conversation
     User: "Send a quick note to Maria letting her know the contract is signed"
-    Action: search for Maria's email address first, then recipientsData={ type="draft", toRecipients=[resolved address], subject inferred }
+    Action: search for Maria's email address first, then recipientsData={ type="draft", toRecipients=[{email: "maria@resolved.com"}], subject inferred }
 
     ### Body Formatting
     The \`content\` field is **Markdown**. It is converted to HTML on the server before being sent to Outlook, so use Markdown syntax for all formatting — do **not** write raw HTML tags (\`<br>\`, \`<p>\`, \`<strong>\`, etc.); they will be shown as literal text.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -44,7 +44,54 @@ export const META = createMeta({
 
     2. **\`type: "reply"\`** — reply-all draft. Pass \`inReplyToMessageId\` with the \`msGraphMessageId\` value from \`search_emails\` or \`outlook_email_search\` results. Graph pre-fills all original recipients — do **not** pass \`toRecipients\` or \`ccRecipients\`. If the email you are replying to came from a shared or delegated mailbox (i.e. \`sourceMailbox\` is non-null in the search result), you **must** pass that same value as \`mailbox\` — otherwise Graph will look up the message under \`/me\` and return a 404. Omit \`mailbox\` only when replying to an email from the signed-in user's own mailbox (\`sourceMailbox\` is null).
 
-    Use \`type: "reply"\` only when explicitly replying to an identified email. Use \`type: "draft"\` for all other cases.
+    ### Replying to a Received Email (Most Common Use Case)
+    **Replying to an email the user just read or retrieved is the most frequent reason to call \`draft_email\`.** Recognise these natural language patterns as reply intent — even without the word "reply":
+    - "Reply to this email"
+    - "Draft a reply to [person]'s email"
+    - "Respond to this" / "Respond to [person]"
+    - "Get back to [person] about this"
+    - "Answer this email" / "Answer [person]"
+    - "Write back to them"
+
+    Note: "Tell [person] that…" and "Let [person] know that…" are **not** automatically reply triggers — the named person may differ from the sender. Treat them as reply intent only when the named person is clearly the sender of the retrieved email; otherwise draft a new email to that person.
+
+    When reply intent is detected and an email was recently retrieved:
+    1. **Do not ask for the recipient or subject.** Use \`type: "reply"\` and pass the \`msGraphMessageId\` of the retrieved email as \`inReplyToMessageId\` — Graph pre-fills all recipients and subject automatically.
+    2. **Draft and call \`draft_email\` immediately.** The user should not have to re-specify the recipient, subject, or thread context.
+
+    Failure to use \`type: "reply"\` with the retrieved email's \`msGraphMessageId\` is the most common mistake — avoid it.
+
+    #### Examples — when to use type: "reply"
+
+    Context: conversation contains an email with msGraphMessageId="AAMk123", from nick@example.com, subject "Payroll System Migration Plan"
+    User: "Draft a reply to this email, tell him we need to reduce ADP cost to 76k max"
+    Action: type="reply", inReplyToMessageId="AAMk123", body addresses the cost constraint (Graph fills recipient and subject)
+
+    Context: conversation contains an email with msGraphMessageId="AAMk456", from sarah@acme.com, subject "Re: Q2 Budget Review"
+    User: "Respond to this — confirm the meeting is on Thursday"
+    Action: type="reply", inReplyToMessageId="AAMk456", body confirms the meeting (Graph fills recipient and subject as-is, no duplicate "Re:")
+
+    Context: conversation contains an email with msGraphMessageId="AAMk789", from investor@fund.com, subject "Due Diligence Update"
+    User: "Get back to them — say we'll have the documents ready by Friday"
+    Action: type="reply", inReplyToMessageId="AAMk789", body states Friday deadline
+
+    Context: conversation contains an email with msGraphMessageId="AAMk321", from alex@partner.com, subject "Integration Timeline"
+    User: "Respond to this and ask for more details about the timeline"
+    Action: type="reply", inReplyToMessageId="AAMk321", body requests timeline details
+
+    #### Examples — when to use type: "draft" (new email, no prior email in context)
+
+    Context: no prior email in conversation
+    User: "Write an email to john@example.com about the upcoming product launch"
+    Action: type="draft", toRecipients=[john@example.com], subject inferred from content
+
+    Context: no prior email in conversation
+    User: "Draft a message to the finance team asking for the Q1 numbers"
+    Action: type="draft", search for finance team address first, then toRecipients=[resolved address], subject inferred
+
+    Context: no prior email in conversation
+    User: "Send a quick note to Maria letting her know the contract is signed"
+    Action: type="draft", search for Maria's email address first, then toRecipients=[resolved address], subject inferred
 
     ### Body Formatting
     The \`content\` field is **Markdown**. It is converted to HTML on the server before being sent to Outlook, so use Markdown syntax for all formatting — do **not** write raw HTML tags (\`<br>\`, \`<p>\`, \`<strong>\`, etc.); they will be shown as literal text.

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email.tool.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email.tool.ts
@@ -121,7 +121,7 @@ export class CreateDraftEmailTool {
     name: 'draft_email',
     title: 'Draft Email',
     description:
-      'Creates a draft email in Outlook. Pass type: "draft" for a fresh draft (toRecipients required; optionally pass mailbox for a shared mailbox). Pass type: "reply" with inReplyToMessageId for a reply-all draft (Graph pre-fills recipients from the original thread; optionally pass mailbox for a shared mailbox). The draft is saved but not sent.',
+      'Creates a draft email in Outlook. **Replying to a received email is the most common use case** — when the user says "reply", "respond", "get back to", "answer this", "write back", or similar after reading an email, use type: "reply" with the inReplyToMessageId from the retrieved email (Graph pre-fills all recipients and subject automatically). For a new email, use type: "draft" with explicit toRecipients and subject. Optionally pass mailbox for shared mailboxes. The draft is saved but not sent.',
     parameters: CreateDraftEmailInputSchema,
     outputSchema: CreateDraftEmailOutputSchema,
     annotations: {


### PR DESCRIPTION
## Summary

The agent was creating standalone new drafts instead of in-thread replies, because the tool description and system prompt gave no guidance on when to use \`type: \"reply\"\` vs \`type: \"draft\"\`.

Changes across three commits:

**1. Fortify \`@Tool\` description and add reply/new-draft examples**
- Update \`@Tool\` description to lead with \"replying is the most common use case\" and enumerate natural language trigger phrases that should route to \`type: \"reply\"\`
- Add a dedicated **\"Replying to a Received Email (Most Common Use Case)\"** section with trigger phrase list, two-step action (use \`msGraphMessageId\`, call immediately), and a \"most common mistake\" callout
- Add \`Context / User / Action\` examples for both \`type: \"reply\"\` and \`type: \"draft\"\` cases so the model can pattern-match unambiguously
- Exclude \"Tell/Let [person] that…\" from reply triggers — those phrases name a potentially different person than the sender (bugbot medium finding)
- Note in reply example that Graph handles subject as-is when it already starts with \"Re:\", preventing duplicate prefix (bugbot low finding)

**2. Fix meta inconsistencies for \`type: \"reply\"\`**
- Scope \"Resolving Email Recipients\" to \`type: \"draft\"\` only — for \`type: \"reply\"\` there are no recipients to resolve; skip that flow entirely
- Update \"What \`draft_email\` Does\" to describe both modes accurately instead of only describing the new-draft case
- Fix \`toolFormatInformation\` subject rule: for \`type: \"reply\"\` the subject comes from the original email in conversation context, not from the tool input (\`ReplyDraftInputSchema\` has no \`subject\` field)

**3. Require agent to reason reply-vs-new-draft before calling \`draft_email\`**
- Make \"reply or new draft?\" the mandatory first step in drafting behavior: check for a retrieved email with \`msGraphMessageId\` in context, default to \`type: \"reply\"\` when one exists, only fall back to \`type: \"draft\"\` when there is genuinely no prior email or the user explicitly starts a new thread

## Test plan

- [ ] Ask the assistant to \"reply to\" an email just retrieved via \`search_emails\` — verify it calls \`draft_email\` with \`type: \"reply\"\` and the correct \`inReplyToMessageId\`, without asking for recipient or subject
- [ ] Ask \"draft a reply to Nick's email about payroll\" after retrieving that email — same expectation
- [ ] Ask \"get back to them and say the documents are ready\" after reading an email — verify \`type: \"reply\"\` is used
- [ ] Ask \"write an email to someone@example.com about X\" with no prior email in context — verify \`type: \"draft\"\` is used and recipient resolution runs
- [ ] Ask \"send a note to Maria about the contract\" with no prior email — verify recipient search runs before drafting
- [ ] Reply to an email from a shared mailbox (\`sourceMailbox\` non-null) — verify \`mailbox\` is passed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)