### PR TITLE
feat(teams-mcp,deps): add GET /health operational-status endpoint (UN-19379)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,7 +488,7 @@ importers:
         version: 4.0.0
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -624,7 +624,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -844,7 +844,7 @@ importers:
         version: 2.43.1
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)(esbuild@0.25.12)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -1016,7 +1016,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -1110,6 +1110,9 @@ importers:
       '@nestjs/swagger':
         specifier: 11.2.6
         version: 11.2.6(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2)
+      '@nestjs/terminus':
+        specifier: 11.1.1
+        version: 11.1.1(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.2))(typescript@5.9.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
@@ -1206,7 +1209,7 @@ importers:
         version: 2.43.1
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)(esbuild@0.25.12)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -1354,7 +1357,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: 11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)
       '@nestjs/schematics':
         specifier: 11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.2)
@@ -7219,36 +7222,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.16.5)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.16.5)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.13.5))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.13.5)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.13.5)(chokidar@4.0.3)
-      '@swc/core': 1.13.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)(esbuild@0.25.12)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5)(chokidar@4.0.3))(@swc/core@1.13.5)(@types/node@22.16.5)(esbuild@0.25.12)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -7267,6 +7241,35 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.13.5)(esbuild@0.25.12)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.13.5)(chokidar@4.0.3)
+      '@swc/core': 1.13.5
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.13.5))(@swc/core@1.13.5)(@types/node@22.16.5)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.16.5)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.16.5)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.13.5))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.13.5)
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/cli': 0.8.1(@swc/core@1.13.5)(chokidar@4.0.3)
@@ -8725,6 +8728,14 @@ snapshots:
       '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.2(@types/node@22.16.5)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.16.5)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.6(vite@7.3.2(@types/node@24.4.0)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
@@ -11546,7 +11557,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.2(@types/node@24.4.0)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.6(vite@7.3.2(@types/node@22.16.5)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6

--- a/services/teams-mcp/.env.test
+++ b/services/teams-mcp/.env.test
@@ -16,4 +16,5 @@ ENCRYPTION_KEY=6cdd833770d2c366bae26b0ca75a72797f3cf06c0646ee5e6f14c076bd0e02d0
 # Unique API Configuration (External Mode for tests)
 UNIQUE_SERVICE_AUTH_MODE=external
 UNIQUE_API_BASE_URL=http://localhost:8092/public/
+UNIQUE_ROOT_SCOPE_ID=scope_test
 UNIQUE_SERVICE_EXTRA_HEADERS={"authorization":"Bearer test-app-key","x-app-id":"test-app-id","x-user-id":"test-user-id","x-company-id":"test-company-id"}

--- a/services/teams-mcp/package.json
+++ b/services/teams-mcp/package.json
@@ -37,6 +37,7 @@
     "@nestjs/event-emitter": "3.0.1",
     "@nestjs/platform-express": "11.1.18",
     "@nestjs/swagger": "11.2.6",
+    "@nestjs/terminus": "11.1.1",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/instrumentation-pg": "0.70.0",
     "@proventuslabs/nestjs-zod": "2.0.0",

--- a/services/teams-mcp/src/app.module.ts
+++ b/services/teams-mcp/src/app.module.ts
@@ -29,11 +29,13 @@ import {
   databaseConfig,
   type EncryptionConfig,
   encryptionConfig,
+  healthConfig,
   type MicrosoftConfigNamespaced,
   microsoftConfig,
   uniqueConfig,
 } from './config';
 import { DRIZZLE, DrizzleDatabase, DrizzleModule } from './drizzle/drizzle.module';
+import { HealthModule } from './health/health.module';
 import { ManifestController } from './manifest.controller';
 import { MsGraphModule } from './msgraph/msgraph.module';
 import { serverInstructions } from './server.instructions';
@@ -51,6 +53,7 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
         authConfig,
         databaseConfig,
         encryptionConfig,
+        healthConfig,
         microsoftConfig,
         uniqueConfig,
       ],
