### PR TITLE
docs(confluence-connector): remove pre-release banner

### DIFF
--- a/services/confluence-connector/docs/README.md
+++ b/services/confluence-connector/docs/README.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 1504182474 -->
 <!-- confluence-space-key: PUBDOC -->
 
-> **Pre-release Notice:** The Confluence Connector v2 is currently in alpha (`2.0.0-alpha.4`). Configuration options and behavior may change before the stable release.
-
 ## Overview
 
 The Confluence Connector is a service that synchronizes page content and file attachments from Confluence to the Unique knowledge base for RAG ingestion. It supports both Confluence Cloud and Confluence Data Center deployments.


### PR DESCRIPTION
Remove the outdated alpha pre-release notice from the Confluence connector docs overview.