### PR TITLE
docs(teams-mcp): document chat/messaging tools and subscription lifecycle

### DIFF
--- a/services/teams-mcp/docs/README.md
+++ b/services/teams-mcp/docs/README.md
@@ -17,7 +17,7 @@
 
 The Teams MCP Server is a cloud-native application that automatically captures meeting transcripts and recordings from Microsoft Teams and ingests them into the Unique knowledge base. This guide provides administrators with essential information about requirements, features, and limitations.
 
-**Note:** This is a connector-style MCP server that does two things. First, it automatically ingests meeting transcripts into the Unique knowledge base in the background. Second, it exposes an interactive tool surface of 14 MCP tools — 8 chat/messaging tools and 6 transcript/KB management tools. All tools use id-only targeting: the workflow is discover-ids-then-act (`list_*` → id → read/write/search). See [Technical Reference — Tools](./technical/tools.md) for the full tool reference.
+**Note:** This is a connector-style MCP server that does two things. First, it automatically ingests meeting transcripts into the Unique knowledge base in the background. Second, it exposes an interactive tool surface of 14 MCP tools — 8 chat/messaging tools and 6 transcript/KB management tools. Chat and channel tools take ids obtained from the `list_*` tools. See [Technical Reference — Tools](./technical/tools.md) for the full tool reference.
 
 For deployment, configuration, and operational details, see the [IT Operator Guide](./operator/README.md).
 
