### PR TITLE
fix(ci): remove --max-image-width unsupported in md2conf 0.6.1

### DIFF
--- a/.github/workflows/_template-docs-confluence.yaml
+++ b/.github/workflows/_template-docs-confluence.yaml
@@ -30,7 +30,6 @@ jobs:
           DOCS_PATH: ${{ inputs.docs-path }}
           SERVICE_NAME: ${{ inputs.service-name }}
           MD2CONF_IMAGE: leventehunyadi/md2conf@sha256:c06844e455977be323fda0d6d709863dc84cf522ce4266ed1b68a45c45ddc6a6 # 0.6.1
-          MAX_IMAGE_WIDTH: 800
         run: |
           echo "-- Publishing $SERVICE_NAME docs to Confluence --"
           docker run --rm \
@@ -42,6 +41,5 @@ jobs:
             $MD2CONF_IMAGE \
             --no-generated-by \
             --render-mermaid \
-            --max-image-width "$MAX_IMAGE_WIDTH" \
             ./
           echo "-- Publishing complete --"


### PR DESCRIPTION
## Summary

- Removes `--max-image-width` argument from the `docker run` command in `_template-docs-confluence.yaml`
- Removes the unused `MAX_IMAGE_WIDTH` env var
- The flag was removed in md2conf 0.6.1 (introduced in #630), causing `unrecognized arguments: --max-image-width` errors

Fixes: https://github.com/Unique-AG/connectors/actions/runs/27198516392/job/80296248318

## Test plan

- [ ] Trigger one of the docs publish workflows (e.g. `[outlook-semantic-mcp] Publish Docs to Confluence`) and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)