### PR TITLE
fix(outlook-semantic-mcp): stop filtering shared mailboxes by accountEnabled

### DIFF
--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -443,11 +443,10 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     const users: GraphUser[] = [];
 
     // Shared mailboxes appear in Entra ID as accountEnabled=false accounts
-    let response = (await client
-      .api('/users')
-      .select('id,mail,displayName')
-      .top(500)
-      .get()) as { value: GraphUser[]; '@odata.nextLink'?: string };
+    let response = (await client.api('/users').select('id,mail,displayName').get()) as {
+      value: GraphUser[];
+      '@odata.nextLink'?: string;
+    };
 
     users.push(...response.value);
 

--- a/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
+++ b/services/outlook-semantic-mcp/src/features/delegated-access/shared-mailbox-sync.service.ts
@@ -445,8 +445,8 @@ export class SharedMailboxSyncService implements OnModuleInit, OnModuleDestroy {
     // Shared mailboxes appear in Entra ID as accountEnabled=false accounts
     let response = (await client
       .api('/users')
-      .filter('accountEnabled eq false')
       .select('id,mail,displayName')
+      .top(500)
       .get()) as { value: GraphUser[]; '@odata.nextLink'?: string };
 
     users.push(...response.value);


### PR DESCRIPTION
## Summary
- Remove the `accountEnabled eq false` filter when discovering shared mailboxes in Entra ID. Not all shared mailboxes are represented as disabled accounts, so the filter dropped valid mailboxes from the sync.
- Add `.top(500)` to fetch users in larger pages.

## Test plan
- Verify shared mailbox sync discovers mailboxes that were previously excluded by the `accountEnabled` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)