### PR TITLE
feat(teams-mcp): ensure service-user permissions on root scope at startup

### DIFF
--- a/services/teams-mcp/docs/operator/configuration.md
+++ b/services/teams-mcp/docs/operator/configuration.md
@@ -250,7 +250,8 @@ The root scope must be created **manually** in the Unique platform before deploy
 
 3. **Grant the service account access**
 
-   - Ensure the Zitadel service account (see above) has read/write permissions on the root scope
+   - Ensure the Zitadel service account (see above) has `MANAGE`, `READ`, and `WRITE` permissions on the root scope
+   - On startup the server self-grants these three access types to the service user (the `x-user-id` from the API headers) on the configured root scope, so a correctly configured deployment converges automatically. If that grant fails (e.g. the scope ID is wrong or the service account lacks permission to manage it), the pod **hard-fails at boot** rather than surfacing the error mid-ingestion — check the startup logs for `root scope <id> permission bootstrap failed`.
 
 4. **Configure in Helm Values**
    ```yaml

--- a/services/teams-mcp/docs/operator/configuration.md
+++ b/services/teams-mcp/docs/operator/configuration.md
@@ -250,8 +250,8 @@ The root scope must be created **manually** in the Unique platform before deploy
 
 3. **Grant the service account access**
 
-   - Ensure the Zitadel service account (see above) has `MANAGE`, `READ`, and `WRITE` permissions on the root scope
-   - On startup the server self-grants these three access types to the service user (the `x-user-id` from the API headers) on the configured root scope, so a correctly configured deployment converges automatically. If that grant fails (e.g. the scope ID is wrong or the service account lacks permission to manage it), the pod **hard-fails at boot** rather than surfacing the error mid-ingestion — check the startup logs for `root scope <id> permission bootstrap failed`.
+   - Grant the Zitadel service account (see above) `MANAGE`, `READ`, and `WRITE` on the root scope through the Unique platform. This remains a required manual step — the server does not provision access on a scope it has no rights to.
+   - On startup the server (re-)issues these three grants for the service user (the `x-user-id` from the API headers) against the configured root scope via the Public API `folder/add-access` endpoint. The call is additive, so re-affirming existing access on every boot is safe. If it is rejected — a wrong/missing `rootScopeId`, or a service account that was never granted management of the scope — the pod **hard-fails at boot** rather than surfacing the error mid-ingestion. Check the startup logs for `root scope <id> permission bootstrap failed`.
 
 4. **Configure in Helm Values**
    ```yaml

--- a/services/teams-mcp/src/unique/root-scope-bootstrap.service.spec.ts
+++ b/services/teams-mcp/src/unique/root-scope-bootstrap.service.spec.ts
@@ -1,0 +1,74 @@
+import type { ConfigService } from '@nestjs/config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UniqueConfigNamespaced } from '~/config';
+import { RootScopeBootstrapService } from './root-scope-bootstrap.service';
+import { ScopeAccessEntityType, ScopeAccessType } from './unique.dtos';
+import type { UniqueScopeService } from './unique-scope.service';
+
+const rootScopeId = 'scope_root_01';
+const serviceUserId = 'user_service_01';
+
+const makeConfig = (unique: Record<string, unknown>) =>
+  ({ get: vi.fn().mockReturnValue(unique) }) as unknown as ConfigService<
+    UniqueConfigNamespaced,
+    true
+  >;
+
+const makeService = (
+  unique: Record<string, unknown>,
+  scopeService: Pick<UniqueScopeService, 'addScopeAccesses'>,
+) => new RootScopeBootstrapService(makeConfig(unique), scopeService as UniqueScopeService);
+
+describe('RootScopeBootstrapService', () => {
+  let mockScopeService: { addScopeAccesses: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockScopeService = { addScopeAccesses: vi.fn().mockResolvedValue(undefined) };
+    vi.clearAllMocks();
+  });
+
+  it('grants MANAGE/READ/WRITE to the service user on the root scope', async () => {
+    const service = makeService(
+      { rootScopeId, serviceExtraHeaders: { 'x-user-id': serviceUserId } },
+      mockScopeService,
+    );
+
+    await service.onApplicationBootstrap();
+
+    expect(mockScopeService.addScopeAccesses).toHaveBeenCalledOnce();
+    expect(mockScopeService.addScopeAccesses).toHaveBeenCalledWith(rootScopeId, [
+      {
+        entityId: serviceUserId,
+        entityType: ScopeAccessEntityType.User,
+        type: ScopeAccessType.Manage,
+      },
+      {
+        entityId: serviceUserId,
+        entityType: ScopeAccessEntityType.User,
+        type: ScopeAccessType.Read,
+      },
+      {
+        entityId: serviceUserId,
+        entityType: ScopeAccessEntityType.User,
+        type: ScopeAccessType.Write,
+      },
+    ]);
+  });
+
+  it('rethrows when the grant fails so startup hard-fails', async () => {
+    mockScopeService.addScopeAccesses.mockRejectedValue(new Error('add-access failed'));
+    const service = makeService(
+      { rootScopeId, serviceExtraHeaders: { 'x-user-id': serviceUserId } },
+      mockScopeService,
+    );
+
+    await expect(service.onApplicationBootstrap()).rejects.toThrow('add-access failed');
+  });
+
+  it('throws the assertion when x-user-id is missing', async () => {
+    const service = makeService({ rootScopeId, serviceExtraHeaders: {} }, mockScopeService);
+
+    await expect(service.onApplicationBootstrap()).rejects.toThrow(/x-user-id/);
+    expect(mockScopeService.addScopeAccesses).not.toHaveBeenCalled();
+  });
+});

