### PR TITLE
docs(teams-mcp): split transcripts/recordings vs chats/channels tracks; reframe ingested-vs-live

### DIFF
--- a/services/teams-mcp/docs/README.md
+++ b/services/teams-mcp/docs/README.md
@@ -1,8 +1,8 @@
 <!-- confluence-page-id: 1802633229 -->
 <!-- confluence-space-key: PUBDOC -->
 
-!!! danger "Pre-Release Disclaimer"
-    **`teams-mcp` is pre-release software.**
+!!! danger "Experimental Software Disclaimer"
+    **`teams-mcp` is experimental software.**
 
     - **No SLA/SSLA**: No service level agreements or support level agreements apply
     - **No Support**: No guaranteed support, response times, or issue resolution
@@ -11,19 +11,19 @@
     - **Data Loss Risk**: Bugs or changes may result in data loss or corruption
     - **Use at Your Own Risk**: This software is provided "as-is" without warranties of any kind
 
-    Pre-release software is intended for evaluation and testing purposes only. Do not rely on this software for production workloads without understanding these limitations.
+    Experimental software is intended for evaluation and testing purposes only. Do not rely on this software for production workloads without understanding these limitations.
 
 ## Overview
 
 The Teams MCP Server is a cloud-native application that automatically captures meeting transcripts and recordings from Microsoft Teams and ingests them into the Unique knowledge base. This guide provides administrators with essential information about requirements, features, and limitations.
 
