### PR TITLE
fix(outlook-semantic-mcp): fix reply draft failures and preserve quoted thread

### DIFF
--- a/services/outlook-semantic-mcp/src/features/content/search/__tests__/ms-graph-kql-search-emails.query.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/__tests__/ms-graph-kql-search-emails.query.spec.ts
@@ -417,6 +417,23 @@ describe('MsGraphKqlSearchEmailsQuery', () => {
     });
   });
 
+  describe('replyToParams', () => {
+    it('marks draft messages as not replyable', async () => {
+      const mockPost = makeSuccessPost({
+        [OWN_EMAIL]: [makeMessage('draft-1', { isDraft: true })],
+      });
+      const { instance } = createQuery({ mockPost });
+
+      const { results } = await instance.run(testUserId, [{ kqlQuery: 'test' }], SEARCH_CONFIG);
+
+      expect(results[0]?.replyToParams).toEqual({
+        inReplyToMessageId: 'draft-1',
+        idIsImmutable: false,
+        isReplyable: false,
+      });
+    });
+  });
+
   describe('outlookWebLink', () => {
     it('includes webLink for own-mailbox results', async () => {
       const mockPost = makeSuccessPost({ [OWN_EMAIL]: [makeMessage('own-1')] });

--- a/services/outlook-semantic-mcp/src/features/content/search/__tests__/search-emails.query.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/__tests__/search-emails.query.spec.ts
@@ -31,6 +31,7 @@ function makeGraphResult(
     uniqueContentUrl: undefined,
     backend: SearchBackend.MsGraph,
     openEmailParams: { id: emailId, idType: SearchBackend.MsGraph, idIsImmutable: false },
+    replyToParams: { inReplyToMessageId: emailId, idIsImmutable: false, isReplyable: true },
     ...overrides,
   };
 }
@@ -52,6 +53,7 @@ function makeUniqueResult(
     uniqueContentUrl: 'https://unique.example.com/doc/1',
     backend: SearchBackend.Unique,
     openEmailParams: { id: `content-${emailId}`, idType: SearchBackend.Unique },
+    replyToParams: { inReplyToMessageId: emailId, idIsImmutable: true, isReplyable: true },
     ...overrides,
   };
 }

--- a/services/outlook-semantic-mcp/src/features/content/search/ms-graph-kql-search-emails.query.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/ms-graph-kql-search-emails.query.ts
@@ -51,6 +51,7 @@ const messageSchema = z.object({
       uniqueBody: z.object({ content: z.string() }).optional().nullish(),
       body: z.object({ content: z.string() }).optional().nullish(),
       bodyPreview: z.string().optional().nullish(),
+      isDraft: z.boolean().optional().nullish(),
     }),
   ),
 });
@@ -65,6 +66,7 @@ interface Hit {
   parentFolderId: string;
   webLink: string;
   text: string;
+  isDraft: boolean;
 }
 
 @Injectable()
@@ -144,6 +146,8 @@ export class MsGraphKqlSearchEmailsQuery {
       const translatedId = translationMap?.get(hit.restId);
       const idIsImmutable = translatedId !== undefined;
       const id = translatedId ?? hit.restId;
+      const mailbox = hit.isDelegated ? hit.mailbox : undefined;
+      const parentFolderId = hit.isDelegated ? hit.parentFolderId : undefined;
 
       results.push({
         msGraphMessageId: id,
@@ -159,9 +163,14 @@ export class MsGraphKqlSearchEmailsQuery {
         openEmailParams: {
           id,
           idType: SearchBackend.MsGraph,
-          mailbox: hit.isDelegated ? hit.mailbox : undefined,
-          parentFolderId: hit.isDelegated ? hit.parentFolderId : undefined,
+          mailbox,
+          parentFolderId,
           idIsImmutable,
+        },
+        replyToParams: {
+          inReplyToMessageId: id,
+          idIsImmutable,
+          isReplyable: !hit.isDraft,
         },
       });
 
@@ -211,7 +220,7 @@ export class MsGraphKqlSearchEmailsQuery {
         return {
           id: request.requestId,
           method: 'GET',
-          url: `${base}?$search=${encodeURIComponent(search)}&$select=subject,from,receivedDateTime,parentFolderId,webLink,uniqueBody,body,bodyPreview&$top=${request.limit}`,
+          url: `${base}?$search=${encodeURIComponent(search)}&$select=subject,from,receivedDateTime,parentFolderId,webLink,uniqueBody,body,bodyPreview,isDraft&$top=${request.limit}`,
           headers: { Prefer: 'outlook.body-content-type="text"' },
         };
       });
@@ -297,6 +306,7 @@ export class MsGraphKqlSearchEmailsQuery {
             parentFolderId: msg.parentFolderId ?? '',
             webLink: msg.webLink ?? '',
             text: msg.uniqueBody?.content || msg.body?.content || msg.bodyPreview || '',
+            isDraft: msg.isDraft === true,
           });
         }
       }

