### PR TITLE
feat(teams-mcp): request fewer Graph scopes when Unique is disabled

### DIFF
--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/main.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/main.tf
@@ -6,14 +6,10 @@ resource "azuread_service_principal" "msgraph" {
 }
 
 locals {
-  # Microsoft Graph delegated scopes required by Teams MCP
-  # Based on SCOPES in services/teams-mcp/src/auth/microsoft.provider.ts
-  graph_scopes = toset([
+  # Microsoft Graph delegated scopes required by Teams MCP.
+  # Based on CHAT_SCOPES / KB_SCOPES in services/teams-mcp/src/auth/microsoft.provider.ts
+  chat_graph_scopes = toset([
     "User.Read",
-    "Calendars.Read",
-    "OnlineMeetings.Read",
-    "OnlineMeetingRecording.Read.All",
-    "OnlineMeetingTranscript.Read.All",
     "ChannelMessage.Send",
     "ChatMessage.Send",
     "Chat.ReadBasic",
@@ -22,6 +18,13 @@ locals {
     "Channel.ReadBasic.All",
     "ChannelMessage.Read.All",
   ])
+  kb_graph_scopes = toset([
+    "Calendars.Read",
+    "OnlineMeetings.Read",
+    "OnlineMeetingRecording.Read.All",
+    "OnlineMeetingTranscript.Read.All",
+  ])
+  graph_scopes = var.unique_integration == "enabled" ? setunion(local.chat_graph_scopes, local.kb_graph_scopes) : local.chat_graph_scopes
 }
 
 resource "azuread_application" "teams_mcp" {

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/variables.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/variables.tf
@@ -89,3 +89,20 @@ variable "service_principal_configuration" {
   })
   default = {}
 }
+
+variable "unique_integration" {
+  description = <<-EOT
+    Whether the Teams MCP deployment enables Unique knowledge-base integration.
+    When "enabled" (default), Graph scopes include calendar/meeting/transcript/recording
+    permissions needed for KB ingestion.
+    When "disabled" (chat-only), only identity + Teams chat/channel messaging scopes are
+    registered — matching UNIQUE_INTEGRATION=disabled on the MCP server.
+  EOT
+  type        = string
+  default     = "enabled"
+
+  validation {
+    condition     = contains(["enabled", "disabled"], var.unique_integration)
+    error_message = "The unique_integration must be one of: 'enabled', or 'disabled'."
+  }
+}

--- a/services/teams-mcp/docs/operator/authentication.md
+++ b/services/teams-mcp/docs/operator/authentication.md
@@ -14,7 +14,27 @@ For technical details about the OAuth flow, see [Microsoft OAuth Setup Flow](../
 
 ## Required Permissions
 
-All permissions are **delegated** — they act on behalf of the signed-in user. Three permissions require admin consent before users can connect.
+All permissions are **delegated** — they act on behalf of the signed-in user. Which scopes are requested depends on `UNIQUE_INTEGRATION`.
+
+### Chat-only (`UNIQUE_INTEGRATION=disabled`)
+
+Only identity + Teams messaging scopes. `ChannelMessage.Read.All` requires admin consent.
+
+| Permission | Type | Admin Consent |
+|------------|------|---------------|
+| `User.Read` | Delegated | No |
+| `offline_access` | Delegated | No |
+| `ChannelMessage.Send` | Delegated | No |
+| `ChatMessage.Send` | Delegated | No |
+| `Chat.ReadBasic` | Delegated | No |
+| `Chat.Read` | Delegated | No |
+| `Team.ReadBasic.All` | Delegated | No |
+| `Channel.ReadBasic.All` | Delegated | No |
+| `ChannelMessage.Read.All` | Delegated | **Yes** |
+
+### Unique knowledge base (`UNIQUE_INTEGRATION=enabled`)
+
+Chat scopes plus calendar/meeting/transcript/recording scopes. Three permissions require admin consent before users can connect.
 
 | Permission | Type | Admin Consent |
 |------------|------|---------------|
@@ -61,6 +81,7 @@ module "teams_mcp_app" {
   display_name     = "Teams MCP Server"
   sign_in_audience = "AzureADMyOrg"  # Single tenant
   notes            = "MCP server for Teams transcript capture"
+  # unique_integration = "disabled"  # chat-only: omits calendar/meeting/transcript scopes
 
   redirect_uris = [
     "https://teams.mcp.example.com/auth/callback"
@@ -89,7 +110,7 @@ module "teams_mcp_app" {
    - Add all permissions listed under [Required Permissions](#required-permissions)
 
 3. Click **Grant admin consent for [Tenant]** and confirm.
-   `OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All` require this step — without it users cannot connect.
+   For Unique-enabled deployments, `OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All` require this step. Chat-only deployments only need admin consent for `ChannelMessage.Read.All`.
 
 4. Go to **Certificates & secrets** → **New client secret**:
    - Set description and expiration
@@ -175,9 +196,9 @@ This secret is passed to Microsoft when creating Graph subscriptions and returne
 
 **This is standard Microsoft behavior, not Teams MCP specific.** All Microsoft 365 apps use the same consent model.
 
-Because three permissions require admin consent (`OnlineMeetingRecording.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ChannelMessage.Read.All`), the consent sequence is:
+Because admin-consent scopes depend on deployment mode (`ChannelMessage.Read.All` always; plus `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` when Unique is enabled), the consent sequence is:
 
-1. **Admin grants consent** for those three permissions (organisation-wide or per-user). The remaining 10 permissions — including all other chat scopes (`ChannelMessage.Send`, `ChatMessage.Send`, `Chat.ReadBasic`, `Chat.Read`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`) — are user-consentable and do not require admin action.
+1. **Admin grants consent** for the admin-required permissions for your mode (organisation-wide or per-user). Remaining permissions — including other chat scopes (`ChannelMessage.Send`, `ChatMessage.Send`, `Chat.ReadBasic`, `Chat.Read`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`) — are user-consentable and do not require admin action.
 2. **User consent** — on first connection, the user sees the Microsoft consent screen and approves the remaining permissions
 
 **How to grant admin consent:**

--- a/services/teams-mcp/docs/technical/permissions.md
+++ b/services/teams-mcp/docs/technical/permissions.md
@@ -5,21 +5,26 @@ All permissions are **Delegated** (not Application), meaning they act on behalf 
 
 ## Permission Summary
 
-| Permission | Type | ID | Admin Consent | Required |
-|------------|------|-----|---------------|----------|
-| `User.Read` | Delegated | `e1fe6dd8-ba31-4d61-89e7-88639da4683d` | No | Yes |
-| `Calendars.Read` | Delegated | `465a38f9-76ea-45b9-9f34-9e8b0d4b0b42` | No | Yes |
-| `OnlineMeetings.Read` | Delegated | `9be106e1-f4e3-4df5-bdff-e4bc531cbe43` | No | Yes |
-| `OnlineMeetingRecording.Read.All` | Delegated | `190c2bb6-1fdd-4fec-9aa2-7d571b5e1fe3` | Yes | Yes |
-| `OnlineMeetingTranscript.Read.All` | Delegated | `30b87d18-ebb1-45db-97f8-82ccb1f0190c` | Yes | Yes |
-| `offline_access` | Delegated | `7427e0e9-2fba-42fe-b0c0-848c9e6a8182` | No | Yes |
-| `ChannelMessage.Send` | Delegated | `ebf0f66e-9fb1-49e4-a278-222f76911cf4` | No | Yes |
-| `ChatMessage.Send` | Delegated | `116b7235-2ffd-4103-963e-baec9c8e5c8b` | No | Yes |
-| `Chat.ReadBasic` | Delegated | `9547fcb5-d03f-419d-9948-5928bbf71b0f` | No | Yes |
-| `Chat.Read` | Delegated | `f501c180-9344-439a-bca0-6cbf209fd270` | No | Yes |
-| `Team.ReadBasic.All` | Delegated | `2280dda6-0bfd-44ee-a2f4-cb867cfc4c1e` | No | Yes |
-| `Channel.ReadBasic.All` | Delegated | `3aeca27b-ee3a-4c2b-8ded-80376e2134a4` | No | Yes |
-| `ChannelMessage.Read.All` | Delegated | `767156cb-16ae-4d10-8f8b-41b657c8c8c8` | Yes | Yes |
+Scopes requested at login depend on `UNIQUE_INTEGRATION`:
+
+- **`disabled` (chat-only)** — identity + Teams chat/channel messaging scopes
+- **`enabled`** — chat scopes plus calendar/meeting/transcript/recording scopes for KB ingestion
+
+| Permission | Type | ID | Admin Consent | Chat-only | Unique enabled |
+|------------|------|-----|---------------|-----------|----------------|
+| `User.Read` | Delegated | `e1fe6dd8-ba31-4d61-89e7-88639da4683d` | No | Yes | Yes |
+| `Calendars.Read` | Delegated | `465a38f9-76ea-45b9-9f34-9e8b0d4b0b42` | No | No | Yes |
+| `OnlineMeetings.Read` | Delegated | `9be106e1-f4e3-4df5-bdff-e4bc531cbe43` | No | No | Yes |
+| `OnlineMeetingRecording.Read.All` | Delegated | `190c2bb6-1fdd-4fec-9aa2-7d571b5e1fe3` | Yes | No | Yes |
+| `OnlineMeetingTranscript.Read.All` | Delegated | `30b87d18-ebb1-45db-97f8-82ccb1f0190c` | Yes | No | Yes |
+| `offline_access` | Delegated | `7427e0e9-2fba-42fe-b0c0-848c9e6a8182` | No | Yes | Yes |
+| `ChannelMessage.Send` | Delegated | `ebf0f66e-9fb1-49e4-a278-222f76911cf4` | No | Yes | Yes |
+| `ChatMessage.Send` | Delegated | `116b7235-2ffd-4103-963e-baec9c8e5c8b` | No | Yes | Yes |
+| `Chat.ReadBasic` | Delegated | `9547fcb5-d03f-419d-9948-5928bbf71b0f` | No | Yes | Yes |
+| `Chat.Read` | Delegated | `f501c180-9344-439a-bca0-6cbf209fd270` | No | Yes | Yes |
+| `Team.ReadBasic.All` | Delegated | `2280dda6-0bfd-44ee-a2f4-cb867cfc4c1e` | No | Yes | Yes |
+| `Channel.ReadBasic.All` | Delegated | `3aeca27b-ee3a-4c2b-8ded-80376e2134a4` | No | Yes | Yes |
+| `ChannelMessage.Read.All` | Delegated | `767156cb-16ae-4d10-8f8b-41b657c8c8c8` | Yes | Yes | Yes |
 
 ## Understanding Consent Requirements
 
@@ -30,9 +35,10 @@ All permissions are **Delegated** (not Application), meaning they act on behalf 
 1. **Admin adds the app and grants admin-required permissions**
 
    - Organization-wide OR per-user
-   - For Teams MCP: `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` require admin consent
+   - For Teams MCP with Unique enabled: `OnlineMeetingRecording.Read.All` and `OnlineMeetingTranscript.Read.All` require admin consent
    - These chat messaging permissions do **not** require admin consent and can be approved by individual users: `ChannelMessage.Send`, `ChatMessage.Send`, `Chat.ReadBasic`, `Chat.Read`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`.
    - `ChannelMessage.Read.All` **does** require admin consent (required for `get_channel_messages` to read channel message content).
+   - Chat-only deployments (`UNIQUE_INTEGRATION=disabled`) do not request calendar/meeting/transcript/recording scopes, so only `ChannelMessage.Read.All` needs admin consent among the requested permissions.
 
 2. **Admin approval workflow (if tenant has it enabled)**
 

--- a/services/teams-mcp/scripts/get-token.ts
+++ b/services/teams-mcp/scripts/get-token.ts
@@ -35,16 +35,15 @@ if (!CLIENT_ID || !CLIENT_SECRET) {
 const PORT = 9542;
 const REDIRECT_URI = `http://localhost:${PORT}/auth/callback`;
 const TENANT = 'common';
-const SCOPES = [
+const UNIQUE_INTEGRATION =
+  process.env.UNIQUE_INTEGRATION === 'disabled' ? 'disabled' : 'enabled';
+
+const CHAT_SCOPES = [
   'openid',
   'profile',
   'email',
   'offline_access',
   'User.Read',
-  'Calendars.Read',
-  'OnlineMeetings.Read',
-  'OnlineMeetingRecording.Read.All',
-  'OnlineMeetingTranscript.Read.All',
   'ChannelMessage.Send',
   'ChatMessage.Send',
   'Chat.ReadBasic',
@@ -52,7 +51,16 @@ const SCOPES = [
   'Team.ReadBasic.All',
   'Channel.ReadBasic.All',
   'ChannelMessage.Read.All',
-].join(' ');
+];
+const KB_SCOPES = [
+  'Calendars.Read',
+  'OnlineMeetings.Read',
+  'OnlineMeetingRecording.Read.All',
+  'OnlineMeetingTranscript.Read.All',
+];
+const SCOPES = (
+  UNIQUE_INTEGRATION === 'enabled' ? [...CHAT_SCOPES, ...KB_SCOPES] : CHAT_SCOPES
+).join(' ');
 
 async function exchangeCode(code: string): Promise<string> {
   const res = await fetch(`https://login.microsoftonline.com/${TENANT}/oauth2/v2.0/token`, {

--- a/services/teams-mcp/src/app.module.ts
+++ b/services/teams-mcp/src/app.module.ts
@@ -17,7 +17,7 @@ import { typeid } from 'typeid-js';
 import * as packageJson from '../package.json';
 import { AMQPModule } from './amqp/amqp.module';
 import { McpOAuthStore } from './auth/mcp-oauth.store';
-import { MicrosoftOAuthProvider } from './auth/microsoft.provider';
+import { createMicrosoftOAuthProvider } from './auth/microsoft.provider';
 import { ChatModule } from './chat/chat.module';
 import {
   type AppConfig,
@@ -32,6 +32,7 @@ import {
   healthConfig,
   type MicrosoftConfigNamespaced,
   microsoftConfig,
+  type UniqueConfigNamespaced,
   uniqueConfig,
 } from './config';
 import { DRIZZLE, DrizzleDatabase, DrizzleModule } from './drizzle/drizzle.module';
@@ -107,7 +108,10 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
       ],
       useFactory: async (
         configService: ConfigService<
-          AppConfigNamespaced & MicrosoftConfigNamespaced & AuthConfigNamespaced,
+          AppConfigNamespaced &
+            MicrosoftConfigNamespaced &
+            AuthConfigNamespaced &
+            UniqueConfigNamespaced,
           true
         >,
         aesService: AesGcmEncryptionService,
@@ -116,7 +120,9 @@ import { GraphErrorFilter } from './utils/graph-error.filter';
         metricService: MetricService,
         amqpConnection: AmqpConnection,
       ) => ({
-        provider: MicrosoftOAuthProvider,
+        provider: createMicrosoftOAuthProvider(
+          configService.get('unique.integration', { infer: true }),
+        ),
 
         clientId: configService.get('microsoft.clientId', { infer: true }),
         clientSecret: configService.get('microsoft.clientSecret', { infer: true }).value,

--- a/services/teams-mcp/src/auth/microsoft.provider.spec.ts
+++ b/services/teams-mcp/src/auth/microsoft.provider.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { CHAT_SCOPES, KB_SCOPES, resolveMicrosoftScopes, SCOPES } from './microsoft.provider';
+
+describe(resolveMicrosoftScopes.name, () => {
+  it('returns chat scopes only when Unique integration is disabled', () => {
+    const scopes = resolveMicrosoftScopes('disabled');
+
+    expect(scopes).toEqual(CHAT_SCOPES);
+    for (const kbScope of KB_SCOPES) {
+      expect(scopes).not.toContain(kbScope);
+    }
+  });
+
+  it('returns chat and knowledge-base scopes when Unique integration is enabled', () => {
+    expect(resolveMicrosoftScopes('enabled')).toEqual(SCOPES);
+    expect(resolveMicrosoftScopes('enabled')).toEqual([...CHAT_SCOPES, ...KB_SCOPES]);
+  });
+});

--- a/services/teams-mcp/src/auth/microsoft.provider.ts
+++ b/services/teams-mcp/src/auth/microsoft.provider.ts
@@ -1,16 +1,13 @@
 import { type OAuthProviderConfig } from '@unique-ag/mcp-oauth';
 import { Strategy as Microsoft } from 'passport-microsoft';
 
-export const SCOPES = [
+/** Always required for OAuth identity + chat/Teams messaging tools. */
+export const CHAT_SCOPES = [
   'openid',
   'profile',
   'email',
   'offline_access',
   'User.Read', // (delegated): e1fe6dd8-ba31-4d61-89e7-88639da4683d
-  'Calendars.Read', // (delegated): 465a38f9-76ea-45b9-9f34-9e8b0d4b0b42
-  'OnlineMeetings.Read', // (delegated): 9be106e1-f4e3-4df5-bdff-e4bc531cbe43
-  'OnlineMeetingRecording.Read.All', // (delegated): 190c2bb6-1fdd-4fec-9aa2-7d571b5e1fe3
-  'OnlineMeetingTranscript.Read.All', // (delegated): 30b87d18-ebb1-45db-97f8-82ccb1f0190c
   'ChannelMessage.Send', // (delegated): send messages to channels
   'ChatMessage.Send', // (delegated): send messages to chats
   'Chat.ReadBasic', // (delegated): list user's chats
@@ -20,20 +17,44 @@ export const SCOPES = [
   'ChannelMessage.Read.All', // (delegated): read channel messages
 ];
 
-export const MicrosoftOAuthProvider: OAuthProviderConfig = {
-  name: 'microsoft',
-  strategy: Microsoft,
-  strategyOptions: ({ serverUrl, clientId, clientSecret, callbackPath }) => ({
-    clientID: clientId,
-    clientSecret,
-    callbackURL: serverUrl + callbackPath,
-    scope: SCOPES,
-  }),
-  profileMapper: (profile) => ({
-    id: profile.id,
-    username: profile.userPrincipalName,
-    email: profile.emails?.[0]?.value,
-    displayName: profile.displayName,
-    raw: profile,
-  }),
-};
+/**
+ * Required only when UNIQUE_INTEGRATION=enabled for transcript/recording
+ * knowledge-base ingestion.
+ */
+export const KB_SCOPES = [
+  'Calendars.Read', // (delegated): 465a38f9-76ea-45b9-9f34-9e8b0d4b0b42
+  'OnlineMeetings.Read', // (delegated): 9be106e1-f4e3-4df5-bdff-e4bc531cbe43
+  'OnlineMeetingRecording.Read.All', // (delegated): 190c2bb6-1fdd-4fec-9aa2-7d571b5e1fe3
+  'OnlineMeetingTranscript.Read.All', // (delegated): 30b87d18-ebb1-45db-97f8-82ccb1f0190c
+];
+
+/** Full scope set when Unique knowledge-base integration is enabled. */
+export const SCOPES = [...CHAT_SCOPES, ...KB_SCOPES];
+
+export function resolveMicrosoftScopes(uniqueIntegration: 'enabled' | 'disabled'): string[] {
+  return uniqueIntegration === 'enabled' ? [...SCOPES] : [...CHAT_SCOPES];
+}
+
+export function createMicrosoftOAuthProvider(
+  uniqueIntegration: 'enabled' | 'disabled',
+): OAuthProviderConfig {
+  const scopes = resolveMicrosoftScopes(uniqueIntegration);
+
+  return {
+    name: 'microsoft',
+    strategy: Microsoft,
+    strategyOptions: ({ serverUrl, clientId, clientSecret, callbackPath }) => ({
+      clientID: clientId,
+      clientSecret,
+      callbackURL: serverUrl + callbackPath,
+      scope: scopes,
+    }),
+    profileMapper: (profile) => ({
+      id: profile.id,
+      username: profile.userPrincipalName,
+      email: profile.emails?.[0]?.value,
+      displayName: profile.displayName,
+      raw: profile,
+    }),
+  };
+}

--- a/services/teams-mcp/src/msgraph/graph-client.factory.ts
+++ b/services/teams-mcp/src/msgraph/graph-client.factory.ts
@@ -14,8 +14,12 @@ import {
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MetricService } from 'nestjs-otel';
-import type { AppConfigNamespaced, MicrosoftConfigNamespaced } from '~/config';
-import { SCOPES } from '../auth/microsoft.provider';
+import type {
+  AppConfigNamespaced,
+  MicrosoftConfigNamespaced,
+  UniqueConfigNamespaced,
+} from '~/config';
+import { resolveMicrosoftScopes } from '../auth/microsoft.provider';
 import { DRIZZLE, DrizzleDatabase } from '../drizzle/drizzle.module';
 import { MetricsMiddleware } from './metrics.middleware';
 import { TokenProvider } from './token.provider';
@@ -29,7 +33,7 @@ export class GraphClientFactory {
 
   public constructor(
     private readonly configService: ConfigService<
-      AppConfigNamespaced & MicrosoftConfigNamespaced,
+      AppConfigNamespaced & MicrosoftConfigNamespaced & UniqueConfigNamespaced,
       true
     >,
     @Inject(DRIZZLE) private readonly drizzle: DrizzleDatabase,
@@ -38,7 +42,9 @@ export class GraphClientFactory {
   ) {
     this.clientId = this.configService.get('microsoft.clientId', { infer: true });
     this.clientSecret = this.configService.get('microsoft.clientSecret', { infer: true }).value;
-    this.scopes = SCOPES;
+    this.scopes = resolveMicrosoftScopes(
+      this.configService.get('unique.integration', { infer: true }),
+    );
   }
 
   public createClientForUser(userProfileId: string): Client {


### PR DESCRIPTION
## Summary
- Split Microsoft Graph OAuth scopes into chat-only (`CHAT_SCOPES`) vs knowledge-base (`KB_SCOPES`), selecting them from `UNIQUE_INTEGRATION`
- Wire the resolved scopes into the OAuth provider and Graph client factory so chat-only deployments skip calendar/meeting/transcript/recording consent
- Align Terraform Entra app registration (`unique_integration`) and operator docs with the same split

## Test plan
- [ ] With `UNIQUE_INTEGRATION=disabled`, start OAuth and confirm consent does not request `Calendars.Read` / `OnlineMeetings.*` / transcript-recording scopes
- [ ] With `UNIQUE_INTEGRATION=enabled`, confirm full scope set is still requested and KB tools work
- [ ] `pnpm --filter @unique-ag/teams-mcp test` / `check-types`
- [ ] For chat-only Terraform: set `unique_integration = "disabled"` and verify only chat Graph scopes are registered


Made with [Cursor](https://cursor.com)