### PR TITLE
feat(mcp-server-module): un-21719 add elicitation support

### DIFF
--- a/packages/mcp-server-module/README.md
+++ b/packages/mcp-server-module/README.md
@@ -47,6 +47,69 @@ export class HelloWorldPrompt {
 }
 ```
 
+## Elicitation
+
+Use `context.elicit()` to collect structured form data from the user, or `context.elicitUrl()` to guide the user through a URL-based flow such as OAuth.
+
+### Form-based elicitation
+
+Example:
+```ts
+@Injectable()
+export class MyTool {
+  @Tool({
+    name: 'create-item',
+    description: 'Creates an item after collecting details from the user',
+  })
+  async createItem(_args: unknown, context: Context): Promise<CallToolResult> {
+    const result = await context.elicit(
+      z.object({
+        name: z.string().meta({ title: 'Name', description: 'Item name' }),
+        confirm: z.boolean().meta({ title: 'Confirm', description: 'Are you sure?' }),
+      }),
+      'Please provide the details for the new item',
+    );
+
+    if (result.action !== 'accept') {
+      return { content: [{ type: 'text', text: 'Cancelled.' }] };
+    }
+
+    // result.content is typed as { name: string; confirm: boolean }
+    return { content: [{ type: 'text', text: `Created: ${result.content.name}` }] };
+  }
+}
+```
+
+### URL-based elicitation (OAuth-style)
+
+Example:
+```ts
+@Injectable()
+export class MyTool {
+  @Tool({
+    name: 'connect-account',
+    description: 'Connects an external account via OAuth',
+  })
+  async connectAccount(_args: unknown, context: Context): Promise<CallToolResult> {
+    const elicitationId = crypto.randomUUID();
+
+    const result = await context.elicitUrl({
+      elicitationId,
+      message: 'Authorize access to your account',
+      url: `https://example.com/oauth/authorize?state=${elicitationId}`,
+    });
+
+    if (result.action !== 'accept') {
+      return { content: [{ type: 'text', text: 'Authorization cancelled.' }] };
+    }
+
+    // OAuth callback has completed server-side; notify the client
+    await result.sendCompletionNotification();
+    return { content: [{ type: 'text', text: 'Account connected.' }] };
+  }
+}
+```
+
 ## Credits
 
 - [@rekog-labs/MCP-Nest](https://github.com/rekog-labs/MCP-Nest/tree/main)

--- a/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
+++ b/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
@@ -16,6 +16,9 @@ export type SerializableValue =
 
 export type McpRequest = CallToolRequest | ReadResourceRequest | GetPromptRequest;
 
+export const isDeclienOrCancelAction = (action: string): action is 'cancel' | 'decline' =>
+  ['cancel', 'decline'].includes(action);
+
 export type FormElicitResult<T extends z.ZodRawShape> =
   | { action: 'accept'; content: z.infer<z.ZodObject<T>> }
   | { action: 'decline' | 'cancel'; content?: undefined };

--- a/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
+++ b/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
@@ -20,10 +20,10 @@ export type FormElicitResult<T extends z.ZodRawShape> =
   | { action: 'accept'; content: z.infer<z.ZodObject<T>> }
   | { action: 'decline' | 'cancel'; content?: undefined };
 
-export type UrlElicitResult = {
+export interface UrlElicitResult {
   action: 'accept' | 'decline' | 'cancel';
   sendCompletionNotification: () => Promise<void>;
-};
+}
 
 /**
  * Enhanced execution context that includes user information

--- a/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
+++ b/packages/mcp-server-module/src/interfaces/mcp-tool.interface.ts
@@ -5,6 +5,7 @@ import {
   Progress,
   ReadResourceRequest,
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 
 export type Literal = boolean | null | number | string | undefined;
 
@@ -14,6 +15,15 @@ export type SerializableValue =
   | { [key: string]: SerializableValue };
 
 export type McpRequest = CallToolRequest | ReadResourceRequest | GetPromptRequest;
+
+export type FormElicitResult<T extends z.ZodRawShape> =
+  | { action: 'accept'; content: z.infer<z.ZodObject<T>> }
+  | { action: 'decline' | 'cancel'; content?: undefined };
+
+export type UrlElicitResult = {
+  action: 'accept' | 'decline' | 'cancel';
+  sendCompletionNotification: () => Promise<void>;
+};
 
 /**
  * Enhanced execution context that includes user information
@@ -26,6 +36,15 @@ export interface Context {
     info: (message: string, data?: SerializableValue) => void;
     warn: (message: string, data?: SerializableValue) => void;
   };
+  elicit<T extends z.ZodRawShape>(
+    schema: z.ZodObject<T>,
+    message: string,
+  ): Promise<FormElicitResult<T>>;
+  elicitUrl(params: {
+    elicitationId: string;
+    message: string;
+    url: string;
+  }): Promise<UrlElicitResult>;
   mcpServer: McpServer;
   mcpRequest: McpRequest;
 }

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -124,14 +124,14 @@ export abstract class McpHandlerBase {
         message: string;
         url: string;
       }): Promise<UrlElicitResult> => {
+        const sendCompletionNotification =
+          mcpServer.server.createElicitationCompletionNotifier(elicitationId);
         const result = await mcpServer.server.elicitInput({
           mode: 'url',
           elicitationId,
           message,
           url,
         });
-        const sendCompletionNotification =
-          mcpServer.server.createElicitationCompletionNotifier(elicitationId);
         return { action: result.action, sendCompletionNotification };
       },
       mcpServer,

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -72,6 +72,7 @@ export abstract class McpHandlerBase {
           message,
           requestedSchema: z.toJSONSchema(schema, { io: 'input' }) as ElicitRequestFormParams['requestedSchema'],
         });
+        // SDK validates content against the JSON Schema derived from schema; cast is safe.
         return result as FormElicitResult<T>;
       },
       elicitUrl: async ({

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -112,7 +112,7 @@ export abstract class McpHandlerBase {
         }
         return {
           action: 'accept',
-          content: schema.parse(result.content),
+          content: safeParsed.data,
         };
       },
       elicitUrl: async ({

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -1,11 +1,22 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Fork of @rekog-labs/MCP-Nest */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { ElicitRequestFormParams, ErrorCode, McpError, Progress } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ElicitRequestFormParams,
+  ErrorCode,
+  McpError,
+  Progress,
+} from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { z } from 'zod';
-import { Context, FormElicitResult, McpRequest, SerializableValue, UrlElicitResult } from '../../interfaces';
+import {
+  Context,
+  FormElicitResult,
+  McpRequest,
+  SerializableValue,
+  UrlElicitResult,
+} from '../../interfaces';
 import { McpRegistryService } from '../mcp-registry.service';
 
 export abstract class McpHandlerBase {
@@ -70,7 +81,9 @@ export abstract class McpHandlerBase {
       ): Promise<FormElicitResult<T>> => {
         const result = await mcpServer.server.elicitInput({
           message,
-          requestedSchema: z.toJSONSchema(schema, { io: 'input' }) as ElicitRequestFormParams['requestedSchema'],
+          requestedSchema: z.toJSONSchema(schema, {
+            io: 'input',
+          }) as ElicitRequestFormParams['requestedSchema'],
         });
         // SDK validates content against the JSON Schema derived from schema; cast is safe.
         return result as FormElicitResult<T>;
@@ -90,7 +103,8 @@ export abstract class McpHandlerBase {
           message,
           url,
         });
-        const sendCompletionNotification = mcpServer.server.createElicitationCompletionNotifier(elicitationId);
+        const sendCompletionNotification =
+          mcpServer.server.createElicitationCompletionNotifier(elicitationId);
         return { action: result.action, sendCompletionNotification };
       },
       mcpServer,

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -1,10 +1,11 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Fork of @rekog-labs/MCP-Nest */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { Progress } from '@modelcontextprotocol/sdk/types.js';
+import { ElicitRequestFormParams, ErrorCode, McpError, Progress } from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { Context, McpRequest, SerializableValue } from '../../interfaces';
+import { z } from 'zod';
+import { Context, FormElicitResult, McpRequest, SerializableValue, UrlElicitResult } from '../../interfaces';
 import { McpRegistryService } from '../mcp-registry.service';
 
 export abstract class McpHandlerBase {
@@ -63,6 +64,34 @@ export abstract class McpHandlerBase {
           });
         },
       },
+      elicit: async <T extends z.ZodRawShape>(
+        schema: z.ZodObject<T>,
+        message: string,
+      ): Promise<FormElicitResult<T>> => {
+        const result = await mcpServer.server.elicitInput({
+          message,
+          requestedSchema: z.toJSONSchema(schema, { io: 'input' }) as ElicitRequestFormParams['requestedSchema'],
+        });
+        return result as FormElicitResult<T>;
+      },
+      elicitUrl: async ({
+        elicitationId,
+        message,
+        url,
+      }: {
+        elicitationId: string;
+        message: string;
+        url: string;
+      }): Promise<UrlElicitResult> => {
+        const result = await mcpServer.server.elicitInput({
+          mode: 'url',
+          elicitationId,
+          message,
+          url,
+        });
+        const sendCompletionNotification = mcpServer.server.createElicitationCompletionNotifier(elicitationId);
+        return { action: result.action, sendCompletionNotification };
+      },
       mcpServer,
       mcpRequest,
     };
@@ -89,6 +118,12 @@ export abstract class McpHandlerBase {
         warn: (_message: string, _data?: SerializableValue) => {
           warn('server report logging not supported in stateless');
         },
+      },
+      elicit: async () => {
+        throw new McpError(ErrorCode.InternalError, 'elicit is not supported in stateless mode');
+      },
+      elicitUrl: async () => {
+        throw new McpError(ErrorCode.InternalError, 'elicitUrl is not supported in stateless mode');
       },
       mcpServer,
       mcpRequest,

--- a/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
+++ b/packages/mcp-server-module/src/services/handlers/mcp-handler.base.ts
@@ -13,10 +13,12 @@ import { z } from 'zod';
 import {
   Context,
   FormElicitResult,
+  isDeclienOrCancelAction,
   McpRequest,
   SerializableValue,
   UrlElicitResult,
 } from '../../interfaces';
+import { formatZodError } from '../../utils/format-zod-error';
 import { McpRegistryService } from '../mcp-registry.service';
 
 export abstract class McpHandlerBase {
@@ -85,8 +87,33 @@ export abstract class McpHandlerBase {
             io: 'input',
           }) as ElicitRequestFormParams['requestedSchema'],
         });
-        // SDK validates content against the JSON Schema derived from schema; cast is safe.
-        return result as FormElicitResult<T>;
+        const action = result.action;
+        if (isDeclienOrCancelAction(action)) {
+          return { action, content: undefined };
+        }
+        // Internally the sdk uses AJV (Another JSON Validator) and will raise a McpError if z.toJSONSchema(schema, { io: 'input', })
+        // validation does not pass. Once we do The z.toJSONSchema(schema, { io: 'input', }) we lose refinements and transforms from zod,
+        // normally we would not need those in elicitation input but in case someone uses them we enforce zod validation and output the
+        // proper requested type to the elicitation caller, after validation we raise the same McpError as the sdk validation does.
+        // Examples of cases where validation would differ.
+        // Cases where safeParse agrees with the SDK's AJV validation (the common case):
+        // - z.string(), z.boolean(), z.number() — JSON Schema represents these exactly, AJV enforces them, Zod
+        // agrees
+        // - z.string().min(3) → minLength: 3 in JSON Schema — AJV enforces it, Zod agrees
+        // - z.string().email() → format: "email" — AJV enforces it (with formats), Zod agrees
+
+        // Cases where safeParse adds something AJV didn't catch:
+        // - .refine(val => val.startsWith('A')) — can't be expressed in JSON Schema, AJV skips it, Zod enforces
+        //  it
+        // - .transform(s => s.trim()) — AJV doesn't transform, Zod would apply it
+        const safeParsed = schema.safeParse(result.content);
+        if (!safeParsed.success) {
+          throw new McpError(ErrorCode.InvalidParams, formatZodError(safeParsed.error));
+        }
+        return {
+          action: 'accept',
+          content: schema.parse(result.content),
+        };
       },
       elicitUrl: async ({
         elicitationId,


### PR DESCRIPTION
## Ticket
UN-21719

## Title
feat(mcp-server-module): add elicitation support to Context

## Description
- Add `elicit(schema, message)` to `Context` — accepts a Zod object schema, converts it to JSON Schema internally, and returns a fully-typed discriminated union result
- Add `elicitUrl({ elicitationId, url })` to `Context` for OAuth-style out-of-band flows, returning the user action plus a `sendCompletionNotification()` callback
- Both methods throw `McpError(InternalError)` in stateless mode where no persistent client connection exists
- Export `FormElicitResult<T>` and `UrlElicitResult` types from the package
- Document both methods in README with usage examples