### PR TITLE
fix(outlook-semantic-mcp): set default Job filter on Grafana dashboard

### DIFF
--- a/services/outlook-semantic-mcp/deploy/helm-charts/outlook-semantic-mcp/files/grafana-dashboard.json
+++ b/services/outlook-semantic-mcp/deploy/helm-charts/outlook-semantic-mcp/files/grafana-dashboard.json
@@ -46,6 +46,7 @@
         "includeAll": false,
         "multi": false,
         "refresh": 2,
+        "regex": "outlook-semantic-mcp",
         "sort": 1,
         "current": {
           "selected": true,


### PR DESCRIPTION
## Summary

- Adds `"regex": "outlook-semantic-mcp"` to the `job` template variable in the Grafana dashboard JSON
- Grafana auto-selects a query variable when only one option matches the regex, so the selection is stable across page loads and auto-refreshes

## Test plan

- [ ] Deploy and open the Outlook Semantic MCP Grafana dashboard
- [ ] Verify the Job dropdown is pre-selected with `outlook-semantic-mcp` on load
- [ ] Trigger a refresh and confirm the selection is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)