### PR TITLE
docs(outlook-semantic-mcp,recordings-and-transcripts,teams-mcp): remove duplicate Confluence page title headers

### DIFF
--- a/docs/recordings-and-transcripts/README.md
+++ b/docs/recordings-and-transcripts/README.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2534866977 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Recordings & Transcripts
-
 !!! note "Beta"
     **Recordings & Transcripts is in beta.** It is suitable for production use, with the following caveats:
 

--- a/docs/recordings-and-transcripts/faq.md
+++ b/docs/recordings-and-transcripts/faq.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2535129116 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Recordings & Transcripts - FAQ
-
 Questions about capturing meeting transcripts and recordings into the Unique knowledge base, and about the Recordings area that presents them. For questions about the Teams MCP Server itself — OAuth, consent, tokens, chat and channel tools — see the [Teams MCP - FAQ](https://unique-ch.atlassian.net/wiki/spaces/PUBDOC/pages/1801846803/Teams+MCP+-+FAQ).
 
 ## Eligibility & Scope

--- a/docs/recordings-and-transcripts/operator.md
+++ b/docs/recordings-and-transcripts/operator.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2535522323 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Recordings & Transcripts - Operator Manual
-
 Enabling Recordings & Transcripts means configuring **two** systems: the [Teams MCP Server](https://unique-ch.atlassian.net/wiki/spaces/PUBDOC/pages/1802633229/Teams-MCP), which captures meeting transcripts into the knowledge base, and the **Unique platform**, which presents them in the Recordings area. Both must point at the same knowledge-base root scope — that single shared value is the most common source of misconfiguration.
 
 !!! warning "Read the eligibility section first"

--- a/docs/recordings-and-transcripts/technical.md
+++ b/docs/recordings-and-transcripts/technical.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2399993877 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Recordings & Transcripts - Technical Manual
-
 This page documents how meeting transcripts and recordings get from Microsoft Teams into the Unique knowledge base, and how the Recordings area reads them back out. For the server that performs the capture — its OAuth model, token handling, chat tools, and deployment — see the [Teams MCP - Technical Manual](https://unique-ch.atlassian.net/wiki/spaces/PUBDOC/pages/1802633247/Teams+MCP+-+Technical+Manual).
 
 ## Architecture

--- a/services/outlook-semantic-mcp/docs/README.md
+++ b/services/outlook-semantic-mcp/docs/README.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2061664285 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP
-
 ## Getting Started
 
 - **IT Operators:** Start with the [Operator Guide](./operator/README.md) for deployment, configuration, and operations

--- a/services/outlook-semantic-mcp/docs/faq.md
+++ b/services/outlook-semantic-mcp/docs/faq.md
@@ -1,9 +1,6 @@
 <!-- confluence-page-id: 2061107213 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - FAQ
-
-
 ## Table of Contents
 
 - [General](#General)

--- a/services/outlook-semantic-mcp/docs/operator/README.md
+++ b/services/outlook-semantic-mcp/docs/operator/README.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2065694735 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP — Operator Manual
-
 ## Overview
 
 The Outlook Semantic MCP Server exposes MCP tools that allow AI assistants to search and retrieve email content. In `microsoft_graph_and_unique_api` mode (the default), it also runs background pipelines that ingest emails from connected Microsoft 365 accounts into the Unique knowledge base via Microsoft Graph webhooks and RabbitMQ. In `microsoft_graph` mode, no ingestion runs — emails are queried live from Microsoft Graph.

--- a/services/outlook-semantic-mcp/docs/operator/authentication.md
+++ b/services/outlook-semantic-mcp/docs/operator/authentication.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2061664301 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Authentication
-
 How the app registration is provisioned depends on your deployment model.
 
 ## Required Permissions

--- a/services/outlook-semantic-mcp/docs/operator/configuration.md
+++ b/services/outlook-semantic-mcp/docs/operator/configuration.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2065629188 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Configuration
-
 ## Deployment Modes
 
 The server supports two deployment modes controlled by `MCP_BACKEND`. **Choose your mode before configuring anything else** — it determines which infrastructure components you need and which configuration sections apply.

--- a/services/outlook-semantic-mcp/docs/operator/deployment.md
+++ b/services/outlook-semantic-mcp/docs/operator/deployment.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2064449566 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Deployment
-
 ## Deployment Modes
 
 **Choose your mode before following any other step in this guide** — prerequisites, configuration, and verification differ by mode. See [Configuration — Deployment Modes](./configuration.md#Deployment-Modes) for the full feature and configuration comparison.

--- a/services/outlook-semantic-mcp/docs/operator/disaster-recovery.md
+++ b/services/outlook-semantic-mcp/docs/operator/disaster-recovery.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2074345526 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Disaster Recovery
-
 This runbook covers recovery procedures for the three stateful components the Outlook Semantic MCP Server depends on: the local PostgreSQL database, RabbitMQ, and the Unique Knowledge Base. Each component has a distinct failure mode and recovery path.
 
 Automatic recovery schedulers (a 2-minute full-sync retry, a live catch-up recovery scheduler that retriggers within 5 minutes on failure or after 30 minutes of inactivity, and an inbox-deletion recovery scheduler) handle transient failures. The scenarios below require explicit operator action because the automatic schedulers are insufficient for total data loss.

--- a/services/outlook-semantic-mcp/docs/operator/local-development.md
+++ b/services/outlook-semantic-mcp/docs/operator/local-development.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2061271048 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Local Development
-
 This guide walks through setting up the Outlook Semantic MCP Server for local development and testing.
 
 ## Prerequisites

--- a/services/outlook-semantic-mcp/docs/technical/README.md
+++ b/services/outlook-semantic-mcp/docs/technical/README.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2063335449 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Technical Reference
-
 ## Overview
 
 This section contains detailed technical documentation for developers and architects working with the Outlook Semantic MCP Server.

--- a/services/outlook-semantic-mcp/docs/technical/architecture.md
+++ b/services/outlook-semantic-mcp/docs/technical/architecture.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2062254116 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Architecture
-
 The Outlook Semantic MCP Server is a NestJS-based microservice that connects Microsoft Outlook email with the Unique platform through the Model Context Protocol (MCP). It syncs emails from connected mailboxes into the Unique knowledge base and exposes MCP tools for AI-assisted email search, draft creation, and contact lookup.
 
 ## High-Level Architecture

--- a/services/outlook-semantic-mcp/docs/technical/features.md
+++ b/services/outlook-semantic-mcp/docs/technical/features.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2258862199 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP – Features
-
 This page describes user-facing features of the Outlook Semantic MCP Server: what is supported, what is not, and any setup required. For per-tool input/output reference, see [Tools](./tools.md). For environment variables and deployment configuration, see [Configuration](../operator/configuration.md).
 
 ### Deployment modes

--- a/services/outlook-semantic-mcp/docs/technical/flows.md
+++ b/services/outlook-semantic-mcp/docs/technical/flows.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2062942216 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Flows
-
 This page documents the key flows in the Outlook Semantic MCP Server: how users connect, how emails are synced in real time and historically, how subscriptions stay alive, and how email drafts are created.
 
 ## User OAuth Connection Flow

--- a/services/outlook-semantic-mcp/docs/technical/permissions.md
+++ b/services/outlook-semantic-mcp/docs/technical/permissions.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2064252966 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Permissions
-
 All permissions are **Delegated** (not Application), meaning they act on behalf of the signed-in user and can only access data that user has access to.
 
 ## Permission Summary

--- a/services/outlook-semantic-mcp/docs/technical/security.md
+++ b/services/outlook-semantic-mcp/docs/technical/security.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2065399822 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Security
-
 This document describes the security architecture, cryptographic decisions, and threat model for the Outlook Semantic MCP Server.
 
 **Security at a Glance:**

--- a/services/outlook-semantic-mcp/docs/technical/subscription-management.md
+++ b/services/outlook-semantic-mcp/docs/technical/subscription-management.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2065072136 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Subscription Management
-
 A Microsoft Graph webhook subscription must be active for live catch-up to function. The server manages the full lifecycle — creation, renewal, expiry detection, and removal.
 
 ## Subscription Creation

--- a/services/outlook-semantic-mcp/docs/technical/tools.md
+++ b/services/outlook-semantic-mcp/docs/technical/tools.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2061238285 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Outlook Semantic MCP - Tools
-
 The Outlook Semantic MCP Server exposes tools whose availability depends on the deployment mode (`MCP_BACKEND`) and debug settings.
 
 !!! warning "Mode A (`microsoft_graph_and_unique_api`) only tools"

--- a/services/teams-mcp/docs/technical/tools.md
+++ b/services/teams-mcp/docs/technical/tools.md
@@ -1,8 +1,6 @@
 <!-- confluence-page-id: 2398519349 -->
 <!-- confluence-space-key: PUBDOC -->
 
-# Teams MCP - Tools
-
 The Teams MCP Server always exposes **8 chat & messaging tools**, which interact with Microsoft Teams chats and channels synchronously through the Microsoft Graph API: list teams/channels/chats, read messages, search across messages, and send messages.
 
 Four further tools exist only in deployments with meeting-transcript capture enabled — see [Transcript & Knowledge-Base Management](#transcript--knowledge-base-management) below.


### PR DESCRIPTION
## Summary
- Remove duplicate top-level `#` page titles from Confluence-synced docs so the title is not repeated under the Confluence page title
- Covers Outlook Semantic MCP (16 pages), Recordings & Transcripts (4 pages), and Teams MCP Tools

## Test plan
- [ ] Spot-check a synced Confluence page (e.g. [Recordings & Transcripts - Operator Manual](https://unique-ch.atlassian.net/wiki/spaces/PUBDOC/pages/2535522323/Recordings+Transcripts+-+Operator+Manual)) after docs sync — body should start at the first section, not repeat the page title
- [ ] Confirm Outlook Semantic MCP and Teams MCP Tools pages similarly no longer show a duplicated H1


Made with [Cursor](https://cursor.com)