--- a/services/teams-mcp/src/unique/root-scope-bootstrap.service.ts
+++ b/services/teams-mcp/src/unique/root-scope-bootstrap.service.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert';
+import { Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { UniqueConfigNamespaced } from '~/config';
+import { normalizeError } from '~/utils/normalize-error';
+import { ScopeAccessEntityType, ScopeAccessType } from './unique.dtos';
+import { UniqueScopeService } from './unique-scope.service';
+
+/**
+ * Self-grants the service user MANAGE/READ/WRITE on the configured root scope at
+ * startup. Ingestion assumes the service user already owns the root scope so it
+ * can create sub-scopes and grant access under it; this hook makes a
+ * misconfiguration crash the pod at boot instead of surfacing as an opaque
+ * platform error mid-ingestion.
+ */
+@Injectable()
+export class RootScopeBootstrapService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(RootScopeBootstrapService.name);
+
+  public constructor(
+    private readonly config: ConfigService<UniqueConfigNamespaced, true>,
+    private readonly scopeService: UniqueScopeService,
+  ) {}
+
+  public async onApplicationBootstrap(): Promise<void> {
+    const { rootScopeId, serviceExtraHeaders } = this.config.get('unique', { infer: true });
+    const serviceUserId = serviceExtraHeaders['x-user-id'];
+    // The config schema already requires x-user-id in both auth modes; this guards
+    // that invariant before we build the access grants.
+    assert.ok(serviceUserId, 'serviceExtraHeaders must contain an x-user-id header');
+
+    const accessTypes = [ScopeAccessType.Manage, ScopeAccessType.Read, ScopeAccessType.Write];
+
+    try {
+      await this.scopeService.addScopeAccesses(
+        rootScopeId,
+        accessTypes.map((type) => ({
+          entityId: serviceUserId,
+          entityType: ScopeAccessEntityType.User,
+          type,
+        })),
+      );
+    } catch (error) {
+      this.logger.error(
+        { scopeId: rootScopeId, error: normalizeError(error) },
+        `root scope ${rootScopeId} permission bootstrap failed`,
+      );
+      // Rethrow so onApplicationBootstrap rejects and Nest crashes the process:
+      // a service user without root-scope access cannot ingest anything.
+      throw error;
+    }
+
+    this.logger.log(
+      { scopeId: rootScopeId, accessTypes },
+      'root scope permission bootstrap succeeded',
+    );
+  }
+}

