### PR TITLE
build(ci): remove manual pnpm version extraction

### DIFF
--- a/.github/workflows/_template-ci.yaml
+++ b/.github/workflows/_template-ci.yaml
@@ -45,15 +45,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Extract PNPM version from package.json
-        id: pnpm-version
-        run: |
-          PNPM_VERSION=$(jq -r '.packageManager | split("@")[1]' package.json)
-          echo "version=$PNPM_VERSION" >> $GITHUB_OUTPUT
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ steps.pnpm-version.outputs.version }}
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/packages.ci.yaml
+++ b/.github/workflows/packages.ci.yaml
@@ -30,15 +30,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Extract PNPM version from package.json
-        id: pnpm-version
-        run: |
-          PNPM_VERSION=$(jq -r '.packageManager | split("@")[1]' package.json)
-          echo "version=$PNPM_VERSION" >> $GITHUB_OUTPUT
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: ${{ steps.pnpm-version.outputs.version }}
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
## Summary

-`pnpm/action-setup` v6.0.8 does not need manual `jq`-based pnpm version extraction step — v6 reads the version directly from the `packageManager` field in `package.json`, making it redundant

## Test plan

- [ ] CI passes on this PR
- [ ] Verify pnpm is installed at the correct version (10.28.1 as declared in `package.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)