-**Note:** This is a connector-style MCP server that does two things. First, it automatically ingests meeting transcripts into the Unique knowledge base in the background. Second, it exposes an interactive tool surface of 14 MCP tools — 8 chat/messaging tools and 6 transcript/KB management tools. Chat and channel tools take ids obtained from the `list_*` tools. See [Technical Reference — Tools](./technical/tools.md) for the full tool reference.
+**Note:** This is a connector-style MCP server that does two things. First, it automatically ingests meeting **transcripts and recordings** into the Unique knowledge base in the background, where they are then queried **from within Unique**. Second, it exposes an interactive tool surface of 14 MCP tools — 8 chat/messaging tools and 6 transcript/KB management tools. Through these tools, **chat and channel messages are accessible in Unique on demand, but are never ingested into it** — they are fetched live from the Microsoft Graph API and exist only in Microsoft, whereas transcripts and recordings are copied into the Unique knowledge base. This ingested-vs-live distinction is the key thing to understand; see [Where the data lives](#where-the-data-lives-ingested-vs-live). Chat and channel tools take ids obtained from the `list_*` tools. See [Technical Reference — Tools](./technical/tools.md) for the full tool reference.
 
 For deployment, configuration, and operational details, see the [IT Operator Guide](./operator/README.md).
 
 ## Quick Summary
 
-**What it does:** Automatically captures meeting transcripts and recordings from Microsoft Teams and ingests them into Unique's AI knowledge base with participant-based access controls
+**What it does:** Two things. (1) Automatically captures meeting transcripts and recordings from Microsoft Teams and **ingests them into Unique's AI knowledge base** with participant-based access controls, where they are queried from within Unique. (2) Exposes interactive tools that make Teams chat and channel messages **accessible in Unique on demand — fetched live from the Microsoft Graph API and never ingested** (they exist only in Microsoft, not in the Unique knowledge base).
 
 **Deployment:** Kubernetes-based NestJS microservice
 
@@ -71,7 +71,34 @@ For detailed permission justifications, see [Microsoft Graph Permissions](./tech
 
 ## Features
 
-### Core Capabilities
+The server offers **two independent capability tracks**:
+
+- **[Meeting Transcripts & Recordings](#meeting-transcripts--recordings)** — background ingestion of meeting transcripts (and their recordings) into the Unique knowledge base, plus tools to search and manage that ingestion. Webhook-driven and asynchronous.
+- **[Chats & Channels Messaging](#chats--channels-messaging)** — an interactive tool surface for reading, searching, and sending Teams chat and channel messages live via Microsoft Graph. Synchronous and on-demand.
+
+The two tracks are described separately below, followed by the [cross-cutting capabilities](#cross-cutting-capabilities) that apply to both.
+
+### Where the Data Lives: Ingested vs. Live
+
+This is the single most important distinction between the two tracks. **Both are accessible through Unique — the difference is where the data is stored.**
+
+!!! important "Both are accessible in Unique; only transcripts are ingested"
+    **Meeting transcripts and recordings are ingested — copied into the Unique knowledge base — and queried from that stored copy. Teams chat and channel messages are also accessible in Unique, through this server's MCP tools, but they are never ingested: they are fetched live from the Microsoft Graph API on demand and exist only in Microsoft, never as a copy in Unique.**
+
+    Messages being "not ingested" means only that Unique keeps no copy of them — **not** that they are inaccessible. The Unique AI can read, search, and send them at any time via the tools; it just reaches back to Microsoft each time instead of reading a stored copy.
+
+| | Meeting transcripts & recordings | Chats & channels messages |
+|---|---|---|
+| **Accessible through Unique?** | **Yes** — via Unique AI and the transcript tools | **Yes** — via the MCP messaging tools |
+| **Ingested (copied) into Unique?** | **Yes** — stored in the knowledge base | **No** — never copied; the data lives only in Microsoft |
+| **How it is served** | Queried from the **stored copy in Unique** — indexed and searchable (`find_transcripts`, `list_meetings`) | Fetched **live from the Microsoft Graph API** on every call (`get_*_messages`, `search_messages`) |
+| **Freshness** | Point-in-time snapshot captured at ingestion | Always current — reflects Teams in real time |
+| **If this server is disconnected** | The copy remains in Unique and stays queryable | No longer reachable — nothing was stored, so there is no copy to fall back on |
+| **Data flow** | Teams → Unique knowledge base (once) → query the copy | Teams → live fetch on each call → returned to the caller (no copy kept) |
+
+### Meeting Transcripts & Recordings
+
+This is the connector track: once a user connects, meeting transcripts (and recordings) are captured automatically and ingested into Unique. Chat and channel messages are **not** part of this track — they are never ingested.
 
 **Real-time Transcript and Recording Capture**
 
@@ -87,20 +114,31 @@ For detailed permission justifications, see [Microsoft Graph Permissions](./tech
 - Meeting participants receive **read** access in Unique
 - Users resolved by email or username in Unique platform
 
-**Self-Service User Connection**
-
-- Users connect their own Microsoft account via [OAuth 2.1](https://oauth.net/2.1/) with [PKCE](https://datatracker.ietf.org/doc/html/rfc7636)
-- No IT administrator involvement required for individual connections
-
 **Automatic Subscription Management**
 
 - Microsoft Graph webhook subscriptions created automatically on user connection
 - Subscriptions renewed automatically before expiration
 - Failed renewals handled gracefully with user reconnection required
 
-**Teams Chat Messaging**
+**Reliability**
 
-Chat and messaging tools target chats and channels by id: call a `list_*` tool to obtain an id (and distinguishing metadata), then pass that id to a read, write, or search tool.
+- RabbitMQ message queue for asynchronous webhook processing
+- Dead Letter Exchange (DLX) for failed message inspection and retry
+- Meets Microsoft's strict webhook response requirements (< 10 seconds)
+- See [FAQ - Why use RabbitMQ for webhook processing?](./faq.md#why-use-rabbitmq-for-webhook-processing) for details
+
+**Search & management tools** (see [Technical Reference — Tools](./technical/tools.md#transcript--knowledge-base-management)):
+
+- `find_transcripts`: Semantic + keyword search within ingested transcripts
+- `list_meetings`: Browse ingested meetings by date, organizer, or participant
+- `ingest_meeting`: Ingest a specific meeting's transcript on demand
+- `start_kb_integration` / `stop_kb_integration` / `verify_kb_integration_status`: Manage and inspect the ingestion subscription
+
+### Chats & Channels Messaging
+
+This is the interactive track: tools that read, search, and send Teams messages live through Microsoft Graph. These messages are fetched on every call and are **never** ingested into the Unique knowledge base.
+
+Chat and messaging tools target chats and channels by id: call a `list_*` tool to obtain an id (and distinguishing metadata), then pass that id to a read, write, or search tool. See [Technical Reference — Tools](./technical/tools.md#teams--channels).
 
 - `list_teams`: List all Microsoft Teams the user is a member of; returns team id and `isArchived` flag
 - `list_channels`: List all channels in a team (by team id); returns channel id, `createdDateTime`, and `membershipType`
@@ -111,7 +149,14 @@ Chat and messaging tools target chats and channels by id: call a `list_*` tool t
 - `send_channel_message`: Send a plain text message to a Teams channel (by team id + channel id)
 - `send_chat_message`: Send a plain text message to a Teams chat (by chat id)
 
-### Advanced Features
+### Cross-Cutting Capabilities
+
+These apply to both tracks.
+
+**Self-Service User Connection**
+
+- Users connect their own Microsoft account via [OAuth 2.1](https://oauth.net/2.1/) with [PKCE](https://datatracker.ietf.org/doc/html/rfc7636)
+- No IT administrator involvement required for individual connections
 
 **Security**
 
@@ -120,13 +165,6 @@ Chat and messaging tools target chats and channels by id: call a `list_*` tool t
 - Refresh token rotation with family-based revocation
 - Short-lived access tokens (60 seconds default)
 - See [Security Documentation](./technical/security.md#token-security) for details
-
-**Reliability**
-
-- RabbitMQ message queue for asynchronous webhook processing
-- Dead Letter Exchange (DLX) for failed message inspection and retry
-- Meets Microsoft's strict webhook response requirements (< 10 seconds)
-- See [FAQ - Why use RabbitMQ for webhook processing?](./faq.md#why-use-rabbitmq-for-webhook-processing) for details
 
 **Observability**
 
@@ -260,24 +298,44 @@ sequenceDiagram
 
 See [Transcript Processing Flow](./technical/flows.md#transcript-processing-flow) for additional details.
 
-### User Workflow
+### Messaging Flow
 
-1. **User Setup** (One-time)
-   - Open MCP client and connect to Teams MCP Server
-   - Sign in with Microsoft account
-   - Grant required permissions
+The two flows above cover the transcript track, which is webhook-driven and asynchronous. The messaging track works differently: chat and channel tools are handled **synchronously and inline** — each tool call queries Microsoft Graph and returns immediately, with no queue, background worker, or ingestion. The caller discovers an id with a `list_*` tool, then passes it to a read, search, or send tool.
 
-2. **Automatic Processing** (Ongoing)
+See [Chat Flows](./technical/flows.md#chat-flows) for the read, search, and send sequence diagrams.
+
+### User Workflows
+
+Both tracks begin with the same one-time connection, then diverge — because their data models differ (see [Where the data lives](#where-the-data-lives-ingested-vs-live)).
+
+**One-time setup (both tracks)**
+
+1. Open MCP client and connect to Teams MCP Server
+2. Sign in with Microsoft account
+3. Grant required permissions
+
+#### Transcripts & Recordings Workflow — ingest once, then query in Unique
+
+1. **Enable ingestion** (One-time) — call `start_kb_integration` (or rely on `MICROSOFT_AUTO_START_INGESTION` if the operator enabled it)
+2. **Automatic capture** (Ongoing)
    - Attend Microsoft Teams meetings with transcription enabled
    - Meeting ends and transcript becomes available
-   - Teams MCP automatically receives webhook notification
-   - Transcript and recording (if available) captured and uploaded
+   - Teams MCP automatically receives a webhook notification
+   - Transcript and recording (if available) are captured and **ingested into the Unique knowledge base**
+3. **Query in Unique** (Ongoing)
+   - Meeting content lives in the Unique knowledge base — organizer gets write + read, participants get read
+   - Search and query it **from within Unique** via Unique AI, or with `find_transcripts` / `list_meetings`
+   - Content remains available in Unique even after the user disconnects
 
-3. **Access in Unique** (Ongoing)
-   - Meeting content available in Unique knowledge base
-   - Organizer has write + read access
-   - Participants have read access
-   - Content searchable and queryable via Unique AI
+#### Chats & Channels Workflow — always query live from the API
+
+1. **Discover the target** (Each use) — call a `list_*` tool (`list_chats`, `list_teams` → `list_channels`) or `search_messages` to obtain the chat/channel id
+2. **Read, search, or send** (Each use)
+   - Pass the id to `get_chat_messages` / `get_channel_messages`, `search_messages`, or `send_*_message`
+   - Messages are fully accessible to the Unique AI through these tools — every call fetches **live from the Microsoft Graph API**, so you always see the current state of Teams
+3. **Accessible, but never stored in Unique**
+   - The tools give the AI on-demand access, but Unique keeps **no copy** — messages are never ingested into the knowledge base; they exist only in Microsoft
+   - Because nothing is stored, there is no knowledge-base copy to query later: once the user disconnects, the tools simply stop returning results
 
 ## Limitations and Constraints
 
@@ -311,19 +369,27 @@ See [Authentication Architecture - Single App Registration Architecture](./techn
 
 ### Not Supported
 
+**Meeting transcripts & recordings:**
+
 - **Real-time transcription**: Only processes completed transcripts, not live captions
 - **Meeting creation**: Read-only access; cannot create or modify meetings
 - **Selective meeting capture**: All meetings with transcription enabled are captured (no organizer-only or meeting-type filter)
-- **Token introspection**: Tokens validated locally with short TTLs for performance
 - **Historical/full sync**: No mechanism to backfill transcripts from meetings that took place before the user connected; see [Why can't historical transcripts be synced?](./faq.md#why-cant-historical-transcripts-be-synced)
 - **Delta/incremental sync**: No ability to poll for missed or updated transcripts since a given point in time; see [Why is there no delta sync?](./faq.md#why-is-there-no-delta-sync)
 - **Missed-notification recovery**: If a subscription lapses, any transcripts produced during the gap are permanently lost — there is no catch-up or replay mechanism
-- **Multi-tenant in one session**: A user belonging to multiple Microsoft tenants must authenticate separately for each tenant; one OAuth session covers exactly one tenant
 - **Transcript format variants**: Only VTT-format transcripts are processed; meetings with transcripts in other formats are silently skipped
 - **Recording size assurance**: No application-level size check on recordings; very large files (e.g., multi-hour all-hands) may time out during download and be skipped, while the transcript is still ingested
+
+**Chats & channels messaging:**
+
 - **Rich message sends**: `send_chat_message` and `send_channel_message` send plain text only — no `@mentions`, no rich content (bold, tables, adaptive cards), and no attachment upload
 - **Message threading/replies**: There is no tool for replying to a specific message in a thread; only new top-level messages can be sent
 - **Chat/channel message ingestion**: Messages read or searched via the messaging tools are fetched live from Microsoft Graph on every call and are **not** ingested into the Unique knowledge base; only meeting transcripts are ingested
+
+**General:**
+
+- **Token introspection**: Tokens validated locally with short TTLs for performance
+- **Multi-tenant in one session**: A user belonging to multiple Microsoft tenants must authenticate separately for each tenant; one OAuth session covers exactly one tenant
 
 ### Microsoft Graph API Constraints
 

--- a/services/teams-mcp/docs/technical/README.md
+++ b/services/teams-mcp/docs/technical/README.md
@@ -7,6 +7,8 @@ This section contains detailed technical documentation for developers and archit
 
 **Note:** The Teams MCP Server is both an MCP server and a connector — it exposes **14 MCP tools** (8 chat/messaging + 6 transcript/KB) that AI clients invoke on demand, and once a user connects their account, it automatically ingests meeting transcripts into the Unique knowledge base in the background. This contrasts with pure connector-style servers which ingest data silently without exposing tools.
 
+**Key distinction:** meeting **transcripts and recordings are ingested into Unique** (copied into the knowledge base) and queried from that stored copy; Teams **chat and channel messages are accessible in Unique through the MCP tools but are never ingested** — they are fetched live from the Microsoft Graph API and exist only in Microsoft. "Not ingested" is about storage, not accessibility. See [README — Where the Data Lives](../README.md#where-the-data-lives-ingested-vs-live).
+
 ## Documentation
 
 | Document | Description |

--- a/services/teams-mcp/docs/technical/architecture.md
+++ b/services/teams-mcp/docs/technical/architecture.md
@@ -128,6 +128,8 @@ flowchart TB
 
 The Chat Module (`src/chat/`) exposes a synchronous request/response tool surface over MCP, distinct from the asynchronous webhook/transcript ingestion path. Tool calls are handled inline — there is no queue or background worker.
 
+**Chat and channel messages are accessible through these tools but are never ingested into Unique.** The Unique AI can read, search, and send them on demand, but each call is served **live from the Microsoft Graph API** — Unique keeps no knowledge-base copy, and the messages exist only in Microsoft. This is the opposite of the Transcript Module, whose output *is* ingested into Unique and later queried from that stored copy (`find_transcripts` / `list_meetings`). "Not ingested" refers to storage, not accessibility. See [README — Where the Data Lives](../README.md#where-the-data-lives-ingested-vs-live).
+
 **Services:**
 
 | Service | File | Responsibility |


### PR DESCRIPTION
## What

Improves the `services/teams-mcp/docs` to clearly separate the two capability tracks and to make the **ingested-vs-live** data model unmistakable.

### Two dedicated tracks
- Restructured README `Features` into **Meeting Transcripts & Recordings**, **Chats & Channels Messaging**, and **Cross-Cutting Capabilities**.
- Grouped `Not Supported` by the same two tracks (+ General).
- Added per-track **User Workflows** (transcript *ingest-once-then-query-in-Unique* vs messaging *always-query-live*) and a `Messaging Flow` note under How It Works.

### The key differentiation
- New **"Where the Data Lives: Ingested vs. Live"** section with a comparison table.
- Framed correctly as a **storage** distinction, not accessibility: Teams messages **are accessible in Unique** through the MCP tools; they are simply **never ingested** — they exist only in Microsoft and are fetched live from Graph on every call. Transcripts & recordings **are** copied into the Unique knowledge base and queried from that stored copy.
- Reinforced the same framing in `technical/README.md` and `technical/architecture.md`.

### Wording
- Renamed the **"Pre-release"** disclaimer to **"Experimental"**.

## Files
- `services/teams-mcp/docs/README.md`
- `services/teams-mcp/docs/technical/README.md`
- `services/teams-mcp/docs/technical/architecture.md`

## Notes
Docs-only change. No code, config, or behavior changes.