### PR TITLE
feat(teams-mcp): auto-start ingestion at login (UN-22169)

### DIFF
--- a/services/teams-mcp/.env.example
+++ b/services/teams-mcp/.env.example
@@ -7,6 +7,7 @@ MICROSOFT_CLIENT_SECRET=<azure-ad-app-client-secret>
 MICROSOFT_WEBHOOK_SECRET=<webhook-secret> # Random 128-char hex secret. Create with e.g. openssl rand -hex 64
 MICROSOFT_PUBLIC_WEBHOOK_URL=https://your-devtunnel.euw.devtunnels.ms # Publicly reachable URL for Microsoft webhooks. Local: devtunnel. Prod/QA: typically same as SELF_URL
 MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC=3 # Hour of day in UTC when scheduled subscription expirations should occur
+MICROSOFT_AUTO_START_INGESTION=false # When true, auto-enqueue a transcript subscription for every user at login (skips the start_kb_integration tool)
 AUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS=60 # 1 minute
 AUTH_REFRESH_TOKEN_EXPIRES_IN_SECONDS=2592000 # 30 days
 AUTH_HMAC_SECRET=<hmac-secret> # Random 64-char hex secret. Create with e.g. openssl rand -hex 32

--- a/services/teams-mcp/README.md
+++ b/services/teams-mcp/README.md
@@ -42,6 +42,7 @@ Copy `.env.example` to `.env` and configure the following:
 | `MICROSOFT_CLIENT_SECRET` | Azure AD application client secret |
 | `MICROSOFT_WEBHOOK_SECRET` | 128-char hex secret used as `clientState` for webhook validation |
 | `MICROSOFT_PUBLIC_WEBHOOK_URL` | Publicly reachable URL for Microsoft webhooks |
+| `MICROSOFT_AUTO_START_INGESTION` | Auto-enqueue a transcript subscription for every user at login (default `false`) |
 | `AUTH_HMAC_SECRET` | 64-char hex secret for JWT signing |
 | `ENCRYPTION_KEY` | 64-char hex secret for AES-GCM token encryption |
 

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/templates/config.yaml
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/templates/config.yaml
@@ -11,6 +11,9 @@ data:
   {{- if .Values.mcpConfig.microsoft.publicWebhookUrl }}
   MICROSOFT_PUBLIC_WEBHOOK_URL: {{ .Values.mcpConfig.microsoft.publicWebhookUrl | quote }}
   {{- end }}
+  {{- if .Values.mcpConfig.microsoft.autoStartIngestion }}
+  MICROSOFT_AUTO_START_INGESTION: {{ .Values.mcpConfig.microsoft.autoStartIngestion | quote }}
+  {{- end }}
   UNIQUE_SERVICE_AUTH_MODE: {{ .Values.mcpConfig.unique.serviceAuthMode | quote }}
   UNIQUE_API_BASE_URL: {{ include "chart.ensureTrailingSlash" (dict "url" .Values.mcpConfig.unique.apiBaseUrl) | quote }}
   UNIQUE_API_VERSION: {{ .Values.mcpConfig.unique.apiVersion | quote }}

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/values.schema.json
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/values.schema.json
@@ -199,6 +199,10 @@
             "publicWebhookUrl": {
               "type": "string",
               "description": "The public webhook URL reachable from external network for Microsoft Graph subscriptions. Optional - defaults to SELF_URL if not provided. Example: https://teams.mcp.unique.app/webhooks"
+            },
+            "autoStartIngestion": {
+              "type": "boolean",
+              "description": "When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool)."
             }
           },
           "required": ["clientId"]

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
@@ -145,6 +145,9 @@ mcpConfig:
     # Optional - defaults to SELF_URL if not provided.
     # example: https://teams.mcp.unique.app
     # publicWebhookUrl: ""
+    # -- When enabled, automatically enqueue a transcript subscription for every user at login
+    # (skips the start_kb_integration tool).
+    autoStartIngestion: false
     # clientSecret is loaded from a secret, see server.envVars
     # webhookSecret is loaded from a secret, see server.envVars
 

