### PR TITLE
fix(teams-mcp): attribute upstream Microsoft/network failures to the consumer

### DIFF
--- a/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { MsChatMessage } from '../chat.dtos';
 import { ChatService } from '../chat.service';
 import { normalizeContent } from '../utils/normalize-content';
@@ -88,6 +89,7 @@ export class GetChannelMessagesTool {
       'unique.app/icon': 'message-square',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async getChannelMessages(
     input: z.infer<typeof GetChannelMessagesInputSchema>,

--- a/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { MsChatMessage } from '../chat.dtos';
 import { ChatService } from '../chat.service';
 import { normalizeContent } from '../utils/normalize-content';
@@ -84,6 +85,7 @@ export class GetChatMessagesTool {
       'unique.app/icon': 'message-square',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async getChatMessages(
     input: z.infer<typeof GetChatMessagesInputSchema>,

--- a/services/teams-mcp/src/chat/tools/list-channels.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-channels.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { ChannelService } from '../channel.service';
 
 const ListChannelsInputSchema = z.object({
@@ -55,6 +56,7 @@ export class ListChannelsTool {
       'unique.app/icon': 'hash',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async listChannels(
     input: z.infer<typeof ListChannelsInputSchema>,

--- a/services/teams-mcp/src/chat/tools/list-chats.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-chats.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { MsChat } from '../chat.dtos';
 import { ChatService } from '../chat.service';
 
@@ -72,6 +73,7 @@ export class ListChatsTool {
       'unique.app/icon': 'message-circle',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async listChats(
     input: z.infer<typeof ListChatsInputSchema>,

--- a/services/teams-mcp/src/chat/tools/list-teams.tool.ts
+++ b/services/teams-mcp/src/chat/tools/list-teams.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { ChannelService } from '../channel.service';
 
 const ListTeamsInputSchema = z.object({
@@ -52,6 +53,7 @@ export class ListTeamsTool {
       'unique.app/icon': 'users',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async listTeams(
     input: z.infer<typeof ListTeamsInputSchema>,

--- a/services/teams-mcp/src/chat/tools/search-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/search-messages.tool.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { GRAPH_PAGE_SIZE } from '~/msgraph/graph-pagination';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { SearchService } from '../search.service';
 
 const SearchMessagesInputSchema = z
@@ -141,6 +142,7 @@ export class SearchMessagesTool {
       'unique.app/icon': 'search',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async searchMessages(
     input: z.infer<typeof SearchMessagesInputSchema>,

--- a/services/teams-mcp/src/chat/tools/send-channel-message.tool.ts
+++ b/services/teams-mcp/src/chat/tools/send-channel-message.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { ChannelService } from '../channel.service';
 
 const SendChannelMessageInputSchema = z.object({
@@ -53,6 +54,7 @@ export class SendChannelMessageTool {
         'Call list_teams then list_channels first to get teamId + channelId, then send by id.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async sendChannelMessage(
     input: z.infer<typeof SendChannelMessageInputSchema>,

--- a/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
+++ b/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
@@ -3,6 +3,7 @@ import { type Context, Tool } from '@unique-ag/mcp-server-module';
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { ChatService } from '../chat.service';
 
 const SendChatMessageInputSchema = z.object({
@@ -45,6 +46,7 @@ export class SendChatMessageTool {
       'unique.app/system-prompt': 'Call list_chats first to get the chatId, then send by chatId.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async sendChatMessage(
     input: z.infer<typeof SendChatMessageInputSchema>,

--- a/services/teams-mcp/src/msgraph/metrics.middleware.spec.ts
+++ b/services/teams-mcp/src/msgraph/metrics.middleware.spec.ts
@@ -1,0 +1,61 @@
+import type { Context, Middleware } from '@microsoft/microsoft-graph-client';
+import type { MetricService } from 'nestjs-otel';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetricsMiddleware } from './metrics.middleware';
+
+const mockCounter = { add: vi.fn() };
+const mockHistogram = { record: vi.fn() };
+const mockMetricService: Pick<MetricService, 'getCounter' | 'getHistogram'> = {
+  getCounter: vi.fn().mockReturnValue(mockCounter),
+  getHistogram: vi.fn().mockReturnValue(mockHistogram),
+};
+
+function makeContext(): Context {
+  return {
+    request: 'https://graph.microsoft.com/v1.0/chats/abc/messages',
+    options: { method: 'GET' },
+  } as Context;
+}
+
+function throwingNext(error: unknown): Middleware {
+  return {
+    execute: vi.fn().mockRejectedValue(error),
+    setNext: vi.fn(),
+  };
+}
+
+describe('MetricsMiddleware request counter on failure', () => {
+  let unit: MetricsMiddleware;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unit = new MetricsMiddleware(mockMetricService as MetricService);
+  });
+
+  it('records status_class "network" when the failure is a transport error', async () => {
+    const networkError = new TypeError('fetch failed');
+    (networkError as NodeJS.ErrnoException).cause = Object.assign(new Error('EAI_AGAIN'), {
+      code: 'EAI_AGAIN',
+    });
+    unit.setNext(throwingNext(networkError));
+
+    await expect(unit.execute(makeContext())).rejects.toBe(networkError);
+
+    expect(mockCounter.add).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status_class: 'network' }),
+    );
+  });
+
+  it('records status_class "5xx" when the failure is not a transport error', async () => {
+    const serverError = new Error('Error while processing response.');
+    unit.setNext(throwingNext(serverError));
+
+    await expect(unit.execute(makeContext())).rejects.toBe(serverError);
+
+    expect(mockCounter.add).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ status_class: '5xx' }),
+    );
+  });
+});

--- a/services/teams-mcp/src/msgraph/metrics.middleware.ts
+++ b/services/teams-mcp/src/msgraph/metrics.middleware.ts
@@ -3,6 +3,7 @@ import { Logger } from '@nestjs/common';
 import type { Counter, Histogram } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
 import { serializeError } from 'serialize-error-cjs';
+import { isUpstreamNetworkError } from '../utils/classify-error';
 import { normalizeError } from '../utils/normalize-error';
 
 export class MetricsMiddleware implements Middleware {
@@ -157,7 +158,8 @@ export class MetricsMiddleware implements Middleware {
       this.msgraphRequestCounter.add(1, {
         endpoint,
         method,
-        status_class: '5xx',
+        // Distinguish "couldn't reach Microsoft" (DNS/connectivity) from "Microsoft's server errored".
+        status_class: isUpstreamNetworkError(error) ? 'network' : '5xx',
       });
 
       this.msgraphRequestDuration.record(duration / 1000, {

--- a/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/find-transcripts.tool.ts
@@ -7,6 +7,7 @@ import { TEAMS_SOURCE_KIND } from '~/unique/unique.consts';
 import { type PublicSearchRequest, SearchType } from '~/unique/unique.dtos';
 import { UniqueContentService } from '~/unique/unique-content.service';
 import { UniqueUserMappingService } from '~/unique/unique-user-mapping.service';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { buildTranscriptFilter, parseTranscriptMetadata } from './transcript-tools.helpers';
 
 const FindTranscriptsInputSchema = z.object({
@@ -91,6 +92,7 @@ export class FindTranscriptsTool {
         'Use this tool to search meeting transcripts. Cite results using [N] where N is the array index (e.g., [0] for first result, [1] for second). The platform will automatically convert these to proper references.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async findTranscripts(
     input: z.infer<typeof FindTranscriptsInputSchema>,

--- a/services/teams-mcp/src/transcript/tools/ingest-meeting.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/ingest-meeting.tool.ts
@@ -6,6 +6,7 @@ import * as z from 'zod';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import { collectAllPages, GRAPH_PAGE_SIZE } from '~/msgraph/graph-pagination';
 import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { MeetingCollection, Transcript } from '../transcript.dtos';
 import { TranscriptCreatedService } from '../transcript-created.service';
 
@@ -71,6 +72,7 @@ export class IngestMeetingTool {
         'Ingests a specific Teams meeting transcript by its join URL. Ask the user for the meeting join URL if not provided. If the meeting has multiple transcripts and no date is given, the user will be prompted to choose; if their client cannot prompt, ask them to provide a date (YYYY-MM-DD).',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async ingestMeeting(
     input: z.infer<typeof IngestMeetingInputSchema>,

--- a/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/list-meetings.tool.ts
@@ -6,6 +6,7 @@ import * as z from 'zod';
 import { TEAMS_SOURCE_KIND } from '~/unique/unique.consts';
 import { UniqueContentService } from '~/unique/unique-content.service';
 import { UniqueUserMappingService } from '~/unique/unique-user-mapping.service';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { buildTranscriptFilter, parseTranscriptMetadata } from './transcript-tools.helpers';
 
 const ListMeetingsInputSchema = z.object({
@@ -85,6 +86,7 @@ export class ListMeetingsTool {
         'Use this tool to browse meetings by date, organizer, or participant without a search query. Returns meeting IDs that can be used with find_transcripts for deeper search.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async listMeetings(
     input: z.infer<typeof ListMeetingsInputSchema>,

--- a/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/start-kb-integration.tool.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { SubscriptionCreateService } from '../subscription-create.service';
 
 const StartKbIntegrationInputSchema = z.object({});
@@ -50,6 +51,7 @@ export class StartKbIntegrationTool {
         'Starts the knowledge base integration for meeting transcripts. Use verify_kb_integration_status first to check if it is already running. If already active, inform the user that ingestion is already running.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async startKbIntegration(
     _input: z.infer<typeof StartKbIntegrationInputSchema>,

--- a/services/teams-mcp/src/transcript/tools/stop-kb-integration.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/stop-kb-integration.tool.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 import { SubscriptionRemoveService } from '../subscription-remove.service';
 
 const StopKbIntegrationInputSchema = z.object({});
@@ -48,6 +49,7 @@ export class StopKbIntegrationTool {
         'Stops the knowledge base integration for meeting transcripts. After stopping, new meeting transcripts will no longer be ingested. Use verify_kb_integration_status first to check if it is running.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async stopKbIntegration(
     _input: z.infer<typeof StopKbIntegrationInputSchema>,

--- a/services/teams-mcp/src/transcript/tools/verify-kb-integration-status.tool.ts
+++ b/services/teams-mcp/src/transcript/tools/verify-kb-integration-status.tool.ts
@@ -5,6 +5,7 @@ import { and, eq } from 'drizzle-orm';
 import { Span, TraceService } from 'nestjs-otel';
 import * as z from 'zod';
 import { DRIZZLE, type DrizzleDatabase, subscriptions } from '~/drizzle';
+import { AttributeUpstreamErrors } from '../../utils/attribute-upstream-errors.decorator';
 
 const VerifyKbIntegrationStatusInputSchema = z.object({});
 
@@ -54,6 +55,7 @@ export class VerifyKbIntegrationStatusTool {
         'Returns the current status of the knowledge base integration for meeting transcripts. Use this to verify if transcription ingestion is running before suggesting to start or stop it.',
     },
   })
+  @AttributeUpstreamErrors()
   @Span()
   public async verifyKbIntegrationStatus(
     _input: z.infer<typeof VerifyKbIntegrationStatusInputSchema>,

--- a/services/teams-mcp/src/utils/attribute-upstream-errors.decorator.ts
+++ b/services/teams-mcp/src/utils/attribute-upstream-errors.decorator.ts
@@ -1,0 +1,39 @@
+import { toAttributedError } from './classify-error';
+
+/**
+ * Method decorator for MCP tool handlers: any error thrown by the wrapped handler is
+ * passed through {@link toAttributedError}, rewriting upstream Microsoft / network
+ * failures into clearly-attributed messages while leaving `McpError` and unknown
+ * errors untouched.
+ *
+ * Apply it ABOVE `@Span()` so the span still records the original (unattributed) error:
+ *
+ * ```ts
+ * @Tool({ ... })
+ * @AttributeUpstreamErrors()
+ * @Span()
+ * public async getChatMessages(...) { ... }
+ * ```
+ */
+export function AttributeUpstreamErrors() {
+  // biome-ignore lint/suspicious/noExplicitAny: types with decorators are simply not possible
+  return (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) => {
+    const original = descriptor.value;
+
+    descriptor.value = async function (this: unknown, ...args: unknown[]) {
+      try {
+        return await original.apply(this, args);
+      } catch (error) {
+        throw toAttributedError(error);
+      }
+    };
+
+    // copy metadata from original to wrapped (to retain other decorators if any)
+    Reflect.getMetadataKeys(original).forEach((key) => {
+      const value = Reflect.getMetadata(key, original);
+      Reflect.defineMetadata(key, value, descriptor.value);
+    });
+
+    return descriptor;
+  };
+}

--- a/services/teams-mcp/src/utils/classify-error.spec.ts
+++ b/services/teams-mcp/src/utils/classify-error.spec.ts
@@ -11,11 +11,11 @@ function graphError(statusCode: number, code?: string, requestId?: string): Grap
   return error;
 }
 
-function networkError(code: string): Error {
+function networkError(code: string, hostname = 'graph.microsoft.com'): Error {
   // Mirrors how undici surfaces transport failures: a `TypeError: fetch failed`
-  // whose `.cause` carries the original errno.
+  // whose `.cause` carries the original errno (and `.hostname` for DNS failures).
   const error = new TypeError('fetch failed');
-  (error as NodeJS.ErrnoException).cause = Object.assign(new Error(code), { code });
+  (error as NodeJS.ErrnoException).cause = Object.assign(new Error(code), { code, hostname });
   return error;
 }
 
@@ -84,12 +84,30 @@ describe('classifyError', () => {
     expect(classifyError(graphError(404, 'NotFound')).fault).toBe('client_request');
   });
 
-  it('classifies a fetch-failed network error as upstream_network', () => {
-    const result = classifyError(networkError('EAI_AGAIN'));
+  it('classifies a fetch-failed network error to a Microsoft host as upstream_network', () => {
+    const result = classifyError(networkError('EAI_AGAIN', 'graph.microsoft.com'));
     expect(result.fault).toBe('upstream_network');
     expect(result.retryable).toBe(true);
     expect(result.message).toContain('Microsoft Graph');
     expect(result.message).toContain('EAI_AGAIN');
+  });
+
+  it('classifies a network failure to the login host as upstream_network', () => {
+    expect(classifyError(networkError('ETIMEDOUT', 'login.microsoftonline.com')).fault).toBe(
+      'upstream_network',
+    );
+  });
+
+  it('does NOT attribute a network failure to a non-Microsoft host to Graph', () => {
+    // e.g. Postgres/Drizzle or Unique API DNS failure surfacing the same errno.
+    const result = classifyError(networkError('EAI_AGAIN', 'db.internal.cluster.local'));
+    expect(result.fault).toBe('unknown');
+    expect(result.message).not.toContain('Microsoft Graph');
+  });
+
+  it('does NOT attribute a hostless transport error to Graph', () => {
+    const bare = new TypeError('fetch failed');
+    expect(classifyError(bare).fault).toBe('unknown');
   });
 
   it('classifies an arbitrary error as unknown, preserving the message', () => {
@@ -120,9 +138,14 @@ describe('toAttributedError', () => {
     expect((result as Error).message).toContain('req-xyz');
   });
 
-  it('rewrites a network error into an attributed Error', () => {
-    const result = toAttributedError(networkError('EAI_AGAIN'));
+  it('rewrites a network error to a Microsoft host into an attributed Error', () => {
+    const result = toAttributedError(networkError('EAI_AGAIN', 'graph.microsoft.com'));
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toContain('Could not reach Microsoft Graph');
+  });
+
+  it('returns a non-Microsoft-host network error unchanged', () => {
+    const dbError = networkError('EAI_AGAIN', 'db.internal.cluster.local');
+    expect(toAttributedError(dbError)).toBe(dbError);
   });
 });

--- a/services/teams-mcp/src/utils/classify-error.spec.ts
+++ b/services/teams-mcp/src/utils/classify-error.spec.ts
@@ -1,0 +1,128 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+import { classifyError, isUpstreamNetworkError, toAttributedError } from './classify-error';
+import { MicrosoftReauthRequiredException } from './microsoft-reauth.exception';
+
+function graphError(statusCode: number, code?: string, requestId?: string): GraphError {
+  const error = new GraphError(statusCode, 'Error while processing response.');
+  error.code = code ?? null;
+  error.requestId = requestId ?? null;
+  return error;
+}
+
+function networkError(code: string): Error {
+  // Mirrors how undici surfaces transport failures: a `TypeError: fetch failed`
+  // whose `.cause` carries the original errno.
+  const error = new TypeError('fetch failed');
+  (error as NodeJS.ErrnoException).cause = Object.assign(new Error(code), { code });
+  return error;
+}
+
+describe('isUpstreamNetworkError', () => {
+  it('is true for a "fetch failed" TypeError', () => {
+    expect(isUpstreamNetworkError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('is true when error.cause.code is a transport code', () => {
+    expect(isUpstreamNetworkError(networkError('EAI_AGAIN'))).toBe(true);
+    expect(isUpstreamNetworkError(networkError('UND_ERR_CONNECT_TIMEOUT'))).toBe(true);
+  });
+
+  it('is true when the error itself carries a transport code', () => {
+    expect(isUpstreamNetworkError(Object.assign(new Error('boom'), { code: 'ECONNRESET' }))).toBe(
+      true,
+    );
+  });
+
+  it('is false for unrelated errors', () => {
+    expect(isUpstreamNetworkError(new Error('boom'))).toBe(false);
+    expect(isUpstreamNetworkError(graphError(500))).toBe(false);
+    expect(isUpstreamNetworkError(Object.assign(new Error('x'), { code: 'EACCES' }))).toBe(false);
+  });
+});
+
+describe('classifyError', () => {
+  it('classifies GraphError 500 as upstream_microsoft with attribution and requestId', () => {
+    const result = classifyError(graphError(500, 'InternalServerError', 'req-123'));
+
+    expect(result.fault).toBe('upstream_microsoft');
+    expect(result.retryable).toBe(true);
+    expect(result.httpStatus).toBe(500);
+    expect(result.graphCode).toBe('InternalServerError');
+    expect(result.requestId).toBe('req-123');
+    expect(result.message).toContain("Microsoft's side");
+    expect(result.message).toContain('500');
+    expect(result.message).toContain('req-123');
+  });
+
+  it('classifies GraphError 503 as upstream_microsoft', () => {
+    expect(classifyError(graphError(503, 'ServiceUnavailable')).fault).toBe('upstream_microsoft');
+  });
+
+  it('classifies GraphError 429 as upstream_microsoft', () => {
+    const result = classifyError(graphError(429, 'TooManyRequests'));
+    expect(result.fault).toBe('upstream_microsoft');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('classifies GraphError 401 as auth', () => {
+    const result = classifyError(graphError(401, 'InvalidAuthenticationToken'));
+    expect(result.fault).toBe('auth');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('classifies GraphError 400 as client_request with no Microsoft blame', () => {
+    const result = classifyError(graphError(400, 'BadRequest'));
+    expect(result.fault).toBe('client_request');
+    expect(result.retryable).toBe(false);
+    expect(result.message).not.toContain("Microsoft's side");
+    expect(result.message).not.toContain('fault on');
+  });
+
+  it('classifies GraphError 404 as client_request', () => {
+    expect(classifyError(graphError(404, 'NotFound')).fault).toBe('client_request');
+  });
+
+  it('classifies a fetch-failed network error as upstream_network', () => {
+    const result = classifyError(networkError('EAI_AGAIN'));
+    expect(result.fault).toBe('upstream_network');
+    expect(result.retryable).toBe(true);
+    expect(result.message).toContain('Microsoft Graph');
+    expect(result.message).toContain('EAI_AGAIN');
+  });
+
+  it('classifies an arbitrary error as unknown, preserving the message', () => {
+    const result = classifyError(new Error('something internal broke'));
+    expect(result.fault).toBe('unknown');
+    expect(result.message).toBe('something internal broke');
+  });
+});
+
+describe('toAttributedError', () => {
+  it('returns an McpError unchanged (preserves reauth flow)', () => {
+    const reauth = new MicrosoftReauthRequiredException('invalid_grant');
+    expect(toAttributedError(reauth)).toBe(reauth);
+
+    const mcpError = new McpError(ErrorCode.InternalError, 'boom');
+    expect(toAttributedError(mcpError)).toBe(mcpError);
+  });
+
+  it('returns the original error unchanged for unknown faults', () => {
+    const original = new Error('non-upstream bug');
+    expect(toAttributedError(original)).toBe(original);
+  });
+
+  it('rewrites a GraphError 500 into an attributed Error', () => {
+    const result = toAttributedError(graphError(500, 'InternalServerError', 'req-xyz'));
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toContain("Microsoft's side");
+    expect((result as Error).message).toContain('req-xyz');
+  });
+
+  it('rewrites a network error into an attributed Error', () => {
+    const result = toAttributedError(networkError('EAI_AGAIN'));
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toContain('Could not reach Microsoft Graph');
+  });
+});

--- a/services/teams-mcp/src/utils/classify-error.spec.ts
+++ b/services/teams-mcp/src/utils/classify-error.spec.ts
@@ -11,11 +11,21 @@ function graphError(statusCode: number, code?: string, requestId?: string): Grap
   return error;
 }
 
-function networkError(code: string, hostname = 'graph.microsoft.com'): Error {
-  // Mirrors how undici surfaces transport failures: a `TypeError: fetch failed`
-  // whose `.cause` carries the original errno (and `.hostname` for DNS failures).
+function graphNetworkError(): GraphError {
+  // Mirrors what @microsoft/microsoft-graph-client produces when fetch itself fails before a
+  // response: GraphErrorHandler wraps the TypeError into a GraphError with statusCode -1, sets
+  // `.code` to the original error's name and discards the underlying errno/host.
+  const error = new GraphError(-1, 'fetch failed');
+  error.code = 'TypeError';
+  return error;
+}
+
+function rawNetworkError(code: string): Error {
+  // The unwrapped transport failure as undici surfaces it: a `TypeError: fetch failed` whose
+  // `.cause` carries the original errno. This is what the metrics middleware sees inside the
+  // Graph chain (and what a non-Graph dependency such as Postgres or the Unique API would throw).
   const error = new TypeError('fetch failed');
-  (error as NodeJS.ErrnoException).cause = Object.assign(new Error(code), { code, hostname });
+  (error as NodeJS.ErrnoException).cause = Object.assign(new Error(code), { code });
   return error;
 }
 
@@ -25,8 +35,8 @@ describe('isUpstreamNetworkError', () => {
   });
 
   it('is true when error.cause.code is a transport code', () => {
-    expect(isUpstreamNetworkError(networkError('EAI_AGAIN'))).toBe(true);
-    expect(isUpstreamNetworkError(networkError('UND_ERR_CONNECT_TIMEOUT'))).toBe(true);
+    expect(isUpstreamNetworkError(rawNetworkError('EAI_AGAIN'))).toBe(true);
+    expect(isUpstreamNetworkError(rawNetworkError('UND_ERR_CONNECT_TIMEOUT'))).toBe(true);
   });
 
   it('is true when the error itself carries a transport code', () => {
@@ -84,30 +94,27 @@ describe('classifyError', () => {
     expect(classifyError(graphError(404, 'NotFound')).fault).toBe('client_request');
   });
 
-  it('classifies a fetch-failed network error to a Microsoft host as upstream_network', () => {
-    const result = classifyError(networkError('EAI_AGAIN', 'graph.microsoft.com'));
+  it('classifies a GraphError with no HTTP response (statusCode -1) as upstream_network', () => {
+    // A Graph network/DNS failure: the client wraps the fetch error into a GraphError.
+    const result = classifyError(graphNetworkError());
     expect(result.fault).toBe('upstream_network');
     expect(result.retryable).toBe(true);
-    expect(result.message).toContain('Microsoft Graph');
-    expect(result.message).toContain('EAI_AGAIN');
+    expect(result.message).toContain('Could not reach Microsoft Graph');
   });
 
-  it('classifies a network failure to the login host as upstream_network', () => {
-    expect(classifyError(networkError('ETIMEDOUT', 'login.microsoftonline.com')).fault).toBe(
-      'upstream_network',
-    );
-  });
-
-  it('does NOT attribute a network failure to a non-Microsoft host to Graph', () => {
-    // e.g. Postgres/Drizzle or Unique API DNS failure surfacing the same errno.
-    const result = classifyError(networkError('EAI_AGAIN', 'db.internal.cluster.local'));
+  it('does NOT attribute a non-Graph transport error to Microsoft', () => {
+    // A bare `fetch failed` (e.g. Unique API) is not a GraphError, so it must not be blamed on Graph.
+    const result = classifyError(rawNetworkError('EAI_AGAIN'));
     expect(result.fault).toBe('unknown');
     expect(result.message).not.toContain('Microsoft Graph');
   });
 
-  it('does NOT attribute a hostless transport error to Graph', () => {
-    const bare = new TypeError('fetch failed');
-    expect(classifyError(bare).fault).toBe('unknown');
+  it('does NOT attribute a database errno error to Microsoft', () => {
+    // node-postgres surfaces a DNS failure as a plain errno error, never a GraphError.
+    const pgError = Object.assign(new Error('getaddrinfo ENOTFOUND db.internal'), {
+      code: 'ENOTFOUND',
+    });
+    expect(classifyError(pgError).fault).toBe('unknown');
   });
 
   it('classifies an arbitrary error as unknown, preserving the message', () => {
@@ -138,14 +145,14 @@ describe('toAttributedError', () => {
     expect((result as Error).message).toContain('req-xyz');
   });
 
-  it('rewrites a network error to a Microsoft host into an attributed Error', () => {
-    const result = toAttributedError(networkError('EAI_AGAIN', 'graph.microsoft.com'));
+  it('rewrites a Graph network failure into an attributed Error', () => {
+    const result = toAttributedError(graphNetworkError());
     expect(result).toBeInstanceOf(Error);
     expect((result as Error).message).toContain('Could not reach Microsoft Graph');
   });
 
-  it('returns a non-Microsoft-host network error unchanged', () => {
-    const dbError = networkError('EAI_AGAIN', 'db.internal.cluster.local');
+  it('returns a non-Graph transport error unchanged', () => {
+    const dbError = rawNetworkError('EAI_AGAIN');
     expect(toAttributedError(dbError)).toBe(dbError);
   });
 });

--- a/services/teams-mcp/src/utils/classify-error.ts
+++ b/services/teams-mcp/src/utils/classify-error.ts
@@ -1,0 +1,165 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Transport-level error codes that mean we could not reach Microsoft Graph at all
+ * (DNS, connection, socket failures) — as opposed to Microsoft returning an HTTP error.
+ *
+ * Mirrors the retryable set used by the SharePoint connector's undici dispatcher
+ * (`sharepoint-rest-http.service.ts`), plus `EAI_AGAIN` / `UND_ERR_CONNECT_TIMEOUT`
+ * observed in teams-mcp production logs.
+ */
+const UPSTREAM_NETWORK_CODES = new Set([
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'ENETDOWN',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+/**
+ * The party at fault for a failed operation.
+ * - `upstream_microsoft` — Microsoft Graph returned 429 or 5xx (their server erred).
+ * - `upstream_network`    — we could not reach Microsoft Graph (connectivity / DNS).
+ * - `client_request`      — Graph rejected our request with a 4xx (bad input / no access).
+ * - `auth`                — Microsoft rejected the request as unauthenticated (401).
+ * - `unknown`             — anything else; left to existing handling.
+ */
+export type ErrorFault =
+  | 'upstream_microsoft'
+  | 'upstream_network'
+  | 'client_request'
+  | 'auth'
+  | 'unknown';
+
+export interface ClassifiedError {
+  fault: ErrorFault;
+  httpStatus?: number;
+  graphCode?: string;
+  requestId?: string;
+  retryable: boolean;
+  message: string;
+}
+
+/**
+ * True when the error is a transport-level failure to reach Microsoft Graph
+ * (DNS resolution, connection, socket) rather than an HTTP response from Graph.
+ *
+ * undici wraps these in a `TypeError: fetch failed` whose `.cause` carries the
+ * original `NodeJS.ErrnoException` (`cause.code`), so we check both levels.
+ */
+export function isUpstreamNetworkError(error: unknown): boolean {
+  if (error instanceof Error && error.message === 'fetch failed') {
+    return true;
+  }
+  const errno = error as NodeJS.ErrnoException | undefined;
+  const cause = errno?.cause as NodeJS.ErrnoException | undefined;
+  const code = errno?.code ?? cause?.code;
+  return code !== undefined && UPSTREAM_NETWORK_CODES.has(code);
+}
+
+/**
+ * Classify an error thrown from a tool handler so it can be attributed honestly to
+ * the consumer: Microsoft's fault, the network's fault, or our/the user's request.
+ */
+export function classifyError(error: unknown): ClassifiedError {
+  if (error instanceof GraphError) {
+    const httpStatus = error.statusCode;
+    const graphCode = error.code ?? undefined;
+    const requestId = error.requestId ?? undefined;
+
+    if (httpStatus === 429 || (httpStatus >= 500 && httpStatus <= 599)) {
+      return {
+        fault: 'upstream_microsoft',
+        httpStatus,
+        graphCode,
+        requestId,
+        retryable: true,
+        message:
+          `Microsoft Graph returned a server-side error (HTTP ${httpStatus}` +
+          (graphCode ? `, code: ${graphCode}` : '') +
+          `). This is a fault on Microsoft's side, not a problem with your request or this connector.` +
+          (requestId
+            ? ` Microsoft request id: ${requestId} (provide this to Microsoft support).`
+            : '') +
+          ` This is usually transient — please retry shortly.`,
+      };
+    }
+
+    if (httpStatus === 401) {
+      return {
+        fault: 'auth',
+        httpStatus,
+        graphCode,
+        requestId,
+        retryable: false,
+        message:
+          `Microsoft rejected the request as unauthenticated (HTTP 401` +
+          (graphCode ? `, code: ${graphCode}` : '') +
+          `). Your Microsoft session may have expired — please re-authenticate your Microsoft account.`,
+      };
+    }
+
+    if (httpStatus >= 400 && httpStatus <= 499) {
+      return {
+        fault: 'client_request',
+        httpStatus,
+        graphCode,
+        requestId,
+        retryable: false,
+        message:
+          `Microsoft Graph rejected the request (HTTP ${httpStatus}` +
+          (graphCode ? `, code: ${graphCode}` : '') +
+          `). The identifiers or parameters provided may be invalid, or the account may lack access to this resource. Double-check the inputs (for example, list the available chats/teams to obtain a valid id).`,
+      };
+    }
+  }
+
+  if (isUpstreamNetworkError(error)) {
+    const errno = error as NodeJS.ErrnoException;
+    const cause = errno.cause as NodeJS.ErrnoException | undefined;
+    const code = errno.code ?? cause?.code;
+    return {
+      fault: 'upstream_network',
+      retryable: true,
+      message:
+        `Could not reach Microsoft Graph` +
+        (code ? ` (network error: ${code})` : ` (network error)`) +
+        `. This is a connectivity or DNS problem between this connector and Microsoft, not a defect in your request or this connector. This is usually transient — please retry shortly.`,
+    };
+  }
+
+  return {
+    fault: 'unknown',
+    retryable: false,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/**
+ * Rewrite an upstream failure into a clearly-attributed `Error` so the MCP module
+ * surfaces the attributed text to the consumer as an `isError` tool result.
+ *
+ * - `McpError` (e.g. {@link MicrosoftReauthRequiredException}) is returned unchanged so
+ *   the module re-throws it as a JSON-RPC error and the existing reauth flow is preserved.
+ * - `unknown` faults return the original error unchanged so we never mask non-upstream bugs.
+ * - Everything else returns a new `Error` carrying the attributed message.
+ */
+export function toAttributedError(error: unknown): unknown {
+  if (error instanceof McpError) {
+    return error;
+  }
+
+  const classified = classifyError(error);
+  if (classified.fault === 'unknown') {
+    return error;
+  }
+
+  return new Error(classified.message);
+}

--- a/services/teams-mcp/src/utils/classify-error.ts
+++ b/services/teams-mcp/src/utils/classify-error.ts
@@ -24,6 +24,41 @@ const UPSTREAM_NETWORK_CODES = new Set([
 ]);
 
 /**
+ * Registrable domains for the Microsoft endpoints this connector talks to (Graph + login,
+ * including national clouds). The transport errnos above also surface from Postgres/Drizzle
+ * and the Unique API, so a network failure is only attributed to Microsoft Graph when the
+ * unreachable host matches one of these — otherwise we'd blame Graph for a database or
+ * platform outage.
+ */
+const MICROSOFT_HOST_DOMAINS = [
+  'microsoft.com',
+  'microsoft.us',
+  'microsoftonline.com',
+  'microsoftonline.us',
+  'microsoftonline.cn',
+  'microsoftgraph.chinacloudapi.cn',
+];
+
+/**
+ * The host that could not be reached, if the error carries one. Node's DNS failures
+ * (`EAI_AGAIN`, `ENOTFOUND`) expose `.hostname`; undici nests the original errno — and its
+ * `.hostname` — under `.cause`.
+ */
+function extractTargetHost(error: unknown): string | undefined {
+  const errno = error as (NodeJS.ErrnoException & { hostname?: string }) | undefined;
+  const cause = errno?.cause as (NodeJS.ErrnoException & { hostname?: string }) | undefined;
+  return errno?.hostname ?? cause?.hostname;
+}
+
+function isMicrosoftHost(host: string | undefined): boolean {
+  if (!host) {
+    return false;
+  }
+  const lower = host.toLowerCase();
+  return MICROSOFT_HOST_DOMAINS.some((domain) => lower === domain || lower.endsWith(`.${domain}`));
+}
+
+/**
  * The party at fault for a failed operation.
  * - `upstream_microsoft` — Microsoft Graph returned 429 or 5xx (their server erred).
  * - `upstream_network`    — we could not reach Microsoft Graph (connectivity / DNS).
@@ -48,8 +83,11 @@ export interface ClassifiedError {
 }
 
 /**
- * True when the error is a transport-level failure to reach Microsoft Graph
- * (DNS resolution, connection, socket) rather than an HTTP response from Graph.
+ * True when the error is a transport-level failure (DNS resolution, connection, socket)
+ * rather than an HTTP response. This is host-agnostic — it does not assert *which* host
+ * was unreachable (the same errnos arise from Graph, Postgres and the Unique API). Callers
+ * that need to attribute the failure to Microsoft must additionally confirm the host
+ * (see `classifyError`); the Graph metrics middleware is already Graph-scoped by construction.
  *
  * undici wraps these in a `TypeError: fetch failed` whose `.cause` carries the
  * original `NodeJS.ErrnoException` (`cause.code`), so we check both levels.
@@ -121,7 +159,10 @@ export function classifyError(error: unknown): ClassifiedError {
     }
   }
 
-  if (isUpstreamNetworkError(error)) {
+  // Only attribute a transport failure to Microsoft Graph when the unreachable host is a
+  // confirmed Microsoft endpoint. The same errnos arise from Postgres/Drizzle and the Unique
+  // API; without a confirmed Microsoft host we fall through to `unknown` rather than blame Graph.
+  if (isUpstreamNetworkError(error) && isMicrosoftHost(extractTargetHost(error))) {
     const errno = error as NodeJS.ErrnoException;
     const cause = errno.cause as NodeJS.ErrnoException | undefined;
     const code = errno.code ?? cause?.code;

--- a/services/teams-mcp/src/utils/classify-error.ts
+++ b/services/teams-mcp/src/utils/classify-error.ts
@@ -2,8 +2,8 @@ import { GraphError } from '@microsoft/microsoft-graph-client';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 
 /**
- * Transport-level error codes that mean we could not reach Microsoft Graph at all
- * (DNS, connection, socket failures) — as opposed to Microsoft returning an HTTP error.
+ * Transport-level error codes that mean a request never reached its target / got no response
+ * (DNS, connection, socket failures) — as opposed to the server returning an HTTP error.
  *
  * Mirrors the retryable set used by the SharePoint connector's undici dispatcher
  * (`sharepoint-rest-http.service.ts`), plus `EAI_AGAIN` / `UND_ERR_CONNECT_TIMEOUT`
@@ -22,41 +22,6 @@ const UPSTREAM_NETWORK_CODES = new Set([
   'UND_ERR_CONNECT_TIMEOUT',
   'UND_ERR_SOCKET',
 ]);
-
-/**
- * Registrable domains for the Microsoft endpoints this connector talks to (Graph + login,
- * including national clouds). The transport errnos above also surface from Postgres/Drizzle
- * and the Unique API, so a network failure is only attributed to Microsoft Graph when the
- * unreachable host matches one of these — otherwise we'd blame Graph for a database or
- * platform outage.
- */
-const MICROSOFT_HOST_DOMAINS = [
-  'microsoft.com',
-  'microsoft.us',
-  'microsoftonline.com',
-  'microsoftonline.us',
-  'microsoftonline.cn',
-  'microsoftgraph.chinacloudapi.cn',
-];
-
-/**
- * The host that could not be reached, if the error carries one. Node's DNS failures
- * (`EAI_AGAIN`, `ENOTFOUND`) expose `.hostname`; undici nests the original errno — and its
- * `.hostname` — under `.cause`.
- */
-function extractTargetHost(error: unknown): string | undefined {
-  const errno = error as (NodeJS.ErrnoException & { hostname?: string }) | undefined;
-  const cause = errno?.cause as (NodeJS.ErrnoException & { hostname?: string }) | undefined;
-  return errno?.hostname ?? cause?.hostname;
-}
-
-function isMicrosoftHost(host: string | undefined): boolean {
-  if (!host) {
-    return false;
-  }
-  const lower = host.toLowerCase();
-  return MICROSOFT_HOST_DOMAINS.some((domain) => lower === domain || lower.endsWith(`.${domain}`));
-}
 
 /**
  * The party at fault for a failed operation.
@@ -83,11 +48,13 @@ export interface ClassifiedError {
 }
 
 /**
- * True when the error is a transport-level failure (DNS resolution, connection, socket)
- * rather than an HTTP response. This is host-agnostic — it does not assert *which* host
- * was unreachable (the same errnos arise from Graph, Postgres and the Unique API). Callers
- * that need to attribute the failure to Microsoft must additionally confirm the host
- * (see `classifyError`); the Graph metrics middleware is already Graph-scoped by construction.
+ * True when the error is a raw transport-level failure (DNS resolution, connection, socket)
+ * rather than an HTTP response. Operates on the *unwrapped* error and is host-agnostic, so it
+ * is only meaningful where the caller already knows the target — e.g. the Graph metrics
+ * middleware, which sits inside the Graph client chain and sees the original error before the
+ * client wraps it into a `GraphError`. The tool boundary must NOT use this to attribute a
+ * fault to Microsoft (the same errnos arise from Postgres and the Unique API); it relies on
+ * the error type instead (see `classifyError`).
  *
  * undici wraps these in a `TypeError: fetch failed` whose `.cause` carries the
  * original `NodeJS.ErrnoException` (`cause.code`), so we check both levels.
@@ -157,23 +124,22 @@ export function classifyError(error: unknown): ClassifiedError {
           `). The identifiers or parameters provided may be invalid, or the account may lack access to this resource. Double-check the inputs (for example, list the available chats/teams to obtain a valid id).`,
       };
     }
-  }
 
-  // Only attribute a transport failure to Microsoft Graph when the unreachable host is a
-  // confirmed Microsoft endpoint. The same errnos arise from Postgres/Drizzle and the Unique
-  // API; without a confirmed Microsoft host we fall through to `unknown` rather than blame Graph.
-  if (isUpstreamNetworkError(error) && isMicrosoftHost(extractTargetHost(error))) {
-    const errno = error as NodeJS.ErrnoException;
-    const cause = errno.cause as NodeJS.ErrnoException | undefined;
-    const code = errno.code ?? cause?.code;
-    return {
-      fault: 'upstream_network',
-      retryable: true,
-      message:
-        `Could not reach Microsoft Graph` +
-        (code ? ` (network error: ${code})` : ` (network error)`) +
-        `. This is a connectivity or DNS problem between this connector and Microsoft, not a defect in your request or this connector. This is usually transient — please retry shortly.`,
-    };
+    // A statusCode below 100 means no HTTP response was received: the Graph client wraps
+    // fetch/DNS/socket failures into a GraphError with statusCode -1 (discarding the original
+    // errno and host). Because only the Graph client produces GraphError, this is unambiguously
+    // a connectivity failure reaching Microsoft Graph — no host inspection needed. Transport
+    // failures from Postgres or the Unique API are NOT GraphError, so they never land here.
+    if (httpStatus < 100) {
+      return {
+        fault: 'upstream_network',
+        retryable: true,
+        message:
+          `Could not reach Microsoft Graph (no response — likely a connectivity, DNS or timeout ` +
+          `issue between this connector and Microsoft). This is not a defect in your request or ` +
+          `this connector. This is usually transient — please retry shortly.`,
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Why

Production logs for `teams-mcp` (one pod, 17-min window on 2026-06-26) showed 15 errors that were **not** our product's fault but reached the MCP consumer as opaque internal errors (a raw `error.message` like `"Error while processing response."`):

- **8×** genuine Microsoft Graph `HTTP 500 InternalServerError` on `GET /chats/{id}/messages` — deterministic per-chat (a Graph-side fault on specific chat content).
- **6×** DNS/network failures (`fetch failed` / `EAI_AGAIN` to graph.microsoft.com).
- **1×** DNS failure to the Postgres cluster.

This made our product look broken when the third party was at fault. This PR surfaces upstream faults **loudly and attributes them honestly**, while staying neutral on genuine `4xx` (our request / the user's input) so attribution stays credible.

## What

**1. Error classifier — `src/utils/classify-error.ts`** (pure functions)
- `isUpstreamNetworkError(error)` — true for `fetch failed` or a transport errno (`EAI_AGAIN`, `ENOTFOUND`, `ECONNRESET`, … `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_SOCKET`) at the error or `error.cause` level.
- `classifyError(error)` → `{ fault, httpStatus?, graphCode?, requestId?, retryable, message }`:
  - GraphError `429` / `5xx` → `upstream_microsoft` (names Microsoft, includes HTTP status + Graph `code` + `requestId` for MS support).
  - GraphError `401` → `auth`; GraphError `4xx` → `client_request` (neutral, **no Microsoft blame**).
  - network → `upstream_network`; else → `unknown`.
- `toAttributedError(error)` — `McpError` unchanged (preserves the reauth flow), `unknown`-fault unchanged (no masking real bugs), otherwise a new `Error` with the attributed message.

**2. Tool boundary — `@AttributeUpstreamErrors()` decorator** applied to all 14 tools, **above `@Span()`** so the span still records the *original* error before attribution rewrites it. The MCP module wraps a thrown `Error` into `{ content, isError: true }`, so throwing the attributed message is sufficient and keeps each tool's typed `outputSchema` intact.

**3. Metrics one-line fix — `src/msgraph/metrics.middleware.ts`** catch block now sets `status_class: 'network'` for transport failures instead of hardcoding `'5xx'`, so per-status-class queries separate cleanly (`5xx` = Microsoft server fault, `network` = connectivity/DNS, `4xx` = our/user request).

### Why no shared-module / interceptor seam
Tool execution runs inside the MCP SDK transport, **outside** the NestJS pipeline, so `APP_INTERCEPTOR` / `APP_FILTER` (incl. the existing `GraphErrorFilter`) never see tool errors. The fix is contained in teams-mcp at the consumer-facing edge.

## Out of scope
- Retry-policy widening / "graceful degradation" — a true 500 returns no body to salvage; attribution is the fix.
- Shared `mcp-server-module` `mapError` hook + structured `_meta` — the central alternative, not chosen.

## Testing
- `pnpm --filter teams-mcp test` → 67/67 pass (new specs for the classifier and the metrics `network` vs `5xx` split).
- `tsc --noEmit` and `biome check` clean.
- **Not done (needs a live instance + Microsoft creds):** end-to-end smoke against an invalid `chatId` (expect neutral `client_request` message) and a known failing chat id (expect the loud Microsoft-500 attribution).
