### PR TITLE
fix(teams-mcp): chat message rendering + chatId description hardening

### DIFF
--- a/services/teams-mcp/src/chat/chat.dtos.ts
+++ b/services/teams-mcp/src/chat/chat.dtos.ts
@@ -79,6 +79,7 @@ export const MsChatMessageSchema = z
       )
       .nullish(),
     messageType: z.string().default('message'),
+    deletedDateTime: z.string().nullish(),
   })
   .transform((msg) => ({
     id: msg.id,
@@ -89,6 +90,7 @@ export const MsChatMessageSchema = z
     contentType: msg.body.contentType,
     attachments: (msg.attachments ?? []).map((a) => ({ id: a.id, name: a.name ?? null })),
     messageType: msg.messageType,
+    deletedDateTime: msg.deletedDateTime ?? null,
   }));
 
 export type MsChatMember = z.infer<typeof MsChatMemberSchema>;

--- a/services/teams-mcp/src/chat/chat.service.ts
+++ b/services/teams-mcp/src/chat/chat.service.ts
@@ -69,7 +69,7 @@ export class ChatService {
       .api(`/chats/${chatId}/messages`)
       .top(limit)
       .orderby(orderBy)
-      .select('id,createdDateTime,from,body,attachments,messageType')
+      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     // Graph does not support a server-side messageType filter on the chat and
@@ -115,7 +115,7 @@ export class ChatService {
       .api(`/teams/${teamId}/channels/${channelId}/messages`)
       .top(limit)
       .orderby(orderBy)
-      .select('id,createdDateTime,from,body,attachments,messageType')
+      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     const raw = await collectUntil(client, response, {
@@ -155,7 +155,7 @@ export class ChatService {
     const client = this.graphClientFactory.createClientForUser(userProfileId);
     const response = await client
       .api(`/chats/${chatId}/messages/${messageId}`)
-      .select('id,createdDateTime,from,body,attachments,messageType')
+      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     return MsChatMessageSchema.parse(response);
@@ -182,7 +182,7 @@ export class ChatService {
     const client = this.graphClientFactory.createClientForUser(userProfileId);
     const response = await client
       .api(`/teams/${teamId}/channels/${channelId}/messages/${messageId}`)
-      .select('id,createdDateTime,from,body,attachments,messageType')
+      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     return MsChatMessageSchema.parse(response);

--- a/services/teams-mcp/src/chat/search.service.ts
+++ b/services/teams-mcp/src/chat/search.service.ts
@@ -198,7 +198,12 @@ export class SearchService {
 
             const content =
               contentFormat === 'normalized'
-                ? normalizeContent(message.content, message.contentType, message.attachments)
+                ? normalizeContent(
+                    message.content,
+                    message.contentType,
+                    message.attachments,
+                    message.deletedDateTime,
+                  )
                 : message.content;
 
             return { ...row, content };

--- a/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-channel-messages.tool.ts
@@ -132,7 +132,7 @@ export class GetChannelMessagesTool {
   ): z.output<typeof GetChannelMessagesOutputSchema>['messages'][number] {
     const content =
       input.contentFormat === 'normalized'
-        ? normalizeContent(m.content, m.contentType, m.attachments)
+        ? normalizeContent(m.content, m.contentType, m.attachments, m.deletedDateTime)
         : m.content;
 
     const msg: z.output<typeof GetChannelMessagesOutputSchema>['messages'][number] = {

--- a/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
@@ -129,7 +129,7 @@ export class GetChatMessagesTool {
   ): z.output<typeof GetChatMessagesOutputSchema>['messages'][number] {
     const content =
       input.contentFormat === 'normalized'
-        ? normalizeContent(m.content, m.contentType, m.attachments)
+        ? normalizeContent(m.content, m.contentType, m.attachments, m.deletedDateTime)
         : m.content;
 
     const msg: z.output<typeof GetChatMessagesOutputSchema>['messages'][number] = {

--- a/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
+++ b/services/teams-mcp/src/chat/tools/get-chat-messages.tool.ts
@@ -11,7 +11,9 @@ import { normalizeContent } from '../utils/normalize-content';
 const GetChatMessagesInputSchema = z.object({
   chatId: z
     .string()
-    .describe('Exact chat id from list_chats or search_messages. Use list_chats first to find it.'),
+    .describe(
+      'Opaque Microsoft Teams chat id (e.g. "19:...@thread.v2"). Do not invent, guess, or reconstruct this id; only copy an exact chatId returned by list_chats or search_messages. If you do not have one, call list_chats first.',
+    ),
   limit: z
     .number()
     .int()

--- a/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
+++ b/services/teams-mcp/src/chat/tools/send-chat-message.tool.ts
@@ -9,7 +9,9 @@ import { ChatService } from '../chat.service';
 const SendChatMessageInputSchema = z.object({
   chatId: z
     .string()
-    .describe('Exact chat id from list_chats or search_messages. Use list_chats first to find it.'),
+    .describe(
+      'Opaque Microsoft Teams chat id (e.g. "19:...@thread.v2"). Do not invent, guess, or reconstruct this id; only copy an exact chatId returned by list_chats or search_messages. If you do not have one, call list_chats first.',
+    ),
   message: z.string().describe('Plain text message content to send'),
 });
 

--- a/services/teams-mcp/src/chat/utils/normalize-content.spec.ts
+++ b/services/teams-mcp/src/chat/utils/normalize-content.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeContent } from './normalize-content';
+
+describe('normalizeContent', () => {
+  it('returns text content unchanged', () => {
+    expect(normalizeContent('hello world', 'text')).toBe('hello world');
+  });
+
+  it('strips HTML formatting while keeping the text', () => {
+    expect(normalizeContent('<p>hello <strong>world</strong></p>', 'html')).toBe('hello world');
+  });
+
+  it('renders an inline image as [image] instead of dropping it', () => {
+    const content =
+      '<div><span><img height="63" src="https://graph.microsoft.com/v1.0/chats/x/messages/y/hostedContents/z/$value" width="67"></span></div>';
+    expect(normalizeContent(content, 'html')).toBe('[image]');
+  });
+
+  it('keeps surrounding text alongside an image', () => {
+    expect(normalizeContent('<p>look at this <img src="x"></p>', 'html')).toBe(
+      'look at this [image]',
+    );
+  });
+
+  it('renders a named attachment as [attachment: name]', () => {
+    const content = '<attachment id="abc"></attachment>';
+    expect(normalizeContent(content, 'html', [{ id: 'abc', name: 'report.pdf' }])).toBe(
+      '[attachment: report.pdf]',
+    );
+  });
+
+  it('falls back to [no text content] for an otherwise-empty body (not [deleted])', () => {
+    expect(normalizeContent('<div></div>', 'html')).toBe('[no text content]');
+  });
+
+  it('returns [deleted] only when deletedDateTime is set', () => {
+    expect(normalizeContent('anything', 'html', [], '2026-07-09T00:00:00Z')).toBe('[deleted]');
+  });
+
+  it('prefers the deletion tombstone over rendering content', () => {
+    expect(normalizeContent('<p>still here</p>', 'html', [], '2026-07-09T00:00:00Z')).toBe(
+      '[deleted]',
+    );
+  });
+
+  it('detects adaptive card JSON blobs as [card]', () => {
+    expect(normalizeContent('{"type":"AdaptiveCard","version":"1.0"}', 'html')).toBe('[card]');
+  });
+});

--- a/services/teams-mcp/src/chat/utils/normalize-content.ts
+++ b/services/teams-mcp/src/chat/utils/normalize-content.ts
@@ -14,20 +14,28 @@ interface Attachment {
  * - </p>, <br>     →  newline
  * - <li>           →  "- " prefix
  * - <attachment id="x"/>  →  [attachment: name] (or [attachment] if name unknown)
+ * - <img …>        →  [image] (inline/hosted-content images carry no text)
  * - Adaptive card JSON blobs  →  [card]
  * - All other tags stripped via `striptags`
  * - HTML entities decoded via `he`
  *
- * Returns '[deleted]' for blank/tombstone content.
- * Returns content unchanged when contentType is 'text'.
+ * Returns '[deleted]' only when `deletedDateTime` is set (Graph's tombstone
+ * signal) — never as a fallback for otherwise-empty content, which is more
+ * often an image, sticker, or card. Content-light messages fall back to
+ * '[no text content]'. Returns content unchanged when contentType is 'text'.
  */
 export function normalizeContent(
   content: string,
   contentType: string,
   attachments: Attachment[] = [],
+  deletedDateTime?: string | null,
 ): string {
+  if (deletedDateTime) {
+    return '[deleted]';
+  }
+
   if (contentType !== 'html') {
-    return content.trim() || '[deleted]';
+    return content.trim() || '[no text content]';
   }
 
   const attachmentMap = new Map(attachments.map((a) => [a.id, a.name]));
@@ -49,6 +57,10 @@ export function normalizeContent(
     return name ? `[attachment: ${name}]` : '[attachment]';
   });
 
+  // Inline / hosted-content images: <img …> → [image]. These are not <attachment>
+  // elements, so without this rule striptags would drop them to an empty string.
+  result = result.replace(/<img[^>]*>/gi, '[image]');
+
   // Strip remaining HTML tags (formatting like <strong>, <em>, etc. — text kept)
   result = striptags(result);
 
@@ -63,5 +75,5 @@ export function normalizeContent(
     return '[card]';
   }
 
-  return result || '[deleted]';
+  return result || '[no text content]';
 }

--- a/services/teams-mcp/src/utils/classify-error.ts
+++ b/services/teams-mcp/src/utils/classify-error.ts
@@ -93,7 +93,7 @@ export function classifyError(error: unknown): ClassifiedError {
           (requestId
             ? ` Microsoft request id: ${requestId} (provide this to Microsoft support).`
             : '') +
-          ` This is usually transient — please retry shortly.`,
+          ` Some of these errors are transient and clear on a retry (for example a rate limit); others are persistent — notably a 500 returned while reading a chat whose messages contain content Graph cannot serialize (such as Loop components or certain cards) recurs on every attempt and will not clear by retrying.`,
       };
     }
 


### PR DESCRIPTION
Three chat-tool fixes surfaced from the same production log.

---

## 1. Inline images rendered as `[deleted]` → now `[image]`, and honest deletion detection

Image messages came back to the model as `[message deleted]` even though nothing was deleted. Teams embeds inline/hosted-content images as **`<img>` tags** (not `<attachment>` elements), so `normalizeContent` had no rule for them — `striptags` dropped the tag to an empty string, which then hit the `[deleted]` fallback. That fallback conflated *"nothing left after stripping"* (image, sticker, card) with an **actually-deleted** message.

- Add an `<img …>` → `[image]` rule before `striptags`.
- Return `[deleted]` **only** when Graph's `deletedDateTime` tombstone is set; use a neutral `[no text content]` for otherwise-empty bodies.
- Thread `deletedDateTime` through the chat/channel message `$select`s, the DTO, and the three `normalizeContent` call sites (`get_chat_messages`, `get_channel_messages`, search hydration).
- Add unit tests for `normalizeContent` (previously untested).

## 2. Forbid inventing `chatId` in tool descriptions

An agent listed chats, then called `send_chat_message` with a **fabricated** chatId — `19:meeting_<base64>@thread.v2` whose base64 decodes to `666b66b6-666b-4666-9666-666666666666` (all 6s, a hallucinated placeholder). Graph returned `404 NotFound`, which the calling agent mis-surfaced as "insufficient permissions."

The `chatId` param descriptions pointed at the happy path but never **forbade** fabricating an id. Reworked into the blunt, prohibitive style the **Atlassian MCP** uses for its own opaque ids (*"Do not invent opaque IDs: only copy … from existing content or tool output"*):

> Opaque Microsoft Teams chat id (e.g. `"19:...@thread.v2"`). Do not invent, guess, or reconstruct this id; only copy an exact chatId returned by list_chats or search_messages. If you do not have one, call list_chats first.

Applied to `send_chat_message` and `get_chat_messages`.

## 3. Drop the blanket "transient" claim from the Graph 5xx message

A Graph `500 "Error while processing response"` on a chat containing content Graph cannot serialize (Loop components, certain cards) is **deterministic** — it recurs on every attempt. The surfaced message told the model it was *"usually transient — please retry shortly"*, prompting futile retries. Reworded to note some 5xx are transient (e.g. rate limits) while others are persistent and will not clear by retrying. **Message text only; the `retryable` flag is unchanged.**

---

## Not included (tracked separately)

- Corrective Graph-404 tool error ("this id was not valid; call list_chats and copy an exact chatId") — gives the agent a real correction loop.
- `list_chats` short reference token (the Teams equivalent of Jira's `PROJ-123`) so there is nothing opaque to hallucinate.
- Any actual mitigation of the Graph 5xx-on-Loop/card bug (no server-side filter exists to exclude those messages — [docs](https://learn.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http)); this PR only corrects the misleading wording.

## Testing

`pnpm check-types`, `pnpm style`, and `pnpm test` all pass (84 tests, incl. 9 new `normalizeContent` cases; existing 19 `classify-error` cases still green). No behavioral code beyond normalization touched.

Refs: [UN-22733](https://unique-ch.atlassian.net/browse/UN-22733)

[UN-22733]: https://unique-ch.atlassian.net/browse/UN-22733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