### PR TITLE
revert(teams-mcp): restore nested + locked meeting folder ingestion

### DIFF
--- a/services/teams-mcp/src/unique/scope-external-id.ts
+++ b/services/teams-mcp/src/unique/scope-external-id.ts
@@ -1,0 +1,23 @@
+export const EXTERNAL_ID_PREFIX = 'teams:' as const;
+
+/**
+ * Builds the deterministic externalId for a meeting (subject) scope.
+ *
+ * Anchored on the Graph onlineMeeting id so recurring meetings share the same
+ * parent scope. `encodeURIComponent` is required because Graph ids are base64-ish
+ * and can contain `/`, `+`, `=`, which would collide with the `/` delimiter.
+ */
+export function buildMeetingExternalId(meetingId: string): string {
+  return `${EXTERNAL_ID_PREFIX}${encodeURIComponent(meetingId)}/meeting`;
+}
+
+/**
+ * Builds the deterministic externalId for an occurrence (session) scope.
+ *
+ * Anchored on the transcript id so each recording session gets its own child
+ * scope, even for multiple meetings on the same day. Re-ingesting re-stamps the
+ * same externalId (idempotent).
+ */
+export function buildOccurrenceExternalId(meetingId: string, transcriptId: string): string {
+  return `${EXTERNAL_ID_PREFIX}${encodeURIComponent(meetingId)}/occurrence:${encodeURIComponent(transcriptId)}`;
+}

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -136,6 +136,12 @@ export class UniqueService {
       entityType: ScopeAccessEntityType.User,
       type: ScopeAccessType.Manage,
     });
+    // NOTE: The subject scope is shared across all occurrences of a recurring series (same
+    // meetingId), and add-access is additive, so the parent accumulates the union of every
+    // occurrence's participants — which the inheritAccess=true children below pick up. This means
+    // a participant from one occurrence can read later occurrences they did not attend. Known and
+    // accepted: locking + grouping recurring sessions under one folder is worth more to us than
+    // per-occurrence roster isolation.
     await this.scopeService.addScopeAccesses(parentScope.id, accesses);
 
     const childScope = await this.scopeService.createScope(parentScope.id, datePath, true);