--- a/services/outlook-semantic-mcp/src/features/content/search/search-emails.query.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/search-emails.query.ts
@@ -173,6 +173,7 @@ export class SearchEmailsQuery {
             semanticText: semanticResult.text,
             graphText: graphResult.text,
           }),
+          replyToParams: graphResult.replyToParams ?? semanticResult.replyToParams,
         },
         hadGraphMatch: true,
       };

--- a/services/outlook-semantic-mcp/src/features/content/search/search-emails.tool.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/search-emails.tool.ts
@@ -90,6 +90,29 @@ const SearchEmailResultSchema = z.object({
     .describe(
       'Pre-constructed input for `open_email`. Pass this object directly as the tool input without modification.',
     ),
+  replyToParams: z
+    .object({
+      inReplyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          'Microsoft Graph message ID for the reply target. Copy into `recipientsData.inReplyToMessageId` when calling `draft_email` with `type: "reply"`. Absent when no Graph message ID is available.',
+        ),
+      idIsImmutable: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether `inReplyToMessageId` is an immutable ID. Copy into `recipientsData.idIsImmutable` when calling `draft_email` with `type: "reply"`.',
+        ),
+      isReplyable: z
+        .boolean()
+        .describe(
+          'Whether this message can be used as a reply target. Do not call `draft_email` with `type: "reply"` when false — pick a different email or explain that a reply is not possible.',
+        ),
+    })
+    .describe(
+      'Reply metadata from search. Copy `inReplyToMessageId` and `idIsImmutable` into matching `recipientsData` fields when `isReplyable` is true. Use top-level `mailbox` on `draft_email` (from `sourceMailbox`) for shared or delegated mailboxes.',
+    ),
 });
 
 const SearchEmailsOutputSchema = z.object({

--- a/services/outlook-semantic-mcp/src/features/content/search/semantic-search-emails.query.ts
+++ b/services/outlook-semantic-mcp/src/features/content/search/semantic-search-emails.query.ts
@@ -42,6 +42,12 @@ export interface OpenEmailParams {
   idIsImmutable?: boolean;
 }
 
+export interface ReplyToParams {
+  inReplyToMessageId?: string;
+  idIsImmutable?: boolean;
+  isReplyable: boolean;
+}
+
 export interface SearchEmailResult {
   uniqueContentId?: string;
   msGraphMessageId?: string;
@@ -55,6 +61,7 @@ export interface SearchEmailResult {
   uniqueContentUrl: string | undefined;
   backend: SearchBackend;
   openEmailParams: OpenEmailParams;
+  replyToParams: ReplyToParams;
 }
 
 interface DelegatedAccess {
@@ -178,6 +185,8 @@ export class SemanticSearchEmailsQuery {
             return metadata?.folderIdPath?.startsWith(uniqueFolderIdPath);
           })?.ownerEmail ?? null;
 
+        const msGraphMessageId = metadata?.id || undefined;
+
         return {
           title: item.content.title ?? '',
           uniqueContentId: item.content.id,
@@ -187,7 +196,7 @@ export class SemanticSearchEmailsQuery {
           // folder-level access at query time, we suppress the link for all delegated mailboxes.
           outlookWebLink: userProfile.email === sourceMailbox ? (metadata?.webLink ?? '') : '',
           sourceMailbox,
-          msGraphMessageId: metadata?.id || undefined,
+          msGraphMessageId,
           folderId: metadata?.parentFolderId ?? '',
           from: metadata?.fromEmailAddress ?? '',
           receivedDateTime:
@@ -197,6 +206,12 @@ export class SemanticSearchEmailsQuery {
           openEmailParams: {
             id: item.content.id,
             idType: SearchBackend.Unique,
+          },
+          replyToParams: {
+            ...(msGraphMessageId
+              ? { inReplyToMessageId: msGraphMessageId, idIsImmutable: true }
+              : {}),
+            isReplyable: !!msGraphMessageId && metadata?.isDraft !== 'true',
           },
         };
       }),

--- a/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
@@ -45,6 +45,24 @@ describe('CreateDraftEmailCommand.createDraft', () => {
     expect(graphRequest.header).toHaveBeenCalledWith('Prefer', 'IdType="ImmutableId"');
   });
 
+  it('sends reply content as comment so the quoted thread is preserved', async () => {
+    const { command, graphRequest } = makeCommand();
+
+    await command.createDraft(USER_PROFILE_ID, {
+      content: 'Thanks for the update.',
+      chatId: null,
+      recipientsData: {
+        type: 'reply',
+        inReplyToMessageId: 'immutable-id-1',
+        idIsImmutable: true,
+      },
+    });
+
+    expect(graphRequest.post).toHaveBeenCalledWith({
+      comment: '<p>Thanks for the update.</p>\n',
+    });
+  });
+
   it('uses top-level mailbox for shared mailbox replies', async () => {
     const api = vi.fn().mockReturnValue({
       header: vi.fn().mockReturnThis(),

--- a/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GraphClientFactory } from '~/msgraph/graph-client.factory';
+import { UserProfileTypeID } from '~/utils/convert-user-profile-id-to-type-id';
+import { CreateDraftEmailCommand } from '../create-draft-email.command';
+
+const USER_PROFILE_ID = { toString: () => 'user-1' } as unknown as UserProfileTypeID;
+
+interface MockGraphRequest {
+  header: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+}
+
+function makeCommand() {
+  const graphRequest: MockGraphRequest = {
+    header: vi.fn().mockReturnThis(),
+    post: vi.fn().mockResolvedValue({ id: 'draft-1', webLink: 'https://outlook.test/draft' }),
+  };
+
+  const graphClientFactory = {
+    createClientForUser: vi.fn().mockReturnValue({
+      api: vi.fn().mockReturnValue(graphRequest),
+    }),
+  } as unknown as GraphClientFactory;
+
+  const command = new CreateDraftEmailCommand(graphClientFactory, { run: vi.fn() } as never);
+
+  return { command, graphRequest };
+}
+
+describe('CreateDraftEmailCommand.createDraft', () => {
+  it('applies ImmutableId header when idIsImmutable is true', async () => {
+    const { command, graphRequest } = makeCommand();
+
+    const result = await command.createDraft(USER_PROFILE_ID, {
+      content: 'Thanks for the update.',
+      chatId: null,
+      recipientsData: {
+        type: 'reply',
+        inReplyToMessageId: 'immutable-id-1',
+        idIsImmutable: true,
+      },
+    });
+
+    expect(result).toMatchObject({ success: true, draftId: 'draft-1' });
+    expect(graphRequest.header).toHaveBeenCalledWith('Prefer', 'IdType="ImmutableId"');
+  });
+
+  it('uses top-level mailbox for shared mailbox replies', async () => {
+    const api = vi.fn().mockReturnValue({
+      header: vi.fn().mockReturnThis(),
+      post: vi.fn().mockResolvedValue({ id: 'draft-1' }),
+    });
+    const command = new CreateDraftEmailCommand(
+      { createClientForUser: vi.fn().mockReturnValue({ api }) } as unknown as GraphClientFactory,
+      { run: vi.fn() } as never,
+    );
+
+    await command.createDraft(USER_PROFILE_ID, {
+      content: 'Thanks for the update.',
+      chatId: null,
+      mailbox: 'shared@example.com',
+      recipientsData: {
+        type: 'reply',
+        inReplyToMessageId: 'immutable-id-1',
+        idIsImmutable: true,
+      },
+    });
+
+    expect(api).toHaveBeenCalledWith(
+      '/users/shared@example.com/messages/immutable-id-1/createReplyAll',
+    );
+  });
+});

--- a/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/__tests__/create-draft-email.command.spec.ts
@@ -70,4 +70,27 @@ describe('CreateDraftEmailCommand.createDraft', () => {
       '/users/shared@example.com/messages/immutable-id-1/createReplyAll',
     );
   });
+
+  it('replaces slashes in reply message IDs for Graph URL paths', async () => {
+    const api = vi.fn().mockReturnValue({
+      header: vi.fn().mockReturnThis(),
+      post: vi.fn().mockResolvedValue({ id: 'draft-1' }),
+    });
+    const command = new CreateDraftEmailCommand(
+      { createClientForUser: vi.fn().mockReturnValue({ api }) } as unknown as GraphClientFactory,
+      { run: vi.fn() } as never,
+    );
+
+    await command.createDraft(USER_PROFILE_ID, {
+      content: 'Thanks for the update.',
+      chatId: null,
+      recipientsData: {
+        type: 'reply',
+        inReplyToMessageId: 'abc/def',
+        idIsImmutable: true,
+      },
+    });
+
+    expect(api).toHaveBeenCalledWith('/me/messages/abc-def/createReplyAll');
+  });
 });

--- a/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Span } from 'nestjs-otel';
 import { z } from 'zod';
+import { encodeGraphItemIdForUrlPath } from '~/msgraph/encode-graph-item-id-for-url-path';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import { UserProfileTypeID } from '~/utils/convert-user-profile-id-to-type-id';
 import { AddAttachmentsToDraftEmailCommand } from './add-attachments-to-draft-email.command';
@@ -101,7 +102,7 @@ export class CreateDraftEmailCommand {
     const apiParams =
       recipientsData.type === 'reply'
         ? {
-            apiPath: `${prefix}/messages/${recipientsData.inReplyToMessageId}/createReplyAll`,
+            apiPath: `${prefix}/messages/${encodeGraphItemIdForUrlPath(recipientsData.inReplyToMessageId)}/createReplyAll`,
             body: { message: sharedBodyFields },
             successMessage: 'Reply-all draft created successfully.',
             idIsImmutable: recipientsData.idIsImmutable === true,

--- a/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
@@ -21,7 +21,11 @@ interface CreateDraftEmailInput {
         toRecipients: Array<{ name?: string; email: string }>;
         ccRecipients?: Array<{ name?: string; email: string }>;
       }
-    | { type: 'reply'; inReplyToMessageId: string };
+    | {
+        type: 'reply';
+        inReplyToMessageId: string;
+        idIsImmutable?: boolean;
+      };
 }
 
 export type CreateDraftEmailResult =
@@ -82,7 +86,7 @@ export class CreateDraftEmailCommand {
     input: CreateDraftEmailInput,
   ): Promise<CreateDraftEmailResult> {
     const userProfileIdString = userProfileId.toString();
-
+    const recipientsData = input.recipientsData;
     const prefix = input.mailbox ? `/users/${input.mailbox}` : '/me';
 
     const sharedBodyFields = {
@@ -93,7 +97,6 @@ export class CreateDraftEmailCommand {
     };
 
     const client = this.graphClientFactory.createClientForUser(userProfileIdString);
-    const recipientsData = input.recipientsData;
 
     const apiParams =
       recipientsData.type === 'reply'
@@ -101,6 +104,7 @@ export class CreateDraftEmailCommand {
             apiPath: `${prefix}/messages/${recipientsData.inReplyToMessageId}/createReplyAll`,
             body: { message: sharedBodyFields },
             successMessage: 'Reply-all draft created successfully.',
+            idIsImmutable: recipientsData.idIsImmutable === true,
           }
         : {
             apiPath: `${prefix}/messages`,
@@ -116,12 +120,16 @@ export class CreateDraftEmailCommand {
                 })) ?? [],
             },
             successMessage: 'Draft email created successfully.',
+            idIsImmutable: false,
           };
 
     try {
-      const message = CreateMessageResponseSchema.parse(
-        await client.api(apiParams.apiPath).post(apiParams.body),
-      );
+      let graphRequest = client.api(apiParams.apiPath);
+      if (apiParams.idIsImmutable) {
+        graphRequest = graphRequest.header('Prefer', 'IdType="ImmutableId"');
+      }
+
+      const message = CreateMessageResponseSchema.parse(await graphRequest.post(apiParams.body));
 
       return {
         success: true,

--- a/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/create-draft-email.command.ts
@@ -90,12 +90,7 @@ export class CreateDraftEmailCommand {
     const recipientsData = input.recipientsData;
     const prefix = input.mailbox ? `/users/${input.mailbox}` : '/me';
 
-    const sharedBodyFields = {
-      body: {
-        contentType: 'HTML',
-        content: markdownToHtml(input.content),
-      },
-    };
+    const htmlContent = markdownToHtml(input.content);
 
     const client = this.graphClientFactory.createClientForUser(userProfileIdString);
 
@@ -103,14 +98,17 @@ export class CreateDraftEmailCommand {
       recipientsData.type === 'reply'
         ? {
             apiPath: `${prefix}/messages/${encodeGraphItemIdForUrlPath(recipientsData.inReplyToMessageId)}/createReplyAll`,
-            body: { message: sharedBodyFields },
+            body: { comment: htmlContent },
             successMessage: 'Reply-all draft created successfully.',
             idIsImmutable: recipientsData.idIsImmutable === true,
           }
         : {
             apiPath: `${prefix}/messages`,
             body: {
-              ...sharedBodyFields,
+              body: {
+                contentType: 'HTML',
+                content: htmlContent,
+              },
               subject: recipientsData.subject,
               toRecipients: recipientsData.toRecipients.map((item) => ({
                 emailAddress: { address: item.email, ...(item.name && { name: item.name }) },

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email-tool.meta.ts
@@ -17,7 +17,7 @@ export const META = createMeta({
     If the user refers to a person and describes content they want communicated, treat it as an email drafting request. There is no "send email" tool — drafting is the final action.
 
     ### Resolving Email Recipients
-    This section applies to \`type: "draft"\` only. For \`type: "reply"\`, skip recipient resolution entirely — pass the \`msGraphMessageId\` directly as \`inReplyToMessageId\` and Graph pre-fills all recipients.
+    This section applies to \`type: "draft"\` only. For \`type: "reply"\`, skip recipient resolution entirely — copy \`inReplyToMessageId\` and \`idIsImmutable\` from the search result's \`replyToParams\` into \`recipientsData\` when \`replyToParams.isReplyable\` is true.
 
     **Do not ask the user for confirmation before searching.** Act immediately.
     For new drafts (\`type: "draft"\`), you **must** resolve the recipient's email address before drafting:
@@ -31,10 +31,10 @@ export const META = createMeta({
     ### Drafting Behavior
     When the user asks you to write, reply to, or draft an email:
     1. **Always reason first: reply or new draft?** Before anything else, check the conversation context:
-       - Is there a retrieved email that the user is **directly reacting to** in this message, and does it have a \`msGraphMessageId\`?
-         - If yes → use \`type: "reply"\` with that ID immediately. Do not ask for recipient or subject.
-       - Does the user refer to a specific email by subject, sender, or topic but it is **not yet in context**, or the in-context result **lacks** \`msGraphMessageId\`?
-         - If yes → call \`search_emails\` to find it. Present the matching emails to the user and ask them to confirm which one to reply to. Once confirmed, use \`type: "reply"\` with the confirmed email's \`msGraphMessageId\`. This confirmation step is required because replying to the wrong email is a hard-to-recover mistake.
+       - Is there a retrieved email that the user is **directly reacting to** in this message, and is \`replyToParams.isReplyable\` true with a non-empty \`replyToParams.inReplyToMessageId\`?
+         - If yes → use \`type: "reply"\` and copy \`inReplyToMessageId\` and \`idIsImmutable\` from \`replyToParams\` into \`recipientsData\` immediately. Do not ask for recipient or subject.
+       - Does the user refer to a specific email by subject, sender, or topic but it is **not yet in context**, or the in-context result has \`replyToParams.isReplyable: false\` or no \`replyToParams.inReplyToMessageId\`?
+         - If yes → call \`search_emails\` to find it. Present the matching emails to the user and ask them to confirm which one to reply to. Once confirmed, use \`type: "reply"\` only if that result's \`replyToParams.isReplyable\` is true. This confirmation step is required because replying to the wrong email is a hard-to-recover mistake.
        - Otherwise → use \`type: "draft"\` and resolve the recipient following the "Resolving Email Recipients" section above.
        Use \`type: "reply"\` only when the user's current message is a clear reaction to a specific, identified email. Do not default to reply just because some email happens to be in context from an earlier search.
     2. **Act immediately — with two exceptions where you must pause and confirm first:**
@@ -48,14 +48,14 @@ export const META = createMeta({
     ### What \`draft_email\` Does
     Creates a draft email in the user's Outlook mailbox. The draft is saved and can be reviewed or sent later.
     - For \`type: "draft"\`: provide subject, body content (Markdown), and at least one recipient. Optionally include CC recipients and attachments.
-    - For \`type: "reply"\`: provide only the body content (Markdown) and the \`inReplyToMessageId\`. Graph pre-fills all recipients and the subject — no need to specify them.
+    - For \`type: "reply"\`: provide body content (Markdown) plus \`inReplyToMessageId\` and \`idIsImmutable\` copied from \`replyToParams\` in \`search_emails\`. Only call when \`replyToParams.isReplyable\` is true. Graph pre-fills all recipients and the subject — no need to specify them.
 
     ### Shared Mailbox and Reply Drafts
     \`draft_email\` requires a \`type\` field that selects the drafting mode:
 
     1. **\`type: "draft"\`** — fresh draft. \`toRecipients\` is required. Optionally pass \`mailbox\` to create the draft in a shared mailbox instead of the signed-in user's own mailbox.
 
-    2. **\`type: "reply"\`** — reply-all draft. Pass \`inReplyToMessageId\` with the \`msGraphMessageId\` value from \`search_emails\` or \`outlook_email_search\` results. Graph pre-fills all original recipients — do **not** pass \`toRecipients\` or \`ccRecipients\`. If the email you are replying to came from a shared or delegated mailbox (i.e. \`sourceMailbox\` is non-null in the search result), you **must** pass that same value as \`mailbox\` — otherwise Graph will look up the message under \`/me\` and return a 404. Omit \`mailbox\` only when replying to an email from the signed-in user's own mailbox (\`sourceMailbox\` is null).
+    2. **\`type: "reply"\`** — reply-all draft. Copy \`inReplyToMessageId\` and \`idIsImmutable\` from \`replyToParams\` in \`search_emails\` or \`outlook_email_search\` results into \`recipientsData\`. Only use when \`replyToParams.isReplyable\` is true. Graph pre-fills all original recipients — do **not** pass \`toRecipients\` or \`ccRecipients\`. If the email came from a shared or delegated mailbox (\`sourceMailbox\` is non-null), pass that value as the top-level \`mailbox\` parameter — otherwise omit \`mailbox\`.
 
     ### Replying to a Received Email (Most Common Use Case)
     **Replying to an email the user just read or retrieved is the most frequent reason to call \`draft_email\`.** Recognise these natural language patterns as reply intent — even without the word "reply":
@@ -69,28 +69,28 @@ export const META = createMeta({
     Note: "Tell [person] that…" and "Let [person] know that…" are **not** automatically reply triggers — the named person may differ from the sender. Treat them as reply intent only when the named person is clearly the sender of the retrieved email; otherwise draft a new email to that person.
 
     When reply intent is detected and an email was recently retrieved:
-    1. **Do not ask for the recipient or subject.** Use \`type: "reply"\` and pass the \`msGraphMessageId\` of the retrieved email as \`inReplyToMessageId\` — Graph pre-fills all recipients and subject automatically.
+    1. **Do not ask for the recipient or subject.** Use \`type: "reply"\` and copy \`inReplyToMessageId\` and \`idIsImmutable\` from \`replyToParams\` — Graph pre-fills all recipients and subject automatically.
     2. **Draft and call \`draft_email\` immediately.** The user should not have to re-specify the recipient, subject, or thread context.
 
-    Failure to use \`type: "reply"\` with the retrieved email's \`msGraphMessageId\` is the most common mistake — avoid it.
+    Do not call \`draft_email\` with \`type: "reply"\` when \`replyToParams.isReplyable\` is false — pick a different email or explain that a reply is not possible.
 
     #### Examples — when to use type: "reply"
 
-    Context: conversation contains an email with msGraphMessageId="AAMk123", from nick@example.com, subject "Payroll System Migration Plan"
+    Context: conversation contains search result replyToParams={ inReplyToMessageId: "AAMk123", idIsImmutable: false, isReplyable: true }, from nick@example.com, subject "Payroll System Migration Plan"
     User: "Draft a reply to this email, tell him we need to reduce ADP cost to 76k max"
-    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk123" }, body addresses the cost constraint (Graph fills recipient and subject)
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk123", idIsImmutable=false }, body addresses the cost constraint (Graph fills recipient and subject)
 
-    Context: conversation contains an email with msGraphMessageId="AAMk456", from sarah@acme.com, subject "Re: Q2 Budget Review"
+    Context: conversation contains search result replyToParams={ inReplyToMessageId: "AAMk456", idIsImmutable: false, isReplyable: true }, from sarah@acme.com, subject "Re: Q2 Budget Review"
     User: "Respond to this — confirm the meeting is on Thursday"
-    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk456" }, body confirms the meeting (Graph fills recipient and subject as-is, no duplicate "Re:")
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk456", idIsImmutable=false }, body confirms the meeting (Graph fills recipient and subject as-is, no duplicate "Re:")
 
-    Context: conversation contains an email with msGraphMessageId="AAMk789", from investor@fund.com, subject "Due Diligence Update"
+    Context: conversation contains search result replyToParams={ inReplyToMessageId: "AAMk789", idIsImmutable: false, isReplyable: true }, from investor@fund.com, subject "Due Diligence Update"
     User: "Get back to them — say we'll have the documents ready by Friday"
-    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk789" }, body states Friday deadline
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk789", idIsImmutable=false }, body states Friday deadline
 
-    Context: conversation contains an email with msGraphMessageId="AAMk321", from alex@partner.com, subject "Integration Timeline"
+    Context: conversation contains search result replyToParams={ inReplyToMessageId: "AAMk321", idIsImmutable: false, isReplyable: true }, from alex@partner.com, subject "Integration Timeline"
     User: "Respond to this and ask for more details about the timeline"
-    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk321" }, body requests timeline details
+    Action: recipientsData={ type="reply", inReplyToMessageId="AAMk321", idIsImmutable=false }, body requests timeline details
 
     #### Examples — when to use type: "draft" (new email, no prior email in context)
 

--- a/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email.tool.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/tools/create-draft-email.tool.ts
@@ -35,7 +35,13 @@ const ReplyDraftInputSchema = z.object({
   inReplyToMessageId: z
     .string()
     .describe(
-      'The msGraphMessageId field from search_emails or outlook_email_search results for the email being replied to. Graph pre-fills all original recipients — do not pass toRecipients or ccRecipients.',
+      'Microsoft Graph message ID for the email being replied to. Use `replyToParams.inReplyToMessageId` from a `search_emails` result.',
+    ),
+  idIsImmutable: z
+    .boolean()
+    .optional()
+    .describe(
+      'Whether `inReplyToMessageId` is an immutable ID. Use `replyToParams.idIsImmutable` from a `search_emails` result.',
     ),
 });
 
@@ -121,7 +127,7 @@ export class CreateDraftEmailTool {
     name: 'draft_email',
     title: 'Draft Email',
     description:
-      'Creates a draft email in Outlook. **Replying to a received email is the most common use case** — when the user says "reply", "respond", "get back to", "answer this", "write back", or similar after reading an email, use type: "reply" with the inReplyToMessageId from the retrieved email (Graph pre-fills all recipients and subject automatically). For a new email, use type: "draft" with explicit toRecipients and subject. Optionally pass mailbox for shared mailboxes. The draft is saved but not sent.',
+      'Creates a draft email in Outlook. **Replying to a received email is the most common use case** — when the user says "reply", "respond", "get back to", "answer this", "write back", or similar after reading an email, use type: "reply" only when the search result\'s `replyToParams.isReplyable` is true — then pass `inReplyToMessageId` and `idIsImmutable` from `replyToParams` (Graph pre-fills all recipients and subject automatically). Pass `sourceMailbox` as top-level `mailbox` for shared or delegated mailboxes. For a new email, use type: "draft" with explicit toRecipients and subject. The draft is saved but not sent.',
     parameters: CreateDraftEmailInputSchema,
     outputSchema: CreateDraftEmailOutputSchema,
     annotations: {

--- a/services/outlook-semantic-mcp/src/msgraph/__tests__/encode-graph-item-id-for-url-path.spec.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/__tests__/encode-graph-item-id-for-url-path.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { encodeGraphItemIdForUrlPath } from '../encode-graph-item-id-for-url-path';
+
+describe('encodeGraphItemIdForUrlPath', () => {
+  it('replaces slashes with hyphens', () => {
+    expect(encodeGraphItemIdForUrlPath('abc/def/ghi')).toBe('abc-def-ghi');
+  });
+
+  it('leaves IDs without slashes unchanged', () => {
+    expect(encodeGraphItemIdForUrlPath('AAMkADc4ZTM3OWQ4')).toBe('AAMkADc4ZTM3OWQ4');
+  });
+});

--- a/services/outlook-semantic-mcp/src/msgraph/encode-graph-item-id-for-url-path.ts
+++ b/services/outlook-semantic-mcp/src/msgraph/encode-graph-item-id-for-url-path.ts
@@ -1,0 +1,3 @@
+export function encodeGraphItemIdForUrlPath(id: string): string {
+  return id.replaceAll('/', '-');
+}


### PR DESCRIPTION
- Add `replyToParams` to `search_emails` results (`inReplyToMessageId`, `idIsImmutable`, `isReplyable`) so agents pass the correct Graph message ID and immutable-ID header when calling `draft_email` with `type: "reply"`.
- Encode base64 message IDs for Graph URL paths by replacing `/` with `-`, preventing broken `createReplyAll` requests.
- Send reply content via Graph's `comment` param instead of `message.body` so the auto-quoted conversation history is preserved (matching Outlook Reply behavior).
- Mark draft messages as non-replyable in search metadata to steer agents away from invalid reply targets.

References: UN-21877