@@ -100,7 +100,7 @@ For detailed permission justifications, see [Microsoft Graph Permissions](./tech
 
 **Teams Chat Messaging**
 
-All chat/messaging tools use **id-only targeting**: there are no name-based parameters. The workflow is **discover-ids-then-act** — call a list tool to obtain an id and distinguishing metadata, then pass that id to a read, write, or search tool.
+Chat and messaging tools target chats and channels by id: call a `list_*` tool to obtain an id (and distinguishing metadata), then pass that id to a read, write, or search tool.
 
 - `list_teams`: List all Microsoft Teams the user is a member of; returns team id and `isArchived` flag
 - `list_channels`: List all channels in a team (by team id); returns channel id, `createdDateTime`, and `membershipType`

--- a/services/teams-mcp/docs/README.md
+++ b/services/teams-mcp/docs/README.md
@@ -17,7 +17,7 @@
 
 The Teams MCP Server is a cloud-native application that automatically captures meeting transcripts and recordings from Microsoft Teams and ingests them into the Unique knowledge base. This guide provides administrators with essential information about requirements, features, and limitations.
 
-**Note:** This is a connector-style MCP server. Once connected, it automatically ingests meeting transcripts into the Unique knowledge base. It also exposes 8 MCP tools for Teams chat messaging: listing teams, channels, and chats; reading chat and channel messages; searching messages by keyword; and sending messages to channels or chats.
+**Note:** This is a connector-style MCP server that does two things. First, it automatically ingests meeting transcripts into the Unique knowledge base in the background. Second, it exposes an interactive tool surface of 14 MCP tools — 8 chat/messaging tools and 6 transcript/KB management tools. All tools use id-only targeting: the workflow is discover-ids-then-act (`list_*` → id → read/write/search). See [Technical Reference — Tools](./technical/tools.md) for the full tool reference.
 
 For deployment, configuration, and operational details, see the [IT Operator Guide](./operator/README.md).
 
@@ -54,6 +54,7 @@ All permissions are **Delegated** (not Application), meaning they act on behalf 
 | Permission | Type | Admin Consent | Required |
 |------------|------|---------------|----------|
 | `User.Read` | Delegated | No | Yes |
+| `Calendars.Read` | Delegated | No | Yes |
 | `OnlineMeetings.Read` | Delegated | No | Yes |
 | `OnlineMeetingRecording.Read.All` | Delegated | Yes | Yes |
 | `OnlineMeetingTranscript.Read.All` | Delegated | Yes | Yes |
@@ -99,14 +100,16 @@ For detailed permission justifications, see [Microsoft Graph Permissions](./tech
 
 **Teams Chat Messaging**
 
-- `list_teams`: List all Microsoft Teams the user is a member of
-- `list_channels`: List all channels in a specific team
-- `list_chats`: List the user's recent chats (1:1, group, and meeting chats)
-- `get_chat_messages`: Retrieve recent messages from a chat
-- `get_channel_messages`: Retrieve recent messages from a channel
-- `search_messages`: Search messages by keyword across chats and channels (Microsoft Search API)
-- `send_channel_message`: Send a plain text message to a Teams channel
-- `send_chat_message`: Send a plain text message to a Teams chat
+All chat/messaging tools use **id-only targeting**: there are no name-based parameters. The workflow is **discover-ids-then-act** — call a list tool to obtain an id and distinguishing metadata, then pass that id to a read, write, or search tool.
+
+- `list_teams`: List all Microsoft Teams the user is a member of; returns team id and `isArchived` flag
+- `list_channels`: List all channels in a team (by team id); returns channel id, `createdDateTime`, and `membershipType`
+- `list_chats`: List the user's recent chats (1:1, group, and meeting chats) by chat id; returns `createdDateTime`, `lastMessageAt`, and members for topic-less or 1:1 chats
+- `get_chat_messages`: Retrieve recent messages from a chat (by chat id)
+- `get_channel_messages`: Retrieve recent messages from a channel (by team id + channel id)
+- `search_messages`: Search messages by keyword across chats and channels via the Microsoft Search API; returns chat/channel ids alongside results, enabling subsequent reads or sends
+- `send_channel_message`: Send a plain text message to a Teams channel (by team id + channel id)
+- `send_chat_message`: Send a plain text message to a Teams chat (by chat id)
 
 ### Advanced Features
 
@@ -318,6 +321,9 @@ See [Authentication Architecture - Single App Registration Architecture](./techn
 - **Multi-tenant in one session**: A user belonging to multiple Microsoft tenants must authenticate separately for each tenant; one OAuth session covers exactly one tenant
 - **Transcript format variants**: Only VTT-format transcripts are processed; meetings with transcripts in other formats are silently skipped
 - **Recording size assurance**: No application-level size check on recordings; very large files (e.g., multi-hour all-hands) may time out during download and be skipped, while the transcript is still ingested
+- **Rich message sends**: `send_chat_message` and `send_channel_message` send plain text only — no `@mentions`, no rich content (bold, tables, adaptive cards), and no attachment upload
+- **Message threading/replies**: There is no tool for replying to a specific message in a thread; only new top-level messages can be sent
+- **Chat/channel message ingestion**: Messages read or searched via the messaging tools are fetched live from Microsoft Graph on every call and are **not** ingested into the Unique knowledge base; only meeting transcripts are ingested
 
 ### Microsoft Graph API Constraints
 

--- a/services/teams-mcp/docs/faq.md
+++ b/services/teams-mcp/docs/faq.md
@@ -13,7 +13,7 @@
 - Exposes **8 chat/messaging tools**: `list_teams`, `list_channels`, `list_chats`, `get_chat_messages`, `get_channel_messages`, `search_messages`, `send_channel_message`, `send_chat_message`
 - Exposes **6 transcript/KB management tools**: `find_transcripts`, `list_meetings`, `ingest_meeting`, `verify_kb_integration_status`, `start_kb_integration`, `stop_kb_integration`
 - All 14 tools are registered unconditionally — no feature flags or mode switching required
-- All tools use **id-only targeting**: the workflow is discover-ids-then-act (`list_*` → id → read/write/search); there are no name-based parameters
+- Chat and channel tools take ids obtained from the `list_*` tools (e.g. `list_chats` → `chatId` → `get_chat_messages`)
 
 **What the user sees:**
 

--- a/services/teams-mcp/docs/faq.md
+++ b/services/teams-mcp/docs/faq.md
@@ -5,38 +5,28 @@
 
 ### What type of MCP server is this?
 
-**Answer:** The Teams MCP Server is a connector-style MCP server, not a traditional MCP server. Unlike traditional MCP servers that provide tools, prompts, resources, or other interactive capabilities, this server operates automatically in the background once connected.
+**Answer:** The Teams MCP Server is both a **connector** and an **interactive MCP server**. It does two things simultaneously: it automatically ingests meeting transcripts into the Unique knowledge base in the background, and it exposes an interactive tool surface of 14 MCP tools that AI clients can call on demand.
 
 **What it does:**
 
-- Once a user connects their Microsoft account, the connector automatically ingests meeting transcripts into the Unique knowledge base
-- It does not expose any MCP tools, prompts, or resources
-- It does not require any tool calls or additional interaction after the initial connection
-- It operates continuously in the background, processing transcripts as they become available
+- Once a user connects their Microsoft account, the connector automatically ingests meeting transcripts into the Unique knowledge base via real-time webhook notifications from Microsoft Graph
+- Exposes **8 chat/messaging tools**: `list_teams`, `list_channels`, `list_chats`, `get_chat_messages`, `get_channel_messages`, `search_messages`, `send_channel_message`, `send_chat_message`
+- Exposes **6 transcript/KB management tools**: `find_transcripts`, `list_meetings`, `ingest_meeting`, `verify_kb_integration_status`, `start_kb_integration`, `stop_kb_integration`
+- All 14 tools are registered unconditionally — no feature flags or mode switching required
+- All tools use **id-only targeting**: the workflow is discover-ids-then-act (`list_*` → id → read/write/search); there are no name-based parameters
 
-**What it does not do:**
+**What the user sees:**
 
-- Provide MCP tools for querying or manipulating data
-- Offer prompts or prompt templates
-- Expose resources for browsing or accessing
-- Require any interaction beyond the initial connection
-
-**Architecture:**
-
-- Uses MCP OAuth for user authentication and connection
-- Does not implement MCP tools, prompts, or resources
-- Operates as a background service that automatically ingests transcripts
-- Processes webhook notifications from Microsoft Graph API
-- Ingests content into Unique knowledge base without requiring tool calls
+- An initial OAuth consent screen to connect their Microsoft account
+- 14 MCP tools available in their AI client immediately after connection
+- Automatic transcript ingestion in the background for all meetings with transcription enabled, once `start_kb_integration` is called
 
 **Design rationale:**
 
-- The connector model allows for automatic, continuous data ingestion
-- Users connect once and transcripts are automatically captured
-- No need for interactive tool calls or resource browsing
-- Simplifies the user experience by removing the need for ongoing interaction
+- The connector model provides automatic, continuous transcript ingestion without requiring user interaction after setup
+- The interactive tool surface gives AI assistants live access to Teams chats, channels, and transcript management — on demand
 
-This is a data ingestion connector that uses the MCP protocol for authentication and connection management, but functions as a background service rather than an interactive MCP server.
+**See also:** [Technical Reference — Tools](./technical/tools.md)
 
 ## Authentication & Permissions
 

--- a/services/teams-mcp/docs/operator/README.md
+++ b/services/teams-mcp/docs/operator/README.md
@@ -5,14 +5,14 @@
 
 This guide provides IT operators with the technical information needed to deploy, configure, and maintain the Teams MCP Server.
 
-The Teams MCP Server exposes 12 MCP tools across two categories:
+The Teams MCP Server exposes 14 MCP tools across two categories:
 
-- **Chat tools** — `list_teams`, `list_channels`, `list_chats`, `get_channel_messages`, `get_chat_messages`, `search_messages`, `send_channel_message`, `send_chat_message`
-- **Transcript tools** — `find_transcripts`, `verify_kb_integration_status`, `start_kb_integration`, `stop_kb_integration`
+- **Chat / messaging tools** — `list_teams`, `list_channels`, `list_chats`, `get_chat_messages`, `get_channel_messages`, `search_messages`, `send_chat_message`, `send_channel_message`
+- **Transcript / KB tools** — `find_transcripts`, `list_meetings`, `ingest_meeting`, `verify_kb_integration_status`, `start_kb_integration`, `stop_kb_integration`
 
-Chat tools let users read, search, and send messages in their Teams channels and chats. Transcript tools manage the Microsoft Graph subscription that ingests meeting transcripts into the Unique knowledge base, and allow users to search those transcripts.
+Chat tools let users read, search, and send messages in their Teams channels and chats. Transcript tools manage the Microsoft Graph subscription that ingests meeting transcripts into the Unique knowledge base, and allow users to manually trigger ingestion and search those transcripts.
 
-For end-user and administrator documentation, see the [Teams MCP Overview](../README.md).
+For end-user and administrator documentation, see the [Teams MCP Overview](../README.md). For a full tool reference, see [Technical — Tools](../technical/tools.md).
 
 ## Documentation
 

--- a/services/teams-mcp/docs/operator/authentication.md
+++ b/services/teams-mcp/docs/operator/authentication.md
@@ -14,7 +14,7 @@ For technical details about the OAuth flow, see [Microsoft OAuth Setup Flow](../
 
 ## Required Permissions
 
-All permissions are **delegated** — they act on behalf of the signed-in user. Two permissions require admin consent before users can connect.
+All permissions are **delegated** — they act on behalf of the signed-in user. Three permissions require admin consent before users can connect.
 
 | Permission | Type | Admin Consent |
 |------------|------|---------------|
@@ -24,6 +24,13 @@ All permissions are **delegated** — they act on behalf of the signed-in user. 
 | `OnlineMeetingRecording.Read.All` | Delegated | **Yes** |
 | `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** |
 | `offline_access` | Delegated | No |
+| `ChannelMessage.Send` | Delegated | No |
+| `ChatMessage.Send` | Delegated | No |
+| `Chat.ReadBasic` | Delegated | No |
+| `Chat.Read` | Delegated | No |
+| `Team.ReadBasic.All` | Delegated | No |
+| `Channel.ReadBasic.All` | Delegated | No |
+| `ChannelMessage.Read.All` | Delegated | **Yes** |
 
 For full justifications, see [Microsoft Graph Permissions](../technical/permissions.md).
 
@@ -35,7 +42,7 @@ For full justifications, see [Microsoft Graph Permissions](../technical/permissi
 https://login.microsoftonline.com/organizations/adminconsent?client_id=8ddffb12-1579-4fa8-8844-ca122e4308bc
 ```
 
-The consent prompt lists the [Required Permissions](#required-permissions) above. Note that `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` require admin consent — the URL above handles that in one step. Without it, users will see an error when trying to connect.
+The consent prompt lists the [Required Permissions](#required-permissions) above. Note that `OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All` require admin consent — the URL above handles all three in one step. Without it, users will see an error when trying to connect.
 
 If your organization uses multiple Azure tenants, confirm you are granting consent for the correct directory. See [Grant tenant-wide admin consent to an application](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent) for a tenant-specific admin consent URL; use application (client) ID `8ddffb12-1579-4fa8-8844-ca122e4308bc`.
 
@@ -82,7 +89,7 @@ module "teams_mcp_app" {
    - Add all permissions listed under [Required Permissions](#required-permissions)
 
 3. Click **Grant admin consent for [Tenant]** and confirm.
-   `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` require this step — without it users cannot connect.
+   `OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All` require this step — without it users cannot connect.
 
 4. Go to **Certificates & secrets** → **New client secret**:
    - Set description and expiration
@@ -168,9 +175,9 @@ This secret is passed to Microsoft when creating Graph subscriptions and returne
 
 **This is standard Microsoft behavior, not Teams MCP specific.** All Microsoft 365 apps use the same consent model.
 
-Because `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` require admin consent, the consent sequence is:
+Because three permissions require admin consent (`OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All`), the consent sequence is:
 
-1. **Admin grants consent** for the two admin-required permissions (organisation-wide or per-user)
+1. **Admin grants consent** for those three permissions (organisation-wide or per-user). The remaining 10 permissions — including all other chat scopes (`ChannelMessage.Send`, `ChatMessage.Send`, `Chat.ReadBasic`, `Chat.Read`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`) — are user-consentable and do not require admin action.
 2. **User consent** — on first connection, the user sees the Microsoft consent screen and approves the remaining permissions
 
 **How to grant admin consent:**

--- a/services/teams-mcp/docs/operator/local-development.md
+++ b/services/teams-mcp/docs/operator/local-development.md
@@ -170,6 +170,17 @@ This URL is used when creating Microsoft Graph subscriptions.
 3. You should see the OAuth metadata JSON
 4. Connect with an MCP client that supports OAuth
 
+### Testing Chat Tools
+
+After connecting a test user via MCP Inspector:
+
+1. **Discover ids** — call `list_teams` to find team ids and `list_chats` to find chat ids. Both return ids alongside display names and metadata so you can identify the right target unambiguously.
+2. **Read messages** — call `get_chat_messages` with a chat id, or `get_channel_messages` with a team id and channel id (use `list_channels` to find channel ids). Both return paginated message history.
+3. **Search** — call `search_messages` with a keyword query. Results span both chats and channels; pass `detail=full` to hydrate full message content.
+4. **Send** — call `send_chat_message` with a chat id to post to a 1:1 or group chat, or `send_channel_message` with a team id and channel id to post to a channel. Verify the message appears in the Teams client.
+
+All tool inputs accept ids only (no display-name lookup at call time) — always use the `list_*` tools first to obtain the correct id.
+
 ### Testing Webhooks
 
 1. Ensure dev tunnel is running

--- a/services/teams-mcp/docs/technical/README.md
+++ b/services/teams-mcp/docs/technical/README.md
@@ -5,7 +5,7 @@
 
 This section contains detailed technical documentation for developers and architects working with the Teams MCP Server.
 
-**Note:** The Teams MCP Server is a connector-style MCP server, not a traditional MCP server. It does not provide tools, prompts, resources, or other MCP capabilities. Once connected, it automatically ingests meeting transcripts into the Unique knowledge base in the background.
+**Note:** The Teams MCP Server is both an MCP server and a connector — it exposes **14 MCP tools** (8 chat/messaging + 6 transcript/KB) that AI clients invoke on demand, and once a user connects their account, it automatically ingests meeting transcripts into the Unique knowledge base in the background. This contrasts with pure connector-style servers which ingest data silently without exposing tools.
 
 ## Documentation
 
@@ -15,4 +15,6 @@ This section contains detailed technical documentation for developers and archit
 | [Flows](./flows.md) | Sequence diagrams for user connection, subscriptions, and processing |
 | [Permissions](./permissions.md) | Microsoft Graph permissions with least-privilege justification |
 | [Security](./security.md) | Encryption, authentication, and threat model |
+| [Subscription Management](./subscription-management.md) | Transcript-ingestion webhook subscription lifecycle (create, renew, status, removal) |
+| [Tools](./tools.md) | Full reference for all 14 MCP tools (8 chat/messaging + 6 transcript/KB) |
 | [FAQ](../faq.md) | Frequently asked questions |

--- a/services/teams-mcp/docs/technical/architecture.md
+++ b/services/teams-mcp/docs/technical/architecture.md
@@ -1,7 +1,7 @@
 <!-- confluence-page-id: 1802502170 -->
 <!-- confluence-space-key: PUBDOC -->
 
-The Teams MCP Server is a NestJS-based microservice that integrates Microsoft Teams meetings with the Unique platform through the Model Context Protocol (MCP). It captures meeting transcripts and recordings from Microsoft Teams and ingests them into Unique with proper access controls.
+The Teams MCP Server is a NestJS-based microservice that integrates Microsoft Teams with the Unique platform through the Model Context Protocol (MCP). It captures meeting transcripts and recordings from Microsoft Teams, ingests them into Unique with proper access controls, and exposes synchronous MCP tools for reading and sending messages across chats and channels.
 
 **Core Capabilities:**
 
@@ -10,6 +10,9 @@ The Teams MCP Server is a NestJS-based microservice that integrates Microsoft Te
 - Handles OAuth2 authentication with Microsoft Entra ID
 - Ingests content into the Unique platform with participant-based access controls
 - Manages subscription lifecycle (create, renew, remove) with scheduled synchronization
+- Reads messages from personal chats and team channels via synchronous MCP tools
+- Searches across chats and channels using the Microsoft Search API
+- Sends messages to chats and channels via synchronous MCP tools
 
 ## High-Level Architecture
 
@@ -26,7 +29,8 @@ flowchart TB
     subgraph TeamsMCP["Teams MCP Server"]
         OAuth["OAuth Module"]
         API["REST API"]
-        Processor["Transcript Processor"]
+        ChatTools["Chat Tools<br/>(synchronous)"]
+        Processor["Transcript Processor<br/>(asynchronous)"]
         GraphClient["Graph Client"]
     end
 
@@ -38,15 +42,18 @@ flowchart TB
     User --> EntraID
     EntraID --> OAuth
     OAuth --> DB
-    
+
+    User -->|"MCP tool calls"| ChatTools
+    ChatTools --> GraphClient
+
     MSGraph -->|"Webhooks"| API
     API --> Queue
     Queue --> Processor
-    
+
     Processor --> GraphClient
     GraphClient --> DB
     GraphClient --> MSGraph
-    
+
     Processor --> Unique
 ```
 
@@ -57,6 +64,13 @@ flowchart TB
 flowchart TB
     subgraph Auth["Authentication"]
         AuthModule["OAuth Provider<br/>Token Store"]
+    end
+
+    subgraph Chat["Chat Module"]
+        ChatSvc["Chat Service<br/>(chats, chat messages)"]
+        ChannelSvc["Channel Service<br/>(teams, channels, channel messages)"]
+        SearchSvc["Search Service<br/>(Microsoft Search API)"]
+        ChatToolLayer["Tool Layer<br/>(8 MCP tools)"]
     end
 
     subgraph Transcript["Transcript Module"]
@@ -81,6 +95,13 @@ flowchart TB
     end
 
     AuthModule --> DB
+    ChatToolLayer --> ChatSvc
+    ChatToolLayer --> ChannelSvc
+    ChatToolLayer --> SearchSvc
+    SearchSvc --> ChatSvc
+    ChatSvc --> GraphClient
+    ChannelSvc --> GraphClient
+    SearchSvc --> GraphClient
     Webhook --> RabbitMQ
     RabbitMQ --> Services
     Services --> GraphClient
@@ -102,6 +123,35 @@ flowchart TB
 | **Transcript Created Service** | Processes new transcripts and fetches recordings |
 | **Unique Service** | Interfaces with Unique Public API for content ingestion |
 | **AMQP Module** | RabbitMQ integration for async message processing |
+
+### Chat Module
+
+The Chat Module (`src/chat/`) exposes a synchronous request/response tool surface over MCP, distinct from the asynchronous webhook/transcript ingestion path. Tool calls are handled inline — there is no queue or background worker.
+
+**Services:**
+
+| Service | File | Responsibility |
+|---------|------|----------------|
+| **ChatService** | `chat.service.ts` | Lists personal chats; fetches and sends chat messages via `/me/chats` and `/chats/{id}/messages` |
+| **ChannelService** | `channel.service.ts` | Lists joined teams and their channels; fetches and sends channel messages via `/me/joinedTeams`, `/teams/{id}/channels`, and `/teams/{id}/channels/{id}/messages` |
+| **SearchService** | `search.service.ts` | Cross-container message search via the Microsoft Search API (`POST /search/query` on Graph v1.0); delegates per-hit hydration to `ChatService` |
+
+**Tool layer** (`src/chat/tools/`):
+
+| Tool | What it does |
+|------|-------------|
+| `list_chats` | Lists recent personal chats with member and preview metadata |
+| `get_chat_messages` | Fetches messages from a personal chat by ID |
+| `send_chat_message` | Posts a plain-text message to a personal chat by ID |
+| `list_teams` | Lists all Teams the user has joined |
+| `list_channels` | Lists channels in a given team by ID |
+| `get_channel_messages` | Fetches messages from a team channel by ID |
+| `send_channel_message` | Posts a plain-text message to a team channel by ID |
+| `search_messages` | Searches messages across chats, channels, or both |
+
+**ID-only targeting:** `list_*` tools return identifiers (chat ID, team ID, channel ID). Those IDs are then passed directly to `get_*_messages` and `send_*_message` tools. There is no name-based resolution — the client must perform the `list_*` → ID → action workflow. See [Chat Flows](./flows.md#Chat-Flows) for sequence diagrams.
+
+**Search specifics (`SearchService`):** The Microsoft Search API does not use `@odata.nextLink`; pagination is driven by `offset`/`size` on the request body and `moreResultsAvailable` on the response. When `detail=full`, each matching hit is hydrated with its full message body via an additional Graph call (N+1). Hydration runs with a concurrency cap of 5 (via `pLimit`). A hit that returns 403 or 404 during hydration falls back to its summary-only row rather than failing the entire page.
 
 ## Infrastructure
 
@@ -324,7 +374,7 @@ The MCP OAuth layer implements the [MCP Authorization specification](https://mod
 
 ## Related Documentation
 
-- [Flows](./flows.md) - User connection, subscription lifecycle, transcript processing
+- [Flows](./flows.md) - User connection, subscription lifecycle, transcript processing, chat read/search/send
 - [Security](./security.md) - Encryption, authentication, and threat model
 - [Microsoft Graph Permissions](./permissions.md) - Required scopes and least-privilege justification
 

--- a/services/teams-mcp/docs/technical/architecture.md
+++ b/services/teams-mcp/docs/technical/architecture.md
@@ -149,7 +149,7 @@ The Chat Module (`src/chat/`) exposes a synchronous request/response tool surfac
 | `send_channel_message` | Posts a plain-text message to a team channel by ID |
 | `search_messages` | Searches messages across chats, channels, or both |
 
-**ID-only targeting:** `list_*` tools return identifiers (chat ID, team ID, channel ID). Those IDs are then passed directly to `get_*_messages` and `send_*_message` tools. There is no name-based resolution — the client must perform the `list_*` → ID → action workflow. See [Chat Flows](./flows.md#Chat-Flows) for sequence diagrams.
+**Targeting by id:** `list_*` tools return identifiers (chat id, team id, channel id) that are passed directly to the `get_*_messages` and `send_*_message` tools. See [Chat Flows](./flows.md#Chat-Flows) for sequence diagrams.
 
 **Search specifics (`SearchService`):** The Microsoft Search API does not use `@odata.nextLink`; pagination is driven by `offset`/`size` on the request body and `moreResultsAvailable` on the response. When `detail=full`, each matching hit is hydrated with its full message body via an additional Graph call (N+1). Hydration runs with a concurrency cap of 5 (via `pLimit`). A hit that returns 403 or 404 during hydration falls back to its summary-only row rather than failing the entire page.
 

--- a/services/teams-mcp/docs/technical/flows.md
+++ b/services/teams-mcp/docs/technical/flows.md
@@ -343,7 +343,7 @@ flowchart TB
 
 The Chat Module exposes a **synchronous request/response** tool surface. Each tool call is handled inline — there is no queue or background worker. This is distinct from the async webhook/transcript ingestion path above.
 
-All chat and channel targeting is **ID-only**: `list_*` tools return identifiers that the caller passes to subsequent `get_*_messages` or `send_*_message` calls. See also: [Tools Reference](./tools.md).
+Each tool targets a chat or channel by id: `list_*` tools return identifiers that the caller passes to subsequent `get_*_messages` or `send_*_message` calls. See also: [Tools Reference](./tools.md).
 
 ### Chat Read Flow
 

--- a/services/teams-mcp/docs/technical/flows.md
+++ b/services/teams-mcp/docs/technical/flows.md
@@ -339,6 +339,139 @@ flowchart TB
 - Meeting participants receive **read** access
 - Users are resolved by email or username in Unique platform
 
+## Chat Flows
+
+The Chat Module exposes a **synchronous request/response** tool surface. Each tool call is handled inline — there is no queue or background worker. This is distinct from the async webhook/transcript ingestion path above.
+
+All chat and channel targeting is **ID-only**: `list_*` tools return identifiers that the caller passes to subsequent `get_*_messages` or `send_*_message` calls. See also: [Tools Reference](./tools.md).
+
+### Chat Read Flow
+
+The read flow applies to both personal chats (`list_chats` → `get_chat_messages`) and team channels (`list_teams` → `list_channels` → `get_channel_messages`). The diagram below shows the personal chat variant; the channel variant substitutes `list_teams`/`list_channels` for `list_chats` and queries `/teams/{teamId}/channels/{channelId}/messages` instead of `/chats/{chatId}/messages`.
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'fontSize': '14px' }}}%%
+sequenceDiagram
+    autonumber
+    participant MCPClient as MCP Client
+    participant TeamsMCP as Teams MCP Server
+    participant MSGraph as Microsoft Graph API
+
+    Note over MCPClient,MSGraph: Step 1 — discover the target ID
+
+    MCPClient->>TeamsMCP: list_chats (limit?)
+    TeamsMCP->>MSGraph: GET /me/chats?$expand=members,lastMessagePreview&$orderby=...
+    MSGraph->>TeamsMCP: Page of chats (id, chatType, topic, members, lastMessagePreview)
+    TeamsMCP->>MCPClient: chats[], hasMore
+
+    Note over MCPClient,MSGraph: Step 2 — fetch messages by ID
+
+    MCPClient->>TeamsMCP: get_chat_messages (chatId, limit, orderBy?, excludeSystemMessages?)
+    TeamsMCP->>MSGraph: GET /chats/{chatId}/messages?$top=limit&$orderby=...
+    MSGraph->>TeamsMCP: First page of messages
+
+    alt excludeSystemMessages = true and page short
+        loop Follow @odata.nextLink until limit user messages collected
+            TeamsMCP->>MSGraph: GET next page (via @odata.nextLink)
+            MSGraph->>TeamsMCP: Next page of messages
+        end
+    end
+
+    Note over TeamsMCP: Normalize Teams HTML body to plain text
+    TeamsMCP->>MCPClient: messages[] (id, from, body, createdDateTime, ...)
+```
+
+**Key points:**
+
+- `list_chats` returns a single bounded page (no auto-pagination); `hasMore` indicates whether more chats exist.
+- Graph does not support server-side `messageType` filtering on message endpoints. When `excludeSystemMessages=true`, the server pages through results client-side until the requested number of user messages is collected.
+- Message bodies are returned as-is from Graph (HTML). The `get_channel_messages` path is identical but targets `/teams/{teamId}/channels/{channelId}/messages`.
+
+### Chat Search Flow
+
+`search_messages` queries the **Microsoft Search API** (`POST /search/query` on Graph v1.0) and optionally hydrates each hit with its full message body.
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'fontSize': '14px' }}}%%
+sequenceDiagram
+    autonumber
+    participant MCPClient as MCP Client
+    participant TeamsMCP as Teams MCP Server
+    participant MSGraph as Microsoft Graph API
+
+    MCPClient->>TeamsMCP: search_messages (query, source?, detail?, offset, size)
+    TeamsMCP->>MSGraph: POST /search/query<br/>{ entityTypes: ['chatMessage'], from: offset, size: size }
+    MSGraph->>TeamsMCP: hitsContainers[{ hits[], moreResultsAvailable }]
+
+    Note over TeamsMCP: Map hits to rows (source derived from resource shape:<br/>channelIdentity → channel, chatId → chat)
+
+    opt source filter applied (chat | channel)
+        Note over TeamsMCP: Drop rows not matching the requested source<br/>(Graph has no server-side entityType sub-filter)
+    end
+
+    alt detail = full
+        Note over TeamsMCP: Hydrate each hit — one extra Graph call per hit (N+1),<br/>concurrency capped at 5 (pLimit)
+        loop For each hit (up to 5 in parallel)
+            alt hit.source = channel
+                TeamsMCP->>MSGraph: GET /teams/{teamId}/channels/{channelId}/messages/{id}
+            else hit.source = chat
+                TeamsMCP->>MSGraph: GET /chats/{chatId}/messages/{id}
+            end
+            MSGraph->>TeamsMCP: Full message (body, attachments, ...)
+            Note over TeamsMCP: On 403 / 404: fall back to summary-only row (no error)
+        end
+    end
+
+    TeamsMCP->>MCPClient: messages[], returnedCount, moreResultsAvailable
+```
+
+**Key points:**
+
+- Pagination uses `offset`/`size` on the request body and `moreResultsAvailable` on the response — **not** `@odata.nextLink`. The caller advances the page by incrementing `offset` by `size`.
+- The source filter (`chat`/`channel`/`all`) is applied client-side after the Graph response, because the Search API's `entityTypes: ['chatMessage']` covers both containers with no sub-filter.
+- `detail=full` issues one additional Graph call per hit. Concurrency is capped at 5 to avoid Graph throttling. A forbidden or deleted hit falls back to its summary row rather than failing the page.
+- See [Tools Reference](./tools.md) for the full `search_messages` parameter list.
+
+### Chat Send Flow
+
+The send flow applies to personal chats (`send_chat_message`) and team channels (`send_channel_message`). The caller must first obtain the target ID via a `list_*` call.
+
+```mermaid
+%%{init: {'theme': 'neutral', 'themeVariables': { 'fontSize': '14px' }}}%%
+sequenceDiagram
+    autonumber
+    participant MCPClient as MCP Client
+    participant TeamsMCP as Teams MCP Server
+    participant MSGraph as Microsoft Graph API
+
+    Note over MCPClient,MSGraph: Step 1 — discover the target ID (if not already known)
+
+    MCPClient->>TeamsMCP: list_chats / list_teams + list_channels
+    TeamsMCP->>MSGraph: GET /me/chats or GET /me/joinedTeams + GET /teams/{id}/channels
+    MSGraph->>TeamsMCP: chats[] / teams[] + channels[]
+    TeamsMCP->>MCPClient: IDs and display names
+
+    Note over MCPClient,MSGraph: Step 2 — send the message by ID
+
+    alt Personal chat
+        MCPClient->>TeamsMCP: send_chat_message (chatId, message)
+        TeamsMCP->>MSGraph: POST /chats/{chatId}/messages<br/>{ body: { contentType: 'text', content: message } }
+        MSGraph->>TeamsMCP: Created message (id)
+        TeamsMCP->>MCPClient: { id }
+    else Team channel
+        MCPClient->>TeamsMCP: send_channel_message (teamId, channelId, message)
+        TeamsMCP->>MSGraph: POST /teams/{teamId}/channels/{channelId}/messages<br/>{ body: { contentType: 'text', content: message } }
+        MSGraph->>TeamsMCP: Created message (id, webUrl)
+        TeamsMCP->>MCPClient: { id, webUrl }
+    end
+```
+
+**Key points:**
+
+- Only plain-text messages are supported (`contentType: 'text'`). Rich HTML or adaptive cards are not sent.
+- `send_channel_message` returns a `webUrl` linking directly to the posted message in Teams. `send_chat_message` returns only the message `id`.
+- The entire flow is synchronous — the tool returns only after Graph confirms the message was created.
+
 ## Related Documentation
 
 - [Architecture](./architecture.md) - System components and infrastructure

--- a/services/teams-mcp/docs/technical/permissions.md
+++ b/services/teams-mcp/docs/technical/permissions.md
@@ -133,7 +133,7 @@ Each permission is the minimum required for its function. No narrower alternativ
 | Aspect | Detail |
 |--------|--------|
 | **Purpose** | List the user's chats with basic metadata (topic, members, chat type) |
-| **Used For** | `list_chats` tool and resolving chats by topic or member name |
+| **Used For** | `list_chats` tool, which returns chat ids plus distinguishing metadata (topic, members, creation and last-message dates) used to pick the right chat id |
 | **Why Not Less** | No narrower permission exists for listing chats |
 | **Why Not `Chat.Read`** | `Chat.ReadBasic` is sufficient for listing chats; `Chat.Read` is only needed for reading message content |
 
@@ -151,18 +151,18 @@ Each permission is the minimum required for its function. No narrower alternativ
 | Aspect | Detail |
 |--------|--------|
 | **Purpose** | List all Teams the user is a member of |
-| **Used For** | `list_teams` tool and resolving teams by display name |
+| **Used For** | `list_teams` tool, which returns team ids plus `isArchived` status to disambiguate same-named teams |
 | **Why Not Less** | No narrower permission exists for listing joined teams |
-| **Why Not `Team.Read.All`** | `Team.ReadBasic.All` is sufficient for listing teams with display names |
+| **Why Not `Team.Read.All`** | `Team.ReadBasic.All` is sufficient for listing teams with the metadata needed for id-based targeting |
 
 ### `Channel.ReadBasic.All`
 
 | Aspect | Detail |
 |--------|--------|
 | **Purpose** | List channels in a Team |
-| **Used For** | `list_channels` tool and resolving channels by display name |
+| **Used For** | `list_channels` tool, which returns channel ids plus `createdDateTime` and `membershipType` used to pick the right channel id |
 | **Why Not Less** | No narrower permission exists for listing channels |
-| **Why Not `Channel.Read.All`** | `Channel.ReadBasic.All` is sufficient for listing channels with display names |
+| **Why Not `Channel.Read.All`** | `Channel.ReadBasic.All` is sufficient for listing channels with the metadata needed for id-based targeting |
 
 ### `ChannelMessage.Read.All`
 

--- a/services/teams-mcp/docs/technical/security.md
+++ b/services/teams-mcp/docs/technical/security.md
@@ -187,6 +187,18 @@ sequenceDiagram
 - Returned in every webhook payload
 - Requests with invalid `clientState` are rejected
 
+## Write Surface (Send Tools)
+
+The `send_chat_message` and `send_channel_message` tools are **write operations** — they post messages to Teams chats and channels as the signed-in user. This is the first write capability in the Teams MCP Server and is worth stating explicitly.
+
+These tools operate under the same delegated-OAuth and token-isolation model as all read operations: Microsoft tokens are stored encrypted on the server and never sent to the client, and the agent can only post to chats and channels that the signed-in user can access. The `ChannelMessage.Send` and `ChatMessage.Send` permissions cover sending only; they do not grant read access to message content.
+
+## Channel Message Admin Consent
+
+Reading channel message content (`get_channel_messages`, `search_messages` with `detail=full`) requires the `ChannelMessage.Read.All` permission, which **requires admin consent** because channel messages may contain sensitive organisational content. Without admin consent for this permission, the send and list tools remain fully functional.
+
+See [Permissions](./permissions.md) for the full consent breakdown and the distinction between user-consentable and admin-consent-required scopes.
+
 ## Secret Management
 
 ### Required Secrets

--- a/services/teams-mcp/docs/technical/subscription-management.md
+++ b/services/teams-mcp/docs/technical/subscription-management.md
@@ -1,0 +1,94 @@
+<!-- confluence-page-id: 2399993877 -->
+<!-- confluence-space-key: PUBDOC -->
+
+# Teams MCP - Subscription Management
+
+A Microsoft Graph webhook subscription must be active for **meeting transcripts to be ingested automatically**. The server manages the full lifecycle — creation, renewal, expiry detection, and removal — and exposes it through three tools: [`start_kb_integration`](./tools.md#start_kb_integration), [`stop_kb_integration`](./tools.md#stop_kb_integration), and [`verify_kb_integration_status`](./tools.md#verify_kb_integration_status).
+
+!!! note "Transcripts only"
+    This subscription covers **meeting-transcript ingestion** into the Unique knowledge base. Chat and channel messages are read live through Microsoft Graph and are never subscribed to or ingested. The [`ingest_meeting`](./tools.md#ingest_meeting) tool does not require a subscription — it pulls a single meeting's transcript on demand.
+
+## Subscription Creation
+
+Unlike a background-only connector, ingestion is **opt-in per user**: a subscription is created when the user calls `start_kb_integration` (it is not created automatically on connect).
+
+1. `start_kb_integration` invokes `SubscriptionCreateService.subscribe()`
+2. The service creates a Graph subscription for the resource `users/{providerUserId}/onlineMeetings/getAllTranscripts` with `changeType: created`
+3. The subscription is registered with `notificationUrl` (transcript notifications) and `lifecycleNotificationUrl` (lifecycle events), authenticated with a `clientState` webhook secret
+4. The subscription record is stored in the `subscriptions` table (`internalType: 'transcript'`) with the Graph subscription id and its expiration time
+
+The expiration time is set to the next occurrence of the configured off-peak UTC hour (see [`MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC`](#configuration) below), giving a predictable renewal window.
+
+## Subscription Renewal
+
+Subscriptions are renewed via Microsoft Graph lifecycle notifications:
+
+- Microsoft sends a `reauthorizationRequired` lifecycle notification before the subscription expires (the exact timing varies; Microsoft does not guarantee a fixed window, but notifications arrive at least ~15 minutes before expiry)
+- The lifecycle webhook controller enqueues the event, and `SubscriptionReauthorizeService.reauthorize()` PATCHes `/subscriptions/{id}` with a new `expirationDateTime`
+- The new expiration is again the next configured UTC expiration hour, and the `subscriptions` record is updated to match
+
+The database is the source of truth: a `reauthorizationRequired` notification for a subscription id that is not in the `subscriptions` table is ignored.
+
+## Subscription Status
+
+The `verify_kb_integration_status` tool reports one of four statuses:
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `active` | Subscription valid, more than 15 minutes until expiry | None required |
+| `expiring_soon` | 15 minutes or less until expiry | Renewal is automatic; no action needed |
+| `expired` | Subscription has lapsed | Call `start_kb_integration` |
+| `not_configured` | No subscription exists | Call `start_kb_integration` |
+
+## `start_kb_integration`
+
+Safe to call at any time — it is idempotent and inspects the existing subscription before acting:
+
+- **No subscription exists:** creates a new subscription (`created`)
+- **Valid subscription, more than 15 minutes until expiry:** returns `already_active`, no changes made
+- **Valid subscription, expiring within 15 minutes:** returns `expiring_soon`, no changes made — automatic renewal is either in progress or imminent, so a new subscription is deliberately not forced (avoids racing an in-flight renewal)
+- **Expired subscription:** deletes the lapsed record and creates a fresh subscription (`created`)
+
+## `stop_kb_integration`
+
+Removes the transcript-ingestion subscription:
+
+- Deletes the `subscriptions` record (the source of truth), then issues `DELETE /subscriptions/{id}` to Microsoft Graph
+- Returns `removed` when a record was deleted, or `not_found` when nothing was active
+
+Removal stops future automatic ingestion. **Previously ingested transcripts remain in the Unique knowledge base** — `stop_kb_integration` does not delete content. To resume automatic ingestion, call `start_kb_integration` again.
+
+!!! note "Graph deletion is best-effort"
+    Because the database is the source of truth, the local record is removed first. If the subsequent Graph `DELETE` fails, the orphaned Graph subscription is harmless: any later notification it produces is discarded because no matching record exists in the `subscriptions` table.
+
+## Subscription Failure Handling
+
+Microsoft Graph sends lifecycle notifications when a subscription's state changes. The server handles the two it acts on automatically; all other lifecycle events are discarded.
+
+| Condition | What Happens | User Action Required? |
+|-----------|-------------|----------------------|
+| `reauthorizationRequired` lifecycle event | Server automatically PATCHes the subscription with a new expiration time | No |
+| `subscriptionRemoved` lifecycle event | Server deletes the local `subscriptions` record (Graph has already removed it) — automatic ingestion stops | Yes — user must call `start_kb_integration` to re-subscribe |
+| Other lifecycle events (e.g. `missed`) | Discarded and logged; no recovery action is taken | No (but missed transcripts are not retroactively recovered — see note) |
+| Subscription expired (missed renewal) | `verify_kb_integration_status` reports `expired`; no notifications are received | Yes — user must call `start_kb_integration` |
+| No subscription exists | `verify_kb_integration_status` reports `not_configured` | Yes — user must call `start_kb_integration` |
+
+!!! warning "No automatic gap recovery"
+    Teams MCP does not run a catch-up pass for transcripts missed while a subscription was lapsed or after a `missed` lifecycle event. To ingest a specific meeting whose transcript was not captured, use [`ingest_meeting`](./tools.md#ingest_meeting) with the meeting's join URL.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC` | `3` | Hour of day (UTC, 0–23) at which scheduled subscription expirations are set. Choose an off-peak hour to avoid disrupting incoming notifications. |
+| `MICROSOFT_WEBHOOK_SECRET` | (required) | Secret sent as the subscription `clientState` and validated on every incoming notification. |
+| `SELF_URL` / `MICROSOFT_PUBLIC_WEBHOOK_URL` | `SELF_URL` | Public URL Microsoft Graph posts notifications to. |
+
+## Related Documentation
+
+- [Tools](./tools.md#start_kb_integration) - `start_kb_integration`, `stop_kb_integration`, `verify_kb_integration_status`, and `ingest_meeting` tool reference
+- [Flows](./flows.md) - Subscription lifecycle and transcript-processing sequence diagrams
+- [Permissions](./permissions.md) - The `OnlineMeetingTranscript.Read.All` / `OnlineMeetingRecording.Read.All` admin-consent scopes the subscription depends on
+- [Configuration](../operator/configuration.md) - `MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC` and webhook settings
+</content>
+</invoke>

--- a/services/teams-mcp/docs/technical/subscription-management.md
+++ b/services/teams-mcp/docs/technical/subscription-management.md
@@ -90,5 +90,3 @@ Microsoft Graph sends lifecycle notifications when a subscription's state change
 - [Flows](./flows.md) - Subscription lifecycle and transcript-processing sequence diagrams
 - [Permissions](./permissions.md) - The `OnlineMeetingTranscript.Read.All` / `OnlineMeetingRecording.Read.All` admin-consent scopes the subscription depends on
 - [Configuration](../operator/configuration.md) - `MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC` and webhook settings
-</content>
-</invoke>

--- a/services/teams-mcp/docs/technical/tools.md
+++ b/services/teams-mcp/docs/technical/tools.md
@@ -1,0 +1,508 @@
+<!-- confluence-page-id: 2398519349 -->
+<!-- confluence-space-key: PUBDOC -->
+
+# Teams MCP - Tools
+
+The Teams MCP Server exposes **14 tools** in two categories:
+
+- **Chat & messaging tools** (8) interact with Microsoft Teams chats and channels synchronously through the Microsoft Graph API: list teams/channels/chats, read messages, search across messages, and send messages.
+- **Transcript & knowledge-base tools** (6) manage meeting-transcript ingestion into the Unique knowledge base and search the transcripts that have already been ingested.
+
+All chat and messaging tools use **id-only targeting**. There is no name-based addressing: you discover the id you need with a `list_*` tool (or `search_messages`), then pass that id to the tool that reads or writes. The canonical workflow is:
+
+```
+list_teams / list_chats / list_channels  →  id  →  get_*_messages / send_*_message
+```
+
+The `list_*` tools return distinguishing metadata (creation dates, last-message timestamps, archived/membership flags, member names) so the agent can pick the right id when several teams, chats, or channels share a display name.
+
+!!! note "Historical note: id-only targeting"
+    Earlier pre-release builds accepted display names and resolved them with an interactive disambiguation picker. That path was removed: every chat/channel tool now takes ids only, and the `list_*` tools surface the metadata needed to choose between same-named entities. (The transcript `ingest_meeting` tool still uses interactive elicitation to pick between multiple transcripts of one recurring meeting — see below.)
+
+## Tool Overview
+
+| Tool | Category | Mutating | Description |
+|------|----------|----------|-------------|
+| [`list_teams`](#list_teams) | Teams & Channels | No | List the Teams the signed-in user belongs to |
+| [`list_channels`](#list_channels) | Teams & Channels | No | List the channels in a team |
+| [`list_chats`](#list_chats) | Chats | No | List the signed-in user's chats |
+| [`get_chat_messages`](#get_chat_messages) | Messages | No | Read recent messages from a chat |
+| [`get_channel_messages`](#get_channel_messages) | Messages | No | Read recent messages from a channel |
+| [`send_chat_message`](#send_chat_message) | Messages | Yes | Send a plain-text message to a chat |
+| [`send_channel_message`](#send_channel_message) | Messages | Yes | Send a plain-text message to a channel |
+| [`search_messages`](#search_messages) | Search | No | Search messages across chats and channels |
+| [`find_transcripts`](#find_transcripts) | Transcript & KB | No | Semantic + keyword search within ingested transcripts |
+| [`list_meetings`](#list_meetings) | Transcript & KB | No | Browse ingested meetings by date/organizer/participant |
+| [`ingest_meeting`](#ingest_meeting) | Transcript & KB | Yes | Ingest a specific meeting's transcript on demand |
+| [`verify_kb_integration_status`](#verify_kb_integration_status) | Transcript & KB | No | Check transcript-ingestion subscription status |
+| [`start_kb_integration`](#start_kb_integration) | Transcript & KB | Yes | Start automatic transcript ingestion |
+| [`stop_kb_integration`](#stop_kb_integration) | Transcript & KB | Yes | Stop automatic transcript ingestion |
+
+**Mutating** means the tool writes data to at least one of the following:
+
+- **Microsoft Teams** — posts a new message to a chat or channel via Microsoft Graph, on behalf of the signed-in user
+- **Internal database** — persists or removes state managed by this server (e.g. the transcript-ingestion subscription record)
+- **Unique knowledge base** — queues meeting-transcript content for indexing into the knowledge base used by `find_transcripts`
+
+| Tool | What it mutates |
+|------|----------------|
+| `send_chat_message` | Posts a new plain-text message to the target chat via Microsoft Graph as the signed-in user |
+| `send_channel_message` | Posts a new plain-text message to the target channel via Microsoft Graph as the signed-in user |
+| `start_kb_integration` | Creates a Microsoft Graph webhook subscription for new transcripts and writes the subscription record to the internal database |
+| `stop_kb_integration` | Cancels the Microsoft Graph webhook subscription and removes the subscription record from the internal database |
+| `ingest_meeting` | Queues the selected meeting transcript(s) for asynchronous ingestion into the Unique knowledge base |
+
+!!! warning "Chat and channel messages are not ingested"
+    The message tools read and write Teams messages live through Microsoft Graph. Unlike meeting transcripts, **chat and channel messages are never copied into the Unique knowledge base** — `get_*_messages` and `search_messages` query Microsoft Graph on every call. Only meeting transcripts are ingested (via `start_kb_integration` / `ingest_meeting`) and searched with `find_transcripts`.
+
+---
+
+## Teams & Channels
+
+### `list_teams`
+
+List all Microsoft Teams the signed-in user is a member of. Each team carries an `isArchived` flag (archived teams are read-only) to distinguish teams that share a display name.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `includeDescriptions` | boolean | No | `false` | Include each team's description. Useful when several teams have similar names. |
+
+**Returns:** A `teams` array. Each entry has `teamId`, `displayName`, `isArchived` (`true`/`false`/`null`), and `description` (only when `includeDescriptions` is `true` and a description exists). Pass `teamId` to `list_channels`, `get_channel_messages`, or `send_channel_message`.
+
+**Example:**
+
+```json
+{
+  "teams": [
+    { "teamId": "19:abc...@thread.tacv2", "displayName": "Engineering", "isArchived": false },
+    { "teamId": "19:def...@thread.tacv2", "displayName": "Engineering", "isArchived": true }
+  ]
+}
+```
+
+---
+
+### `list_channels`
+
+List all channels in a team, identified by `teamId`. Each channel carries its creation date and membership type (`standard`, `private`, or `shared`) to tell apart channels that share a display name.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `teamId` | string | Yes | — | Exact team id from `list_teams`. |
+| `includeDescriptions` | boolean | No | `false` | Include each channel's description. |
+
+**Returns:** The `teamId` and a `channels` array. Each entry has `channelId`, `displayName`, `createdDateTime`, `membershipType`, and `description` (only when `includeDescriptions` is `true`). Pass `teamId` + `channelId` to `get_channel_messages` or `send_channel_message`.
+
+**Example:**
+
+```json
+{
+  "teamId": "19:abc...@thread.tacv2",
+  "channels": [
+    {
+      "channelId": "19:ch1...@thread.tacv2",
+      "displayName": "General",
+      "createdDateTime": "2023-04-01T09:00:00Z",
+      "membershipType": "standard"
+    }
+  ]
+}
+```
+
+---
+
+## Chats
+
+### `list_chats`
+
+List the signed-in user's chats (1:1, group, and meeting chats), most recent first. Each chat carries its creation date and last-message timestamp to tell apart chats that share a topic or members. For chats without a topic (typically 1:1 chats), the member list is returned so the chat can be identified by participant.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `limit` | integer (1–50) | No | `50` | Maximum number of chats to return. |
+| `includeMemberEmails` | boolean | No | `false` | Include member email addresses (only for topic-less chats). Useful when two members share a display name. |
+
+**Returns:** A `chats` array and a `truncated` flag (`true` when more chats exist than were returned). Each chat has `chatId`, `chatType`, `topic` (nullable), `createdDateTime`, `lastMessageAt`, and — for chats without a topic — a `members` array (`displayName`, plus `email` when `includeMemberEmails` is `true`). Pass `chatId` to `get_chat_messages` or `send_chat_message`.
+
+**Example:**
+
+```json
+{
+  "chats": [
+    {
+      "chatId": "19:meeting_xyz@thread.v2",
+      "chatType": "meeting",
+      "topic": "Weekly Sync",
+      "createdDateTime": "2024-01-10T08:00:00Z",
+      "lastMessageAt": "2024-06-20T14:32:00Z"
+    },
+    {
+      "chatId": "19:1on1@unq.gbl.spaces",
+      "chatType": "oneOnOne",
+      "topic": null,
+      "createdDateTime": "2023-11-02T10:00:00Z",
+      "lastMessageAt": "2024-06-19T09:15:00Z",
+      "members": [{ "displayName": "Alice Smith" }]
+    }
+  ],
+  "truncated": false
+}
+```
+
+---
+
+## Messages
+
+The two `get_*_messages` tools share the same content-shaping options. Content can be returned **normalized** (the default — Teams HTML converted to readable plain text) or **raw** (Teams HTML verbatim). Normalization rewrites `<at>Name</at>` mentions to `@Name`, attachment references to `[attachment: name]` (or `[attachment]` when the name is unknown), adaptive-card payloads to `[card]`, and blank/tombstone messages to `[deleted]`.
+
+### `get_chat_messages`
+
+Retrieve recent messages from a chat, identified by `chatId`. Call `list_chats` (or `search_messages`) first to find the `chatId`.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `chatId` | string | Yes | — | Exact chat id from `list_chats` or `search_messages`. |
+| `limit` | integer (1–50) | No | `20` | Maximum number of messages to return (newest first). |
+| `contentFormat` | `normalized` \| `raw` | No | `normalized` | `normalized` converts HTML to readable text; `raw` returns Teams HTML verbatim. |
+| `includeSystemMessages` | boolean | No | `false` | Include event notifications (member added, call ended). |
+| `timestampFormat` | `full` \| `short` \| `none` | No | `short` | `full` = ISO 8601 with ms; `short` = `YYYY-MM-DD HH:mm`; `none` = omit timestamps. |
+| `detail` | `standard` \| `full` | No | `standard` | `standard` returns sender, content, and timestamp; `full` also adds `contentType` (the source format from Graph). |
+
+**Returns:** The `chatId` and a `messages` array (newest first). Each message has `id`, `senderDisplayName` (nullable), `content`, `createdDateTime` (omitted when `timestampFormat=none`), and `contentType` (only when `detail=full`).
+
+**Example:**
+
+```json
+{
+  "chatId": "19:1on1@unq.gbl.spaces",
+  "messages": [
+    {
+      "id": "1718901120000",
+      "senderDisplayName": "Alice Smith",
+      "content": "@Bob Jones can you review the PR? [attachment: design.pdf]",
+      "createdDateTime": "2024-06-20 14:32"
+    }
+  ]
+}
+```
+
+---
+
+### `get_channel_messages`
+
+Retrieve recent messages from a channel, identified by `teamId` + `channelId`. Call `list_teams` then `list_channels` first to find the ids.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `teamId` | string | Yes | — | Exact team id from `list_teams`. |
+| `channelId` | string | Yes | — | Exact channel id from `list_channels` (for that team). |
+| `limit` | integer (1–50) | No | `20` | Maximum number of messages to return (newest first). |
+| `contentFormat` | `normalized` \| `raw` | No | `normalized` | `normalized` converts HTML to readable text; `raw` returns Teams HTML verbatim. |
+| `includeSystemMessages` | boolean | No | `false` | Include event notifications (member added, call ended). |
+| `timestampFormat` | `full` \| `short` \| `none` | No | `short` | `full` = ISO 8601 with ms; `short` = `YYYY-MM-DD HH:mm`; `none` = omit timestamps. |
+| `detail` | `standard` \| `full` | No | `standard` | `standard` returns sender, content, and timestamp; `full` also adds `contentType`. |
+
+**Returns:** The `teamId`, `channelId`, and a `messages` array (same shape as `get_chat_messages`).
+
+**Example:**
+
+```json
+{
+  "teamId": "19:abc...@thread.tacv2",
+  "channelId": "19:ch1...@thread.tacv2",
+  "messages": [
+    {
+      "id": "1718900000000",
+      "senderDisplayName": "Carol Lee",
+      "content": "Deploy is green.",
+      "createdDateTime": "2024-06-20 13:50"
+    }
+  ]
+}
+```
+
+---
+
+### `send_chat_message`
+
+Send a plain-text message to a chat (1:1 or group), identified by `chatId`. Call `list_chats` first to find the `chatId`.
+
+!!! warning "Plain text only"
+    Send tools accept **plain text only**. Rich content, `@mentions`, threading/replies, and attachment uploads are not supported. The message is posted as the signed-in user.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `chatId` | string | Yes | — | Exact chat id from `list_chats` or `search_messages`. |
+| `message` | string | Yes | — | Plain-text message content to send. |
+
+**Returns:** `messageId` and the `chatId` the message was posted to.
+
+**Example:**
+
+```json
+{ "messageId": "1718901500000", "chatId": "19:1on1@unq.gbl.spaces" }
+```
+
+---
+
+### `send_channel_message`
+
+Send a plain-text message to a channel, identified by `teamId` + `channelId`. Call `list_teams` then `list_channels` first to find the ids.
+
+!!! warning "Plain text only"
+    Plain text only — no rich content, `@mentions`, threading/replies, or attachments. The message is posted as the signed-in user.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `teamId` | string | Yes | — | Exact team id from `list_teams`. |
+| `channelId` | string | Yes | — | Exact channel id from `list_channels` (for that team). |
+| `message` | string | Yes | — | Plain-text message content to send. |
+| `includeWebUrl` | boolean | No | `false` | Include the Teams web URL of the sent message in the response. |
+
+**Returns:** `messageId`, and `webUrl` when `includeWebUrl` is `true` and Graph returned one.
+
+**Example:**
+
+```json
+{ "messageId": "1718901600000", "webUrl": "https://teams.microsoft.com/l/message/..." }
+```
+
+---
+
+## Search
+
+### `search_messages`
+
+Search Microsoft Teams messages by keyword across 1:1 chats, group chats, and channels in a single query, using the [Microsoft Search API](https://learn.microsoft.com/en-us/graph/search-concept-overview) (`POST /search/query` on Graph **v1.0**). Supports identity and scope filters. Results are snippets by default; set `detail=full` to hydrate message bodies. At least one search criterion (`query`, `from`, `to`, `mentions`, `sentAfter`, `sentBefore`, `hasAttachment`, `isRead`, or `isMentioned`) must be provided.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | No | — | Free-text keywords to match in message content. Multi-word terms are quoted automatically. |
+| `from` | string | No | — | Sender name or email (KQL `from:`). Matches the message author. |
+| `to` | string | No | — | Recipient name or email (KQL `to:`). |
+| `mentions` | string (GUID) | No | — | User object id of a mentioned user; dashes are stripped automatically. |
+| `sentAfter` | string (ISO date) | No | — | Only messages sent on or after this date (e.g. `2024-01-15`). |
+| `sentBefore` | string (ISO date) | No | — | Only messages sent on or before this date (e.g. `2024-01-31`). |
+| `hasAttachment` | boolean | No | — | Restrict to messages with (`true`) or without (`false`) attachments. |
+| `isRead` | boolean | No | — | Restrict to read (`true`) or unread (`false`) messages. |
+| `isMentioned` | boolean | No | — | Restrict to messages where the signed-in user is (`true`) or is not (`false`) mentioned. |
+| `source` | `chat` \| `channel` \| `all` | No | `all` | Filter results by container. Applied after the search, so a non-`all` value shrinks the returned page. |
+| `detail` | `summary` \| `full` | No | `summary` | `summary` returns the hit snippet only (1 Graph call). `full` hydrates each hit with its message body (one extra Graph call per hit). |
+| `contentFormat` | `normalized` \| `raw` | No | `normalized` | Only applies when `detail=full`. `normalized` converts HTML to readable text; `raw` returns Teams HTML verbatim. |
+| `offset` | integer (≥ 0) | No | `0` | Number of results to skip for pagination (maps to Graph `from`). |
+| `size` | integer (1–`GRAPH_PAGE_SIZE`) | No | `25` | Maximum number of results per page. |
+
+**Returns:** A `messages` array, `returnedCount` (rows on **this page**, after the `source` filter — not total corpus matches), and `moreResultsAvailable` (paginate with `offset` until this is `false`). Each hit has:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Message id |
+| `source` | `chat` or `channel` (derived from the hit's resource shape) |
+| `chatId` | Chat id (present for chat hits, else `null`) |
+| `teamId` | Team id (present for channel hits, else `null`) |
+| `channelId` | Channel id (present for channel hits, else `null`) |
+| `senderDisplayName` | Sender name (nullable) |
+| `summary` | Search snippet (nullable) |
+| `content` | Hydrated message body — present only when `detail=full` and hydration succeeded |
+| `createdDateTime` | Message timestamp (nullable) |
+| `webUrl` | Deep link to the message (nullable) |
+
+Pass the returned `chatId` (or `teamId` + `channelId`) straight to `get_*_messages` or `send_*_message`.
+
+!!! note "How `detail=full` hydration behaves"
+    Hydration issues one extra Graph call per hit (an N+1 fan-out), capped at 5 concurrent requests to stay throttle-friendly. If an individual hit is forbidden or deleted, that row falls back to summary-only (no `content`) rather than failing the whole page.
+
+**Example:**
+
+```json
+{
+  "messages": [
+    {
+      "id": "1718900000000",
+      "source": "channel",
+      "chatId": null,
+      "teamId": "19:abc...@thread.tacv2",
+      "channelId": "19:ch1...@thread.tacv2",
+      "senderDisplayName": "Carol Lee",
+      "summary": "Deploy is <c0>green</c0>.",
+      "createdDateTime": "2024-06-20T13:50:00Z",
+      "webUrl": "https://teams.microsoft.com/l/message/..."
+    }
+  ],
+  "returnedCount": 1,
+  "moreResultsAvailable": false
+}
+```
+
+---
+
+## Transcript & Knowledge-Base Management
+
+These tools manage and search **meeting transcripts** ingested into the Unique knowledge base. This is distinct from the message tools above — chat and channel messages are never ingested.
+
+### `find_transcripts`
+
+Search within ingested meeting transcripts using hybrid semantic + keyword search. Returns relevant passages that can be cited with `[N]` notation, where `N` is the result index.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | — | Search query to match content within transcripts. |
+| `subject` | string | No | — | Filter by meeting subject (partial match). |
+| `dateFrom` | string (ISO 8601 datetime) | No | — | Only transcripts whose meeting started on or after this datetime. |
+| `dateTo` | string (ISO 8601 datetime) | No | — | Only transcripts whose meeting started on or before this datetime. |
+| `organizer` | string | No | — | Filter by meeting organizer name or email (partial match). |
+| `participant` | string | No | — | Filter by participant name or email (partial match). |
+| `limit` | integer (1–100) | No | `10` | Maximum number of results to return. |
+
+**Returns:** A `results` array of passages. Each has `id` (content id), `chunkId`, `title`, `key`, `text` (the passage), `url` (`unique://content/{id}`), `meetingDate`, `startDatetime`, `endDatetime`, `organizer`, and `participants`. Cite a passage with `[N]` where `N` is its array index.
+
+**Example:**
+
+```json
+{
+  "results": [
+    {
+      "id": "cont_abc123",
+      "title": "Q2 Planning",
+      "text": "We agreed to ship the connector in July...",
+      "url": "unique://content/cont_abc123",
+      "meetingDate": "2024-06-01T10:00:00Z",
+      "organizer": "Alice Smith",
+      "participants": ["Alice Smith", "Bob Jones"]
+    }
+  ]
+}
+```
+
+---
+
+### `list_meetings`
+
+Browse ingested meetings without a search query. Use this to discover meetings by date range, organizer, participant, or subject; then use `find_transcripts` to search within them.
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `dateFrom` | string (ISO 8601 datetime) | No | — | Meetings that started on or after this datetime. |
+| `dateTo` | string (ISO 8601 datetime) | No | — | Meetings that started on or before this datetime. |
+| `organizer` | string | No | — | Filter by organizer name or email (partial match). |
+| `participant` | string | No | — | Filter by participant name or email (partial match). |
+| `subject` | string | No | — | Filter by meeting subject (partial match). |
+| `skip` | integer (≥ 0) | No | `0` | Number of results to skip (pagination). |
+| `take` | integer (1–50) | No | `20` | Maximum number of meetings to return. |
+
+**Returns:** A `meetings` array and `total` (number of matching meetings). Each meeting has `id` (content id — reference it in other tools), `title`, `meetingDate`, `startDatetime`, `endDatetime`, `organizer`, and `participants`.
+
+**Example:**
+
+```json
+{
+  "meetings": [
+    {
+      "id": "cont_abc123",
+      "title": "Q2 Planning",
+      "meetingDate": "2024-06-01T10:00:00Z",
+      "organizer": "Alice Smith",
+      "participants": ["Alice Smith", "Bob Jones"]
+    }
+  ],
+  "total": 1
+}
+```
+
+---
+
+### `ingest_meeting`
+
+Ingest a specific Teams meeting's transcript on demand, identified by its join URL. Use this to ingest a meeting that predates the knowledge-base integration, or to re-pull a single occurrence. You must be the organizer or an invited attendee. Ingestion runs asynchronously; the tool returns once the transcript is queued.
+
+!!! note "Interactive transcript selection"
+    When a recurring meeting has multiple transcripts and no `date` is given, the tool prompts the user to choose via MCP elicitation. If the client does not support elicitation, pass an explicit `date` (`YYYY-MM-DD`).
+
+**Input parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `joinUrl` | string (URL) | Yes | — | The Teams meeting join URL (`joinWebUrl`). You must be the organizer or an invited attendee. |
+| `date` | string (ISO date) | No | — | Day (`YYYY-MM-DD`, UTC) to pick a transcript when a recurring meeting has several. |
+
+**Returns:** `success`, a human-readable `message`, `meeting` (`id`, `subject`, `joinUrl` — or `null` if not found), and `queued` (array of `{ transcriptId, createdDate }` for each transcript queued for ingestion).
+
+**Example:**
+
+```json
+{
+  "success": true,
+  "message": "Queued 1 transcript(s) for ingestion. They will appear in the knowledge base shortly.",
+  "meeting": { "id": "MSo...", "subject": "Q2 Planning", "joinUrl": "https://teams.microsoft.com/l/meetup-join/..." },
+  "queued": [{ "transcriptId": "MSMjMCMj...", "createdDate": "2024-06-01T10:05:00.000Z" }]
+}
+```
+
+---
+
+### `verify_kb_integration_status`
+
+Check the status of the transcript-ingestion knowledge-base integration: whether automatic ingestion is active, expiring soon, expired, or not configured.
+
+**Input parameters:** None
+
+**Returns:** `status` (`active` \| `expiring_soon` \| `expired` \| `not_configured`), a `message`, and `subscription` (`id`, `expiresAt`, `minutesUntilExpiration`, `createdAt`, `updatedAt` — or `null` when not configured).
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `active` | Ingestion subscription is valid | None required |
+| `expiring_soon` | Expires within 15 minutes | Renewal is automatic; no action needed |
+| `expired` | Subscription has lapsed | Call `start_kb_integration` |
+| `not_configured` | No subscription exists | Call `start_kb_integration` |
+
+---
+
+### `start_kb_integration`
+
+Start automatic ingestion of meeting transcripts into the knowledge base. Creates a Microsoft Graph webhook subscription so new transcripts are ingested as they become available. Safe to call when already active — it returns `already_active` without creating a duplicate.
+
+**Input parameters:** None
+
+**Returns:** `success`, a `message`, and `subscription` (`id`, `expiresAt`, `minutesUntilExpiration`, `status` — one of `created`, `already_active`, `expiring_soon`).
+
+---
+
+### `stop_kb_integration`
+
+Stop automatic ingestion of meeting transcripts. Removes the Microsoft Graph webhook subscription; previously ingested transcripts remain in the knowledge base.
+
+**Input parameters:** None
+
+**Returns:** `success`, a `message`, and `subscription` (`id`, `status` — `removed` or `not_found` — or `null` when nothing was active).
+
+---
+
+## Related Documentation
+
+- [Architecture](./architecture.md) - System components, including the chat and transcript modules
+- [Flows](./flows.md) - Sequence diagrams for the read, search, send, and transcript flows
+- [Subscription Management](./subscription-management.md) - Lifecycle behind `start_kb_integration` / `stop_kb_integration` / `verify_kb_integration_status`
+- [Permissions](./permissions.md) - Microsoft Graph permissions required by these tools
+- [Security](./security.md) - Token isolation, delegated access, and the message-send write surface
+</content>
+</invoke>

--- a/services/teams-mcp/docs/technical/tools.md
+++ b/services/teams-mcp/docs/technical/tools.md
@@ -504,5 +504,3 @@ Stop automatic ingestion of meeting transcripts. Removes the Microsoft Graph web
 - [Subscription Management](./subscription-management.md) - Lifecycle behind `start_kb_integration` / `stop_kb_integration` / `verify_kb_integration_status`
 - [Permissions](./permissions.md) - Microsoft Graph permissions required by these tools
 - [Security](./security.md) - Token isolation, delegated access, and the message-send write surface
-</content>
-</invoke>

--- a/services/teams-mcp/docs/technical/tools.md
+++ b/services/teams-mcp/docs/technical/tools.md
@@ -8,16 +8,13 @@ The Teams MCP Server exposes **14 tools** in two categories:
 - **Chat & messaging tools** (8) interact with Microsoft Teams chats and channels synchronously through the Microsoft Graph API: list teams/channels/chats, read messages, search across messages, and send messages.
 - **Transcript & knowledge-base tools** (6) manage meeting-transcript ingestion into the Unique knowledge base and search the transcripts that have already been ingested.
 
-All chat and messaging tools use **id-only targeting**. There is no name-based addressing: you discover the id you need with a `list_*` tool (or `search_messages`), then pass that id to the tool that reads or writes. The canonical workflow is:
+Chat and messaging tools target chats and channels by id: you discover the id with a `list_*` tool (or `search_messages`), then pass it to the tool that reads or writes:
 
 ```
 list_teams / list_chats / list_channels  →  id  →  get_*_messages / send_*_message
 ```
 
 The `list_*` tools return distinguishing metadata (creation dates, last-message timestamps, archived/membership flags, member names) so the agent can pick the right id when several teams, chats, or channels share a display name.
-
-!!! note "Historical note: id-only targeting"
-    Earlier pre-release builds accepted display names and resolved them with an interactive disambiguation picker. That path was removed: every chat/channel tool now takes ids only, and the `list_*` tools surface the metadata needed to choose between same-named entities. (The transcript `ingest_meeting` tool still uses interactive elicitation to pick between multiple transcripts of one recurring meeting — see below.)
 
 ## Tool Overview
 


### PR DESCRIPTION
## What

Brings the `services/teams-mcp/docs/` tree into agreement with the shipped **0.2.22** behavior. The docs were written on the (now false) premise that this is a background-only connector with **no interactive tools**. It now exposes **14 MCP tools** (8 chat/messaging + 6 transcript/KB) with **id-only targeting** (`list_* → id → act`).

Releases that drove this: 0.2.20 (#344, added ChatModule), 0.2.21 (#653), 0.2.22 (#656, reversed to id-only).

## New pages

- **`technical/tools.md`** — single source of truth for the tool surface: overview table → "what it mutates" → per-tool params/returns/JSON examples, mirroring `outlook-semantic-mcp`. Includes the full `search_messages` contract (Microsoft Search API on Graph v1.0, `detail=full` N+1 hydration, `offset`/`moreResultsAvailable` pagination) and content-normalization rules. _(Confluence: 2398519349)_
- **`technical/subscription-management.md`** — transcript-ingestion webhook lifecycle (create / renew / status / removal) behind `start_kb_integration` / `stop_kb_integration` / `verify_kb_integration_status`. Documents the Teams-specific divergences from outlook (opt-in via `start_kb_integration`, `getAllTranscripts` resource, no automatic gap recovery). _(Confluence: 2399993877)_

## Correctness fixes

- Removed false "does not expose/provide tools" statements (`faq.md`, `technical/README.md`).
- Reworded `permissions.md` justifications from resolve-by-name to the id-discovery model.
- Reconciled the three permission tables (`README.md`, `operator/authentication.md`, `technical/permissions.md`) to the canonical **13 scopes** with identical admin-consent flags.

## Audience coverage

- **architecture.md** — ChatModule as a first-class component (chat/channel/search services) + synchronous chat request path.
- **flows.md** — new read / search / send chat sequence diagrams (Mermaid).
- **security.md** — note on the message-send write surface + `ChannelMessage.Read.All` admin consent.
- **operator/** — corrected tool inventory (14), expanded auth scope table, added "Testing chat tools" to local-development. `configuration.md` deliberately unchanged (no real chat env var; hydration concurrency is hard-coded).

## Verification

- All 14 registered tools (`src/{chat,transcript}/tools/*.tool.ts`) appear in `tools.md`.
- Tool param tables spot-checked against the Zod schemas (esp. `search_messages`).
- Stale-term sweep clean (only intentional historical notes remain).
- Three permission tables have identical 13-scope sets + admin-consent flags.
- New Mermaid diagrams validated.
- Both new pages carry their `confluence-page-id` / `confluence-space-key: PUBDOC` headers.

Docs-only change; no source modified.