### PR TITLE
feat(teams-mcp)!: move autoStartIngestion to unique config

### DIFF
--- a/services/teams-mcp/.env.example
+++ b/services/teams-mcp/.env.example
@@ -1,13 +1,11 @@
 LOG_LEVEL=debug
 SELF_URL=http://localhost:9542
-AMQP_URL=amqp://rabbitmq:rabbitmq@localhost:5672
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/teams_mcp
 MICROSOFT_CLIENT_ID=<azure-ad-app-client-id>
 MICROSOFT_CLIENT_SECRET=<azure-ad-app-client-secret>
 MICROSOFT_WEBHOOK_SECRET=<webhook-secret> # Random 128-char hex secret. Create with e.g. openssl rand -hex 64
 MICROSOFT_PUBLIC_WEBHOOK_URL=https://your-devtunnel.euw.devtunnels.ms # Publicly reachable URL for Microsoft webhooks. Local: devtunnel. Prod/QA: typically same as SELF_URL
 MICROSOFT_SUBSCRIPTION_EXPIRATION_TIME_HOURS_UTC=3 # Hour of day in UTC when scheduled subscription expirations should occur
-MICROSOFT_AUTO_START_INGESTION=false # When true, auto-enqueue a transcript subscription for every user at login (skips the start_kb_integration tool)
 AUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS=60 # 1 minute
 AUTH_REFRESH_TOKEN_EXPIRES_IN_SECONDS=2592000 # 30 days
 AUTH_HMAC_SECRET=<hmac-secret> # Random 64-char hex secret. Create with e.g. openssl rand -hex 32
@@ -37,6 +35,7 @@ UNIQUE_ROOT_SCOPE_ID=<root-scope-id>
 # --- Common Unique API settings ---
 # UNIQUE_API_VERSION=2023-12-06 # The Public API version to use
 # UNIQUE_USER_FETCH_CONCURRENCY=5 # Concurrency limit for fetching users when resolving scope accesses
+# UNIQUE_AUTO_START_INGESTION=false # When true, auto-enqueue a transcript subscription for every user at login (skips the start_kb_integration tool)
 
 # OTEL_SERVICE_NAME=teams-mcp
 # OTEL_SERVICE_VERSION

--- a/services/teams-mcp/README.md
+++ b/services/teams-mcp/README.md
@@ -42,7 +42,6 @@ Copy `.env.example` to `.env` and configure the following:
 | `MICROSOFT_CLIENT_SECRET` | Azure AD application client secret |
 | `MICROSOFT_WEBHOOK_SECRET` | 128-char hex secret used as `clientState` for webhook validation |
 | `MICROSOFT_PUBLIC_WEBHOOK_URL` | Publicly reachable URL for Microsoft webhooks |
-| `MICROSOFT_AUTO_START_INGESTION` | Auto-enqueue a transcript subscription for every user at login (default `false`) |
 | `AUTH_HMAC_SECRET` | 64-char hex secret for JWT signing |
 | `ENCRYPTION_KEY` | 64-char hex secret for AES-GCM token encryption |
 
