### PR TITLE
build(deps): move docker images to node 26 trixie and install pnpm directly

### DIFF
--- a/services/confluence-connector/deploy/Dockerfile
+++ b/services/confluence-connector/deploy/Dockerfile
@@ -5,19 +5,14 @@ ARG APP_NAME=confluence-connector
 # ------------------------------------------------------------------------------
 # Stage 1: base
 # Shared foundation for pruner, deps, and builder stages.
-# Using full bookworm image (not slim) because we need build tools for native modules.
+# Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm@sha256:076dd90a458a4baf8b8d2716f022a2c8db245dbe70c7de38bacad1708258eeab AS base
+FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Set explicit cache location so we can copy it to runner stage
-ENV COREPACK_HOME="/corepack"
-# Copy root package.json so corepack can read "packageManager" field
-COPY package.json /tmp/package.json
-WORKDIR /tmp
-# Corepack manages pnpm version from package.json "packageManager" field
-# prepare --activate downloads and caches pnpm for offline use in runner
-RUN corepack enable && corepack prepare --activate
+# Install pnpm directly. Node 25+ no longer bundles corepack.
+# Keep the version in sync with "packageManager" in the root package.json.
+RUN npm install -g pnpm@10.28.1
 
 # ------------------------------------------------------------------------------
 # Stage 2: pruner
@@ -69,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16 AS runner
+FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 
@@ -86,14 +81,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --system --gid 1001 nodejs \
     && useradd --system --uid 1001 --gid nodejs --shell /bin/bash --create-home nestjs
 
-# pnpm/corepack kept for consistency with other services, though this service
+# pnpm kept for consistency with other services, though this service
 # has no database migrations. Can be removed if image size is a concern.
+# Using /tmp paths because nestjs user can write there.
 ENV PNPM_HOME="/tmp/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV COREPACK_HOME="/tmp/.cache/corepack"
-RUN corepack enable
-# Copy pre-downloaded pnpm from base stage (avoids runtime download)
-COPY --from=base --chown=nestjs:nodejs /corepack $COREPACK_HOME
+RUN npm install -g pnpm@10.28.1
 
 ENV NODE_ENV=production
 

--- a/services/confluence-connector/deploy/Dockerfile
+++ b/services/confluence-connector/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG APP_NAME=confluence-connector
 # Shared foundation for pruner, deps, and builder stages.
 # Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
+FROM node:26.3.0-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm directly. Node 25+ no longer bundles corepack.
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
+FROM node:26.3.0-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/confluence-connector/package.json
+++ b/services/confluence-connector/package.json
@@ -80,5 +80,6 @@
     "typescript": "5.9.2",
     "unplugin-swc": "1.5.7",
     "vitest": "3.2.6"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }

--- a/services/kyckr-mcp/deploy/Dockerfile
+++ b/services/kyckr-mcp/deploy/Dockerfile
@@ -5,19 +5,14 @@ ARG APP_NAME=kyckr-mcp
 # ------------------------------------------------------------------------------
 # Stage 1: base
 # Shared foundation for pruner, deps, and builder stages.
-# Using full bookworm image (not slim) because we need build tools for native modules.
+# Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm@sha256:076dd90a458a4baf8b8d2716f022a2c8db245dbe70c7de38bacad1708258eeab AS base
+FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Set explicit cache location so we can copy it to runner stage
-ENV COREPACK_HOME="/corepack"
-# Copy root package.json so corepack can read "packageManager" field
-COPY package.json /tmp/package.json
-WORKDIR /tmp
-# Corepack manages pnpm version from package.json "packageManager" field
-# prepare --activate downloads and caches pnpm for offline use in runner
-RUN corepack enable && corepack prepare --activate
+# Install pnpm directly. Node 25+ no longer bundles corepack.
+# Keep the version in sync with "packageManager" in the root package.json.
+RUN npm install -g pnpm@10.28.1
 
 # ------------------------------------------------------------------------------
 # Stage 2: pruner
@@ -69,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16 AS runner
+FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/kyckr-mcp/deploy/Dockerfile
+++ b/services/kyckr-mcp/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG APP_NAME=kyckr-mcp
 # Shared foundation for pruner, deps, and builder stages.
 # Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
