### PR TITLE
feat(outlook-semantic-mcp,unique-api): add more logs around attachments upload, resolve users case insensitive in unique by email

### DIFF
--- a/packages/unique-api/src/users/users.queries.ts
+++ b/packages/unique-api/src/users/users.queries.ts
@@ -6,6 +6,7 @@ export interface ListUsersQueryInput {
   where?: {
     email?: {
       equals: string;
+      mode?: 'insensitive';
     };
     active?: {
       equals: boolean;

--- a/packages/unique-api/src/users/users.service.ts
+++ b/packages/unique-api/src/users/users.service.ts
@@ -66,6 +66,7 @@ export class UsersService implements UniqueUsersFacade {
       where: {
         email: {
           equals: email,
+          mode: 'insensitive',
         },
         active: {
           equals: true,

--- a/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
@@ -98,6 +98,10 @@ export class AddAttachmentsToDraftEmailCommand {
       total: attachments.length,
       succeeded: attachments.length - attachmentsFailed.length,
       failed: attachmentsFailed.length,
+      failedAttachementsDetails: attachmentsFailed.map((item) => ({
+        fileName: createSmeared(item.fileName),
+        failedReason: item.reason,
+      })),
     });
 
     return { attachmentsFailed };

--- a/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
@@ -89,7 +89,7 @@ export class AddAttachmentsToDraftEmailCommand {
           const { failedInfo } = processResult;
           this.logger.warn({
             ...logInfoForFile,
-            err: new Error(failedInfo.reason),
+            err: failedInfo.reason,
             msg: 'Attachment failed',
           });
           attachmentsFailed.push(failedInfo);

--- a/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/add-attachments-to-draft-email.command.ts
@@ -63,12 +63,21 @@ export class AddAttachmentsToDraftEmailCommand {
 
     // This function is here because we cache the result.
     const resolveUniqueIdentity = this.createUniqueIdentityResolver(profile.email);
+    const logInfo = {
+      userProfileId: userProfileIdString,
+      draftId,
+      chatId,
+      ...(mailbox ? { mailbox: createSmeared(mailbox) } : {}),
+    };
 
-    for (const { data, fileName } of attachments) {
+    for (const { data, fileName: fileNameRaw } of attachments) {
+      const fileName = createSmeared(fileNameRaw);
+      const logInfoForFile = { ...logInfo, fileName };
+
       try {
         const processResult = await this.processAttachment({
           data,
-          fileName: createSmeared(fileName),
+          fileName,
           userProfileId: userProfileIdString,
           client,
           draftId,
@@ -77,31 +86,31 @@ export class AddAttachmentsToDraftEmailCommand {
           mailbox,
         });
         if (processResult.status === 'failed') {
-          attachmentsFailed.push(processResult.reason);
+          const { failedInfo } = processResult;
+          this.logger.warn({
+            ...logInfoForFile,
+            err: new Error(failedInfo.reason),
+            msg: 'Attachment failed',
+          });
+          attachmentsFailed.push(failedInfo);
         }
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         this.logger.warn({
+          ...logInfoForFile,
           err,
-          userProfileId: userProfileIdString,
-          draftId,
           msg: 'Attachment failed',
         });
-        attachmentsFailed.push({ fileName, reason });
+        attachmentsFailed.push({ fileName: fileName.value, reason });
       }
     }
 
     this.logger.log({
+      ...logInfo,
       msg: 'Attachment upload run complete',
-      userProfileId: userProfileIdString,
-      draftId,
       total: attachments.length,
       succeeded: attachments.length - attachmentsFailed.length,
       failed: attachmentsFailed.length,
-      failedAttachementsDetails: attachmentsFailed.map((item) => ({
-        fileName: createSmeared(item.fileName),
-        failedReason: item.reason,
-      })),
     });
 
     return { attachmentsFailed };
@@ -160,7 +169,7 @@ export class AddAttachmentsToDraftEmailCommand {
       default:
         return {
           status: 'failed',
-          reason: { fileName: fileName.value, reason: 'Unrecognised attachment type' },
+          failedInfo: { fileName: fileName.value, reason: 'Unrecognised attachment type' },
         };
     }
   }

--- a/services/outlook-semantic-mcp/src/features/email-management/email-attachments/stream-unique-attachment.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/email-attachments/stream-unique-attachment.command.ts
@@ -40,7 +40,7 @@ export class StreamUniqueAttachmentCommand {
     if (uniqueConfig.serviceAuthMode !== 'cluster_local') {
       return {
         status: 'failed',
-        reason: {
+        failedInfo: {
           fileName: fileName.value,
           reason: 'App is not running in cluster local',
         },
@@ -49,7 +49,7 @@ export class StreamUniqueAttachmentCommand {
     if (!uniqueIdentity) {
       return {
         status: 'failed',
-        reason: {
+        failedInfo: {
           fileName: fileName.value,
           reason: 'Could not resolve unique identity',
         },
@@ -88,7 +88,7 @@ export class StreamUniqueAttachmentCommand {
       });
       return {
         status: 'failed',
-        reason: {
+        failedInfo: {
           fileName: fileName.value,
           reason: `Unique content download failed (${response.status}): ${text}`,
         },
@@ -100,7 +100,7 @@ export class StreamUniqueAttachmentCommand {
       await response.body?.cancel();
       return {
         status: 'failed',
-        reason: {
+        failedInfo: {
           fileName: fileName.value,
           reason: 'Missing content-length header or empty body from content service',
         },

--- a/services/outlook-semantic-mcp/src/features/email-management/email-attachments/upload-in-memory-attachment.command.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/email-attachments/upload-in-memory-attachment.command.ts
@@ -28,19 +28,20 @@ export class UploadInMemoryAttachmentCommand {
   }): Promise<{ status: 'success' }> {
     const prefix = mailbox ? `/users/${mailbox}` : '/me';
     if (totalSize <= 3 * 1024 * 1024) {
-      this.logger.log({
-        msg: 'Uploading attachment via simple POST',
+      const logInfo = {
         userProfileId,
         draftId,
         fileName,
         sizeBytes: totalSize,
-      });
+      };
+      this.logger.log({ ...logInfo, msg: 'Uploading attachment via simple POST' });
       await client.api(`${prefix}/messages/${draftId}/attachments`).post({
         '@odata.type': '#microsoft.graph.fileAttachment',
         name: fileName.value,
         contentBytes: data.toString('base64'),
         contentType: mimeType,
       });
+      this.logger.log({ ...logInfo, msg: 'Uploading attachment via simple POST succeded' });
       return { status: 'success' };
     }
 

--- a/services/outlook-semantic-mcp/src/features/email-management/email-attachments/utils.ts
+++ b/services/outlook-semantic-mcp/src/features/email-management/email-attachments/utils.ts
@@ -15,5 +15,5 @@ export interface AttachmentFailure {
 }
 
 export type AttachmentUploadResult =
-  | { status: 'failed'; reason: AttachmentFailure }
+  | { status: 'failed'; failedInfo: AttachmentFailure }
   | { status: 'success' };


### PR DESCRIPTION
1. Add better logging around failed attachments
2. Resolve users in unique using case insensitive matching

Refs: UN-23547