@@ -82,6 +81,7 @@ UNIQUE_SERVICE_EXTRA_HEADERS={"x-company-id":"<company-id>","x-user-id":"<user-i
 | `AUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS` | `60` | Access token TTL |
 | `AUTH_REFRESH_TOKEN_EXPIRES_IN_SECONDS` | `2592000` | Refresh token TTL (30 days) |
 | `UNIQUE_USER_FETCH_CONCURRENCY` | `5` | Concurrent user resolution limit |
+| `UNIQUE_AUTO_START_INGESTION` | `false` | Auto-enqueue a transcript subscription for every user at login (skips the `start_kb_integration` tool) |
 
 For complete configuration reference, see [Configuration Guide](./docs/operator/configuration.md).
 

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/README.md
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/README.md
@@ -60,7 +60,6 @@ spec:
 | env.OTEL_EXPORTER_PROMETHEUS_PORT | string | `"51346"` |  |
 | env.OTEL_METRICS_EXPORTER | string | `"prometheus"` |  |
 | envVars | list | `[]` | Environment variables from secrets (required secrets listed at bottom of file) |
-| extraEnvCM | list | `["teams-mcp-config"]` | ConfigMap(s) to load environment variables from (must match release name + '-config') |
 | fullnameOverride | string | `"teams-mcp"` |  |
 | grafana.dashboard.enabled | bool | `true` | Enable Grafana dashboard ConfigMap creation |
 | grafana.dashboard.folder | string | `"mcp-servers"` | Grafana folder where the dashboard will be placed |
@@ -69,7 +68,7 @@ spec:
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"unique-ag/connectors/services/teams-mcp"` |  |
-| image.tag | string | `"0.2.22"` |  |
+| image.tag | string | `"0.3.5"` |  |
 | ingress.additionalLabels | object | `{}` | Additional labels for the ingress resource |
 | ingress.annotations | object | `{"konghq.com/plugins":"unique-route-metrics"}` | Annotations for the ingress resource |
 | ingress.enabled | bool | `false` | Enable ingress resource creation |
@@ -84,21 +83,21 @@ spec:
 | internalServices.dependencies.ingestion.servicePort | int | `8091` |  |
 | internalServices.dependents.ingressGateway.name | string | `"gateway"` |  |
 | internalServices.dependents.ingressGateway.namespace | string | `"system"` |  |
-| mcpConfig | object | `{"app":{"selfUrl":"{{ fail \"mcpConfig.app.selfUrl is mandatory. Override in your deployment values.\" }}"},"auth":{"accessTokenExpiresInSeconds":60,"refreshTokenExpiresInSeconds":2592000},"enabled":true,"microsoft":{"autoStartIngestion":false,"clientId":"{{ fail \"mcpConfig.microsoft.clientId is mandatory. Override in your deployment values.\" }}"},"unique":{"apiBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.chat) }}/public/","apiVersion":"2023-12-06","ingestionServiceBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.ingestion) }}","rootScopeId":"","serviceAuthMode":"cluster_local","serviceExtraHeaders":{},"userFetchConcurrency":5}}` | Configuration for the deployed Teams MCP Server, will be mapped to environment variables Users preferring setting all variables by hand disable the enabled flag and set the extraEnvCM to [] |
+| mcpConfig | object | `{"app":{"selfUrl":"{{ fail \"mcpConfig.app.selfUrl is mandatory. Override in your deployment values.\" }}"},"auth":{"accessTokenExpiresInSeconds":60,"refreshTokenExpiresInSeconds":2592000},"enabled":true,"microsoft":{"clientId":"{{ fail \"mcpConfig.microsoft.clientId is mandatory. Override in your deployment values.\" }}"},"unique":{"apiBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.chat) }}/public/","apiVersion":"2023-12-06","autoStartIngestion":false,"ingestionServiceBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.ingestion) }}","integration":"enabled","rootScopeId":"","serviceAuthMode":"cluster_local","serviceExtraHeaders":{},"userFetchConcurrency":5}}` | Configuration for the deployed Teams MCP Server, will be mapped to environment variables |
 | mcpConfig.app | object | `{"selfUrl":"{{ fail \"mcpConfig.app.selfUrl is mandatory. Override in your deployment values.\" }}"}` | Application configuration |
 | mcpConfig.app.selfUrl | string | `"{{ fail \"mcpConfig.app.selfUrl is mandatory. Override in your deployment values.\" }}"` | The URL of the MCP Server. Used for OAuth callbacks. The URL must be reachable from the redirect location, e.g. must be publicly accessible. example: https://teams.mcp.unique.app |
 | mcpConfig.auth | object | `{"accessTokenExpiresInSeconds":60,"refreshTokenExpiresInSeconds":2592000}` | Authentication configuration for the MCP server |
 | mcpConfig.auth.accessTokenExpiresInSeconds | int | `60` | Access token expiration time in seconds |
 | mcpConfig.auth.refreshTokenExpiresInSeconds | int | `2592000` | Refresh token expiration time in seconds (default: 30 days) |
-| mcpConfig.enabled | bool | `true` | if disabled, extraEnvCM must be set to [] |
-| mcpConfig.microsoft | object | `{"autoStartIngestion":false,"clientId":"{{ fail \"mcpConfig.microsoft.clientId is mandatory. Override in your deployment values.\" }}"}` | Microsoft Graph API configuration |
-| mcpConfig.microsoft.autoStartIngestion | bool | `false` | When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool). |
+| mcpConfig.microsoft | object | `{"clientId":"{{ fail \"mcpConfig.microsoft.clientId is mandatory. Override in your deployment values.\" }}"}` | Microsoft Graph API configuration |
 | mcpConfig.microsoft.clientId | string | `"{{ fail \"mcpConfig.microsoft.clientId is mandatory. Override in your deployment values.\" }}"` | The client ID of the Microsoft App Registration example: 12345678-1234-1234-1234-123456789012 |
-| mcpConfig.unique | object | `{"apiBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.chat) }}/public/","apiVersion":"2023-12-06","ingestionServiceBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.ingestion) }}","rootScopeId":"","serviceAuthMode":"cluster_local","serviceExtraHeaders":{},"userFetchConcurrency":5}` | Unique API configuration |
+| mcpConfig.unique | object | `{"apiBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.chat) }}/public/","apiVersion":"2023-12-06","autoStartIngestion":false,"ingestionServiceBaseUrl":"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.ingestion) }}","integration":"enabled","rootScopeId":"","serviceAuthMode":"cluster_local","serviceExtraHeaders":{},"userFetchConcurrency":5}` | Unique API configuration |
 | mcpConfig.unique.apiBaseUrl | string | `"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.chat) }}/public/"` | The Public API URL; auto-derived from internalServices.dependencies.chat with /public/ suffix override with an explicit URL when serviceAuthMode is external, e.g. https://gateway.unique.app/public/chat/ |
 | mcpConfig.unique.apiVersion | string | `"2023-12-06"` | The Public API version to use |
+| mcpConfig.unique.autoStartIngestion | bool | `false` | When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool). |
 | mcpConfig.unique.ingestionServiceBaseUrl | string | `"{{ include \"base.internalService.url\" (dict \"root\" . \"dep\" .Values.internalServices.dependencies.ingestion) }}"` | Base URL for Unique ingestion service; auto-derived from internalServices.dependencies.ingestion override with an explicit URL when serviceAuthMode is external, e.g. https://api.unique.app/ingestion |
-| mcpConfig.unique.rootScopeId | string | (required) | The root scope ID under which to create transcript and recording folders |
+| mcpConfig.unique.integration | string | `"enabled"` | Enable Unique knowledge-base integration (transcript ingestion). When disabled, chat tools work without Unique/Zitadel configuration. possible values: enabled, disabled |
+| mcpConfig.unique.rootScopeId | string | (required when integration=enabled) | The root scope ID under which to create transcript and recording folders Required when integration is enabled |
 | mcpConfig.unique.serviceAuthMode | string | `"cluster_local"` | Authentication mode for Unique API services possible values: cluster_local, external cluster_local: communicates using in-cluster URLs with service headers external: communicates using external URLs with app key authentication |
 | mcpConfig.unique.serviceExtraHeaders | object | `{}` | Extra headers to send with requests to Unique API services (JSON string) For cluster_local mode: '{"x-company-id": "...", "x-user-id": "..."}' |
 | mcpConfig.unique.userFetchConcurrency | int | `5` | Concurrency limit for fetching users when resolving scope accesses |
@@ -168,4 +167,3 @@ spec:
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)
-

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/templates/_helpers.tpl
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/templates/_helpers.tpl
@@ -27,10 +27,6 @@ All mcpConfig environment variables, shared by deployment and hook job container
 - name: MICROSOFT_PUBLIC_WEBHOOK_URL
   value: {{ .Values.mcpConfig.microsoft.publicWebhookUrl | quote }}
 {{- end }}
-{{- if .Values.mcpConfig.microsoft.autoStartIngestion }}
-- name: MICROSOFT_AUTO_START_INGESTION
-  value: {{ .Values.mcpConfig.microsoft.autoStartIngestion | quote }}
-{{- end }}
 - name: UNIQUE_INTEGRATION
   value: {{ .Values.mcpConfig.unique.integration | quote }}
 {{- if eq .Values.mcpConfig.unique.integration "enabled" }}
@@ -49,6 +45,10 @@ All mcpConfig environment variables, shared by deployment and hook job container
 {{- if eq .Values.mcpConfig.unique.serviceAuthMode "cluster_local" }}
 - name: UNIQUE_INGESTION_SERVICE_BASE_URL
   value: {{ include "chart.ensureTrailingSlash" (dict "url" (tpl .Values.mcpConfig.unique.ingestionServiceBaseUrl .)) | quote }}
+{{- end }}
+{{- if .Values.mcpConfig.unique.autoStartIngestion }}
+- name: UNIQUE_AUTO_START_INGESTION
+  value: {{ .Values.mcpConfig.unique.autoStartIngestion | quote }}
 {{- end }}
 {{- end }}
 - name: AUTH_ACCESS_TOKEN_EXPIRES_IN_SECONDS

--- a/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
+++ b/services/teams-mcp/deploy/helm-charts/teams-mcp/values.yaml
@@ -287,9 +287,6 @@ mcpConfig:
     # Optional - defaults to SELF_URL if not provided.
     # example: https://teams.mcp.unique.app
     # publicWebhookUrl: ""
-    # -- When enabled, automatically enqueue a transcript subscription for every user at login
-    # (skips the start_kb_integration tool).
-    autoStartIngestion: false
     # clientSecret is loaded from a secret, see envVars
     # webhookSecret is loaded from a secret, see envVars
 
@@ -329,6 +326,10 @@ mcpConfig:
     # -- Base URL for Unique ingestion service; auto-derived from internalServices.dependencies.ingestion
     # override with an explicit URL when serviceAuthMode is external, e.g. https://api.unique.app/ingestion
     ingestionServiceBaseUrl: '{{ include "base.internalService.url" (dict "root" . "dep" .Values.internalServices.dependencies.ingestion) }}'
+
+    # -- When enabled, automatically enqueue a transcript subscription for every user at login
+    # (skips the start_kb_integration tool).
+    autoStartIngestion: false
 
   # -- Authentication configuration for the MCP server
   auth:

--- a/services/teams-mcp/docs/README.md
+++ b/services/teams-mcp/docs/README.md
@@ -314,7 +314,7 @@ Both tracks begin with the same one-time connection, then diverge — because th
 
 #### Transcripts & Recordings Workflow — ingest once, then query in Unique
 
-1. **Enable ingestion** (One-time) — call `start_kb_integration` (or rely on `MICROSOFT_AUTO_START_INGESTION` if the operator enabled it)
+1. **Enable ingestion** (One-time) — call `start_kb_integration` (or rely on `UNIQUE_AUTO_START_INGESTION` if the operator enabled it)
 2. **Automatic capture** (Ongoing)
    - Attend Microsoft Teams meetings with transcription enabled
    - Meeting ends and transcript becomes available

--- a/services/teams-mcp/docs/operator/configuration.md
+++ b/services/teams-mcp/docs/operator/configuration.md
@@ -34,7 +34,6 @@ Set via `mcpConfig.microsoft` in Helm values:
 |----------|-----------|---------|-------------|
 | `MICROSOFT_CLIENT_ID` | `mcpConfig.microsoft.clientId` | (required) | Entra app client ID |
 | `MICROSOFT_PUBLIC_WEBHOOK_URL` | `mcpConfig.microsoft.publicWebhookUrl` | `SELF_URL` | Webhook URL if different from SELF_URL |
-| `MICROSOFT_AUTO_START_INGESTION` | `mcpConfig.microsoft.autoStartIngestion` | `false` | When enabled, auto-enqueue a transcript subscription for every user at login (skips the `start_kb_integration` tool) |
 
 ### Unique API Configuration
 
@@ -52,6 +51,7 @@ When `UNIQUE_INTEGRATION=disabled`, other Unique variables are not required (cha
 | `UNIQUE_USER_FETCH_CONCURRENCY` | `mcpConfig.unique.userFetchConcurrency` | `5` | Parallel user lookups |
 | `UNIQUE_INGESTION_SERVICE_BASE_URL` | `mcpConfig.unique.ingestionServiceBaseUrl` | (required when enabled + cluster_local) | Ingestion service endpoint |
 | `UNIQUE_SERVICE_EXTRA_HEADERS` | `mcpConfig.unique.serviceExtraHeaders` | (required when enabled) | Zitadel service account headers (`x-company-id`, `x-user-id`, …) |
+| `UNIQUE_AUTO_START_INGESTION` | `mcpConfig.unique.autoStartIngestion` | `false` | When enabled, auto-enqueue a transcript subscription for every user at login (skips the `start_kb_integration` tool) |
 
 ### Authentication Configuration
 

--- a/services/teams-mcp/docs/technical/flows.md
+++ b/services/teams-mcp/docs/technical/flows.md
@@ -3,7 +3,7 @@
 
 ## User Connection Flow
 
-Everything starts when a user connects to the MCP server. This triggers OAuth authentication. After authentication, the user can start the KB integration via the `start_kb_integration` tool to begin receiving meeting notifications. Alternatively, operators can enable `MICROSOFT_AUTO_START_INGESTION`, in which case every login automatically enqueues a transcript subscription (no tool call required).
+Everything starts when a user connects to the MCP server. This triggers OAuth authentication. After authentication, the user can start the KB integration via the `start_kb_integration` tool to begin receiving meeting notifications. Alternatively, operators can enable `UNIQUE_AUTO_START_INGESTION`, in which case every login automatically enqueues a transcript subscription (no tool call required).
 
 ```mermaid
 %%{init: {'theme': 'neutral', 'themeVariables': { 'fontSize': '14px' }}}%%
@@ -40,7 +40,7 @@ flowchart LR
     Consent --> Callback
     Callback --> Exchange
     Exchange --> Store
-    Store -->|MICROSOFT_AUTO_START_INGESTION on| AutoStart
+    Store -->|UNIQUE_AUTO_START_INGESTION on| AutoStart
     Store -.->|manual| StartTool
     AutoStart --> Enqueue
     Enqueue --> CreateSub

--- a/services/teams-mcp/src/config/microsoft.config.ts
+++ b/services/teams-mcp/src/config/microsoft.config.ts
@@ -30,12 +30,6 @@ const ConfigSchema = z.object({
     .describe(
       'The hour of the day in UTC when scheduled subscription expirations should occur. This should be done during off-peak hours to avoid disruptions of incoming notifications.',
     ),
-  autoStartIngestion: z
-    .stringbool()
-    .default(false)
-    .describe(
-      'When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool).',
-    ),
 });
 
 export const microsoftConfig = registerConfig('microsoft', ConfigSchema);

--- a/services/teams-mcp/src/config/unique.config.ts
+++ b/services/teams-mcp/src/config/unique.config.ts
@@ -25,6 +25,12 @@ const baseConfig = z.object({
     .positive()
     .default(5)
     .describe('The concurrency limit for fetching users when resolving scope accesses.'),
+  autoStartIngestion: z
+    .stringbool()
+    .default(false)
+    .describe(
+      'When enabled, automatically enqueue a transcript subscription for every user at login (skips the start_kb_integration tool).',
+    ),
 });
 
 // ==== Config for local in-cluster communication with Unique API services ====

--- a/services/teams-mcp/src/kb-integration/kb-integration-config.module.spec.ts
+++ b/services/teams-mcp/src/kb-integration/kb-integration-config.module.spec.ts
@@ -21,6 +21,7 @@ const enabledConfig = {
   apiVersion: '2023-12-06',
   rootScopeId: 'scope_root_01',
   userFetchConcurrency: 5,
+  autoStartIngestion: false,
   serviceExtraHeaders: {
     authorization: 'Bearer app-key',
     'x-app-id': 'app_01',

--- a/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { MicrosoftConfig } from '~/config';
+import type { EnabledUniqueConfig } from '~/config';
 import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { PostAuthorizationListener } from './post-authorization.listener';
 import type { SubscriptionCreateService } from './subscription-create.service';
@@ -12,7 +12,7 @@ const makeListener = (
   autoStartIngestion: boolean,
   subscriptionCreate: Pick<SubscriptionCreateService, 'enqueueSubscriptionRequested'>,
 ) => {
-  const config = { autoStartIngestion } as unknown as MicrosoftConfig;
+  const config = { autoStartIngestion } as unknown as EnabledUniqueConfig;
   return new PostAuthorizationListener(config, subscriptionCreate as SubscriptionCreateService);
 };
 

--- a/services/teams-mcp/src/transcript/post-authorization.listener.ts
+++ b/services/teams-mcp/src/transcript/post-authorization.listener.ts
@@ -8,7 +8,8 @@ import { serializeError } from 'serialize-error-cjs';
 import { DEAD_EXCHANGE, MAIN_EXCHANGE } from '~/amqp/amqp.constants';
 import { wrapErrorHandlerOTEL } from '~/amqp/amqp.utils';
 import { UserAuthorizedEventDto } from '~/auth/dtos/user-authorized-event.dto';
-import { type MicrosoftConfig, microsoftConfig } from '~/config';
+import type { EnabledUniqueConfig } from '~/config';
+import { KB_INTEGRATION_ENABLED_CONFIG } from '~/kb-integration/kb-integration-config.module';
 import { convertUserProfileIdToTypeId } from '~/utils/convert-user-profile-id-to-type-id';
 import { normalizeError } from '~/utils/normalize-error';
 import { SubscriptionCreateService } from './subscription-create.service';
@@ -18,7 +19,7 @@ export class PostAuthorizationListener {
   private readonly logger = new Logger(PostAuthorizationListener.name);
 
   public constructor(
-    @Inject(microsoftConfig.KEY) private readonly config: MicrosoftConfig,
+    @Inject(KB_INTEGRATION_ENABLED_CONFIG) private readonly config: EnabledUniqueConfig,
     private readonly subscriptionCreate: SubscriptionCreateService,
   ) {}
 

--- a/services/teams-mcp/src/transcript/transcript.module.ts
+++ b/services/teams-mcp/src/transcript/transcript.module.ts
@@ -30,7 +30,7 @@ import { TranscriptUtilsService } from './transcript-utils.service';
     SubscriptionReauthorizeService,
     SubscriptionRemoveService,
     TranscriptCreatedService,
-    // Auto-start ingestion at login (gated by MICROSOFT_AUTO_START_INGESTION)
+    // Auto-start ingestion at login (gated by UNIQUE_AUTO_START_INGESTION)
     PostAuthorizationListener,
     // KB Integration MCP Tools
     VerifyKbIntegrationStatusTool,


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: Moves `autoStartIngestion` off `microsoft.config.ts` and onto `unique.config.ts`'s shared `baseConfig`, since auto-starting ingestion only makes sense when Unique integration is enabled. The env var changes from `MICROSOFT_AUTO_START_INGESTION` to `UNIQUE_AUTO_START_INGESTION`, and the Helm value path changes from `mcpConfig.microsoft.autoStartIngestion` to `mcpConfig.unique.autoStartIngestion`. Existing deployments setting the old env var or Helm value must be updated or auto-start ingestion will silently fall back to disabled.
- `PostAuthorizationListener` now injects `EnabledUniqueConfig` via `KB_INTEGRATION_ENABLED_CONFIG`, matching the pattern already used by other Unique-config consumers, instead of `MicrosoftConfig`.
- Updates the Helm chart (`values.yaml`, `_helpers.tpl`, regenerated `README.md` via `helm-docs`), `.env.example`, and operator/technical docs to reflect the move.

## Breaking change
- `MICROSOFT_AUTO_START_INGESTION` → `UNIQUE_AUTO_START_INGESTION`
- `mcpConfig.microsoft.autoStartIngestion` → `mcpConfig.unique.autoStartIngestion` (Helm values)

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full `vitest` suite passes (93 tests)
- [x] `biome check` passes on changed files
- [x] Rendered the Helm chart locally (`helm template`) and confirmed `UNIQUE_AUTO_START_INGESTION` is emitted only when `mcpConfig.unique.integration=enabled` and `autoStartIngestion=true`, and omitted otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)