+FROM node:26.3.0-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm directly. Node 25+ no longer bundles corepack.
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
+FROM node:26.3.0-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/kyckr-mcp/package.json
+++ b/services/kyckr-mcp/package.json
@@ -69,5 +69,6 @@
     "typescript": "5.9.2",
     "unplugin-swc": "1.5.7",
     "vitest": "3.2.6"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }

--- a/services/outlook-semantic-mcp/deploy/Dockerfile
+++ b/services/outlook-semantic-mcp/deploy/Dockerfile
@@ -5,19 +5,14 @@ ARG APP_NAME=outlook-semantic-mcp
 # ------------------------------------------------------------------------------
 # Stage 1: base
 # Shared foundation for pruner, deps, and builder stages.
-# Using full bookworm image (not slim) because we need build tools for native modules.
+# Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm@sha256:076dd90a458a4baf8b8d2716f022a2c8db245dbe70c7de38bacad1708258eeab AS base
+FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Set explicit cache location so we can copy it to runner stage
-ENV COREPACK_HOME="/corepack"
-# Copy root package.json so corepack can read "packageManager" field
-COPY package.json /tmp/package.json
-WORKDIR /tmp
-# Corepack manages pnpm version from package.json "packageManager" field
-# prepare --activate downloads and caches pnpm for offline use in runner
-RUN corepack enable && corepack prepare --activate
+# Install pnpm directly. Node 25+ no longer bundles corepack.
+# Keep the version in sync with "packageManager" in the root package.json.
+RUN npm install -g pnpm@10.28.1
 
 # ------------------------------------------------------------------------------
 # Stage 2: pruner
@@ -71,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16 AS runner
+FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 
@@ -88,15 +83,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --system --gid 1001 nodejs \
     && useradd --system --uid 1001 --gid nodejs --shell /bin/bash --create-home nestjs
 
-# pnpm/corepack needed at runtime for migrations via docker-compose command override:
+# pnpm needed at runtime for migrations via docker-compose command override:
 #   command: ["pnpm", "run", "db:migrate"]
 # Using /tmp paths because nestjs user can write there
 ENV PNPM_HOME="/tmp/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV COREPACK_HOME="/tmp/.cache/corepack"
-RUN corepack enable
-# Copy pre-downloaded pnpm from base stage (avoids runtime download)
-COPY --from=base --chown=nestjs:nodejs /corepack $COREPACK_HOME
+RUN npm install -g pnpm@10.28.1
 
 ENV NODE_ENV=production
 

--- a/services/outlook-semantic-mcp/deploy/Dockerfile
+++ b/services/outlook-semantic-mcp/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG APP_NAME=outlook-semantic-mcp
 # Shared foundation for pruner, deps, and builder stages.
 # Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
+FROM node:26.3.0-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm directly. Node 25+ no longer bundles corepack.
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
+FROM node:26.3.0-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/sharepoint-connector/deploy/Dockerfile
+++ b/services/sharepoint-connector/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG APP_NAME=sharepoint-connector
 # Shared foundation for pruner, deps, and builder stages.
 # Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
+FROM node:26.3.0-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm directly. Node 25+ no longer bundles corepack.
@@ -64,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
+FROM node:26.3.0-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/sharepoint-connector/deploy/Dockerfile
+++ b/services/sharepoint-connector/deploy/Dockerfile
@@ -5,19 +5,14 @@ ARG APP_NAME=sharepoint-connector
 # ------------------------------------------------------------------------------
 # Stage 1: base
 # Shared foundation for pruner, deps, and builder stages.
-# Using full bookworm image (not slim) because we need build tools for native modules.
+# Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm@sha256:076dd90a458a4baf8b8d2716f022a2c8db245dbe70c7de38bacad1708258eeab AS base
+FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Set explicit cache location so we can copy it to runner stage
-ENV COREPACK_HOME="/corepack"
-# Copy root package.json so corepack can read "packageManager" field
-COPY package.json /tmp/package.json
-WORKDIR /tmp
-# Corepack manages pnpm version from package.json "packageManager" field
-# prepare --activate downloads and caches pnpm for offline use in runner
-RUN corepack enable && corepack prepare --activate
+# Install pnpm directly. Node 25+ no longer bundles corepack.
+# Keep the version in sync with "packageManager" in the root package.json.
+RUN npm install -g pnpm@10.28.1
 
 # ------------------------------------------------------------------------------
 # Stage 2: pruner
