### PR TITLE
fix(teams-mcp): tolerate null contentCorrelationId and optional organizer tenantId

### DIFF
--- a/services/teams-mcp/src/transcript/transcript-created.service.ts
+++ b/services/teams-mcp/src/transcript/transcript-created.service.ts
@@ -230,7 +230,7 @@ export class TranscriptCreatedService {
     span?.addEvent('microsoft graph data retrieved', {
       meetingId,
       transcriptId,
-      contentCorrelationId: transcript.contentCorrelationId,
+      contentCorrelationId: transcript.contentCorrelationId ?? undefined,
     });
     this.logger.debug(
       {
@@ -243,13 +243,16 @@ export class TranscriptCreatedService {
 
     span?.addEvent('transcript processing completed');
 
-    // Fetch the correlated recording (if available) before ingesting
-    const recording = await this.recordingService.fetchRecording(
-      userProfileId,
-      ownerPath,
-      meetingId,
-      transcript.contentCorrelationId,
-    );
+    // Fetch the correlated recording (if available) before ingesting. A transcript-only meeting
+    // has no contentCorrelationId, so there is no recording to correlate — skip the lookup.
+    const recording = transcript.contentCorrelationId
+      ? await this.recordingService.fetchRecording(
+          userProfileId,
+          ownerPath,
+          meetingId,
+          transcript.contentCorrelationId,
+        )
+      : null;
 
     await this.unique.ingestTranscript(
       {

--- a/services/teams-mcp/src/transcript/transcript.dtos.spec.ts
+++ b/services/teams-mcp/src/transcript/transcript.dtos.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { Transcript } from './transcript.dtos';
+
+const baseTranscript = {
+  id: 'transcript-1',
+  meetingId: 'meeting-1',
+  callId: 'call-1',
+  contentCorrelationId: 'correlation-1',
+  transcriptContentUrl: 'https://graph.microsoft.com/v1.0/transcript/content',
+  createdDateTime: '2026-07-14T10:00:00Z',
+  endDateTime: '2026-07-14T11:00:00Z',
+  meetingOrganizer: {
+    application: null,
+    device: null,
+    user: {
+      userIdentityType: 'aadUser',
+      tenantId: 'tenant-1',
+      id: 'user-1',
+      displayName: 'Organizer',
+    },
+  },
+};
+
+describe('Transcript', () => {
+  it('parses a fully populated transcript', () => {
+    const result = Transcript.parse(baseTranscript);
+    expect(result.contentCorrelationId).toBe('correlation-1');
+    expect(result.meetingOrganizer.user.tenantId).toBe('tenant-1');
+  });
+
+  it('accepts a null contentCorrelationId when the transcript has no recording', () => {
+    const result = Transcript.parse({ ...baseTranscript, contentCorrelationId: null });
+    expect(result.contentCorrelationId).toBeNull();
+  });
+
+  it('accepts a missing tenantId on the meeting organizer', () => {
+    const { tenantId: _tenantId, ...userWithoutTenant } = baseTranscript.meetingOrganizer.user;
+    const result = Transcript.parse({
+      ...baseTranscript,
+      meetingOrganizer: {
+        ...baseTranscript.meetingOrganizer,
+        user: userWithoutTenant,
+      },
+    });
+    expect(result.meetingOrganizer.user.tenantId).toBeUndefined();
+  });
+
+  it('still requires the transcript id', () => {
+    const { id: _id, ...withoutId } = baseTranscript;
+    expect(() => Transcript.parse(withoutId)).toThrow();
+  });
+});

--- a/services/teams-mcp/src/transcript/transcript.dtos.ts
+++ b/services/teams-mcp/src/transcript/transcript.dtos.ts
@@ -237,7 +237,9 @@ export const Transcript = z.object({
   id: z.string(),
   meetingId: z.string(),
   callId: z.string(),
-  contentCorrelationId: z.string(),
+  // Graph returns null when the transcript has no correlated recording; the field is only a
+  // link to a recording, so it is legitimately absent for transcript-only meetings.
+  contentCorrelationId: z.string().nullish(),
   transcriptContentUrl: stringToURL(),
   createdDateTime: isoDatetimeToDate({ offset: true }),
   endDateTime: isoDatetimeToDate({ offset: true }),
@@ -246,7 +248,8 @@ export const Transcript = z.object({
     device: z.string().nullable(),
     user: z.object({
       userIdentityType: z.string(),
-      tenantId: z.string(),
+      // identity.tenantId is documented as Optional and can be omitted for some organizers.
+      tenantId: z.string().nullish(),
       id: z.string(),
       displayName: z.string().nullable(),
     }),
@@ -357,7 +360,8 @@ export const Recording = z.object({
     device: z.string().nullable(),
     user: z.object({
       userIdentityType: z.string(),
-      tenantId: z.string(),
+      // identity.tenantId is documented as Optional and can be omitted for some organizers.
+      tenantId: z.string().nullish(),
       id: z.string(),
       displayName: z.string().nullable(),
     }),

--- a/services/teams-mcp/src/unique/unique.service.ts
+++ b/services/teams-mcp/src/unique/unique.service.ts
@@ -43,7 +43,7 @@ export class UniqueService {
       date: Date;
       startDateTime: Date;
       endDateTime: Date;
-      contentCorrelationId: string;
+      contentCorrelationId?: string | null;
       participants: { id?: string; name: string; email: string }[];
       owner: { id: string; name: string; email: string };
     },
@@ -365,7 +365,7 @@ export class UniqueService {
       endDateTime: Date;
       meetingId: string;
       subject: string;
-      contentCorrelationId: string;
+      contentCorrelationId?: string | null;
       owner: { name: string; email: string };
       participants: { name: string; email: string }[];
     },
@@ -378,9 +378,13 @@ export class UniqueService {
       start_datetime: startDateTime.toISOString(),
       end_datetime: endDateTime.toISOString(),
       meeting_id: meeting.meetingId,
-      content_correlation_id: meeting.contentCorrelationId,
       organizer_email: meeting.owner.email.toLowerCase(),
     };
+
+    // Only present when the transcript is linked to a recording.
+    if (meeting.contentCorrelationId) {
+      metadata.content_correlation_id = meeting.contentCorrelationId;
+    }
 
     if (meeting.subject) {
       metadata.subject = meeting.subject;


### PR DESCRIPTION
## What

`ingest_meeting` crashes in PROD with a `ZodError` before the transcript can be queued. The error surfaces to users as "Invalid input: expected string, received null" — which reads like an invalid-URL problem, but the join URL resolves fine. The failure is DTO validation of the transcript list returned by Microsoft Graph.

Two fields the `Transcript` DTO declared as **required strings** come back empty from Graph:

| Field | DTO declared | Graph returns |
|---|---|---|
| `contentCorrelationId` | `z.string()` | `null` (transcript-only meeting, no linked recording) |
| `meetingOrganizer.user.tenantId` | `z.string()` | absent for some organizers |

## Why these are legitimately optional (verified against live Graph docs)

- **`contentCorrelationId`** — [callTranscript resource](https://learn.microsoft.com/en-us/graph/api/resources/calltranscript?view=graph-rest-1.0): "The unique identifier that links the transcript with its corresponding recording." Naturally absent when there is no recording; PROD confirms `null`.
- **`tenantId`** — [identity resource](https://learn.microsoft.com/en-us/graph/api/resources/identity?view=graph-rest-1.0): documented verbatim as *"Unique identity of the tenant. **Optional.**"*

## Changes

- Relax `Transcript.contentCorrelationId` and `Transcript.meetingOrganizer.user.tenantId` to `.nullish()`.
- Apply the same `tenantId` fix to the `Recording` DTO (identical `identity` shape — would crash the recording path the same way).
- Skip the recording-correlation lookup when there is no `contentCorrelationId` (nothing to correlate).
- Thread the nullable `contentCorrelationId` through `ingestTranscript` / `buildContentMetadata`; omit the `content_correlation_id` metadata key when absent.
- Add a `Transcript` DTO regression test (null `contentCorrelationId`, missing `tenantId`, and still-required `id`).

## Testing

- `npm test` — 88 passed
- `npm run check-types` — clean
- `biome check` — clean

## Observed in PROD

`teams-mcp` (finance-gpt namespace), 2 occurrences in a 15-min window, both from the `unique-ai-mcp-client-module-Teams MCP` client, on two different join URLs (a new `/meet/` short link and a classic `/l/meetup-join/` link). Thrown at `ingest-meeting.tool.ts:134` (`z.array(Transcript).parse(items)`).