--- a/services/teams-mcp/docs/operator/configuration.md
+++ b/services/teams-mcp/docs/operator/configuration.md
@@ -34,6 +34,7 @@ Set via `mcpConfig.microsoft` in Helm values:
 |----------|-----------|---------|-------------|
 | `MICROSOFT_CLIENT_ID` | `mcpConfig.microsoft.clientId` | (required) | Entra app client ID |
 | `MICROSOFT_PUBLIC_WEBHOOK_URL` | `mcpConfig.microsoft.publicWebhookUrl` | `SELF_URL` | Webhook URL if different from SELF_URL |
+| `MICROSOFT_AUTO_START_INGESTION` | `mcpConfig.microsoft.autoStartIngestion` | `false` | When enabled, auto-enqueue a transcript subscription for every user at login (skips the `start_kb_integration` tool) |
 
 ### Unique API Configuration
 

--- a/services/teams-mcp/docs/technical/flows.md
+++ b/services/teams-mcp/docs/technical/flows.md
@@ -3,7 +3,7 @@
 
 ## User Connection Flow
 
-Everything starts when a user connects to the MCP server. This triggers OAuth authentication. After authentication, the user can start the KB integration via the `start_kb_integration` tool to begin receiving meeting notifications.
+Everything starts when a user connects to the MCP server. This triggers OAuth authentication. After authentication, the user can start the KB integration via the `start_kb_integration` tool to begin receiving meeting notifications. Alternatively, operators can enable `MICROSOFT_AUTO_START_INGESTION`, in which case every login automatically enqueues a transcript subscription (no tool call required).
 
 ```mermaid
 %%{init: {'theme': 'neutral', 'themeVariables': { 'fontSize': '14px' }}}%%
@@ -21,8 +21,10 @@ flowchart LR
         Store["Store encrypted tokens"]
     end
 
-    subgraph Setup["Subscription Setup (via Tool)"]
-        StartTool["User calls start_kb_integration"]
+    subgraph Setup["Subscription Setup"]
+        AutoStart["Auto-enqueue subscription (flag on)"]
+        StartTool["User calls start_kb_integration (manual)"]
+        Enqueue["Publish subscription-requested"]
         CreateSub["Create Graph subscription"]
         StoreSub["Store subscription record"]
     end
@@ -38,7 +40,10 @@ flowchart LR
     Consent --> Callback
     Callback --> Exchange
     Exchange --> Store
-    Store --> StartTool
+    Store -->|MICROSOFT_AUTO_START_INGESTION on| AutoStart
+    Store -.->|manual| StartTool
+    AutoStart --> Enqueue
+    Enqueue --> CreateSub
     StartTool --> CreateSub
     CreateSub --> StoreSub
     StoreSub --> Active

--- a/services/teams-mcp/src/app.module.ts
+++ b/services/teams-mcp/src/app.module.ts
@@ -3,6 +3,7 @@ import { defaultLoggerOptions } from '@unique-ag/logger';
 import { McpAuthJwtGuard, McpOAuthModule } from '@unique-ag/mcp-oauth';
 import { McpModule } from '@unique-ag/mcp-server-module';
 import { ProbeModule } from '@unique-ag/probe';
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -93,7 +94,14 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
     }),
     McpOAuthModule.forRootAsync({
       imports: [DrizzleModule],
-      inject: [ConfigService, AesGcmEncryptionService, DRIZZLE, CACHE_MANAGER, MetricService],
+      inject: [
+        ConfigService,
+        AesGcmEncryptionService,
+        DRIZZLE,
+        CACHE_MANAGER,
+        MetricService,
+        AmqpConnection,
+      ],
       useFactory: async (
         configService: ConfigService<
           AppConfigNamespaced & MicrosoftConfigNamespaced & AuthConfigNamespaced,
@@ -103,6 +111,7 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
         drizzle: DrizzleDatabase,
         cacheManager: Cache,
         metricService: MetricService,
+        amqpConnection: AmqpConnection,
       ) => ({
         provider: MicrosoftOAuthProvider,
 
@@ -120,7 +129,7 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
           infer: true,
         }),
 
-        oauthStore: new McpOAuthStore(drizzle, aesService, cacheManager),
+        oauthStore: new McpOAuthStore(drizzle, aesService, cacheManager, amqpConnection),
         encryptionService: aesService,
         metricService,
       }),

--- a/services/teams-mcp/src/auth/dtos/user-authorized-event.dto.ts
+++ b/services/teams-mcp/src/auth/dtos/user-authorized-event.dto.ts
@@ -1,0 +1,6 @@
+import z from 'zod/v4';
+
+export const UserAuthorizedEventDto = z.object({
+  type: z.literal('unique.teams-mcp.auth.user-authorized'),
+  payload: z.object({ userProfileId: z.string() }),
+});

--- a/services/teams-mcp/src/auth/mcp-oauth.store.spec.ts
+++ b/services/teams-mcp/src/auth/mcp-oauth.store.spec.ts
@@ -7,11 +7,13 @@ describe('McpOAuthStore', () => {
   let mockDrizzle: MockDrizzleDatabase;
   let mockEncryption: MockEncryptionService;
   let mockCache: MockCacheManager;
+  let mockAmqp: { publish: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     mockDrizzle = new MockDrizzleDatabase();
     mockEncryption = new MockEncryptionService();
     mockCache = new MockCacheManager();
+    mockAmqp = { publish: vi.fn().mockResolvedValue(true) };
     vi.clearAllMocks();
   });
 
@@ -43,7 +45,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextInsertReturningRows = [savedClient];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.storeClient(mockClient);
 
@@ -66,7 +73,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextSelectRows = [drizzleClient];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getClient('test-client-id');
 
@@ -77,7 +89,12 @@ describe('McpOAuthStore', () => {
     it('returns undefined when client not found', async () => {
       mockDrizzle.__nextSelectRows = [];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getClient('non-existent');
 
@@ -99,7 +116,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextSelectRows = [drizzleClient];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.findClient('Test Client');
 
@@ -108,7 +130,12 @@ describe('McpOAuthStore', () => {
     });
 
     it('generates client ID with normalized name', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = unit.generateClientId({
         client_name: 'Test Client App!',
@@ -131,7 +158,12 @@ describe('McpOAuthStore', () => {
     };
 
     it('stores authorization code', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.storeAuthCode(mockAuthCode);
 
@@ -154,7 +186,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextSelectRows = [drizzleAuthCode];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getAuthCode('test-auth-code');
 
@@ -183,7 +220,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextSelectRows = [expiredAuthCode];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getAuthCode('expired-code');
 
@@ -192,7 +234,12 @@ describe('McpOAuthStore', () => {
     });
 
     it('removes authorization code', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.removeAuthCode('test-code');
 
@@ -218,12 +265,52 @@ describe('McpOAuthStore', () => {
       const userProfileId = 'user_profile_01kcrvsne6fq9att23mp4z5ef2';
       mockDrizzle.__nextInsertReturningRows = [{ id: userProfileId }];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.upsertUserProfile(mockUser);
 
       expect(result).toBe(userProfileId);
       expect(mockDrizzle.insert).toHaveBeenCalled();
+    });
+
+    it('publishes a user-authorized event after upserting the profile', async () => {
+      const userProfileId = 'user_profile_01kcrvsne6fq9att23mp4z5ef2';
+      mockDrizzle.__nextInsertReturningRows = [{ id: userProfileId }];
+
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
+
+      await unit.upsertUserProfile(mockUser);
+
+      expect(mockAmqp.publish).toHaveBeenCalledWith(
+        'unique.teams-mcp.main',
+        'unique.teams-mcp.auth.user-authorized',
+        { type: 'unique.teams-mcp.auth.user-authorized', payload: { userProfileId } },
+      );
+    });
+
+    it('still resolves the profile id when publishing the event rejects', async () => {
+      const userProfileId = 'user_profile_01kcrvsne6fq9att23mp4z5ef2';
+      mockDrizzle.__nextInsertReturningRows = [{ id: userProfileId }];
+      mockAmqp.publish.mockRejectedValue(new Error('broker down'));
+
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
+
+      await expect(unit.upsertUserProfile(mockUser)).resolves.toBe(userProfileId);
     });
 
     it('gets user profile by ID', async () => {
@@ -244,7 +331,12 @@ describe('McpOAuthStore', () => {
 
       mockDrizzle.__nextSelectRows = [mockProfile];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getUserProfileById('profile-123');
 
@@ -281,7 +373,12 @@ describe('McpOAuthStore', () => {
         },
       ];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.storeAccessToken('test-token', mockAccessTokenMetadata);
 
@@ -297,7 +394,12 @@ describe('McpOAuthStore', () => {
     it('gets access token from cache first', async () => {
       mockCache.get.mockResolvedValue(mockAccessTokenMetadata);
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getAccessToken('test-token');
 
@@ -320,7 +422,12 @@ describe('McpOAuthStore', () => {
         },
       ];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.getAccessToken('test-token');
 
@@ -339,7 +446,12 @@ describe('McpOAuthStore', () => {
     });
 
     it('removes access token and clears cache', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.removeAccessToken('test-token');
 
@@ -350,7 +462,12 @@ describe('McpOAuthStore', () => {
 
   describe('Refresh Token Family management', () => {
     it('revokes token family', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.revokeTokenFamily('family-123');
 
@@ -358,7 +475,12 @@ describe('McpOAuthStore', () => {
     });
 
     it('marks refresh token as used', async () => {
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       await unit.markRefreshTokenAsUsed('refresh-token');
 
@@ -368,7 +490,12 @@ describe('McpOAuthStore', () => {
     it('checks if refresh token is used', async () => {
       mockDrizzle.__nextSelectRows = [{ usedAt: new Date() }];
 
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.isRefreshTokenUsed('refresh-token');
 
@@ -380,7 +507,12 @@ describe('McpOAuthStore', () => {
   describe('Token cleanup', () => {
     it('cleans up expired tokens', async () => {
       mockDrizzle.__nextDeleteReturningRows = [{ id: 't1' }, { id: 't2' }];
-      const unit = new McpOAuthStore(mockDrizzle as any, mockEncryption, mockCache as any);
+      const unit = new McpOAuthStore(
+        mockDrizzle as any,
+        mockEncryption,
+        mockCache as any,
+        mockAmqp as any,
+      );
 
       const result = await unit.cleanupExpiredTokens(30);
 

--- a/services/teams-mcp/src/auth/mcp-oauth.store.ts
+++ b/services/teams-mcp/src/auth/mcp-oauth.store.ts
@@ -10,11 +10,13 @@ import {
   PassportUser,
   RefreshTokenMetadata,
 } from '@unique-ag/mcp-oauth';
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { Logger } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 import { eq, lt } from 'drizzle-orm';
 import { serializeError } from 'serialize-error-cjs';
 import { typeid } from 'typeid-js';
+import { MAIN_EXCHANGE } from '../amqp/amqp.constants';
 import { DrizzleDatabase } from '../drizzle/drizzle.module';
 import {
   authorizationCodes,
@@ -32,6 +34,7 @@ import {
   toDrizzleSessionInsert,
 } from '../utils/case-converter';
 import { normalizeError } from '../utils/normalize-error';
+import { UserAuthorizedEventDto } from './dtos/user-authorized-event.dto';
 
 export class McpOAuthStore implements IOAuthStore {
   private readonly logger = new Logger(this.constructor.name);
@@ -44,6 +47,7 @@ export class McpOAuthStore implements IOAuthStore {
     private readonly drizzle: DrizzleDatabase,
     private readonly encryptionService: IEncryptionService,
     private readonly cacheManager: Cache,
+    private readonly amqpConnection: AmqpConnection,
   ) {}
 
   public async storeClient(client: OAuthClient): Promise<OAuthClient> {
@@ -178,7 +182,24 @@ export class McpOAuthStore implements IOAuthStore {
       throw new Error('Failed to upsert user profile');
     }
 
-    return saved.id;
+    const userProfileId = saved.id;
+    const event = UserAuthorizedEventDto.parse({
+      type: 'unique.teams-mcp.auth.user-authorized',
+      payload: { userProfileId },
+    });
+    // We do not await the publish because we do not want to break the authorization flow in any possible way.
+    this.amqpConnection
+      .publish(MAIN_EXCHANGE.name, event.type, event)
+      .then()
+      .catch((error) => {
+        this.logger.error({
+          message: 'Failed to publish user authorized event',
+          userProfileId,
+          error: serializeError(normalizeError(error)),
+        });
+      });
+
+    return userProfileId;
   }
 
   public async getUserProfileById(

--- a/services/teams-mcp/src/auth/mcp-oauth.store.ts
+++ b/services/teams-mcp/src/auth/mcp-oauth.store.ts
@@ -188,9 +188,11 @@ export class McpOAuthStore implements IOAuthStore {
       payload: { userProfileId },
     });
     // We do not await the publish because we do not want to break the authorization flow in any possible way.
-    this.amqpConnection
-      .publish(MAIN_EXCHANGE.name, event.type, event)
-      .then()
+    // `publish` runs synchronously and can throw (e.g. the managed channel isn't ready yet under
+    // `connectionInitOptions.wait: false`), so we defer it into a microtask to turn any synchronous
+    // throw into a rejection the `.catch` can handle — keeping the auth flow intact regardless.
+    Promise.resolve()
+      .then(() => this.amqpConnection.publish(MAIN_EXCHANGE.name, event.type, event))
       .catch((error) => {
         this.logger.error({
           message: 'Failed to publish user authorized event',

--- a/services/teams-mcp/src/config/microsoft.config.ts
+++ b/services/teams-mcp/src/config/microsoft.config.ts
@@ -30,6 +30,12 @@ const ConfigSchema = z.object({
     .describe(
       'The hour of the day in UTC when scheduled subscription expirations should occur. This should be done during off-peak hours to avoid disruptions of incoming notifications.',
     ),
+  autoStartIngestion: z
+    .stringbool()
+    .default(false)
+    .describe(
+      'When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool).',
+    ),
 });
 
 export const microsoftConfig = registerConfig('microsoft', ConfigSchema);

--- a/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
@@ -1,16 +1,12 @@
-import { fromString, parseTypeId, typeid } from 'typeid-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MicrosoftConfig } from '~/config';
+import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { PostAuthorizationListener } from './post-authorization.listener';
 import type { SubscriptionCreateService } from './subscription-create.service';
 
 const userProfileId = 'user_profile_01jxk5r1s2fq9att23mp4z5ef2';
 
-const expectedTypeId = () => {
-  const tid = fromString(userProfileId, 'user_profile');
-  const pid = parseTypeId(tid);
-  return typeid(pid.prefix, pid.suffix);
-};
+const expectedTypeId = () => convertUserProfileIdToTypeId(userProfileId);
 
 const makeListener = (
   autoStartIngestion: boolean,

--- a/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
@@ -1,0 +1,71 @@
+import { fromString, parseTypeId, typeid } from 'typeid-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MicrosoftConfig } from '~/config';
+import { PostAuthorizationListener } from './post-authorization.listener';
+import type { SubscriptionCreateService } from './subscription-create.service';
+
+const userProfileId = 'user_profile_01jxk5r1s2fq9att23mp4z5ef2';
+
+const expectedTypeId = () => {
+  const tid = fromString(userProfileId, 'user_profile');
+  const pid = parseTypeId(tid);
+  return typeid(pid.prefix, pid.suffix);
+};
+
+const makeListener = (
+  autoStartIngestion: boolean,
+  subscriptionCreate: Pick<SubscriptionCreateService, 'enqueueSubscriptionRequested'>,
+) => {
+  const config = { autoStartIngestion } as unknown as MicrosoftConfig;
+  return new PostAuthorizationListener(config, subscriptionCreate as SubscriptionCreateService);
+};
+
+const userAuthorizedEvent = (id: string) => ({
+  type: 'unique.teams-mcp.auth.user-authorized' as const,
+  payload: { userProfileId: id },
+});
+
+describe('PostAuthorizationListener', () => {
+  let mockSubscriptionCreate: { enqueueSubscriptionRequested: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockSubscriptionCreate = {
+      enqueueSubscriptionRequested: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.clearAllMocks();
+  });
+
+  it('enqueues a subscription request with the converted id when the flag is on', async () => {
+    const listener = makeListener(true, mockSubscriptionCreate);
+
+    await listener.onUserAuthorized(userAuthorizedEvent(userProfileId));
+
+    expect(mockSubscriptionCreate.enqueueSubscriptionRequested).toHaveBeenCalledOnce();
+    expect(mockSubscriptionCreate.enqueueSubscriptionRequested).toHaveBeenCalledWith(
+      expectedTypeId(),
+    );
+  });
+
+  it('does nothing when the flag is off', async () => {
+    const listener = makeListener(false, mockSubscriptionCreate);
+
+    await listener.onUserAuthorized(userAuthorizedEvent(userProfileId));
+
+    expect(mockSubscriptionCreate.enqueueSubscriptionRequested).not.toHaveBeenCalled();
+  });
+
+  it('does not rethrow when enqueue throws', async () => {
+    mockSubscriptionCreate.enqueueSubscriptionRequested.mockRejectedValue(
+      new Error('enqueue failed'),
+    );
+    const listener = makeListener(true, mockSubscriptionCreate);
+
+    await expect(
+      listener.onUserAuthorized(userAuthorizedEvent(userProfileId)),
+    ).resolves.toBeUndefined();
+
+    expect(mockSubscriptionCreate.enqueueSubscriptionRequested).toHaveBeenCalledWith(
+      expectedTypeId(),
+    );
+  });
+});

--- a/services/teams-mcp/src/transcript/post-authorization.listener.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.ts
@@ -1,0 +1,65 @@
+import {
+  defaultNackErrorHandler,
+  RabbitPayload,
+  RabbitSubscribe,
+} from '@golevelup/nestjs-rabbitmq';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { serializeError } from 'serialize-error-cjs';
+import { fromString, parseTypeId, typeid } from 'typeid-js';
+import { DEAD_EXCHANGE, MAIN_EXCHANGE } from '~/amqp/amqp.constants';
+import { wrapErrorHandlerOTEL } from '~/amqp/amqp.utils';
+import { UserAuthorizedEventDto } from '~/auth/dtos/user-authorized-event.dto';
+import { type MicrosoftConfig, microsoftConfig } from '~/config';
+import { normalizeError } from '~/utils/normalize-error';
+import { SubscriptionCreateService } from './subscription-create.service';
+
+@Injectable()
+export class PostAuthorizationListener {
+  private readonly logger = new Logger(PostAuthorizationListener.name);
+
+  public constructor(
+    @Inject(microsoftConfig.KEY) private readonly config: MicrosoftConfig,
+    private readonly subscriptionCreate: SubscriptionCreateService,
+  ) {}
+
+  @RabbitSubscribe({
+    exchange: MAIN_EXCHANGE.name,
+    queue: 'unique.teams-mcp.auth.post-authorization',
+    routingKey: ['unique.teams-mcp.auth.user-authorized'],
+    createQueueIfNotExists: true,
+    queueOptions: {
+      deadLetterExchange: DEAD_EXCHANGE.name,
+    },
+    errorHandler: wrapErrorHandlerOTEL(defaultNackErrorHandler),
+  })
+  public async onUserAuthorized(@RabbitPayload() payload: unknown): Promise<void> {
+    const event = UserAuthorizedEventDto.parse(payload);
+    const { userProfileId } = event.payload;
+
+    if (!this.config.autoStartIngestion) {
+      this.logger.debug(
+        { userProfileId },
+        'Auto-start ingestion is disabled, skipping subscription enqueue for authorized user',
+      );
+      return;
+    }
+
+    const tid = fromString(userProfileId, 'user_profile');
+    const pid = parseTypeId(tid);
+    const userProfileTypeid = typeid(pid.prefix, pid.suffix);
+
+    try {
+      await this.subscriptionCreate.enqueueSubscriptionRequested(userProfileTypeid);
+      this.logger.log(
+        { userProfileId },
+        'Enqueued transcript subscription request after user authorization',
+      );
+    } catch (error) {
+      this.logger.error({
+        message: 'Failed to enqueue transcript subscription after user authorization',
+        userProfileId,
+        error: serializeError(normalizeError(error)),
+      });
+    }
+  }
+}

--- a/services/teams-mcp/src/transcript/post-authorization.listener.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.ts
@@ -5,11 +5,11 @@ import {
 } from '@golevelup/nestjs-rabbitmq';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { serializeError } from 'serialize-error-cjs';
-import { fromString, parseTypeId, typeid } from 'typeid-js';
 import { DEAD_EXCHANGE, MAIN_EXCHANGE } from '~/amqp/amqp.constants';
 import { wrapErrorHandlerOTEL } from '~/amqp/amqp.utils';
 import { UserAuthorizedEventDto } from '~/auth/dtos/user-authorized-event.dto';
 import { type MicrosoftConfig, microsoftConfig } from '~/config';
+import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { normalizeError } from '~/utils/normalize-error';
 import { SubscriptionCreateService } from './subscription-create.service';
 
@@ -44,12 +44,10 @@ export class PostAuthorizationListener {
       return;
     }
 
-    const tid = fromString(userProfileId, 'user_profile');
-    const pid = parseTypeId(tid);
-    const userProfileTypeid = typeid(pid.prefix, pid.suffix);
-
     try {
-      await this.subscriptionCreate.enqueueSubscriptionRequested(userProfileTypeid);
+      await this.subscriptionCreate.enqueueSubscriptionRequested(
+        convertUserProfileIdToTypeId(userProfileId),
+      );
       this.logger.log(
         { userProfileId },
         'Enqueued transcript subscription request after user authorization',

--- a/services/teams-mcp/src/transcript/tools/ingest-meeting.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/ingest-meeting.tool.ts
@@ -2,10 +2,10 @@ import { type McpAuthenticatedRequest } from '@unique-ag/mcp-oauth';
 import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
-import { fromString, parseTypeId, typeid } from 'typeid-js';
 import * as z from 'zod';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import { collectAllPages, GRAPH_PAGE_SIZE } from '~/msgraph/graph-pagination';
+import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { MeetingCollection, Transcript } from '../transcript.dtos';
 import { TranscriptCreatedService } from '../transcript-created.service';
 
@@ -227,9 +227,7 @@ export class IngestMeetingTool {
     }
 
     // 5. Enqueue an ingest event per selected transcript (async — the upload happens downstream).
-    const userProfileTid = fromString(userProfileId, 'user_profile');
-    const pid = parseTypeId(userProfileTid);
-    const userProfileTypeid = typeid(pid.prefix, pid.suffix);
+    const userProfileTypeid = convertUserProfileIdToTypeId(userProfileId);
 
     for (const transcript of selected) {
       await this.transcriptCreated.enqueueIngestRequested({

--- a/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
@@ -2,8 +2,8 @@ import { type McpAuthenticatedRequest } from '@unique-ag/mcp-oauth';
 import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
-import { fromString, parseTypeId, typeid } from 'typeid-js';
 import * as z from 'zod';
+import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { SubscriptionCreateService } from '../subscription-create.service';
 
 const StartKbIntegrationInputSchema = z.object({});
@@ -66,11 +66,9 @@ export class StartKbIntegrationTool {
 
     this.logger.log({ userProfileId }, 'Starting knowledge base integration for user');
 
-    const tid = fromString(userProfileId, 'user_profile');
-    const pid = parseTypeId(tid);
-    const userProfileTypeid = typeid(pid.prefix, pid.suffix);
-
-    const result = await this.subscriptionCreate.subscribe(userProfileTypeid);
+    const result = await this.subscriptionCreate.subscribe(
+      convertUserProfileIdToTypeId(userProfileId),
+    );
     const { status, subscription } = result;
 
     const expiresAt = new Date(subscription.expiresAt);

--- a/services/teams-mcp/src/transcript/tools/stop-kb-integration.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/stop-kb-integration.tool.ts
@@ -2,8 +2,8 @@ import { type McpAuthenticatedRequest } from '@unique-ag/mcp-oauth';
 import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
-import { fromString, parseTypeId, typeid } from 'typeid-js';
 import * as z from 'zod';
+import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { SubscriptionRemoveService } from '../subscription-remove.service';
 
 const StopKbIntegrationInputSchema = z.object({});
@@ -64,11 +64,9 @@ export class StopKbIntegrationTool {
 
     this.logger.log({ userProfileId }, 'Stopping knowledge base integration for user');
 
-    const tid = fromString(userProfileId, 'user_profile');
-    const pid = parseTypeId(tid);
-    const userProfileTypeid = typeid(pid.prefix, pid.suffix);
-
-    const result = await this.subscriptionRemove.removeByUserProfileId(userProfileTypeid);
+    const result = await this.subscriptionRemove.removeByUserProfileId(
+      convertUserProfileIdToTypeId(userProfileId),
+    );
     const { status, subscription } = result;
 
     const messages: Record<typeof status, string> = {

--- a/services/teams-mcp/src/transcript/transcript.module.ts
+++ b/services/teams-mcp/src/transcript/transcript.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DrizzleModule } from '~/drizzle/drizzle.module';
 import { MsGraphModule } from '~/msgraph/msgraph.module';
 import { UniqueModule } from '~/unique/unique.module';
+import { PostAuthorizationListener } from './post-authorization.listener';
 import { SubscriptionCreateService } from './subscription-create.service';
 import { SubscriptionReauthorizeService } from './subscription-reauthorize.service';
 import { SubscriptionRemoveService } from './subscription-remove.service';
@@ -27,6 +28,8 @@ import { TranscriptUtilsService } from './transcript-utils.service';
     SubscriptionReauthorizeService,
     SubscriptionRemoveService,
     TranscriptCreatedService,
+    // Auto-start ingestion at login (gated by MICROSOFT_AUTO_START_INGESTION)
+    PostAuthorizationListener,
     // KB Integration MCP Tools
     VerifyKbIntegrationStatusTool,
     StartKbIntegrationTool,

--- a/services/teams-mcp/src/utils/convert-user-profile-id-to-type-id.ts
+++ b/services/teams-mcp/src/utils/convert-user-profile-id-to-type-id.ts
@@ -1,0 +1,9 @@
+import { fromString, parseTypeId, type TypeID, typeid } from 'typeid-js';
+
+export type UserProfileTypeID = TypeID<'user_profile'>;
+
+export const convertUserProfileIdToTypeId = (userProfileId: string): UserProfileTypeID => {
+  const tid = fromString(userProfileId, 'user_profile');
+  const pid = parseTypeId(tid);
+  return typeid(pid.prefix, pid.suffix);
+};


### PR DESCRIPTION
## Context

Today a teams-mcp user must manually call the `start_kb_integration` MCP tool after OAuth login to begin transcript ingestion. [UN-22169](https://unique-ch.atlassian.net/browse/UN-22169) asks for an **optional, deployment-wide** switch that auto-enqueues a transcript subscription for every user the moment they finish login — mirroring the pattern already shipped in `outlook-semantic-mcp`.

The flag is **all-users, ENV-only** (no per-user opt-out state). When on, every login enqueues a subscription; `subscribe()` is already idempotent so re-logins are safe and the subscription self-heals after expiry.

## How it works

```
login → McpOAuthStore publishes "user-authorized" (fire-and-forget)
      → PostAuthorizationListener (gated by MICROSOFT_AUTO_START_INGESTION)
      → SubscriptionCreateService.enqueueSubscriptionRequested()
      → publishes "subscription-requested"
      → TranscriptController.onLifecycleNotification (existing consumer)
      → SubscriptionCreateService.subscribe()  → Graph subscription + DB row
