### PR TITLE
feat(teams-mcp): interactive disambiguation + richer list metadata

### DIFF
--- a/services/teams-mcp/src/chat/channel.service.ts
+++ b/services/teams-mcp/src/chat/channel.service.ts
@@ -1,9 +1,11 @@
-import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { type Context } from '@unique-ag/mcp-server-module';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import { collectAllPages } from '~/msgraph/graph-pagination';
 import { MsChannel, MsChannelSchema, MsTeam, MsTeamSchema } from './chat.dtos';
+import { disambiguate } from './disambiguate';
 
 @Injectable()
 export class ChannelService {
@@ -46,7 +48,7 @@ export class ChannelService {
     // /teams/{id}/channels supports $select but not $top; it pages via @odata.nextLink.
     const response = await client
       .api(`/teams/${teamId}/channels`)
-      .select('id,displayName,description')
+      .select('id,displayName,description,createdDateTime,membershipType,webUrl')
       .get();
 
     const { items } = await collectAllPages(client, response, { label: 'listChannels' });
@@ -59,7 +61,11 @@ export class ChannelService {
   }
 
   @Span()
-  public async resolveTeamByName(userProfileId: string, teamName: string): Promise<MsTeam> {
+  public async resolveTeamByName(
+    userProfileId: string,
+    teamName: string,
+    context: Context,
+  ): Promise<MsTeam> {
     const span = this.traceService.getSpan();
     span?.setAttribute('user_profile_id', userProfileId);
 
@@ -76,13 +82,19 @@ export class ChannelService {
       throw new NotFoundException(`Team "${teamName}" not found`);
     }
 
-    // Multiple teams can share a display name; refuse to silently pick one and
-    // risk acting on the wrong team.
+    // Multiple teams can share a display name; present a picker rather than
+    // silently picking one and risking acting on the wrong team.
     if (matches.length > 1) {
       span?.addEvent('ambiguous team name', { matchCount: matches.length });
-      throw new ConflictException(
-        `Team name "${teamName}" matches multiple teams (${matches.length}). Please be more specific.`,
-      );
+      const team = await disambiguate(matches, {
+        context,
+        toLabel: (t) =>
+          `${t.displayName}${t.description ? ` — ${t.description}` : ''}${t.isArchived ? ' · archived' : ''}`,
+        promptMessage: `Multiple teams match "${teamName}". Which one did you mean?`,
+        conflictMessage: `Team name "${teamName}" matches multiple teams (${matches.length}). Please be more specific.`,
+      });
+      span?.setAttribute('resolved_team_id', team.id);
+      return team;
     }
 
     const [team] = matches as [MsTeam];
@@ -96,6 +108,7 @@ export class ChannelService {
     teamId: string,
     channelName: string,
     teamName: string,
+    context: Context,
   ): Promise<MsChannel> {
     const span = this.traceService.getSpan();
     span?.setAttribute('user_profile_id', userProfileId);
@@ -116,9 +129,15 @@ export class ChannelService {
 
     if (matches.length > 1) {
       span?.addEvent('ambiguous channel name', { matchCount: matches.length });
-      throw new ConflictException(
-        `Channel name "${channelName}" matches multiple channels in team "${teamName}" (${matches.length}). Please be more specific.`,
-      );
+      const channel = await disambiguate(matches, {
+        context,
+        toLabel: (c) =>
+          `${c.displayName} · ${c.membershipType ?? ''}${c.description ? ` — ${c.description}` : ''}`,
+        promptMessage: `Multiple channels in team "${teamName}" match "${channelName}". Which one did you mean?`,
+        conflictMessage: `Channel name "${channelName}" matches multiple channels in team "${teamName}" (${matches.length}). Please be more specific.`,
+      });
+      span?.setAttribute('resolved_channel_id', channel.id);
+      return channel;
     }
 
     const [channel] = matches as [MsChannel];

--- a/services/teams-mcp/src/chat/chat.dtos.ts
+++ b/services/teams-mcp/src/chat/chat.dtos.ts
@@ -2,10 +2,16 @@ import * as z from 'zod';
 
 // ─── Teams ────────────────────────────────────────────────────────────────────
 
+// NOTE: /me/joinedTeams populates only id, displayName, description, isArchived,
+// and tenantId — visibility, webUrl, and createdDateTime are always returned as
+// null on that endpoint (see user-list-joinedteams docs), so they are not
+// modelled here. `isArchived` is the one extra populated field useful for
+// disambiguating same-named teams (an archived team is read-only).
 export const MsTeamSchema = z.object({
   id: z.string(),
   displayName: z.string(),
   description: z.string().nullish(),
+  isArchived: z.boolean().nullish(),
 });
 
 export type MsTeam = z.infer<typeof MsTeamSchema>;
@@ -16,6 +22,8 @@ export const MsChannelSchema = z.object({
   id: z.string(),
   displayName: z.string(),
   description: z.string().nullish(),
+  createdDateTime: z.string().nullish(),
+  membershipType: z.string().nullish(),
 });
 
 export type MsChannel = z.infer<typeof MsChannelSchema>;
@@ -28,12 +36,25 @@ export const MsChatMemberSchema = z.object({
   email: z.string().nullish(),
 });
 
-export const MsChatSchema = z.object({
-  id: z.string(),
-  chatType: z.string(),
-  topic: z.string().nullish(),
-  members: z.array(MsChatMemberSchema),
-});
+// `lastMessagePreview` is a navigation property (chatMessageInfo) only returned
+// when $expanded on the list-chats operation; we keep just its timestamp.
+export const MsChatSchema = z
+  .object({
+    id: z.string(),
+    chatType: z.string(),
+    topic: z.string().nullish(),
+    createdDateTime: z.string().nullish(),
+    lastMessagePreview: z.object({ createdDateTime: z.string().nullish() }).nullish(),
+    members: z.array(MsChatMemberSchema),
+  })
+  .transform((chat) => ({
+    id: chat.id,
+    chatType: chat.chatType,
+    topic: chat.topic,
+    createdDateTime: chat.createdDateTime ?? null,
+    lastMessageAt: chat.lastMessagePreview?.createdDateTime ?? null,
+    members: chat.members,
+  }));
 
 export const MsChatMessageSchema = z
   .object({

--- a/services/teams-mcp/src/chat/chat.service.ts
+++ b/services/teams-mcp/src/chat/chat.service.ts
@@ -1,5 +1,6 @@
+import { type Context } from '@unique-ag/mcp-server-module';
 import { type PageCollection } from '@microsoft/microsoft-graph-client';
-import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
@@ -10,6 +11,7 @@ import {
   GRAPH_PAGE_SIZE,
 } from '~/msgraph/graph-pagination';
 import { MsChat, MsChatMessage, MsChatMessageSchema, MsChatSchema } from './chat.dtos';
+import { disambiguate } from './disambiguate';
 
 @Injectable()
 export class ChatService {
@@ -36,10 +38,10 @@ export class ChatService {
     // — /me/chats is not sorted by activity by default.
     const response: PageCollection = await client
       .api('/me/chats')
-      .expand('members')
+      .expand('members,lastMessagePreview')
       .top(limit)
       .orderby('lastMessagePreview/createdDateTime desc')
-      .select('id,chatType,topic,members')
+      .select('id,chatType,topic,members,createdDateTime')
       .get();
 
     const chats = z.array(MsChatSchema).parse(response.value);
@@ -99,6 +101,7 @@ export class ChatService {
   public async resolveChatByNameOrMember(
     userProfileId: string,
     identifier: string,
+    context: Context,
   ): Promise<MsChat> {
     const span = this.traceService.getSpan();
     span?.setAttribute('user_profile_id', userProfileId);
@@ -138,17 +141,29 @@ export class ChatService {
       );
     }
 
-    // TODO: replace with context.elicitInput() once exposed on Context interface
-    // in mcp-server-module. Present a picker with chat type, topic/member name,
-    // and last message timestamp so the user can select the intended chat.
     if (matches.length > 1) {
+      span?.addEvent('ambiguous chat identifier', { matchCount: matches.length });
       const matchDescriptions = matches
         .map((c) => c.topic ?? c.members.map((m) => m.displayName).join(', '))
         .join('; ');
-      span?.addEvent('ambiguous chat identifier', { matchCount: matches.length });
-      throw new ConflictException(
-        `Identifier "${identifier}" matches multiple chats: ${matchDescriptions}. Please be more specific.`,
-      );
+      // Present an interactive picker so the model/user can choose the intended
+      // chat; falls back to the original "be more specific" error when the
+      // client does not support elicitation or the user declines.
+      const chat = await disambiguate(matches, {
+        context,
+        toLabel: (c) => {
+          const memberNames =
+            c.members
+              .map((m) => m.displayName)
+              .filter(Boolean)
+              .join(', ') || 'unknown';
+          return `${c.topic ?? '1:1'} · ${c.chatType} · members: ${memberNames} · last msg ${c.lastMessageAt ?? 'n/a'}`;
+        },
+        promptMessage: `Multiple chats match "${identifier}". Which one did you mean?`,
+        conflictMessage: `Identifier "${identifier}" matches multiple chats: ${matchDescriptions}. Please be more specific.`,
+      });
+      span?.setAttribute('resolved_chat_id', chat.id);
+      return chat;
     }
 
     // matches.length === 1 is guaranteed by the checks above
@@ -165,9 +180,9 @@ export class ChatService {
   ): Promise<{ chats: MsChat[]; truncated: boolean }> {
     const response = await client
       .api('/me/chats')
-      .expand('members')
+      .expand('members,lastMessagePreview')
       .top(GRAPH_PAGE_SIZE)
-      .select('id,chatType,topic,members')
+      .select('id,chatType,topic,members,createdDateTime')
       .get();
 
     const { items, truncated } = await collectAllPages(client, response, {

--- a/services/teams-mcp/src/chat/disambiguate.ts
+++ b/services/teams-mcp/src/chat/disambiguate.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert';
 import { type Context } from '@unique-ag/mcp-server-module';
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, Logger } from '@nestjs/common';
 import * as z from 'zod';
+
+const logger = new Logger('disambiguate');
 
 // Above this many matches a single-select picker is more hindrance than help;
 // fall back to asking the user to be more specific instead.
@@ -63,7 +65,13 @@ export async function disambiguate<T>(
       throw err;
     }
     // Otherwise elicit itself threw — stateless mode or the client lacks the
-    // elicitation capability. Fall back to today's behaviour.
+    // elicitation capability. Log it so a genuinely unexpected error (rather
+    // than the expected "elicitation unsupported") is still visible, then fall
+    // back to today's behaviour.
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'Elicitation failed; falling back to ConflictException',
+    );
     throw new ConflictException(opts.conflictMessage);
   }
 }

--- a/services/teams-mcp/src/chat/disambiguate.ts
+++ b/services/teams-mcp/src/chat/disambiguate.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert';
+import { type Context } from '@unique-ag/mcp-server-module';
+import { ConflictException } from '@nestjs/common';
+import * as z from 'zod';
+
+// Above this many matches a single-select picker is more hindrance than help;
+// fall back to asking the user to be more specific instead.
+const PICKER_MAX = 10;
+
+/**
+ * Resolve an ambiguous set of candidate entities to a single one by presenting
+ * the user an interactive single-select picker via `context.elicit()`.
+ *
+ * Falls back to throwing the original `ConflictException` when the picker is
+ * not an option: too many candidates, the user declines/cancels, or the client
+ * (or stateless transport) does not support elicitation. This preserves today's
+ * "be more specific" behaviour for non-elicitation clients.
+ *
+ * Callers handle the 0- and 1-match cases themselves; this is only invoked when
+ * `matches.length > 1`.
+ *
+ * @param matches candidate entities (length > 1)
+ * @param opts.toLabel human-readable label; MUST encode enough metadata
+ *   (date/members/type) to tell duplicates apart
+ * @param opts.promptMessage shown above the picker
+ * @param opts.conflictMessage thrown when elicitation is unavailable/declined
+ */
+export async function disambiguate<T>(
+  matches: T[],
+  opts: {
+    context: Context;
+    toLabel: (item: T) => string;
+    promptMessage: string;
+    conflictMessage: string;
+  },
+): Promise<T> {
+  if (matches.length > PICKER_MAX) {
+    throw new ConflictException(opts.conflictMessage);
+  }
+
+  // Index-prefixed labels guarantee unique enum keys even if two items render
+  // identically (e.g. two same-topic chats with no other distinguishing data).
+  const labeled = matches.map((item, i) => ({ key: `${i + 1}. ${opts.toLabel(item)}`, item }));
+  const keys = labeled.map((l) => l.key) as [string, ...string[]];
+
+  try {
+    const result = await opts.context.elicit(
+      z.object({ selection: z.enum(keys).describe('Which one did you mean?') }),
+      opts.promptMessage,
+    );
+    // User declined or cancelled the picker → let the caller retry with a better name.
+    if (result.action !== 'accept') {
+      throw new ConflictException(opts.conflictMessage);
+    }
+    const picked = labeled.find((l) => l.key === result.content.selection);
+    // `selection` is constrained to `keys` by the enum and the framework
+    // re-validates the response against the same schema, so this always matches.
+    assert.ok(picked, 'elicited selection did not match any candidate');
+    return picked.item;
+  } catch (err) {
+    // A decline/cancel surfaces as the ConflictException thrown above — rethrow it.
+    if (err instanceof ConflictException) {
+      throw err;
+    }
+    // Otherwise elicit itself threw — stateless mode or the client lacks the
+    // elicitation capability. Fall back to today's behaviour.
+    throw new ConflictException(opts.conflictMessage);
+  }
+}

--- a/services/teams-mcp/src/chat/disambiguate.ts
+++ b/services/teams-mcp/src/chat/disambiguate.ts
@@ -68,10 +68,10 @@ export async function disambiguate<T>(
     // elicitation capability. Log it so a genuinely unexpected error (rather
     // than the expected "elicitation unsupported") is still visible, then fall
     // back to today's behaviour.
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      'Elicitation failed; falling back to ConflictException',
-    );
+    // Pass the full error (not just its message) so the logger's error
+    // serializer keeps the stack trace and type — that detail is what tells an
+    // expected "elicitation unsupported" case apart from a real defect.
+    logger.warn({ err }, 'Elicitation failed; falling back to ConflictException');
     throw new ConflictException(opts.conflictMessage);
   }
 }

--- a/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
@@ -82,7 +82,7 @@ export class GetChannelMessagesTool {
   @Span()
   public async getChannelMessages(
     input: z.infer<typeof GetChannelMessagesInputSchema>,
-    _context: Context,
+    context: Context,
     request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof GetChannelMessagesOutputSchema>> {
     const userProfileId = request.user?.userProfileId;
@@ -96,15 +96,18 @@ export class GetChannelMessagesTool {
 
     this.logger.log({ userProfileId, limit: input.limit }, 'Getting channel messages');
 
-    const team = await this.channelService.resolveTeamByName(userProfileId, input.teamName);
+    const team = await this.channelService.resolveTeamByName(
+      userProfileId,
+      input.teamName,
+      context,
+    );
 
-    // TODO: if channel resolution fails, could use context.elicitInput() to show
-    // available channels as a picker rather than throwing NotFoundException.
     const channel = await this.channelService.resolveChannelByName(
       userProfileId,
       team.id,
       input.channelName,
       input.teamName,
+      context,
     );
     span?.setAttribute('resolved_team_id', team.id);
     span?.setAttribute('resolved_channel_id', channel.id);

--- a/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
@@ -86,7 +86,7 @@ export class GetChatMessagesTool {
   @Span()
   public async getChatMessages(
     input: z.infer<typeof GetChatMessagesInputSchema>,
-    _context: Context,
+    context: Context,
     request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof GetChatMessagesOutputSchema>> {
     const userProfileId = request.user?.userProfileId;
@@ -103,6 +103,7 @@ export class GetChatMessagesTool {
     const chat = await this.chatService.resolveChatByNameOrMember(
       userProfileId,
       input.chatIdentifier,
+      context,
     );
     span?.setAttribute('resolved_chat_id', chat.id);
 

--- a/services/teams-mcp/src/chat/tools/list-channels.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-channels.tool.ts
@@ -21,6 +21,8 @@ const ListChannelsOutputSchema = z.object({
     z.object({
       displayName: z.string(),
       description: z.string().optional(),
+      createdDateTime: z.string().nullable(),
+      membershipType: z.string().nullable(),
     }),
   ),
 });
@@ -38,7 +40,7 @@ export class ListChannelsTool {
     name: 'list_channels',
     title: 'List Team Channels',
     description:
-      'List all channels in a Microsoft Teams team. Use this to discover channel names before calling send_channel_message.',
+      'List all channels in a Microsoft Teams team. Each channel includes its creation date and membership type (standard, private, or shared), which help distinguish channels that share a display name. Use this to discover channel names before calling send_channel_message.',
     parameters: ListChannelsInputSchema,
     outputSchema: ListChannelsOutputSchema,
     annotations: {
@@ -55,7 +57,7 @@ export class ListChannelsTool {
   @Span()
   public async listChannels(
     input: z.infer<typeof ListChannelsInputSchema>,
-    _context: Context,
+    context: Context,
     request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof ListChannelsOutputSchema>> {
     const userProfileId = request.user?.userProfileId;
@@ -68,7 +70,11 @@ export class ListChannelsTool {
 
     this.logger.log({ userProfileId }, 'Listing channels for team');
 
-    const team = await this.channelService.resolveTeamByName(userProfileId, input.teamName);
+    const team = await this.channelService.resolveTeamByName(
+      userProfileId,
+      input.teamName,
+      context,
+    );
     const channels = await this.channelService.listChannels(userProfileId, team.id);
     span?.setAttribute('resolved_team_id', team.id);
 
@@ -77,8 +83,15 @@ export class ListChannelsTool {
     return {
       teamName: team.displayName,
       channels: channels.map((c) => {
-        const channel: { displayName: string; description?: string } = {
+        const channel: {
+          displayName: string;
+          description?: string;
+          createdDateTime: string | null;
+          membershipType: string | null;
+        } = {
           displayName: c.displayName,
+          createdDateTime: c.createdDateTime ?? null,
+          membershipType: c.membershipType ?? null,
         };
         if (input.includeDescriptions && c.description) {
           channel.description = c.description;

--- a/services/teams-mcp/src/chat/tools/list-chats.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-chats.tool.ts
@@ -29,6 +29,8 @@ const ListChatsOutputSchema = z.object({
     z.object({
       chatType: z.string(),
       topic: z.string().nullable(),
+      createdDateTime: z.string().nullable(),
+      lastMessageAt: z.string().nullable(),
       members: z
         .array(
           z.object({
@@ -55,7 +57,7 @@ export class ListChatsTool {
     name: 'list_chats',
     title: 'List My Chats',
     description:
-      "List the current user's Microsoft Teams chats (1:1, group, and meeting chats). Returns up to 50 most recent chats. Use the topic or a member's display name as chatIdentifier in get_chat_messages or send_chat_message.",
+      "List the current user's Microsoft Teams chats (1:1, group, and meeting chats). Returns up to 50 most recent chats, each with its creation date (createdDateTime) and the timestamp of its last message (lastMessageAt) to help tell apart chats that share a topic or member. Use the topic or a member's display name as chatIdentifier in get_chat_messages or send_chat_message.",
     parameters: ListChatsInputSchema,
     outputSchema: ListChatsOutputSchema,
     annotations: {
@@ -103,10 +105,14 @@ export class ListChatsTool {
     const mapped: {
       chatType: string;
       topic: string | null;
+      createdDateTime: string | null;
+      lastMessageAt: string | null;
       members?: { displayName: string | null; email?: string | null }[];
     } = {
       chatType: chat.chatType,
       topic: chat.topic ?? null,
+      createdDateTime: chat.createdDateTime,
+      lastMessageAt: chat.lastMessageAt,
     };
 
     // Only include members for chats without a topic (1:1 chats need member names as their identifier)

--- a/services/teams-mcp/src/chat/tools/list-teams.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-teams.tool.ts
@@ -19,6 +19,7 @@ const ListTeamsOutputSchema = z.object({
     z.object({
       displayName: z.string(),
       description: z.string().optional(),
+      isArchived: z.boolean().nullable(),
     }),
   ),
 });
@@ -36,7 +37,7 @@ export class ListTeamsTool {
     name: 'list_teams',
     title: 'List My Teams',
     description:
-      'List all Microsoft Teams the current user is a member of. Use this to discover team names before calling list_channels or send_channel_message.',
+      'List all Microsoft Teams the current user is a member of. Each team includes an isArchived flag (archived teams are read-only), which helps distinguish teams that share a display name. Use this to discover team names before calling list_channels or send_channel_message.',
     parameters: ListTeamsInputSchema,
     outputSchema: ListTeamsOutputSchema,
     annotations: {
@@ -72,8 +73,9 @@ export class ListTeamsTool {
 
     return {
       teams: teams.map((t) => {
-        const team: { displayName: string; description?: string } = {
+        const team: { displayName: string; description?: string; isArchived: boolean | null } = {
           displayName: t.displayName,
+          isArchived: t.isArchived ?? null,
         };
         if (input.includeDescriptions && t.description) {
           team.description = t.description;

--- a/services/teams-mcp/src/chat/tools/send-channel-message.tool.ts
+++ b/services/teams-mcp/src/chat/tools/send-channel-message.tool.ts
@@ -52,7 +52,7 @@ export class SendChannelMessageTool {
   @Span()
   public async sendChannelMessage(
     input: z.infer<typeof SendChannelMessageInputSchema>,
-    _context: Context,
+    context: Context,
     request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof SendChannelMessageOutputSchema>> {
     const userProfileId = request.user?.userProfileId;
@@ -72,6 +72,7 @@ export class SendChannelMessageTool {
       input.channelName,
       input.message,
       input.includeWebUrl,
+      context,
     );
   }
 
@@ -81,13 +82,15 @@ export class SendChannelMessageTool {
     channelName: string,
     message: string,
     includeWebUrl: boolean,
+    context: Context,
   ): Promise<z.output<typeof SendChannelMessageOutputSchema>> {
-    const team = await this.channelService.resolveTeamByName(userProfileId, teamName);
+    const team = await this.channelService.resolveTeamByName(userProfileId, teamName, context);
     const channel = await this.channelService.resolveChannelByName(
       userProfileId,
       team.id,
       channelName,
       teamName,
+      context,
     );
     const result = await this.channelService.sendChannelMessage(
       userProfileId,

--- a/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
+++ b/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
@@ -47,7 +47,7 @@ export class SendChatMessageTool {
   @Span()
   public async sendChatMessage(
     input: z.infer<typeof SendChatMessageInputSchema>,
-    _context: Context,
+    context: Context,
     request: McpAuthenticatedRequest,
   ): Promise<z.output<typeof SendChatMessageOutputSchema>> {
     const userProfileId = request.user?.userProfileId;
@@ -61,15 +61,20 @@ export class SendChatMessageTool {
 
     this.logger.log({ userProfileId }, 'Sending chat message');
 
-    return this.resolveAndSend(userProfileId, input.chatIdentifier, input.message);
+    return this.resolveAndSend(userProfileId, input.chatIdentifier, input.message, context);
   }
 
   private async resolveAndSend(
     userProfileId: string,
     chatIdentifier: string,
     message: string,
+    context: Context,
   ): Promise<z.output<typeof SendChatMessageOutputSchema>> {
-    const chat = await this.chatService.resolveChatByNameOrMember(userProfileId, chatIdentifier);
+    const chat = await this.chatService.resolveChatByNameOrMember(
+      userProfileId,
+      chatIdentifier,
+      context,
+    );
     const result = await this.chatService.sendChatMessage(userProfileId, chat.id, message);
     return { messageId: result.id, chatId: chat.id };
   }


### PR DESCRIPTION
## Context

When a user asks the model to act on a Teams chat/team/channel by name and two entities share that name, resolution threw a `ConflictException` ("matches multiple… Please be more specific.") with **no way for the model to disambiguate** — a dead end. The codebase already anticipated the fix with TODOs pointing at `context.elicitInput()` "once exposed on the Context interface." That capability is now exposed (`Context.elicit(schema, message)`), so this PR wires it up.

## What changed

1. **Interactive picker.** New shared `disambiguate()` helper (`chat/disambiguate.ts`) presents a `context.elicit()` single-select when a name matches multiple entities. Labels are index-prefixed (`1.`, `2.`) so identical labels stay distinct.
2. **Graceful fallback.** Falls back to today's `ConflictException` when: >10 matches (a 50-option picker is worse than asking for specificity), the user declines/cancels, or `elicit` throws (stateless transport / client lacks the capability). No regression for non-elicitation clients.
3. **Applies to chats, teams, and channels.** `Context` is threaded through the three resolvers and the tools that call them; both stale TODOs removed.
4. **Richer list metadata** (so picker labels are meaningful and the model has context up front):
   - `list_chats`: `createdDateTime` + `lastMessageAt` (via `$expand=lastMessagePreview`)
   - `list_channels`: `createdDateTime` + `membershipType`
   - `list_teams`: `isArchived`
   - Tool descriptions updated to advertise the new metadata.

### Note on team metadata
The plan called for adding `visibility` and `webUrl` to teams. Live Graph docs (`user-list-joinedteams`) confirm `/me/joinedTeams` returns those — plus `createdDateTime` — as **always `null`**; only `id`, `displayName`, `description`, `isArchived`, and `tenantId` are populated. Shipping always-null fields would mislead the model, so I added `isArchived` (the one useful populated field for telling same-named teams apart) instead.

## Verification
- `pnpm run check-types` → clean
- `pnpm build` → success
- `biome check` → clean

## Out of scope
Exposing raw IDs as tool params (rejected in favor of the picker), URL-mode elicitation, server composition, pagination redesign. No unit tests — this MCP has no test suite yet and adding one is out of scope for this PR.