### PR TITLE
fix(hello-mcp): run the image as uid 1000, matching the chart

### DIFF
--- a/services/hello-mcp/deploy/Dockerfile
+++ b/services/hello-mcp/deploy/Dockerfile
@@ -15,7 +15,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Runtime: no uv binary — only venv + system Python 3.12
 FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 WORKDIR /app
-RUN groupadd --system --gid 1001 app && useradd --system --uid 1001 --gid app app
+# uid 1000 is what the base Helm chart renders as runAsUser, pod and container side
+RUN groupadd --system --gid 1000 app && useradd --system --uid 1000 --gid app app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1
 USER app

--- a/services/hello-mcp/deploy/Dockerfile
+++ b/services/hello-mcp/deploy/Dockerfile
@@ -15,7 +15,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Runtime: no uv binary — only venv + system Python 3.12
 FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 WORKDIR /app
-# uid 1000 is what the base Helm chart renders as runAsUser, pod and container side
 RUN groupadd --system --gid 1000 app && useradd --system --uid 1000 --gid app app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1


### PR DESCRIPTION
The chart pulls in the base library chart, which renders runAsNonRoot: true and runAsUser: 1000 pod and container side when values do not override it, and hello-mcp does not override it. The image created its `app` user with uid and gid 1001, so the process ran as 1000 while every file it owns, including the venv copied in with --chown=app:app, belonged to 1001. It works because the app only reads, but it is an inconsistency waiting for the first write.

uid and gid are now 1000. Nothing else changes: the base images stay upstream and digest pinned, uv stays pinned, /tmp stays the writable emptyDir the chart mounts.