### PR TITLE
feat(sharepoint-connector): replace noisy sync failure alert with SyncDegraded

### DIFF
--- a/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/README.md
+++ b/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/README.md
@@ -142,14 +142,14 @@ spec:
 | prometheus.additionalAlerts.SharepointConnectorGraphQLErrors.for | string | `"30s"` |  |
 | prometheus.additionalAlerts.SharepointConnectorGraphQLErrors.labels.alertGroup | string | `"sharepoint-connector"` |  |
 | prometheus.additionalAlerts.SharepointConnectorGraphQLErrors.labels.severity | string | `"warning"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.alert | string | `"SharepointConnectorSyncFailures"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.annotations.description | string | `"The SharePoint Connector is experiencing sync failures. Current failure rate: {{ $value | humanizePercentage }}."` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.annotations.runbook | string | `"1. Inspect application logs for specific error messages\n2. Check the failure_step label to identify where the sync failed\n3. Verify SharePoint connectivity and permissions\n4. Check for rate limiting or throttling issues\n5. Check for recent changes to the deployment as well as its underlying infrastructure\n"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.annotations.summary | string | `"SharePoint Connector sync failures detected"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.expr | string | `"(\n  sum(rate(spc_sync_duration_seconds_count{result=\"failure\"}[5m]))\n  /\n  sum(rate(spc_sync_duration_seconds_count[5m]))\n) > 0.01\n"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.for | string | `"30s"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.labels.alertGroup | string | `"sharepoint-connector"` |  |
-| prometheus.additionalAlerts.SharepointConnectorSyncFailures.labels.severity | string | `"warning"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.alert | string | `"SharepointConnectorSyncDegraded"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.annotations.description | string | `"Site sync failure ratio over ~5 cycles exceeded 50%. Current: {{ $value | humanizePercentage }}."` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.annotations.runbook | string | `"1. Inspect application logs for specific error messages\n2. Check the failure_step label to identify where the sync failed\n3. Verify SharePoint connectivity and permissions\n"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.annotations.summary | string | `"SharePoint Connector sync degraded"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.expr | string | `"(\n  sum(rate(spc_sync_duration_seconds_count{result=\"failure\",sync_type=\"site\"}[75m]))\n  /\n  sum(rate(spc_sync_duration_seconds_count{sync_type=\"site\"}[75m]))\n) > 0.5\n"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.for | string | `"15m"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.labels.alertGroup | string | `"sharepoint-connector"` |  |
+| prometheus.additionalAlerts.SharepointConnectorSyncDegraded.labels.severity | string | `"warning"` |  |
 | prometheus.additionalAlerts.SharepointConnectorUniqueAPIErrors.alert | string | `"SharepointConnectorUniqueAPIErrors"` |  |
 | prometheus.additionalAlerts.SharepointConnectorUniqueAPIErrors.annotations.description | string | `"The SharePoint Connector is experiencing Unique REST API errors (4xx/5xx responses). Current error rate: {{ $value | humanizePercentage }}."` |  |
 | prometheus.additionalAlerts.SharepointConnectorUniqueAPIErrors.annotations.runbook | string | `"1. Inspect application logs for specific error messages\n2. Check for recent deployments or configuration changes (both the connector and the Unique Services)\n3. Verify network connectivity between connector and Unique Services\n4. Verify service user settings and permissions within Unique\n"` |  |

--- a/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.yaml
+++ b/services/sharepoint-connector/deploy/helm-charts/sharepoint-connector/values.yaml
@@ -181,24 +181,22 @@ prometheus:
       labels:
         severity: warning
         alertGroup: sharepoint-connector
-    SharepointConnectorSyncFailures:
-      alert: SharepointConnectorSyncFailures
+    SharepointConnectorSyncDegraded:
+      alert: SharepointConnectorSyncDegraded
       annotations:
-        summary: "SharePoint Connector sync failures detected"
-        description: "The SharePoint Connector is experiencing sync failures. Current failure rate: {{ $value | humanizePercentage }}."
+        summary: "SharePoint Connector sync degraded"
+        description: "Site sync failure ratio over ~5 cycles exceeded 50%. Current: {{ $value | humanizePercentage }}."
         runbook: |
           1. Inspect application logs for specific error messages
           2. Check the failure_step label to identify where the sync failed
           3. Verify SharePoint connectivity and permissions
-          4. Check for rate limiting or throttling issues
-          5. Check for recent changes to the deployment as well as its underlying infrastructure
       expr: |
         (
-          sum(rate(spc_sync_duration_seconds_count{result="failure"}[5m]))
+          sum(rate(spc_sync_duration_seconds_count{result="failure",sync_type="site"}[75m]))
           /
-          sum(rate(spc_sync_duration_seconds_count[5m]))
-        ) > 0.01
-      for: 30s
+          sum(rate(spc_sync_duration_seconds_count{sync_type="site"}[75m]))
+        ) > 0.5
+      for: 15m
       labels:
         severity: warning
         alertGroup: sharepoint-connector

--- a/services/sharepoint-connector/docs/operator/configuration.md
+++ b/services/sharepoint-connector/docs/operator/configuration.md
@@ -686,7 +686,7 @@ The Helm chart organizes alerts into three categories, each independently toggle
 | ----------- | ------------------------------------ | -------------------------------- |
 | `graphql`   | `SharepointConnectorGraphQLErrors`   | GraphQL API error rate alert     |
 | `uniqueApi` | `SharepointConnectorUniqueAPIErrors` | Unique REST API error rate alert |
-| `syncs`     | `SharepointConnectorSyncFailures`    | Sync cycle failure alert         |
+| `syncs`     | `SharepointConnectorSyncDegraded`    | Site sync failure ratio alert    |
 
 Each category supports `enabled`, `disabled` (per-alert), and `customRules` (to override `for`, `severity`, `threshold`).
 


### PR DESCRIPTION
## Summary
- Replace the noisy `SharepointConnectorSyncFailures` default alert with `SharepointConnectorSyncDegraded` in the chart's `prometheus.additionalAlerts`.
- The new alert scopes to site syncs (`sync_type="site"`), evaluates the failure ratio over a ~5-cycle `75m` window, and fires only above a `0.5` ratio sustained for `15m` (vs. the old `5m` window, `>0.01` ratio, `30s` for).
- This removes false positives caused by transient, self-healing sync failures while still catching sustained degradation.

## Details
- `values.yaml`: swapped the alert definition (expr, `for`, threshold, summary/description, trimmed runbook to the 3 relevant steps).
- `README.md`: regenerated (hand-updated) the helm-docs value rows for the renamed alert.
- `docs/operator/configuration.md`: updated the default-alerts table row.

The chart `version`/`appVersion` bump is handled automatically by release-please from this `feat` commit; no manual version edit is included.

## Notes / open question
- The alert was **renamed** (`SharepointConnectorSyncFailures` → `SharepointConnectorSyncDegraded`), so any external dashboards, silences, or routing referencing the old name must be updated. If preferred, I can keep the old name to avoid that churn.

## Test plan
- [ ] `helm template` renders the `SharepointConnectorSyncDegraded` PrometheusRule with the expected expr/labels.
- [ ] Confirm the PromQL expression is valid against the `spc_sync_duration_seconds_count` series with `sync_type="site"`.
- [ ] Verify release-please opens a version-bump PR after merge.

Made with [Cursor](https://cursor.com)