### PR TITLE
feat(teams-mcp): add subject and meeting_id to ingested artifact metadata

### DIFF
--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -349,6 +349,8 @@ export class UniqueService {
       date: Date;
       startDateTime: Date;
       endDateTime: Date;
+      meetingId: string;
+      subject: string;
       contentCorrelationId: string;
       owner: { name: string; email: string };
       participants: { name: string; email: string }[];
@@ -361,9 +363,14 @@ export class UniqueService {
       date: meeting.date.toISOString(),
       start_datetime: startDateTime.toISOString(),
       end_datetime: endDateTime.toISOString(),
+      meeting_id: meeting.meetingId,
       content_correlation_id: meeting.contentCorrelationId,
       organizer_email: meeting.owner.email.toLowerCase(),
     };
+
+    if (meeting.subject) {
+      metadata.subject = meeting.subject;
+    }
 
     if (meeting.owner.name) {
       metadata.organizer_name = meeting.owner.name;


### PR DESCRIPTION
## Summary

Makes Teams meeting artifacts (transcripts and recordings) self-describing via metadata, so nothing has to be inferred from folder structure:

- `meeting_id` — the Graph online-meeting id, always set
- `subject` — the meeting subject, omitted when empty (consistent with the other optional keys)

Both keys are added in `buildContentMetadata`, so transcript and recording uploads get them uniformly alongside the existing `date`, `start_datetime`, `end_datetime`, `content_correlation_id`, and organizer/participant keys.

Additive only — the sole consumer parsing these metadata keys (`transcript-tools.helpers.ts`) is unaffected, and metadata flows through `/content/upsert` as an opaque JSON object.

## Out of scope

- `series_id` — requires an extra Graph calendar-event call; deferred to a future PR.

Part of the meeting-artifacts metadata foundation (reports inheriting this metadata lands separately in the monorepo).