@@ -149,6 +152,7 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
     AMQPModule,
     TranscriptModule,
     ChatModule,
+    HealthModule,
   ],
   controllers: [ManifestController],
   providers: [

--- a/services/teams-mcp/src/config/health.config.ts
+++ b/services/teams-mcp/src/config/health.config.ts
@@ -1,4 +1,8 @@
-import { type ConfigType, type NamespacedConfigType, registerConfig } from '@proventuslabs/nestjs-zod';
+import {
+  type ConfigType,
+  type NamespacedConfigType,
+  registerConfig,
+} from '@proventuslabs/nestjs-zod';
 import { z } from 'zod';
 
 const ConfigSchema = z.object({

--- a/services/teams-mcp/src/config/health.config.ts
+++ b/services/teams-mcp/src/config/health.config.ts
@@ -1,0 +1,28 @@
+import { type ConfigType, type NamespacedConfigType, registerConfig } from '@proventuslabs/nestjs-zod';
+import { z } from 'zod';
+
+const ConfigSchema = z.object({
+  connectivityTimeoutMs: z.coerce
+    .number()
+    .int()
+    .prefault(3000)
+    .describe('Timeout (ms) for the unauthenticated MS Graph connectivity ping.'),
+  amqpCheckTimeoutMs: z.coerce
+    .number()
+    .int()
+    .prefault(5000)
+    .describe('Timeout (ms) for the RabbitMQ exchange check.'),
+  subscriptionExpiredThreshold: z.coerce
+    .number()
+    .min(0)
+    .max(1)
+    .prefault(0.15)
+    .describe(
+      'Ratio of expired transcript subscriptions (expired ÷ total) above which the subscription health indicator reports `down`.',
+    ),
+});
+
+export const healthConfig = registerConfig('health', ConfigSchema);
+
+export type HealthConfigNamespaced = NamespacedConfigType<typeof healthConfig>;
+export type HealthConfig = ConfigType<typeof healthConfig>;

--- a/services/teams-mcp/src/config/index.ts
+++ b/services/teams-mcp/src/config/index.ts
@@ -3,6 +3,7 @@ import type { AppConfigNamespaced } from './app.config';
 import type { AuthConfigNamespaced } from './auth.config';
 import type { DatabaseConfigNamespaced } from './database.config';
 import type { EncryptionConfigNamespaced } from './encryption.config';
+import type { HealthConfigNamespaced } from './health.config';
 import type { MicrosoftConfigNamespaced } from './microsoft.config';
 import type { UniqueConfigNamespaced } from './unique.config';
 
@@ -11,6 +12,7 @@ export * from './app.config';
 export * from './auth.config';
 export * from './database.config';
 export * from './encryption.config';
+export * from './health.config';
 export * from './microsoft.config';
 export * from './unique.config';
 
@@ -19,5 +21,6 @@ export type ConfigNamespaced = AMQPConfigNamespaced &
   AuthConfigNamespaced &
   DatabaseConfigNamespaced &
   EncryptionConfigNamespaced &
+  HealthConfigNamespaced &
   MicrosoftConfigNamespaced &
   UniqueConfigNamespaced;

--- a/services/teams-mcp/src/health/amqp-health.indicator.ts
+++ b/services/teams-mcp/src/health/amqp-health.indicator.ts
@@ -1,0 +1,43 @@
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { Inject, Injectable } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+import { MAIN_EXCHANGE } from '~/amqp/amqp.constants';
+import { HealthConfig, healthConfig } from '~/config';
+
+@Injectable()
+export class AmqpHealthIndicator {
+  private readonly checkExchangeTimeoutMs: number;
+
+  public constructor(
+    private readonly amqpConnection: AmqpConnection,
+    @Inject(healthConfig.KEY) config: HealthConfig,
+    private readonly healthIndicatorService: HealthIndicatorService,
+  ) {
+    this.checkExchangeTimeoutMs = config.amqpCheckTimeoutMs;
+  }
+
+  public async check(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+    try {
+      if (!this.amqpConnection.connected || !this.amqpConnection.channel) {
+        return indicator.down({ message: 'AMQP not connected' });
+      }
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(
+          () => reject(new Error('AMQP checkExchange timed out')),
+          this.checkExchangeTimeoutMs,
+        );
+      });
+      await Promise.race([
+        this.amqpConnection.channel
+          .checkExchange(MAIN_EXCHANGE.name)
+          .finally(() => clearTimeout(timeoutHandle)),
+        timeout,
+      ]);
+      return indicator.up();
+    } catch (error) {
+      return indicator.down({ message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+}

--- a/services/teams-mcp/src/health/database-health.indicator.ts
+++ b/services/teams-mcp/src/health/database-health.indicator.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+import { sql } from 'drizzle-orm';
+import { DRIZZLE, DrizzleDatabase } from '~/drizzle';
+
+@Injectable()
+export class DatabaseHealthIndicator {
+  public constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleDatabase,
+    private readonly healthIndicatorService: HealthIndicatorService,
+  ) {}
+
+  public async check(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+    try {
+      await this.db.execute(sql`SELECT 1`);
+      return indicator.up();
+    } catch (error) {
+      return indicator.down({ message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+}

--- a/services/teams-mcp/src/health/health.controller.ts
+++ b/services/teams-mcp/src/health/health.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get } from '@nestjs/common';
+import { HealthCheck, HealthCheckService } from '@nestjs/terminus';
+import { AmqpHealthIndicator } from './amqp-health.indicator';
+import { DatabaseHealthIndicator } from './database-health.indicator';
+import { MsGraphConnectivityHealthIndicator } from './ms-graph-connectivity-health.indicator';
+import { SubscriptionHealthIndicator } from './subscription-health.indicator';
+
+@Controller('health')
+export class HealthController {
+  public constructor(
+    private readonly healthCheckService: HealthCheckService,
+    private readonly databaseIndicator: DatabaseHealthIndicator,
+    private readonly amqpIndicator: AmqpHealthIndicator,
+    private readonly connectivityIndicator: MsGraphConnectivityHealthIndicator,
+    private readonly subscriptionIndicator: SubscriptionHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  public check() {
+    return this.healthCheckService.check([
+      () => this.databaseIndicator.check('database'),
+      () => this.amqpIndicator.check('amqp'),
+      () => this.connectivityIndicator.check('connectivity'),
+      () => this.subscriptionIndicator.check('subscription'),
+    ]);
+  }
+}

--- a/services/teams-mcp/src/health/health.module.ts
+++ b/services/teams-mcp/src/health/health.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { DrizzleModule } from '~/drizzle/drizzle.module';
+import { AmqpHealthIndicator } from './amqp-health.indicator';
+import { DatabaseHealthIndicator } from './database-health.indicator';
+import { HealthController } from './health.controller';
+import { MsGraphConnectivityHealthIndicator } from './ms-graph-connectivity-health.indicator';
+import { SubscriptionHealthIndicator } from './subscription-health.indicator';
+
+@Module({
+  imports: [TerminusModule, DrizzleModule],
+  controllers: [HealthController],
+  providers: [
+    DatabaseHealthIndicator,
+    AmqpHealthIndicator,
+    MsGraphConnectivityHealthIndicator,
+    SubscriptionHealthIndicator,
+  ],
+})
+export class HealthModule {}

--- a/services/teams-mcp/src/health/ms-graph-connectivity-health.indicator.ts
+++ b/services/teams-mcp/src/health/ms-graph-connectivity-health.indicator.ts
@@ -1,0 +1,46 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+import { HealthConfig, healthConfig } from '~/config';
+import { extractErrorCode, type PingResult } from './ping-result';
+
+const GRAPH_URL = 'https://graph.microsoft.com/v1.0/';
+
+@Injectable()
+export class MsGraphConnectivityHealthIndicator {
+  private readonly timeoutMs: number;
+
+  public constructor(
+    @Inject(healthConfig.KEY) config: HealthConfig,
+    private readonly healthIndicatorService: HealthIndicatorService,
+  ) {
+    this.timeoutMs = config.connectivityTimeoutMs;
+  }
+
+  public async check(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+    const result = await this.ping(GRAPH_URL);
+
+    if (!result.reachable) {
+      return indicator.down({ graph: 'unreachable', graphError: result.errorCode });
+    }
+
+    return indicator.up({ graph: 'reachable' });
+  }
+
+  private async ping(url: string): Promise<PingResult> {
+    try {
+      // Node's global fetch is undici under the hood, so transport failures surface the same
+      // TypeError/`.cause` shape that `extractErrorCode` unwraps.
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+      // Discard the body so the socket is released instead of held until GC.
+      await response.body?.cancel();
+      // Any HTTP response (including 401 from unauthenticated requests) is treated as
+      // reachable — we're testing network path, not authentication.
+      return { reachable: true };
+    } catch (error) {
+      return { reachable: false, errorCode: extractErrorCode(error) };
+    }
+  }
+}

--- a/services/teams-mcp/src/health/ping-result.ts
+++ b/services/teams-mcp/src/health/ping-result.ts
@@ -1,0 +1,12 @@
+export type PingResult = { reachable: true } | { reachable: false; errorCode: string };
+
+export function extractErrorCode(error: unknown): string {
+  if (error instanceof DOMException && error.name === 'TimeoutError') {
+    return 'TIMEOUT';
+  }
+  // undici wraps transport failures in a TypeError whose `.cause` holds the original
+  // system error (ECONNREFUSED, ENOTFOUND, ENETUNREACH, etc.) as a NodeJS.ErrnoException.
+  const errno = error as NodeJS.ErrnoException;
+  const cause = errno.cause as NodeJS.ErrnoException | undefined;
+  return errno.code ?? cause?.code ?? 'UNKNOWN';
+}

--- a/services/teams-mcp/src/health/subscription-health.indicator.ts
+++ b/services/teams-mcp/src/health/subscription-health.indicator.ts
@@ -1,0 +1,58 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HealthIndicatorResult, HealthIndicatorService } from '@nestjs/terminus';
+import { count, sql } from 'drizzle-orm';
+import { HealthConfig, healthConfig } from '~/config';
+import { DRIZZLE, DrizzleDatabase, subscriptions } from '~/drizzle';
+
+// Subscriptions are renewed daily (see TranscriptUtilsService.getNextScheduledExpiration), with a
+// 2-hour lifecycle buffer required before expiry. Anything inside that window is "expiring soon" —
+// an observability-only signal that does not by itself trip the indicator to `down`.
+const EXPIRING_SOON_THRESHOLD_MINUTES = 120;
+
+@Injectable()
+export class SubscriptionHealthIndicator {
+  private readonly expiredThreshold: number;
+
+  public constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleDatabase,
+    @Inject(healthConfig.KEY) config: HealthConfig,
+    private readonly healthIndicatorService: HealthIndicatorService,
+  ) {
+    this.expiredThreshold = config.subscriptionExpiredThreshold;
+  }
+
+  public async check(key: string): Promise<HealthIndicatorResult> {
+    const indicator = this.healthIndicatorService.check(key);
+
+    try {
+      const soonThreshold = sql`NOW() + (${EXPIRING_SOON_THRESHOLD_MINUTES} * INTERVAL '1 minute')`;
+      const [row] = await this.db
+        .select({
+          total: count(),
+          expired: sql<number>`COALESCE(SUM(CASE
+            WHEN ${subscriptions.expiresAt} < NOW() THEN 1 ELSE 0 END), 0)`,
+          expiringSoon: sql<number>`COALESCE(SUM(CASE
+            WHEN ${subscriptions.expiresAt} >= NOW() AND ${subscriptions.expiresAt} < ${soonThreshold}
+            THEN 1 ELSE 0 END), 0)`,
+        })
+        .from(subscriptions);
+
+      const total = row?.total ?? 0;
+      const expired = Number(row?.expired ?? 0);
+      const expiringSoon = Number(row?.expiringSoon ?? 0);
+      const ratio = total > 0 ? expired / total : 0;
+
+      const details = {
+        total,
+        expired,
+        expiringSoon,
+        threshold: this.expiredThreshold,
+        ratio,
+      };
+
+      return ratio > this.expiredThreshold ? indicator.down(details) : indicator.up(details);
+    } catch (error) {
+      return indicator.down({ message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+}

--- a/services/teams-mcp/test/health.e2e-spec.ts
+++ b/services/teams-mcp/test/health.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AppModule } from '../src/app.module';
+
+describe('Health endpoint (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/health (GET) reports operational status for each dependency', async () => {
+    // Terminus returns 200 when every indicator is up and 503 otherwise; either way the body
+    // exposes the per-indicator breakdown, which is what we assert on.
+    const res = await request(app.getHttpServer()).get('/health');
+
+    expect([200, 503]).toContain(res.status);
+    expect(res.body).toMatchObject({
+      status: expect.any(String),
+      info: expect.any(Object),
+      error: expect.any(Object),
+      details: expect.any(Object),
+    });
+
+    const indicators = res.body.details;
+    expect(indicators).toHaveProperty('database');
+    expect(indicators).toHaveProperty('amqp');
+    expect(indicators).toHaveProperty('connectivity');
+    expect(indicators).toHaveProperty('subscription');
+  });
+});

--- a/services/teams-mcp/vitest.e2e.config.ts
+++ b/services/teams-mcp/vitest.e2e.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '~': resolve(__dirname, './src'),
       '@generated': resolve(__dirname, './@generated'),
     },
   },


### PR DESCRIPTION
## What

Adds a `@nestjs/terminus`-based **`GET /health`** readiness endpoint to teams-mcp, served on the existing HTTP port (`9542`). The existing `/probe` liveness/version endpoint is untouched — `/probe` = liveness/version, `/health` = readiness/operational, matching outlook-semantic-mcp.

Closes UN-19379.

## Indicators

| key | signal |
|-----|--------|
| `database` | `SELECT 1` via Drizzle |
| `amqp` | connection guard + `checkExchange(MAIN_EXCHANGE.name)`, raced against a configurable timeout |
| `connectivity` | unauthenticated GET to `https://graph.microsoft.com/v1.0/` — tests network path, not auth (any HTTP response = reachable) |
| `subscription` | **teams-specific operational signal**: `expired / total` ratio over the `subscriptions` table; `down` when it exceeds `subscriptionExpiredThreshold` (default `0.15`). Mirrors outlook's ratio-based process health. |

The approach is a verbatim copy of outlook-semantic-mcp's terminus health module, **minus the Unique-API indicator** (teams-mcp talks to Unique over HTTP, not the GraphQL `@unique-ag/unique-api` client whose `.health` helper outlook/sharepoint use).

## Config

New `health.config.ts` (`registerConfig('health', …)`): `connectivityTimeoutMs` (3000), `amqpCheckTimeoutMs` (5000), `subscriptionExpiredThreshold` (0.15).

## Notes / deviations

- **Global `fetch` instead of the `undici` package** in the connectivity indicator — teams-mcp doesn't depend on `undici` (outlook does) and already uses global `fetch`, which is undici under the hood (same error shapes `extractErrorCode` unwraps). Avoids a new dependency.
- **Two pre-existing e2e gaps fixed** so the new `test/health.e2e-spec.ts` (and the existing `app.e2e-spec.ts`) can boot:
  - `vitest.e2e.config.ts` was missing the `~` path alias (its `resolve.alias` only had `@generated`), so every `~/…` import failed to resolve under the e2e config.
  - `.env.test` was missing the required `UNIQUE_ROOT_SCOPE_ID`, so `AppModule` config validation threw on boot.
- **No schema change** — subscription health is inferred from `expiresAt` staleness (renewal is webhook-driven); an explicit reauth-failure column is a possible follow-up, out of scope.

## Verification

- ✅ `check-types` clean · ✅ `nest build` · ✅ unit tests 75/75, no regression