### PR TITLE
fix(teams-mcp): only send OData params Graph supports on chat/channel message endpoints [UN-22733]

### DIFF
--- a/services/teams-mcp/src/chat/chat.service.ts
+++ b/services/teams-mcp/src/chat/chat.service.ts
@@ -29,12 +29,14 @@ export class ChatService {
     // Single-page by design (not collectAllPages): a bounded "recent chats"
     // window with an accurate `hasMore`. $orderby is required for "most recent"
     // — /me/chats is not sorted by activity by default.
+    // /me/chats supports only $expand, $top, $filter and $orderby — $select is
+    // rejected as an unsupported OData parameter (see chat-list docs), so we let
+    // the members/lastMessagePreview expansions bring back the fields we need.
     const response: PageCollection = await client
       .api('/me/chats')
       .expand('members,lastMessagePreview')
       .top(limit)
       .orderby('lastMessagePreview/createdDateTime desc')
-      .select('id,chatType,topic,members,createdDateTime')
       .get();
 
     const chats = z.array(MsChatSchema).parse(response.value);
@@ -65,11 +67,13 @@ export class ChatService {
     );
 
     const client = this.graphClientFactory.createClientForUser(userProfileId);
+    // The chat messages endpoint supports only $top, $orderby and $filter — a
+    // $select is rejected as an unsupported OData parameter (see chat-list-messages
+    // docs), so we request the full message and let the schema pick out fields.
     const response = await client
       .api(`/chats/${chatId}/messages`)
       .top(limit)
       .orderby(orderBy)
-      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     // Graph does not support a server-side messageType filter on the chat and
@@ -96,9 +100,9 @@ export class ChatService {
     teamId: string,
     channelId: string,
     limit: number,
-    options: { orderBy?: string; excludeSystemMessages?: boolean } = {},
+    options: { excludeSystemMessages?: boolean } = {},
   ): Promise<MsChatMessage[]> {
-    const { orderBy = 'createdDateTime desc', excludeSystemMessages = false } = options;
+    const { excludeSystemMessages = false } = options;
     const span = this.traceService.getSpan();
     span?.setAttribute('user_profile_id', userProfileId);
     span?.setAttribute('team_id', teamId);
@@ -111,11 +115,13 @@ export class ChatService {
     );
 
     const client = this.graphClientFactory.createClientForUser(userProfileId);
+    // Unlike /chats/{id}/messages, the channel messages endpoint supports only
+    // $top and $expand — any $orderby or $select is rejected with HTTP 400 (see
+    // channel-list-messages docs). Messages come back sorted by the last modified
+    // date of the reply chain, so we page with $top alone and take the newest.
     const response = await client
       .api(`/teams/${teamId}/channels/${channelId}/messages`)
       .top(limit)
-      .orderby(orderBy)
-      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     const raw = await collectUntil(client, response, {
@@ -153,10 +159,10 @@ export class ChatService {
     );
 
     const client = this.graphClientFactory.createClientForUser(userProfileId);
-    const response = await client
-      .api(`/chats/${chatId}/messages/${messageId}`)
-      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
-      .get();
+    // Getting a single message supports no OData query parameters at all — a
+    // $select is rejected (see chatmessage-get docs) — so we fetch the full
+    // message and let the schema pick out the fields we need.
+    const response = await client.api(`/chats/${chatId}/messages/${messageId}`).get();
 
     return MsChatMessageSchema.parse(response);
   }
@@ -180,9 +186,11 @@ export class ChatService {
     );
 
     const client = this.graphClientFactory.createClientForUser(userProfileId);
+    // Getting a single message supports no OData query parameters at all — a
+    // $select is rejected (see chatmessage-get docs) — so we fetch the full
+    // message and let the schema pick out the fields we need.
     const response = await client
       .api(`/teams/${teamId}/channels/${channelId}/messages/${messageId}`)
-      .select('id,createdDateTime,from,body,attachments,messageType,deletedDateTime')
       .get();
 
     return MsChatMessageSchema.parse(response);


### PR DESCRIPTION
Part of UN-22733

## Problem

Production logs showed `get_channel_messages` failing with **HTTP 400** from Microsoft Graph, surfaced as a misleading *"invalid identifiers"* error — even though the team/channel ids were valid (they had just come back from a successful `list_channels`).

Root cause: the channel-messages listing request sent `$orderby=createdDateTime desc` and `$select=...`, but `GET /teams/{id}/channels/{id}/messages` supports **only** `$top` and `$expand` — *"The other OData query parameters aren't currently supported."* ([channel-list-messages docs](https://learn.microsoft.com/en-us/graph/api/channel-list-messages?view=graph-rest-1.0)). The structurally-identical chat-messages call worked because `/chats/{id}/messages` **does** support `$orderby`.

## Audit

I then verified **every** chat/channel Graph query in the service against the live docs:

| Call | Endpoint | Was sending | Doc allows | Fix |
|---|---|---|---|---|
| `getChannelMessages` | `/teams/{}/channels/{}/messages` | `top`,`orderby`,`select` | `$top`,`$expand` | drop `orderby`+`select` |
| `getChatMessages` | `/chats/{}/messages` | `top`,`orderby`,`select` | `$top`,`$orderby`,`$filter` | drop `select` |
| `listChats` | `/me/chats` | `expand`,`top`,`orderby`,`select` | `$expand`,`$top`,`$filter`,`$orderby` | drop `select` |
| `getChatMessageById` | `/chats/{}/messages/{}` | `select` | *none* | drop `select` |
| `getChannelMessageById` | `/teams/{}/channels/{}/messages/{}` | `select` | *none* | drop `select` |
| `listChannels` | `/teams/{}/channels` | `select` | `$filter`,`$select` ✅ | no change |
| `listTeams`, `send*`, `search` | — | none / body | — | no change |

The three extra `$select` violations were **latent**: unlike the channel-listing endpoint (which strictly 400s), those endpoints silently ignore an unsupported `$select` today — so they worked, but were one Graph enforcement change away from breaking.

## Change

Removed every unsupported OData parameter. Responses now come back in full and the non-strict Zod schemas pick out the fields we need — no behavioral change beyond slightly larger payloads. `listChannels` keeps its `$select` (explicitly supported and recommended by the docs). Each removal carries an inline comment citing the specific doc to prevent regressions.

## Verification

- `pnpm check-types` ✅
- `pnpm biome check src` (102 files) ✅
- `pnpm test` — 84/84 ✅

Docs were fetched live via the `msgraph-docs` skill rather than relying on training data.

