### PR TITLE
chore(ci): fix hello-mcp release-please component, add DS-Engels to manifest codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @Unique-AG/Data-Flow @Unique-AG/Architects @Unique-AG/Platform
 
 /services/hello-mcp/ @Unique-AG/DS-Engels
+.release-please-manifest.json @Unique-AG/Data-Flow @Unique-AG/Architects @Unique-AG/Platform @Unique-AG/DS-Engels

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -105,6 +105,7 @@
     },
     "services/hello-mcp": {
       "release-type": "python",
+      "component": "hello-mcp",
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
## Summary
- Add the missing `component: "hello-mcp"` to `release-please-config.json`. Python packages don't auto-detect their release-please component name the way Node's `package.json` does, so `hello-mcp` was releasing under an unnamed component with an unbounded commit range — see [#715](https://github.com/Unique-AG/connectors/pull/715), where the changelog compare link came out as bare `0.0.1...0.1.0` and pulled in an unrelated breaking-change note from #168, and the PR title was missing the package name (`chore(main): release 0.1.0` instead of `chore(main): release hello-mcp 0.1.0`). Flagged by Cursor Bugbot on #715.
- Add `@Unique-AG/DS-Engels` (alongside the existing `*` owners) as codeowners of `.release-please-manifest.json`.

## Test plan
- [ ] Confirm the next release-please run produces a correctly named `hello-mcp@...` tag/title for the pending hello-mcp release
- [ ] Confirm #715 is either corrected in place or can be closed in favor of a fresh, correctly-scoped PR