--- a/services/teams-mcp/src/unique/root-scope-bootstrap.service.ts
+++ b/services/teams-mcp/src/unique/root-scope-bootstrap.service.ts
@@ -7,11 +7,17 @@ import { ScopeAccessEntityType, ScopeAccessType } from './unique.dtos';
 import { UniqueScopeService } from './unique-scope.service';
 
 /**
- * Self-grants the service user MANAGE/READ/WRITE on the configured root scope at
+ * (Re-)grants the service user MANAGE/READ/WRITE on the configured root scope at
  * startup. Ingestion assumes the service user already owns the root scope so it
- * can create sub-scopes and grant access under it; this hook makes a
- * misconfiguration crash the pod at boot instead of surfacing as an opaque
- * platform error mid-ingestion.
+ * can create sub-scopes and grant access under it; this hook enforces that
+ * assumption at boot, making a misconfiguration crash the pod immediately
+ * instead of surfacing as an opaque platform error mid-ingestion.
+ *
+ * The grant goes through the Public API `folder/add-access`, which is additive —
+ * re-affirming access the service user already has is safe on every boot. It is
+ * not a from-zero provisioner: granting still requires the service user to be
+ * permitted to manage the scope (the manual grant documented in the operator
+ * configuration guide), so a truly unconfigured root scope fails fast here.
  */
 @Injectable()
 export class RootScopeBootstrapService implements OnApplicationBootstrap {

--- a/services/teams-mcp/src/unique/unique.module.ts
+++ b/services/teams-mcp/src/unique/unique.module.ts
@@ -9,6 +9,7 @@ import {
 } from '@qfetch/qfetch';
 import type { UniqueConfigNamespaced } from '~/config';
 import { DrizzleModule } from '../drizzle/drizzle.module';
+import { RootScopeBootstrapService } from './root-scope-bootstrap.service';
 import { UNIQUE_FETCH } from './unique.consts';
 import { UniqueService } from './unique.service';
 import { UniqueContentService } from './unique-content.service';
@@ -39,6 +40,7 @@ import { UniqueUserMappingService } from './unique-user-mapping.service';
     UniqueScopeService,
     UniqueContentService,
     UniqueService,
+    RootScopeBootstrapService,
   ],
   exports: [
     UNIQUE_FETCH,

--- a/services/teams-mcp/test/app.e2e-spec.ts
+++ b/services/teams-mcp/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AppModule } from '../src/app.module';
+import { RootScopeBootstrapService } from '../src/unique/root-scope-bootstrap.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -10,7 +11,12 @@ describe('AppController (e2e)', () => {
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      // The bootstrap hook grants root-scope access against the Unique API at boot;
+      // stub it so app.init() does not require a live Unique API for these e2e tests.
+      .overrideProvider(RootScopeBootstrapService)
+      .useValue({ onApplicationBootstrap: () => Promise.resolve() })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();

--- a/services/teams-mcp/test/health.e2e-spec.ts
+++ b/services/teams-mcp/test/health.e2e-spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AppModule } from '../src/app.module';
+import { RootScopeBootstrapService } from '../src/unique/root-scope-bootstrap.service';
 
 describe('Health endpoint (e2e)', () => {
   let app: INestApplication;
@@ -10,7 +11,12 @@ describe('Health endpoint (e2e)', () => {
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      // The bootstrap hook grants root-scope access against the Unique API at boot;
+      // stub it so app.init() does not require a live Unique API for these e2e tests.
+      .overrideProvider(RootScopeBootstrapService)
+      .useValue({ onApplicationBootstrap: () => Promise.resolve() })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();


### PR DESCRIPTION
## Context

`teams-mcp` ingests Teams transcripts/recordings by creating sub-scopes under a pre-provisioned **root scope** (`UNIQUE_ROOT_SCOPE_ID`) and granting access on those sub-scopes. It **assumes** the service user already has `MANAGE`/`WRITE`/`READ` on the root scope — but nothing establishes or verifies that. If the service user lacks those accesses, `createScope`/`add-access` under the root fails at ingestion time with an opaque platform error.

`sharepoint-connector` solves the equivalent problem with `InitializeRootScopeCommand`. This ports that idea to teams-mcp as a **startup bootstrap** so misconfiguration surfaces immediately at boot instead of mid-ingestion.

## Changes

- **New `RootScopeBootstrapService`** (`src/unique/root-scope-bootstrap.service.ts`) implementing `OnApplicationBootstrap`. It reads `unique.rootScopeId` and `serviceExtraHeaders['x-user-id']` from config and self-grants the service user `MANAGE`/`READ`/`WRITE` on the root scope via the existing `UniqueScopeService.addScopeAccesses`. On failure it logs a clear error and **rethrows** so the pod hard-fails at boot (Nest rejects `NestFactory.create` when `onApplicationBootstrap` throws).
- **Wired into `UniqueModule`** providers (not exported; Nest runs the lifecycle hook automatically).
- **Unit tests** covering the happy path (exactly three USER accesses on the scope), hard-fail on grant rejection, and the missing-`x-user-id` assertion guard.

teams-mcp is simpler than sharepoint here: the service user id is already known (the `x-user-id` header, required in both auth modes) and the root scope is pre-provisioned — so no `me` lookup, no scope creation, no external-id claiming.

## Out of scope

- No new env var, no `me`/getCurrentUser endpoint, no scope existence pre-check (a bad `rootScopeId` already hard-fails via `add-access`).
- No per-ingestion re-verification (startup-only).

## Verification

- Unit: `pnpm --filter teams-mcp test` (3/3 pass)
- Typecheck: `pnpm --filter teams-mcp build`
- Lint: Biome clean