@@ -69,7 +64,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16 AS runner
+FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 
@@ -86,14 +81,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --system --gid 1001 nodejs \
     && useradd --system --uid 1001 --gid nodejs --shell /bin/bash --create-home nestjs
 
-# pnpm/corepack kept for consistency with other services, though this service
+# pnpm kept for consistency with other services, though this service
 # has no database migrations. Can be removed if image size is a concern.
+# Using /tmp paths because nestjs user can write there.
 ENV PNPM_HOME="/tmp/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV COREPACK_HOME="/tmp/.cache/corepack"
-RUN corepack enable
-# Copy pre-downloaded pnpm from base stage (avoids runtime download)
-COPY --from=base --chown=nestjs:nodejs /corepack $COREPACK_HOME
+RUN npm install -g pnpm@10.28.1
 
 ENV NODE_ENV=production
 

--- a/services/sharepoint-connector/package.json
+++ b/services/sharepoint-connector/package.json
@@ -82,5 +82,6 @@
     "typescript": "5.9.2",
     "unplugin-swc": "1.5.7",
     "vitest": "3.2.6"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }

--- a/services/teams-mcp/deploy/Dockerfile
+++ b/services/teams-mcp/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG APP_NAME=teams-mcp
 # Shared foundation for pruner, deps, and builder stages.
 # Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
+FROM node:26.3.0-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm directly. Node 25+ no longer bundles corepack.
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
+FROM node:26.3.0-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 

--- a/services/teams-mcp/deploy/Dockerfile
+++ b/services/teams-mcp/deploy/Dockerfile
@@ -5,19 +5,14 @@ ARG APP_NAME=teams-mcp
 # ------------------------------------------------------------------------------
 # Stage 1: base
 # Shared foundation for pruner, deps, and builder stages.
-# Using full bookworm image (not slim) because we need build tools for native modules.
+# Using full trixie image (not slim) because we need build tools for native modules.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm@sha256:076dd90a458a4baf8b8d2716f022a2c8db245dbe70c7de38bacad1708258eeab AS base
+FROM node:26-trixie@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-# Set explicit cache location so we can copy it to runner stage
-ENV COREPACK_HOME="/corepack"
-# Copy root package.json so corepack can read "packageManager" field
-COPY package.json /tmp/package.json
-WORKDIR /tmp
-# Corepack manages pnpm version from package.json "packageManager" field
-# prepare --activate downloads and caches pnpm for offline use in runner
-RUN corepack enable && corepack prepare --activate
+# Install pnpm directly. Node 25+ no longer bundles corepack.
+# Keep the version in sync with "packageManager" in the root package.json.
+RUN npm install -g pnpm@10.28.1
 
 # ------------------------------------------------------------------------------
 # Stage 2: pruner
@@ -71,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/turbo \
 # Stage 5: runner
 # Minimal production image. Only this stage is included in the final image.
 # ------------------------------------------------------------------------------
-FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16 AS runner
+FROM node:26-trixie-slim@sha256:95a34da32a840bd9b3b09a5b773591c16923e350174b1c50e1200c75bf15eaa9 AS runner
 ARG APP_NAME
 WORKDIR /app
 
@@ -88,15 +83,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --system --gid 1001 nodejs \
     && useradd --system --uid 1001 --gid nodejs --shell /bin/bash --create-home nestjs
 
-# pnpm/corepack needed at runtime for migrations via docker-compose command override:
+# pnpm needed at runtime for migrations via docker-compose command override:
 #   command: ["pnpm", "run", "db:migrate"]
 # Using /tmp paths because nestjs user can write there
 ENV PNPM_HOME="/tmp/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV COREPACK_HOME="/tmp/.cache/corepack"
-RUN corepack enable
-# Copy pre-downloaded pnpm from base stage (avoids runtime download)
-COPY --from=base --chown=nestjs:nodejs /corepack $COREPACK_HOME
+RUN npm install -g pnpm@10.28.1
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Bump the Node 26 base images from bookworm to trixie (pinned by digest) and replace corepack with a direct pnpm@10.28.1 install, since Node 25+ no longer bundles corepack. Add the packageManager field to services that were missing it to keep the pinned pnpm version aligned.

Refs: UN-21822