@@ -143,6 +149,9 @@ export class UniqueService {
 
     // Stamp the occurrence (session) scope, anchored on the transcript id so each
     // recording session gets a unique externalId even for same-day meetings.
+    // NOTE: datePath is second-precision, so two transcripts in the same second under the same
+    // parent would collide onto one child scope and overwrite its externalId. Not reachable in
+    // practice: Teams cannot produce two transcripts for the same meeting in the same second.
     await this.scopeService.updateScope(childScope.id, {
       externalId: buildOccurrenceExternalId(meeting.meetingId, transcript.id),
     });

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { Span, TraceService } from 'nestjs-otel';
 import pLimit from 'p-limit';
 import type { UniqueConfigNamespaced } from '~/config';
+import { buildMeetingExternalId, buildOccurrenceExternalId } from './scope-external-id';
 import { TEAMS_SOURCE_KIND, TEAMS_SOURCE_NAME } from './unique.consts';
 import {
   type PublicScopeAccessSchema,
@@ -100,36 +101,54 @@ export class UniqueService {
     );
 
     const rootScopeId = this.config.get('unique.rootScopeId', { infer: true });
-
-    // A meeting is one movable folder under the recording root: artifacts are uploaded into it
-    // and inherit its grants. Created with inheritAccess=false so it is private to the
-    // participants/organizer rather than auto-visible to every root-scope grantee. The name is
-    // deterministic (subject + meetingId hash + date) so re-ingestion reuses the same folder.
-    const meetingScope = await this.scopeService.createScope(
-      rootScopeId,
-      this.buildMeetingFolderName(meeting.subject, meeting.meetingId, meeting.date),
-      false,
+    const { subjectPath, datePath } = this.mapMeetingToRelativePaths(
+      meeting.subject,
+      meeting.meetingId,
+      meeting.date,
     );
-    span?.setAttribute('meeting_scope_id', meetingScope.id);
 
-    // Grant on the folder BEFORE uploading so content is stamped with these grants at creation:
-    // participants get READ; the organizer gets READ + WRITE + MANAGE. Grants are matched per
-    // access type, so the organizer needs all three tokens to read, write, and manage.
+    const parentScope = await this.scopeService.createScope(rootScopeId, subjectPath, false);
+    span?.setAttribute('parent_scope_id', parentScope.id);
+
+    // Stamp the meeting (subject) scope with a deterministic externalId so it is
+    // externally managed (locked in the UI) and idempotently re-stampable.
+    await this.scopeService.updateScope(parentScope.id, {
+      externalId: buildMeetingExternalId(meeting.meetingId),
+    });
+
     const accesses = participants.map<PublicScopeAccessSchema>((p) => ({
       entityId: p.id,
       entityType: ScopeAccessEntityType.User,
       type: ScopeAccessType.Read,
     }));
-    accesses.push(
-      { entityId: owner.id, entityType: ScopeAccessEntityType.User, type: ScopeAccessType.Read },
-      { entityId: owner.id, entityType: ScopeAccessEntityType.User, type: ScopeAccessType.Write },
-      { entityId: owner.id, entityType: ScopeAccessEntityType.User, type: ScopeAccessType.Manage },
-    );
-    span?.setAttribute('access_count', accesses.length);
-    await this.scopeService.addScopeAccesses(meetingScope.id, accesses);
+    accesses.push({
+      entityId: owner.id,
+      entityType: ScopeAccessEntityType.User,
+      type: ScopeAccessType.Write,
+    });
+    accesses.push({
+      entityId: owner.id,
+      entityType: ScopeAccessEntityType.User,
+      type: ScopeAccessType.Read,
+    });
+    accesses.push({
+      entityId: owner.id,
+      entityType: ScopeAccessEntityType.User,
+      type: ScopeAccessType.Manage,
+    });
+    await this.scopeService.addScopeAccesses(parentScope.id, accesses);
+
+    const childScope = await this.scopeService.createScope(parentScope.id, datePath, true);
+    span?.setAttribute('child_scope_id', childScope.id);
+
+    // Stamp the occurrence (session) scope, anchored on the transcript id so each
+    // recording session gets a unique externalId even for same-day meetings.
+    await this.scopeService.updateScope(childScope.id, {
+      externalId: buildOccurrenceExternalId(meeting.meetingId, transcript.id),
+    });
 
     this.logger.log(
-      { transcriptId: transcript.id, scopeId: meetingScope.id },
+      { transcriptId: transcript.id, scopeId: childScope.id },
       'Beginning transcript upload to Unique system',
     );
 
@@ -139,7 +158,7 @@ export class UniqueService {
     try {
       const transcriptUpload = await this.contentService.upsertContent({
         storeInternally: true,
-        scopeId: meetingScope.id,
+        scopeId: childScope.id,
         sourceKind: TEAMS_SOURCE_KIND,
         sourceName: TEAMS_SOURCE_NAME,
         sourceOwnerType: SourceOwnerType.Company,
@@ -160,7 +179,7 @@ export class UniqueService {
 
       await this.contentService.upsertContent({
         storeInternally: true,
-        scopeId: meetingScope.id,
+        scopeId: childScope.id,
         sourceKind: TEAMS_SOURCE_KIND,
         sourceName: TEAMS_SOURCE_NAME,
         sourceOwnerType: SourceOwnerType.Company,
@@ -177,7 +196,8 @@ export class UniqueService {
 
     span?.addEvent('transcript_ingestion_completed', {
       transcriptId: transcript.id,
-      scopeId: meetingScope.id,
+      parentScopeId: parentScope.id,
+      childScopeId: childScope.id,
     });
 
     // Upload recording if provided (with SKIP_INGESTION).
@@ -190,7 +210,7 @@ export class UniqueService {
       let recordingSpool: SpooledContent | undefined;
       try {
         this.logger.log(
-          { recordingId: recording.id, scopeId: meetingScope.id },
+          { recordingId: recording.id, scopeId: childScope.id },
           'Downloading meeting recording before upload',
         );
         recordingSpool = await this.contentService.spoolContent(recording.content);
@@ -212,13 +232,13 @@ export class UniqueService {
       if (recordingSpool) {
         try {
           this.logger.log(
-            { recordingId: recording.id, scopeId: meetingScope.id },
+            { recordingId: recording.id, scopeId: childScope.id },
             'Beginning recording upload to Unique system (skip ingestion)',
           );
 
           const recordingUpload = await this.contentService.upsertContent({
             storeInternally: true,
-            scopeId: meetingScope.id,
+            scopeId: childScope.id,
             sourceKind: TEAMS_SOURCE_KIND,
             sourceName: TEAMS_SOURCE_NAME,
             sourceOwnerType: SourceOwnerType.Company,
@@ -240,7 +260,7 @@ export class UniqueService {
           );
           await this.contentService.upsertContent({
             storeInternally: true,
-            scopeId: meetingScope.id,
+            scopeId: childScope.id,
             sourceKind: TEAMS_SOURCE_KIND,
             sourceName: TEAMS_SOURCE_NAME,
             sourceOwnerType: SourceOwnerType.Company,
@@ -257,7 +277,8 @@ export class UniqueService {
 
           span?.addEvent('recording_stored', {
             recordingId: recording.id,
-            scopeId: meetingScope.id,
+            parentScopeId: parentScope.id,
+            childScopeId: childScope.id,
           });
         } catch (error) {
           // The download succeeded but opening/uploading/finalizing the record failed (rare — e.g.
@@ -281,28 +302,43 @@ export class UniqueService {
       {
         transcriptId: transcript.id,
         recordingId: recording?.id,
-        scopeId: meetingScope.id,
+        parentScopeId: parentScope.id,
+        childScopeId: childScope.id,
       },
       'Successfully completed meeting transcript ingestion process',
     );
   }
 
-  /**
-   * Deterministic, path-safe folder name for one meeting occurrence: subject plus a stable
-   * suffix from the meetingId hash plus the occurrence date. Recurring occurrences of one series
-   * share a meetingId (and subject) but differ by date, so each gets its own folder; two
-   * different meetings that share a title differ by hash. The folder API splits on '/', so the
-   * date is rendered as a path-safe segment ('T' -> ' ', ':' -> '-'). Stable across re-ingestion,
-   * so `createScope` (idempotent by parent + name) reuses the same folder.
-   */
-  private buildMeetingFolderName(subject: string, meetingId: string, happenedAt: Date): string {
-    const dateIso = happenedAt.toISOString().slice(0, 19).replace('T', ' ').replaceAll(':', '-');
-    return `${subject || 'Untitled Meeting'} (${this.shortHash(meetingId)}) — ${dateIso}`;
+  private mapMeetingToRelativePaths(
+    subject: string,
+    meetingId: string,
+    happenedAt: Date,
+  ): { subjectPath: string; datePath: string } {
+    // Parent (subject) folder: human-readable subject plus a stable, path-safe
+    // suffix derived from the meetingId. Recurring occurrences of one series
+    // share the same meetingId (and subject) so they collapse into one folder
+    // as intended; two *different* meetings that happen to share a title get
+    // distinct folders, so their `meeting` externalIds no longer overwrite each
+    // other. e.g. "Weekly Sync (a1b2c3d4)"
+    const subjectPath = `${subject || 'Untitled Meeting'} (${this.shortHash(meetingId)})`;
+
+    // Child (session) folder: second-precision UTC timestamp (not just the
+    // calendar date) so multiple transcripts/recordings on the same day each
+    // get their own folder. `happenedAt` is the transcript's createdDateTime —
+    // the onlineMeeting startDateTime is the recurring series' master time and
+    // is identical for every occurrence, so it cannot be used here. ':' -> '-'
+    // keeps the segment path-safe (the folder API splits on '/'). e.g.
+    // "2024-01-15 14-30-45"
+    const datePath = happenedAt.toISOString().slice(0, 19).replace('T', ' ').replaceAll(':', '-');
+
+    return { subjectPath, datePath };
   }
 
   /**
-   * Short, stable, path-safe digest of an id — used to disambiguate folder names without leaking
-   * the raw Graph id (which can contain '/', '+', '=' that would break folder paths).
+   * Short, stable, path-safe digest of an id — used to disambiguate folder
+   * names without leaking the raw Graph id (which can contain '/', '+', '='
+   * that would break folder paths). Deterministic, so re-ingestion re-uses the
+   * same folder.
    */
   private shortHash(value: string): string {
     return createHash('sha256').update(value).digest('hex').slice(0, 8);


### PR DESCRIPTION
## Summary

Rolls back the folder-per-meeting ingestion introduced in #640, restoring the **two-level, externally-managed (locked)** hierarchy:

```
<root>/<subject (hash)>/<full iso timestamp>/<artifacts>
```

#640 had not been released yet, so there is no migration / backfill to do — this simply returns ingestion to the prior behavior.

### What changed

**`src/unique/scope-external-id.ts`** — restored (it was deleted by #640). Provides `buildMeetingExternalId` / `buildOccurrenceExternalId`.

**`src/unique/unique.service.ts`** — reverted ingestion to the locked, nested hierarchy:
- Restored `mapMeetingToRelativePaths` → `subjectPath` = `"<subject> (<hash>)"`, `datePath` = second-precision UTC ISO timestamp (e.g. `2024-01-15 14-30-45`).
- **Parent (subject) scope**: `createScope(rootScopeId, subjectPath, false)` → stamped with `buildMeetingExternalId` (**locked**); access granted here (participants `READ`; organizer `READ`+`WRITE`+`MANAGE`).
- **Child (occurrence) scope**: `createScope(parentScope.id, datePath, true)` → inherits parent access → stamped with `buildOccurrenceExternalId` (**locked**).
- Transcript + recording uploads target the child occurrence scope; spans/logs report `parentScopeId` + `childScopeId` again.

### Intentionally NOT reverted

Discovery stays on `sourceKind: MICROSOFT_365_TEAMS` filtering (from #640) — it is independent of folder layout and strictly more robust. So `find-transcripts.tool.ts`, `list-meetings.tool.ts`, `transcript-tools.helpers.ts`, and the `sourceKind` plumbing in `unique-content.service.ts` / `unique.dtos.ts` are unchanged.

### Verification
- `tsc --noEmit` clean
- `biome check` clean