```

We add only the front half (login event + gated listener) and reuse the pre-existing, tested lifecycle enqueue pipeline (`enqueueSubscriptionRequested` was previously defined but unused).

## Changes

- **Config**: `MICROSOFT_AUTO_START_INGESTION` (`microsoft.autoStartIngestion`, `stringbool`, default `false`).
- **Auth event DTO**: new `user-authorized-event.dto.ts`.
- **Store**: `McpOAuthStore` gains `AmqpConnection`; `upsertUserProfile()` publishes the event **fire-and-forget** with `.catch()` logging so login never fails on AMQP errors.
- **Listener**: new ENV-gated `PostAuthorizationListener` — flag off → no-op; flag on → enqueue subscription request (try/catch, no rethrow).
- **Wiring**: `app.module.ts` injects `AmqpConnection` into the OAuth store factory; listener registered in `transcript.module.ts`.
- **Docs & Helm**: `.env.example`, `README`, operator config table, flows diagram (auto-start + manual branches), and Helm `config.yaml` / `values.yaml` / `values.schema.json`.

## Out of scope / unchanged
- No DB migration. Manual `start_kb_integration` / `stop_kb_integration` tools untouched. With the flag on, `stop` is effectively a pause that re-arms on next login (accepted).

## Verification
- `pnpm --filter teams-mcp test` — **54/54 pass** (new listener spec + store spec).
- `check-types`, `style`, `build` clean; `helm template` renders `MICROSOFT_AUTO_START_INGESTION` correctly.

[UN-22169]: https://unique-ch.atlassian.net/browse/UN-22169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
