### PR TITLE
fix(confluence-connector): make mermaid diagrams publishable

### DIFF
--- a/services/confluence-connector/docs/README.md
+++ b/services/confluence-connector/docs/README.md
@@ -189,7 +189,7 @@ sequenceDiagram
 
         Connector->>Confluence: Fetch full page content
         Confluence->>Connector: Page HTML body
-        opt Page has ac:image references to Confluence attachments
+        opt Page has #60;ac:image#62; references to Confluence attachments
             opt Some references point to another page
                 Connector->>Confluence: Look up target page by (spaceKey, title)
                 Confluence->>Connector: Target page + its attachments

--- a/services/confluence-connector/docs/README.md
+++ b/services/confluence-connector/docs/README.md
@@ -189,7 +189,7 @@ sequenceDiagram
 
         Connector->>Confluence: Fetch full page content
         Confluence->>Connector: Page HTML body
-        opt Page has <ac:image> references to Confluence attachments
+        opt Page has ac:image references to Confluence attachments
             opt Some references point to another page
                 Connector->>Confluence: Look up target page by (spaceKey, title)
                 Confluence->>Connector: Target page + its attachments

--- a/services/confluence-connector/docs/technical/flows.md
+++ b/services/confluence-connector/docs/technical/flows.md
@@ -110,15 +110,15 @@ sequenceDiagram
         loop For each new/updated page (concurrency-limited)
             Connector->>Confluence: GET page by ID<br/>(body.storage)
             Confluence->>Connector: Page HTML content
-            Note over Connector: Parse storage XML, locate &lt;ac:image&gt; macros
+            Note over Connector: Parse storage XML, locate ac:image macros
             opt Image attachments referenced
                 opt Some references point to another page
-                    Connector->>Confluence: GET /rest/api/content?spaceKey=&amp;title=
+                    Connector->>Confluence: GET /rest/api/content by spaceKey and title
                     Confluence->>Connector: Target page + its attachments
                 end
                 Connector->>Confluence: Download each referenced image
                 Confluence->>Connector: Image binary streams
-                Note over Connector: Base64-encode and splice<br/>&lt;img src="data:..."&gt; in place of macros
+                Note over Connector: Base64-encode and splice<br/>img data-URI in place of macros
             end
             Connector->>Unique: Register content
             Connector->>Unique: PUT buffer upload (text/html)

--- a/services/confluence-connector/docs/technical/flows.md
+++ b/services/confluence-connector/docs/technical/flows.md
@@ -110,15 +110,15 @@ sequenceDiagram
         loop For each new/updated page (concurrency-limited)
             Connector->>Confluence: GET page by ID<br/>(body.storage)
             Confluence->>Connector: Page HTML content
-            Note over Connector: Parse storage XML, locate ac:image macros
+            Note over Connector: Parse storage XML, locate #60;ac:image#62; macros
             opt Image attachments referenced
                 opt Some references point to another page
-                    Connector->>Confluence: GET /rest/api/content by spaceKey and title
+                    Connector->>Confluence: GET /rest/api/content?spaceKey=#38;title=
                     Confluence->>Connector: Target page + its attachments
                 end
                 Connector->>Confluence: Download each referenced image
                 Confluence->>Connector: Image binary streams
-                Note over Connector: Base64-encode and splice<br/>img data-URI in place of macros
+                Note over Connector: Base64-encode and splice<br/>#60;img src="data:..."#62; in place of macros
             end
             Connector->>Unique: Register content
             Connector->>Unique: PUT buffer upload (text/html)


### PR DESCRIPTION
## Why
Fix https://github.com/Unique-AG/connectors/actions/runs/28379691066/job/84078639538 

The `[confluence-connector] Publish Docs to Confluence` workflow was failing: `md2conf` renders Mermaid diagrams with `--render-mermaid`, and Mermaid's parser cannot handle raw `<`, `>`, or `&` inside sequence-diagram note/message labels. The `flows.md` content-sync diagram referenced `<ac:image>`, `<img src="data:...">`, and `?spaceKey=&title=`, so the publish job aborted on `flows.md` and never updated Confluence (and therefore docs.unique.ai).

## What

Escape those characters using Mermaid entity codes so the diagrams parse **and** keep their exact technical notation:

- `#60;` renders as `<`
- `#62;` renders as `>`
- `#38;` renders as `&`

This preserves the real `<ac:image>` macro, the `<img src="data:...">` element, and the `?spaceKey=&title=` query string in the rendered diagrams, rather than dropping the notation.

## Verification

Rendered all 16 Mermaid diagrams under `services/confluence-connector/docs/` locally with `@mermaid-js/mermaid-cli` — 0 failures, and the output shows the angle brackets and ampersand correctly.