### PR TITLE
feat(backstop-mcp): add data hygiene and MCP tool surface

### DIFF
--- a/services/backstop-mcp/.env.example
+++ b/services/backstop-mcp/.env.example
@@ -16,17 +16,6 @@ PUBLIC_BASE_URL=http://localhost:9010
 # Backstop REST API base URL
 BACKSTOP_BASE_URL=https://api.backstopsolutions.com
 
-# Tuning knobs for the shared Backstop HTTP client — sane defaults, override only if needed.
-# BACKSTOP_DEFAULT_TIMEOUT_SECONDS=30
-# BACKSTOP_REPORTS_TIMEOUT_SECONDS=120
-# BACKSTOP_MAX_CONCURRENT_REQUESTS_PER_USER=5
-# BACKSTOP_MAX_RETRY_ATTEMPTS=5
-# BACKSTOP_MAX_RETRY_WAIT_MS=30000
-# BACKSTOP_DEFAULT_PAGE_SIZE=100
-# BACKSTOP_REPORT_PAGE_SIZE=500
-# BACKSTOP_PAGE_LIMIT_PARAM=page[limit]
-# BACKSTOP_PAGE_OFFSET_PARAM=page[offset]
-
 # Optional JSON map of human overlays for weird CRM custom-field names, e.g.:
 # BACKSTOP_CUSTOM_FIELD_OVERRIDES={"organizations:is1":{"display_name":"Investor Status","aliases":["investor status"]}}
 # Keys are entityType:crmName. See custom_fields/overrides.py.
@@ -48,6 +37,28 @@ BACKSTOP_BASE_URL=https://api.backstopsolutions.com
 # This token can read instance-wide custom-field metadata; treat it as a shared secret.
 # BACKSTOP_SERVICE_USERNAME=
 # BACKSTOP_SERVICE_API_TOKEN=
+
+# Which entity-relationship types mean employment, and which of those mean it has ended, for
+# departed-contact detection. Comma-separated. Ids match a type id exactly; markers match
+# case-insensitively as substrings of the type's name. Setting a MARKERS var replaces its
+# defaults (empty value = ids only for that bucket).
+#
+# The FORMER half does the detecting: tenants model a departure as a separate relationship type
+# ("is a former employee of" alongside "is employee of") and rarely fill in endDate. So the two
+# marker lists must not overlap — "employee" matches both type names, "former" only one.
+#
+# List the instance's own types with:
+#   GET /entity-relationship-types
+# and configure the FORMER ids from it — exact ids beat markers, but they differ per instance.
+#
+# An organization's own GET returns the *mirror* of these types ("is employee of (mirror)",
+# "is a former employee of (mirror)") — same names plus the suffix, but different ids. Name
+# markers already match both directions on their own; exact FORMER ids do not, so list the
+# mirror type's id too if this deployment configures ids rather than markers.
+# BACKSTOP_EMPLOYMENT_RELATIONSHIP_TYPE_IDS=
+# BACKSTOP_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS=employ
+# BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_IDS=
+# BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS=former,previous,ex-,no longer
 
 # Database - either DB_URL / DATABASE_URL or all individual settings.
 # DATABASE_URL is also accepted (injected by the base Helm chart when postgresql.enabled).

--- a/services/backstop-mcp/README.md
+++ b/services/backstop-mcp/README.md
@@ -9,12 +9,8 @@ a Backstop username + personal API token. That credential is verified against Ba
 never as a shared service account. Failed logins are rate-limited per username
 (`AUTH_LOGIN_MAX_ATTEMPTS`) so the form can't be used to test credentials against Backstop.
 
-This PR adds CRM custom-field schema discovery and caching (`features/custom_fields`) on top of
-the Backstop client, the OAuth/login bridge, and the `party_resolver` name-to-record lookup
-library. The schema is fetched lazily (or warmed at startup with an optional service account),
-cached in Postgres with a TTL, and enriched with human-facing glossaries per entity type. No MCP
-tools are exposed yet — `list_custom_fields`, `get_organization`, `get_person`, and
-`get_system_info` land in a later PR.
+Tools resolve records by name rather than by ID: "Capstone" or "Investor Status" is looked up
+against the live instance, and an ambiguous match asks the user to pick one.
 
 ## Layout
 
@@ -25,21 +21,19 @@ src/backstop_mcp/
   logging.py metrics.py  cross-cutting, used by both sides below
   features/              what the connector does
     resolution.py          the shared "which record is that?" algebra + ambiguity policy
-    entity_types.py        canonical Backstop entity-type vocabulary
     auth/                  Backstop credential bridging: login form, encryption, token rotation
     custom_fields/         CRM custom-field schema discovery, caching and resolution
     party_resolver/        name / email / trusted-ID lookup for organizations, people, contacts
-  server/                how it's exposed over MCP — no tools registered yet
-    runtime.py             the process-wide service holder tools will reach through
-    tools/                 empty registry until the first tool lands
-    middleware/            the custom-field glossary middleware (tools/list enrichment)
+  server/                how it's exposed over MCP
+    runtime.py             the process-wide service holder tools reach through
+    tools/                 tool functions + the single registry declaring them
+    middleware/            FastMCP and ASGI middleware
   backstop_client/       HTTP transport: auth headers, concurrency gate, retries, pagination
   db/                    SQLAlchemy models, engine, alembic migrations
 ```
 
 The layering rule is that **nothing under `features/` may import from `server/`** — the server
-wires features together, never the reverse. `tests/test_layering.py` enforces it, and grows as
-each package arrives.
+wires features together, never the reverse. `tests/test_layering.py` enforces it.
 
 ## Run locally
 
@@ -54,8 +48,7 @@ uv run backstop-mcp
 - MCP endpoint: `http://localhost:9010/mcp` (HTTP transport)
 - Health: `GET /health` — liveness via `unique_mcp.monitoring.setup_ops`
 - Probe: `GET /probe` — process-up (setup_ops)
-- Ready: `GET /ready` — 503 when Postgres is unreachable; also reports whether the custom-field
-  schema has loaded (never gates readiness — it fills lazily by design)
+- Ready: `GET /ready` — 503 when Postgres is unreachable
 - Metrics: `GET /metrics` — Prometheus (setup_ops)
 
 Generate an encryption key with:

--- a/services/backstop-mcp/README.md
+++ b/services/backstop-mcp/README.md
@@ -21,6 +21,7 @@ src/backstop_mcp/
   logging.py metrics.py  cross-cutting, used by both sides below
   features/              what the connector does
     resolution.py          the shared "which record is that?" algebra + ambiguity policy
+    entity_types.py        canonical Backstop entity-type vocabulary
     auth/                  Backstop credential bridging: login form, encryption, token rotation
     custom_fields/         CRM custom-field schema discovery, caching and resolution
     party_resolver/        name / email / trusted-ID lookup for organizations, people, contacts
@@ -49,7 +50,9 @@ uv run backstop-mcp
 - MCP endpoint: `http://localhost:9010/mcp` (HTTP transport)
 - Health: `GET /health` — liveness via `unique_mcp.monitoring.setup_ops`
 - Probe: `GET /probe` — process-up (setup_ops)
-- Ready: `GET /ready` — 503 when Postgres is unreachable or custom-field schema is not loaded
+- Ready: `GET /ready` — 503 when Postgres is unreachable. Also reports whether the
+  custom-field schema has loaded, which never gates readiness: it fills lazily per caller,
+  and tools degrade to `list_custom_fields` without it
 - Metrics: `GET /metrics` — Prometheus (setup_ops)
 
 Generate an encryption key with:

--- a/services/backstop-mcp/README.md
+++ b/services/backstop-mcp/README.md
@@ -24,6 +24,7 @@ src/backstop_mcp/
     auth/                  Backstop credential bridging: login form, encryption, token rotation
     custom_fields/         CRM custom-field schema discovery, caching and resolution
     party_resolver/        name / email / trusted-ID lookup for organizations, people, contacts
+    data_hygiene/          employment edges, departed contacts, as-of provenance
   server/                how it's exposed over MCP
     runtime.py             the process-wide service holder tools reach through
     tools/                 tool functions + the single registry declaring them
@@ -48,7 +49,7 @@ uv run backstop-mcp
 - MCP endpoint: `http://localhost:9010/mcp` (HTTP transport)
 - Health: `GET /health` — liveness via `unique_mcp.monitoring.setup_ops`
 - Probe: `GET /probe` — process-up (setup_ops)
-- Ready: `GET /ready` — 503 when Postgres is unreachable
+- Ready: `GET /ready` — 503 when Postgres is unreachable or custom-field schema is not loaded
 - Metrics: `GET /metrics` — Prometheus (setup_ops)
 
 Generate an encryption key with:

--- a/services/backstop-mcp/src/backstop_mcp/app.py
+++ b/services/backstop-mcp/src/backstop_mcp/app.py
@@ -39,6 +39,7 @@ from backstop_mcp.features.custom_fields import (
     create_custom_fields_service,
     warmup_lifespan,
 )
+from backstop_mcp.features.data_hygiene import create_employment_index_factory
 from backstop_mcp.logging import configure_logging
 from backstop_mcp.metrics import configure_metrics
 from backstop_mcp.server.middleware import CustomFieldGlossaryMiddleware
@@ -63,9 +64,6 @@ def create_app(
     type here (`BackstopTransportSettings`, `RetrySettings`, `FieldOverride`,
     `BackstopCredentialSecret`), so the tuning knobs a deployment sets are the ones every request
     actually uses.
-
-    Still no tools registered — `list_custom_fields`, `get_organization`, `get_person` and
-    `get_system_info` land in a later PR, wired in here the same way.
     """
     config = config or AppConfig()
     backstop_config = backstop_config or BackstopConfig()
@@ -111,7 +109,19 @@ def create_app(
         overrides=_field_overrides(backstop_config.custom_field_overrides),
         ttl_minutes=backstop_config.custom_field_schema_ttl_minutes,
     )
-    configure_services(Services(backstop=backstop_clients, custom_fields=custom_fields_service))
+    employment_index_factory = create_employment_index_factory(
+        employment_type_ids=backstop_config.employment_relationship_type_ids,
+        employment_type_markers=backstop_config.employment_relationship_type_markers,
+        former_type_ids=backstop_config.former_employment_relationship_type_ids,
+        former_type_markers=backstop_config.former_employment_relationship_type_markers,
+    )
+    configure_services(
+        Services(
+            backstop=backstop_clients,
+            custom_fields=custom_fields_service,
+            employment_index_factory=employment_index_factory,
+        )
+    )
 
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncGenerator[None, None]:

--- a/services/backstop-mcp/src/backstop_mcp/config.py
+++ b/services/backstop-mcp/src/backstop_mcp/config.py
@@ -15,9 +15,10 @@ from pydantic import (
     PrivateAttr,
     SecretStr,
     TypeAdapter,
+    field_validator,
     model_validator,
 )
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from sqlalchemy.engine.url import URL, make_url
 
 
@@ -245,6 +246,53 @@ class BackstopConfig(BaseSettings):
     # custom-field metadata, so treat it like any other shared secret.
     service_username: str | None = None
     service_api_token: SecretStr | None = None
+
+    # Which entity-relationship types mean employment, and which of those mean it has ended,
+    # for departed-contact detection (UN-23678). Comma-separated env values. Ids match a type id
+    # exactly; markers match case-insensitively as substrings of the type's name.
+    #
+    # The FORMER half is what actually detects a departure. A tenant models one as a separate
+    # relationship type rather than as a date: the instance this was built against carries both
+    # `is employee of` and `is a former employee of`, and fills in `endDate` on well under one
+    # percent of records. Which is also why the two marker lists must not overlap — matching
+    # "employee" cannot tell those two type names apart, so the departure word is the marker.
+    #
+    # Ids are exact but per-instance (an admin's numeric ids mean nothing on another deployment)
+    # and so have no default; `GET /entity-relationship-types` lists the ones a deployment can
+    # set, with `entityRestrictions` showing which link people to organizations. Setting a
+    # markers env var *replaces* its defaults; setting it empty leaves ids as that bucket's only
+    # signal. They live here rather than inside the feature so that every knob a deployment can
+    # turn is visible in one place — the detector itself has no built-in vocabulary.
+    #
+    # `NoDecode` keeps pydantic-settings from JSON-decoding the CSV before our validator runs.
+    employment_relationship_type_ids: Annotated[tuple[str, ...], NoDecode] = Field(default=())
+    employment_relationship_type_markers: Annotated[tuple[str, ...], NoDecode] = Field(
+        default=("employ",)
+    )
+    former_employment_relationship_type_ids: Annotated[tuple[str, ...], NoDecode] = Field(
+        default=()
+    )
+    former_employment_relationship_type_markers: Annotated[tuple[str, ...], NoDecode] = Field(
+        default=("former", "previous", "ex-", "no longer")
+    )
+
+    @field_validator(
+        "employment_relationship_type_ids",
+        "employment_relationship_type_markers",
+        "former_employment_relationship_type_ids",
+        "former_employment_relationship_type_markers",
+        mode="before",
+    )
+    @classmethod
+    def _split_csv_tuple(cls, value: object) -> object:
+        if value is None or value == "":
+            return ()
+        if isinstance(value, str):
+            return tuple(part.strip() for part in value.split(",") if part.strip())
+        if isinstance(value, list):
+            items = cast(list[object], value)
+            return tuple(str(item).strip() for item in items if str(item).strip())
+        return value
 
     @model_validator(mode="after")
     def _require_complete_service_account(self) -> "BackstopConfig":

--- a/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/a1b2c3d4e5f6_add_custom_field_schema_snapshots.py
+++ b/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/a1b2c3d4e5f6_add_custom_field_schema_snapshots.py
@@ -1,7 +1,7 @@
 """add custom field schema snapshots
 
 Revision ID: a1b2c3d4e5f6
-Revises: 0be78700d2dc
+Revises: b2c3d4e5f6a7
 Create Date: 2026-08-03 16:20:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a1b2c3d4e5f6"
-down_revision: str | Sequence[str] | None = "0be78700d2dc"
+down_revision: str | Sequence[str] | None = "b2c3d4e5f6a7"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/a1b2c3d4e5f6_add_custom_field_schema_snapshots.py
+++ b/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/a1b2c3d4e5f6_add_custom_field_schema_snapshots.py
@@ -1,7 +1,7 @@
 """add custom field schema snapshots
 
 Revision ID: a1b2c3d4e5f6
-Revises: b2c3d4e5f6a7
+Revises: 0be78700d2dc
 Create Date: 2026-08-03 16:20:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a1b2c3d4e5f6"
-down_revision: str | Sequence[str] | None = "b2c3d4e5f6a7"
+down_revision: str | Sequence[str] | None = "0be78700d2dc"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/b2c3d4e5f6a7_add_login_attempts.py
+++ b/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/b2c3d4e5f6a7_add_login_attempts.py
@@ -1,7 +1,7 @@
 """add login attempts
 
 Revision ID: b2c3d4e5f6a7
-Revises: a1b2c3d4e5f6
+Revises: 0be78700d2dc
 Create Date: 2026-08-05 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "b2c3d4e5f6a7"
-down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "0be78700d2dc"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/b2c3d4e5f6a7_add_login_attempts.py
+++ b/services/backstop-mcp/src/backstop_mcp/db/migrations/versions/b2c3d4e5f6a7_add_login_attempts.py
@@ -1,7 +1,7 @@
 """add login attempts
 
 Revision ID: b2c3d4e5f6a7
-Revises: 0be78700d2dc
+Revises: a1b2c3d4e5f6
 Create Date: 2026-08-05 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "b2c3d4e5f6a7"
-down_revision: str | Sequence[str] | None = "0be78700d2dc"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/services/backstop-mcp/src/backstop_mcp/features/__init__.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/__init__.py
@@ -1,9 +1,9 @@
 """Feature implementations: what this connector actually does.
 
-So far: Backstop credential bridging (`auth`), CRM custom-field schema discovery
-(`custom_fields`), name-to-record lookup (`party_resolver`), the shared entity-type vocabulary
+Everything here is domain logic — Backstop credential bridging (`auth`), CRM custom-field
+schema discovery (`custom_fields`), name-to-record lookup (`party_resolver`), read-response
+provenance and departed-contact detection (`data_hygiene`), the shared entity-type vocabulary
 (`entity_types`), and the resolution algebra party/custom-field resolution share (`resolution`).
-Read-response provenance and departed-contact detection (`data_hygiene`) land in a later PR.
 
 Layering rules, both enforced by `tests/test_layering.py`:
 

--- a/services/backstop-mcp/src/backstop_mcp/features/custom_fields/values.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/custom_fields/values.py
@@ -14,6 +14,7 @@ from backstop_mcp.backstop_client import (
 from backstop_mcp.dates import parse_lenient_date
 from backstop_mcp.features.custom_fields.entity_types import normalize_entity_type
 from backstop_mcp.features.custom_fields.types import CustomFieldDefinition
+from backstop_mcp.features.data_hygiene import AsOf, extract_as_of
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +23,10 @@ _REGULAR_FIELDS = "regularCustomFieldValues,modifiedTimestamp,modifiedBy"
 
 @dataclass(frozen=True)
 class CustomFieldValueRead:
-    """One custom-field value read from Backstop.
-
-    Entity-level provenance (`as_of`) lands once `features.data_hygiene` does — this PR reads
-    only the value itself.
-    """
+    """One custom-field value plus optional entity-level provenance from the same GET."""
 
     value: object | None
+    as_of: AsOf | None = None
 
 
 class RegularCustomFieldValueAttributes(BaseModel):
@@ -110,7 +108,8 @@ async def read_custom_field_value(
     """Read one custom field's current value, via the path selected by `isTimeSeries`.
 
     Choosing the wrong path returns nothing for a field that does exist, which is why the flag
-    is honoured rather than guessed at.
+    is honoured rather than guessed at. Regular reads piggyback entity `as_of` on the same GET;
+    time-series leaves `as_of` None rather than adding a second round trip.
     """
     entity = normalize_entity_type(entity_type)
     if entity is None:
@@ -121,7 +120,7 @@ async def read_custom_field_value(
         value = await _read_time_series_value(
             client, entity=entity, safe_id=safe_id, definition=definition
         )
-        return CustomFieldValueRead(value=value)
+        return CustomFieldValueRead(value=value, as_of=None)
     return await _read_regular_value(client, entity=entity, safe_id=safe_id, definition=definition)
 
 
@@ -166,8 +165,14 @@ async def _read_regular_value(
         schema=BackstopApiResourceDocument[EntityWithRegularCustomFieldsAttributes],
     )
     attrs = document.data.attributes
+    as_of = extract_as_of(
+        {
+            "modifiedTimestamp": attrs.modified_timestamp,
+            "modifiedBy": attrs.modified_by,
+        }
+    )
     values = attrs.regular_custom_field_values or []
     for entry in values:
         if entry.definition_id == definition.definition_id:
-            return CustomFieldValueRead(value=entry.value)
-    return CustomFieldValueRead(value=None)
+            return CustomFieldValueRead(value=entry.value, as_of=as_of)
+    return CustomFieldValueRead(value=None, as_of=as_of)

--- a/services/backstop-mcp/src/backstop_mcp/features/custom_fields/values.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/custom_fields/values.py
@@ -14,7 +14,7 @@ from backstop_mcp.backstop_client import (
 from backstop_mcp.dates import parse_lenient_date
 from backstop_mcp.features.custom_fields.entity_types import normalize_entity_type
 from backstop_mcp.features.custom_fields.types import CustomFieldDefinition
-from backstop_mcp.features.data_hygiene import AsOf, extract_as_of
+from backstop_mcp.features.data_hygiene import AsOf, ProvenanceFields, extract_as_of
 
 logger = logging.getLogger(__name__)
 
@@ -36,14 +36,12 @@ class RegularCustomFieldValueAttributes(BaseModel):
     value: object | None = None
 
 
-class EntityWithRegularCustomFieldsAttributes(BaseModel):
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+class EntityWithRegularCustomFieldsAttributes(ProvenanceFields):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore", populate_by_name=True)
 
     regular_custom_field_values: list[RegularCustomFieldValueAttributes] | None = Field(
         default=None, alias="regularCustomFieldValues"
     )
-    modified_timestamp: str | None = Field(default=None, alias="modifiedTimestamp")
-    modified_by: object | None = Field(default=None, alias="modifiedBy")
 
 
 class TimeSeriesCustomFieldValueAttributes(BaseModel):
@@ -165,12 +163,7 @@ async def _read_regular_value(
         schema=BackstopApiResourceDocument[EntityWithRegularCustomFieldsAttributes],
     )
     attrs = document.data.attributes
-    as_of = extract_as_of(
-        {
-            "modifiedTimestamp": attrs.modified_timestamp,
-            "modifiedBy": attrs.modified_by,
-        }
-    )
+    as_of = extract_as_of(attrs)
     values = attrs.regular_custom_field_values or []
     for entry in values:
         if entry.definition_id == definition.definition_id:

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
@@ -1,0 +1,57 @@
+"""Read-response provenance and departed-contact detection.
+
+The public surface is deliberately small: `EmploymentIndexFactory.index_for_person` /
+`index_for_organization` for the employment index, `entity_relationships` to pull the
+side-loads those methods take, and `extract_as_of` for provenance. `employment.py` is the pure
+scan the factory composes — importable for tests, not part of what tools are handed.
+"""
+
+from backstop_mcp.features.data_hygiene.employment import (
+    EmploymentIndex,
+    build_organization_employment_index,
+    build_person_employment_index,
+)
+from backstop_mcp.features.data_hygiene.entity_relationships import entity_relationships
+from backstop_mcp.features.data_hygiene.provenance import extract_as_of
+from backstop_mcp.features.data_hygiene.responses import (
+    AsOfEcho,
+    DepartedContactEcho,
+    as_of_echo,
+    departed_echo,
+)
+from backstop_mcp.features.data_hygiene.service import (
+    EmploymentIndexFactory,
+    create_employment_index_factory,
+)
+from backstop_mcp.features.data_hygiene.types import (
+    AsOf,
+    DepartedEmployment,
+    DepartureSignal,
+    EmploymentRules,
+    EmploymentStatus,
+    EntityRelationshipInclude,
+    EntityRelationshipRef,
+    TypeVocabulary,
+)
+
+__all__ = [
+    "AsOf",
+    "AsOfEcho",
+    "DepartedContactEcho",
+    "DepartedEmployment",
+    "DepartureSignal",
+    "EmploymentIndex",
+    "EmploymentIndexFactory",
+    "EmploymentRules",
+    "EmploymentStatus",
+    "EntityRelationshipInclude",
+    "EntityRelationshipRef",
+    "TypeVocabulary",
+    "as_of_echo",
+    "build_organization_employment_index",
+    "build_person_employment_index",
+    "create_employment_index_factory",
+    "departed_echo",
+    "entity_relationships",
+    "extract_as_of",
+]

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
@@ -6,18 +6,13 @@ side-loads those methods take, and `extract_as_of` for provenance. `employment.p
 scan the factory composes — importable for tests, not part of what tools are handed.
 """
 
-from backstop_mcp.features.data_hygiene.employment import (
-    EmploymentIndex,
-    build_organization_employment_index,
-    build_person_employment_index,
-)
+from backstop_mcp.features.data_hygiene.employment import EmploymentIndex, build_employment_index
 from backstop_mcp.features.data_hygiene.entity_relationships import entity_relationships
 from backstop_mcp.features.data_hygiene.provenance import extract_as_of
 from backstop_mcp.features.data_hygiene.responses import (
-    AsOfEcho,
-    DepartedContactEcho,
-    as_of_echo,
-    departed_echo,
+    DepartedContactResponse,
+    as_of_response,
+    departed_response,
 )
 from backstop_mcp.features.data_hygiene.service import (
     EmploymentIndexFactory,
@@ -31,13 +26,13 @@ from backstop_mcp.features.data_hygiene.types import (
     EmploymentStatus,
     EntityRelationshipInclude,
     EntityRelationshipRef,
+    ProvenanceFields,
     TypeVocabulary,
 )
 
 __all__ = [
     "AsOf",
-    "AsOfEcho",
-    "DepartedContactEcho",
+    "DepartedContactResponse",
     "DepartedEmployment",
     "DepartureSignal",
     "EmploymentIndex",
@@ -46,12 +41,12 @@ __all__ = [
     "EmploymentStatus",
     "EntityRelationshipInclude",
     "EntityRelationshipRef",
+    "ProvenanceFields",
     "TypeVocabulary",
-    "as_of_echo",
-    "build_organization_employment_index",
-    "build_person_employment_index",
+    "as_of_response",
+    "build_employment_index",
     "create_employment_index_factory",
-    "departed_echo",
+    "departed_response",
     "entity_relationships",
     "extract_as_of",
 ]

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/__init__.py
@@ -1,9 +1,9 @@
 """Read-response provenance and departed-contact detection.
 
-The public surface is deliberately small: `EmploymentIndexFactory.index_for_person` /
-`index_for_organization` for the employment index, `entity_relationships` to pull the
-side-loads those methods take, and `extract_as_of` for provenance. `employment.py` is the pure
-scan the factory composes — importable for tests, not part of what tools are handed.
+The public surface is deliberately small: `EmploymentIndexFactory.index` for the employment
+index (person or organization side-loads), `entity_relationships` to pull those includes, and
+`extract_as_of` for provenance. `employment.py` is the pure scan the factory composes —
+importable for tests, not part of what tools are handed.
 """
 
 from backstop_mcp.features.data_hygiene.employment import EmploymentIndex, build_employment_index

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
@@ -5,20 +5,12 @@ any of it directly — they go through `service.EmploymentIndexFactory`, which o
 vocabulary. List/org-contact tools should use that verdict to exclude departed people
 from "who do we contact at X" answers unless the user asked for historical contacts; a by-id
 person fetch returns the person with the flag set rather than hiding the record.
-
-`_employment_edges` is the shared building block for reading employment off *either* side of a
-relationship — a person's own GET or an organization's own GET — with `person_side` as the only
-difference between the two directions. It is one step below `EmploymentIndex` (a later addition):
-it normalises the raw payload into edges, but does not yet reduce several edges for the same pair
-down to one winner.
 """
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 from typing import TypeGuard
-
-from pydantic import ValidationError
 
 from backstop_mcp.backstop_client import BackstopApiResource
 from backstop_mcp.coerce import as_clean_str
@@ -37,6 +29,9 @@ from backstop_mcp.features.data_hygiene.types import (
     RelationshipTypeAttributes,
 )
 from backstop_mcp.features.entity_types import normalize_entity_type
+
+type RelationshipResource = BackstopApiResource[EntityRelationshipAttributes]
+type RelationshipTypeResource = BackstopApiResource[RelationshipTypeAttributes]
 
 
 @dataclass(frozen=True)
@@ -112,8 +107,7 @@ def _rank(edge: EmploymentEdge) -> tuple[bool, date, bool]:
 
 
 def _to_record(edge: EmploymentEdge) -> EmploymentRecord:
-    departure = edge.evidence if edge.status is EmploymentStatus.FORMER else None
-    return EmploymentRecord(status=edge.status, departure=departure)
+    return EmploymentRecord(status=edge.status, departure=edge.departure)
 
 
 def classify_employment(
@@ -129,8 +123,9 @@ def classify_employment(
       employee of` contains `employee`); an employment-first test would call it `CURRENT` and
       report someone who has left as a live contact.
     * `IRRELEVANT` — employment vocabulary is configured, the type has a name to judge, and it
-      matches nothing.
-    * `CURRENT` — otherwise.
+      matches nothing — or the type id is present but its name did not side-load, so we cannot
+      treat it as employment evidence (a portal-style edge must not clear a real departure).
+    * `CURRENT` — otherwise (including truly untyped relationships, so `endDate` still applies).
     """
     if rules.former.matches(type_id=type_id, type_name=type_name):
         return EmploymentStatus.FORMER
@@ -140,42 +135,21 @@ def classify_employment(
         return EmploymentStatus.CURRENT
     if rules.employment.matches(type_id=type_id, type_name=type_name):
         return EmploymentStatus.CURRENT
-    if type_name is None:
-        # Nothing to judge: either the record carries no type, or its type resource did not
-        # side-load. Both leave the person→org gate below as the only evidence, so read it as
-        # current — that keeps `endDate` in play and never invents a departure out of a record we
-        # could not classify.
+    if type_name is None and type_id is None:
+        # Truly untyped: leave the person→org gate as the only evidence and read it as current
+        # so `endDate` stays in play.
         return EmploymentStatus.CURRENT
     return EmploymentStatus.IRRELEVANT
 
 
-def _relationship_type_names(*, resources: list[dict[str, object]]) -> dict[str, str]:
-    """`id → name` for the side-loaded relationship types. Unnamed and malformed ones are dropped.
-
-    A type we cannot read leaves its relationships with no name to match, which
-    `classify_employment` treats as no type signal — never as a positive finding.
-    """
+def _relationship_type_names(*, resources: Sequence[RelationshipTypeResource]) -> dict[str, str]:
+    """`id → name` for the side-loaded relationship types. Unnamed ones are dropped."""
     names: dict[str, str] = {}
-    for raw in resources:
-        try:
-            resource = BackstopApiResource[RelationshipTypeAttributes].model_validate(raw)
-        except ValidationError:
-            continue
+    for resource in resources:
         name = as_clean_str(resource.attributes.name)
         if name is not None:
             names[resource.id] = name
     return names
-
-
-def _safe_parse_relationship(
-    *, raw: dict[str, object]
-) -> tuple[EntityRelationshipAttributes, str | None] | None:
-    try:
-        resource = BackstopApiResource[EntityRelationshipAttributes].model_validate(raw)
-    except ValidationError:
-        return None
-    type_ids = resource.related_ids(EntityRelationshipRef.TYPE)
-    return resource.attributes, type_ids[0] if type_ids else None
 
 
 def _side_type(*, side: EntityRefAttributes) -> str | None:
@@ -218,61 +192,30 @@ def _is_organization(side_type: str | None) -> TypeGuard[str]:
     return side_type in ORG_SIDE_TYPES
 
 
-def _safe_parse_date(*, raw: str | None) -> date | None:
-    """The calendar day an `endDate` (or `startDate` / `createdTimestamp`) names, however the
-    instance spelled it.
-
-    The leading ten characters cover both a plain `YYYY-MM-DD` and the full timestamp Backstop
-    actually writes into this date field; the second attempt is for compact ISO forms
-    (`20221231T101530`), whose date part is not ten characters long.
-    """
-    if raw is None:
-        return None
-    text = raw.strip()
-    if not text:
-        return None
-    try:
-        return date.fromisoformat(text[:10])
-    except ValueError:
-        pass
-    try:
-        return datetime.fromisoformat(text).date()
-    except ValueError:
-        return None
-
-
 def _employment_edges(
     *,
-    relationships: list[dict[str, object]],
-    relationship_types: list[dict[str, object]],
+    relationships: Sequence[RelationshipResource],
+    relationship_types: Sequence[RelationshipTypeResource],
     rules: EmploymentRules,
     today: date,
-    person_side: bool,
 ) -> list[EmploymentEdge]:
     """Every person↔organization relationship, normalised into one `EmploymentEdge` each.
 
-    `person_side` names which literal JSON side is "self" when the payload came from the
-    person's own GET (`sourceEntity`) versus the organization's own GET (`destinationEntity`).
-    Structural matching itself stays direction-agnostic: `_employer_side`'s type-based check
-    already tells the organization side from the person side regardless of which literal key
-    each landed on, so both `person_id` and `organization_id` are pulled from whichever side
-    matched — `person_side` only needs to be threaded through for callers building an index (a
-    later addition) that must record which id belongs to which entity type.
+    Structural matching is direction-agnostic: `_employer_side`'s type-based check already tells
+    the organization side from the person side regardless of which literal key each landed on.
 
     `IRRELEVANT` edges are dropped — they neither vouch for the person nor speak against them, so
     they carry no employment signal for `EmploymentIndex` to fold. An edge with no usable date at
     all (`effective_date=None`) is kept: it sorts last downstream rather than being dropped
     outright, so it still wins when it is the only edge for its pair.
     """
-    _ = person_side
     type_names = _relationship_type_names(resources=relationship_types)
     edges: list[EmploymentEdge] = []
 
-    for raw in relationships:
-        parsed = _safe_parse_relationship(raw=raw)
-        if parsed is None:
-            continue
-        attrs, type_id = parsed
+    for resource in relationships:
+        attrs = resource.attributes
+        type_ids = resource.related_ids(EntityRelationshipRef.TYPE)
+        type_id = type_ids[0] if type_ids else None
         employer = _employer_side(attrs=attrs)
         if employer is None:
             continue
@@ -285,17 +228,18 @@ def _employment_edges(
         if status is EmploymentStatus.IRRELEVANT:
             continue
 
-        created = _safe_parse_date(raw=attrs.created_timestamp)
-        started = _safe_parse_date(raw=attrs.start_date)
-        ended = _safe_parse_date(raw=attrs.end_date)
+        created = attrs.created_timestamp
+        started = attrs.start_date
+        ended = attrs.end_date
 
+        departure: DepartedEmployment | None = None
         if status is EmploymentStatus.FORMER:
             effective_date = ended if ended is not None else created
-            evidence = DepartedEmployment(
+            departure = DepartedEmployment(
                 signal=DepartureSignal.FORMER_TYPE,
                 organization_id=employer.organization_id,
                 organization_type=employer.organization_type,
-                end_date=ended.isoformat() if ended is not None else None,
+                end_date=ended,
                 relationship_type_id=type_id,
                 relationship_type_name=type_name,
             )
@@ -304,36 +248,27 @@ def _employment_edges(
             # departure dated at that `endDate`.
             status = EmploymentStatus.FORMER
             effective_date = ended
-            evidence = DepartedEmployment(
+            departure = DepartedEmployment(
                 signal=DepartureSignal.END_DATE,
                 organization_id=employer.organization_id,
                 organization_type=employer.organization_type,
-                end_date=ended.isoformat(),
+                end_date=ended,
                 relationship_type_id=type_id,
                 relationship_type_name=type_name,
             )
         else:
             effective_date = started if started is not None else created
-            # `evidence` is only ever read by the resolver (a later addition) for a `FORMER`
-            # edge; a plain `CURRENT` edge has no departure to describe, so `signal`/`end_date`
-            # here are a placeholder to satisfy the required field, not a claim about anything.
-            evidence = DepartedEmployment(
-                signal=DepartureSignal.END_DATE,
-                organization_id=employer.organization_id,
-                organization_type=employer.organization_type,
-                end_date=None,
-                relationship_type_id=type_id,
-                relationship_type_name=type_name,
-            )
 
         edges.append(
             EmploymentEdge(
                 person_id=person_id,
                 organization_id=employer.organization_id,
                 organization_type=employer.organization_type,
+                relationship_type_id=type_id,
+                relationship_type_name=type_name,
                 status=status,
                 effective_date=effective_date,
-                evidence=evidence,
+                departure=departure,
             )
         )
 
@@ -344,10 +279,9 @@ def _person_id(*, attrs: EntityRelationshipAttributes) -> str | None:
     """The person side's id, whichever literal JSON key (`sourceEntity`/`destinationEntity`) it
     landed on.
 
-    Mirrors `_employer_side`'s type-based matching rather than trusting a `person_side` flag for
-    structural matching, so the two functions never disagree about which side is which. A person
-    side with no `resourceId` is skipped for the same reason an unidentified organization is: an
-    id-less side would collide every such relationship into one bucket.
+    Mirrors `_employer_side`'s type-based matching. A person side with no `resourceId` is skipped
+    for the same reason an unidentified organization is: an id-less side would collide every such
+    relationship into one bucket.
     """
     sides = [
         (side, _side_type(side=side))
@@ -366,47 +300,19 @@ def _person_id(*, attrs: EntityRelationshipAttributes) -> str | None:
     return as_clean_str(person.resource_id)
 
 
-def build_person_employment_index(
+def build_employment_index(
     *,
-    relationships: list[dict[str, object]],
-    relationship_types: list[dict[str, object]],
+    relationships: Sequence[RelationshipResource],
+    relationship_types: Sequence[RelationshipTypeResource],
     rules: EmploymentRules,
     today: date,
 ) -> EmploymentIndex:
-    """The `EmploymentIndex` for `entityRelationships` side-loaded off a person's own GET.
-
-    A person's own GET puts the person at `sourceEntity`, so `person_side=True`. The rest is
-    exactly `build_organization_employment_index`'s work: `person_side` carries no behavior yet
-    (see `_employment_edges`), so the only real difference between the two builders is which
-    literal value they pass.
-    """
-    edges = _employment_edges(
-        relationships=relationships,
-        relationship_types=relationship_types,
-        rules=rules,
-        today=today,
-        person_side=True,
+    """The `EmploymentIndex` for `entityRelationships` side-loaded off a person or organization."""
+    return EmploymentIndex(
+        _employment_edges(
+            relationships=relationships,
+            relationship_types=relationship_types,
+            rules=rules,
+            today=today,
+        )
     )
-    return EmploymentIndex(edges)
-
-
-def build_organization_employment_index(
-    *,
-    relationships: list[dict[str, object]],
-    relationship_types: list[dict[str, object]],
-    rules: EmploymentRules,
-    today: date,
-) -> EmploymentIndex:
-    """The `EmploymentIndex` for `entityRelationships` side-loaded off an organization's own GET.
-
-    An organization's own GET puts the person at `destinationEntity`, so `person_side=False` —
-    the mirror image of `build_person_employment_index`.
-    """
-    edges = _employment_edges(
-        relationships=relationships,
-        relationship_types=relationship_types,
-        rules=rules,
-        today=today,
-        person_side=False,
-    )
-    return EmploymentIndex(edges)

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
@@ -13,7 +13,6 @@ from datetime import date
 from typing import TypeGuard
 
 from backstop_mcp.backstop_client import BackstopApiResource
-from backstop_mcp.coerce import as_clean_str
 from backstop_mcp.features.data_hygiene.types import (
     ORG_SIDE_TYPES,
     PERSON_SIDE_TYPES,
@@ -146,9 +145,8 @@ def _relationship_type_names(*, resources: Sequence[RelationshipTypeResource]) -
     """`id → name` for the side-loaded relationship types. Unnamed ones are dropped."""
     names: dict[str, str] = {}
     for resource in resources:
-        name = as_clean_str(resource.attributes.name)
-        if name is not None:
-            names[resource.id] = name
+        if resource.attributes.name is not None:
+            names[resource.id] = resource.attributes.name
     return names
 
 
@@ -181,10 +179,9 @@ def _employer_side(*, attrs: EntityRelationshipAttributes) -> _Employer | None:
     else:
         return None
 
-    organization_id = as_clean_str(organization.resource_id)
-    if organization_id is None:
+    if organization.resource_id is None:
         return None
-    return _Employer(organization_id=organization_id, organization_type=organization_type)
+    return _Employer(organization_id=organization.resource_id, organization_type=organization_type)
 
 
 def _is_organization(side_type: str | None) -> TypeGuard[str]:
@@ -297,7 +294,7 @@ def _person_id(*, attrs: EntityRelationshipAttributes) -> str | None:
         person = second
     else:
         return None
-    return as_clean_str(person.resource_id)
+    return person.resource_id
 
 
 def build_employment_index(

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/employment.py
@@ -1,0 +1,412 @@
+"""Employment detection from side-loaded `entityRelationships`.
+
+The scan and the type classification it rests on, pure and fully parameterised. Tools do not call
+any of it directly — they go through `service.EmploymentIndexFactory`, which owns the employment
+vocabulary. List/org-contact tools should use that verdict to exclude departed people
+from "who do we contact at X" answers unless the user asked for historical contacts; a by-id
+person fetch returns the person with the flag set rather than hiding the record.
+
+`_employment_edges` is the shared building block for reading employment off *either* side of a
+relationship — a person's own GET or an organization's own GET — with `person_side` as the only
+difference between the two directions. It is one step below `EmploymentIndex` (a later addition):
+it normalises the raw payload into edges, but does not yet reduce several edges for the same pair
+down to one winner.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import TypeGuard
+
+from pydantic import ValidationError
+
+from backstop_mcp.backstop_client import BackstopApiResource
+from backstop_mcp.coerce import as_clean_str
+from backstop_mcp.features.data_hygiene.types import (
+    ORG_SIDE_TYPES,
+    PERSON_SIDE_TYPES,
+    DepartedEmployment,
+    DepartureSignal,
+    EmploymentEdge,
+    EmploymentRecord,
+    EmploymentRules,
+    EmploymentStatus,
+    EntityRefAttributes,
+    EntityRelationshipAttributes,
+    EntityRelationshipRef,
+    RelationshipTypeAttributes,
+)
+from backstop_mcp.features.entity_types import normalize_entity_type
+
+
+@dataclass(frozen=True)
+class _Employer:
+    """The organization side of one person→org relationship, once it is known to have both."""
+
+    organization_id: str
+    organization_type: str
+
+
+class EmploymentIndex:
+    """One winner per `(person_id, organization_id)` pair, folded out of `_employment_edges`.
+
+    A tenant's `entityRelationships` can carry several records for the same pair — a live `is
+    employee of` alongside an ended `is a former employee of`, or successive relationships across
+    a re-hire — and the caller needs one verdict, not a list to re-resolve on every read. The fold
+    happens once, in `__init__`; every query method after that is a plain dict lookup.
+
+    Winner per pair: the edge with the greatest `effective_date`. A tie breaks toward **departed**
+    — a same-day former record is the more recent human action, and under-reporting a departure is
+    the costlier error for a "who do we contact" answer. An edge with no usable date at all still
+    counts, but sorts behind every dated edge for its pair, so it only wins when it is the sole
+    edge for that pair.
+    """
+
+    def __init__(self, edges: Sequence[EmploymentEdge]) -> None:
+        winners: dict[tuple[str, str], EmploymentEdge] = {}
+        for edge in edges:
+            key = (edge.person_id, edge.organization_id)
+            current = winners.get(key)
+            if current is None or _outranks(edge, current):
+                winners[key] = edge
+        self._records: dict[tuple[str, str], EmploymentRecord] = {
+            key: _to_record(edge) for key, edge in winners.items()
+        }
+
+    def status(self, *, person_id: str, organization_id: str) -> EmploymentStatus:
+        """The winning edge's status, or `IRRELEVANT` — "no employment evidence" — for an unknown
+        pair. Never a false `CURRENT`: a pair this index has never seen is not a live employee.
+        """
+        record = self._records.get((person_id, organization_id))
+        if record is None:
+            return EmploymentStatus.IRRELEVANT
+        return record.status
+
+    def departure(self, *, person_id: str, organization_id: str) -> DepartedEmployment | None:
+        """The winning edge's departure evidence, when the pair's resolved status is `FORMER`."""
+        record = self._records.get((person_id, organization_id))
+        if record is None or record.status is not EmploymentStatus.FORMER:
+            return None
+        return record.departure
+
+    def pairs(self, *, status: EmploymentStatus) -> tuple[EmploymentRecord, ...]:
+        """Every resolved pair whose winning status matches `status`, for list annotation."""
+        return tuple(record for record in self._records.values() if record.status is status)
+
+
+def _outranks(edge: EmploymentEdge, current: EmploymentEdge) -> bool:
+    """Whether `edge` beats `current` as the winner for their shared pair.
+
+    Compared as `(has a date, date, is departed)` tuples so a dated edge always beats an undated
+    one, the later date wins between two dated edges, and a same-day tie breaks toward `FORMER`.
+    """
+    return _rank(edge) > _rank(current)
+
+
+def _rank(edge: EmploymentEdge) -> tuple[bool, date, bool]:
+    return (
+        edge.effective_date is not None,
+        edge.effective_date if edge.effective_date is not None else date.min,
+        edge.status is EmploymentStatus.FORMER,
+    )
+
+
+def _to_record(edge: EmploymentEdge) -> EmploymentRecord:
+    departure = edge.evidence if edge.status is EmploymentStatus.FORMER else None
+    return EmploymentRecord(status=edge.status, departure=departure)
+
+
+def classify_employment(
+    *,
+    type_id: str | None,
+    type_name: str | None,
+    rules: EmploymentRules,
+) -> EmploymentStatus:
+    """What one relationship's type says about employment at the organization.
+
+    * `FORMER` — the type is one the deployment calls past employment. Tested *first*, because a
+      tenant's past-employment name tends to contain its current-employment name (`is a former
+      employee of` contains `employee`); an employment-first test would call it `CURRENT` and
+      report someone who has left as a live contact.
+    * `IRRELEVANT` — employment vocabulary is configured, the type has a name to judge, and it
+      matches nothing.
+    * `CURRENT` — otherwise.
+    """
+    if rules.former.matches(type_id=type_id, type_name=type_name):
+        return EmploymentStatus.FORMER
+    if rules.employment.is_empty:
+        # No employment vocabulary configured, so every person→org type is admitted. See
+        # `EmploymentRules` for what that costs.
+        return EmploymentStatus.CURRENT
+    if rules.employment.matches(type_id=type_id, type_name=type_name):
+        return EmploymentStatus.CURRENT
+    if type_name is None:
+        # Nothing to judge: either the record carries no type, or its type resource did not
+        # side-load. Both leave the person→org gate below as the only evidence, so read it as
+        # current — that keeps `endDate` in play and never invents a departure out of a record we
+        # could not classify.
+        return EmploymentStatus.CURRENT
+    return EmploymentStatus.IRRELEVANT
+
+
+def _relationship_type_names(*, resources: list[dict[str, object]]) -> dict[str, str]:
+    """`id → name` for the side-loaded relationship types. Unnamed and malformed ones are dropped.
+
+    A type we cannot read leaves its relationships with no name to match, which
+    `classify_employment` treats as no type signal — never as a positive finding.
+    """
+    names: dict[str, str] = {}
+    for raw in resources:
+        try:
+            resource = BackstopApiResource[RelationshipTypeAttributes].model_validate(raw)
+        except ValidationError:
+            continue
+        name = as_clean_str(resource.attributes.name)
+        if name is not None:
+            names[resource.id] = name
+    return names
+
+
+def _safe_parse_relationship(
+    *, raw: dict[str, object]
+) -> tuple[EntityRelationshipAttributes, str | None] | None:
+    try:
+        resource = BackstopApiResource[EntityRelationshipAttributes].model_validate(raw)
+    except ValidationError:
+        return None
+    type_ids = resource.related_ids(EntityRelationshipRef.TYPE)
+    return resource.attributes, type_ids[0] if type_ids else None
+
+
+def _side_type(*, side: EntityRefAttributes) -> str | None:
+    if side.resource_type is None:
+        return None
+    return normalize_entity_type(side.resource_type)
+
+
+def _employer_side(*, attrs: EntityRelationshipAttributes) -> _Employer | None:
+    """The organization a relationship could attribute employment to, when there is one.
+
+    Needs a person on one side and an organization on the other, in either direction, and needs
+    that organization to be identifiable. An organization side with no `resourceId` is skipped
+    rather than keyed on a placeholder: every such side would share one bucket, so a live
+    relationship to one unnamed company would clear a departure from a different one.
+    """
+    sides = [
+        (side, _side_type(side=side))
+        for side in (attrs.source_entity, attrs.destination_entity)
+        if side is not None
+    ]
+    if len(sides) != 2:
+        return None
+    (first, first_type), (second, second_type) = sides
+    if first_type in PERSON_SIDE_TYPES and _is_organization(second_type):
+        organization, organization_type = second, second_type
+    elif second_type in PERSON_SIDE_TYPES and _is_organization(first_type):
+        organization, organization_type = first, first_type
+    else:
+        return None
+
+    organization_id = as_clean_str(organization.resource_id)
+    if organization_id is None:
+        return None
+    return _Employer(organization_id=organization_id, organization_type=organization_type)
+
+
+def _is_organization(side_type: str | None) -> TypeGuard[str]:
+    """`TypeGuard` rather than a bare `in`, so the matched side's type reads as the `str` it is."""
+    return side_type in ORG_SIDE_TYPES
+
+
+def _safe_parse_date(*, raw: str | None) -> date | None:
+    """The calendar day an `endDate` (or `startDate` / `createdTimestamp`) names, however the
+    instance spelled it.
+
+    The leading ten characters cover both a plain `YYYY-MM-DD` and the full timestamp Backstop
+    actually writes into this date field; the second attempt is for compact ISO forms
+    (`20221231T101530`), whose date part is not ten characters long.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text).date()
+    except ValueError:
+        return None
+
+
+def _employment_edges(
+    *,
+    relationships: list[dict[str, object]],
+    relationship_types: list[dict[str, object]],
+    rules: EmploymentRules,
+    today: date,
+    person_side: bool,
+) -> list[EmploymentEdge]:
+    """Every person↔organization relationship, normalised into one `EmploymentEdge` each.
+
+    `person_side` names which literal JSON side is "self" when the payload came from the
+    person's own GET (`sourceEntity`) versus the organization's own GET (`destinationEntity`).
+    Structural matching itself stays direction-agnostic: `_employer_side`'s type-based check
+    already tells the organization side from the person side regardless of which literal key
+    each landed on, so both `person_id` and `organization_id` are pulled from whichever side
+    matched — `person_side` only needs to be threaded through for callers building an index (a
+    later addition) that must record which id belongs to which entity type.
+
+    `IRRELEVANT` edges are dropped — they neither vouch for the person nor speak against them, so
+    they carry no employment signal for `EmploymentIndex` to fold. An edge with no usable date at
+    all (`effective_date=None`) is kept: it sorts last downstream rather than being dropped
+    outright, so it still wins when it is the only edge for its pair.
+    """
+    _ = person_side
+    type_names = _relationship_type_names(resources=relationship_types)
+    edges: list[EmploymentEdge] = []
+
+    for raw in relationships:
+        parsed = _safe_parse_relationship(raw=raw)
+        if parsed is None:
+            continue
+        attrs, type_id = parsed
+        employer = _employer_side(attrs=attrs)
+        if employer is None:
+            continue
+        person_id = _person_id(attrs=attrs)
+        if person_id is None:
+            continue
+
+        type_name = type_names.get(type_id) if type_id is not None else None
+        status = classify_employment(type_id=type_id, type_name=type_name, rules=rules)
+        if status is EmploymentStatus.IRRELEVANT:
+            continue
+
+        created = _safe_parse_date(raw=attrs.created_timestamp)
+        started = _safe_parse_date(raw=attrs.start_date)
+        ended = _safe_parse_date(raw=attrs.end_date)
+
+        if status is EmploymentStatus.FORMER:
+            effective_date = ended if ended is not None else created
+            evidence = DepartedEmployment(
+                signal=DepartureSignal.FORMER_TYPE,
+                organization_id=employer.organization_id,
+                organization_type=employer.organization_type,
+                end_date=ended.isoformat() if ended is not None else None,
+                relationship_type_id=type_id,
+                relationship_type_name=type_name,
+            )
+        elif ended is not None and ended < today:
+            # A `CURRENT`-type relationship whose own end date has already passed: rewritten to a
+            # departure dated at that `endDate`.
+            status = EmploymentStatus.FORMER
+            effective_date = ended
+            evidence = DepartedEmployment(
+                signal=DepartureSignal.END_DATE,
+                organization_id=employer.organization_id,
+                organization_type=employer.organization_type,
+                end_date=ended.isoformat(),
+                relationship_type_id=type_id,
+                relationship_type_name=type_name,
+            )
+        else:
+            effective_date = started if started is not None else created
+            # `evidence` is only ever read by the resolver (a later addition) for a `FORMER`
+            # edge; a plain `CURRENT` edge has no departure to describe, so `signal`/`end_date`
+            # here are a placeholder to satisfy the required field, not a claim about anything.
+            evidence = DepartedEmployment(
+                signal=DepartureSignal.END_DATE,
+                organization_id=employer.organization_id,
+                organization_type=employer.organization_type,
+                end_date=None,
+                relationship_type_id=type_id,
+                relationship_type_name=type_name,
+            )
+
+        edges.append(
+            EmploymentEdge(
+                person_id=person_id,
+                organization_id=employer.organization_id,
+                organization_type=employer.organization_type,
+                status=status,
+                effective_date=effective_date,
+                evidence=evidence,
+            )
+        )
+
+    return edges
+
+
+def _person_id(*, attrs: EntityRelationshipAttributes) -> str | None:
+    """The person side's id, whichever literal JSON key (`sourceEntity`/`destinationEntity`) it
+    landed on.
+
+    Mirrors `_employer_side`'s type-based matching rather than trusting a `person_side` flag for
+    structural matching, so the two functions never disagree about which side is which. A person
+    side with no `resourceId` is skipped for the same reason an unidentified organization is: an
+    id-less side would collide every such relationship into one bucket.
+    """
+    sides = [
+        (side, _side_type(side=side))
+        for side in (attrs.source_entity, attrs.destination_entity)
+        if side is not None
+    ]
+    if len(sides) != 2:
+        return None
+    (first, first_type), (second, second_type) = sides
+    if first_type in PERSON_SIDE_TYPES and _is_organization(second_type):
+        person = first
+    elif second_type in PERSON_SIDE_TYPES and _is_organization(first_type):
+        person = second
+    else:
+        return None
+    return as_clean_str(person.resource_id)
+
+
+def build_person_employment_index(
+    *,
+    relationships: list[dict[str, object]],
+    relationship_types: list[dict[str, object]],
+    rules: EmploymentRules,
+    today: date,
+) -> EmploymentIndex:
+    """The `EmploymentIndex` for `entityRelationships` side-loaded off a person's own GET.
+
+    A person's own GET puts the person at `sourceEntity`, so `person_side=True`. The rest is
+    exactly `build_organization_employment_index`'s work: `person_side` carries no behavior yet
+    (see `_employment_edges`), so the only real difference between the two builders is which
+    literal value they pass.
+    """
+    edges = _employment_edges(
+        relationships=relationships,
+        relationship_types=relationship_types,
+        rules=rules,
+        today=today,
+        person_side=True,
+    )
+    return EmploymentIndex(edges)
+
+
+def build_organization_employment_index(
+    *,
+    relationships: list[dict[str, object]],
+    relationship_types: list[dict[str, object]],
+    rules: EmploymentRules,
+    today: date,
+) -> EmploymentIndex:
+    """The `EmploymentIndex` for `entityRelationships` side-loaded off an organization's own GET.
+
+    An organization's own GET puts the person at `destinationEntity`, so `person_side=False` —
+    the mirror image of `build_person_employment_index`.
+    """
+    edges = _employment_edges(
+        relationships=relationships,
+        relationship_types=relationship_types,
+        rules=rules,
+        today=today,
+        person_side=False,
+    )
+    return EmploymentIndex(edges)

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
@@ -5,19 +5,50 @@ type because a nested include leaves nothing on the primary pointing at them. Ca
 result into `EmploymentIndexFactory.index_for_person` / `index_for_organization`.
 """
 
+import logging
 from typing import TypedDict
 
+from pydantic import ValidationError
+
 from backstop_mcp.backstop_client import (
+    BackstopApiResource,
     BackstopApiResourceDocument,
     follow_included,
     included_by_type,
 )
-from backstop_mcp.features.data_hygiene.types import EntityRelationshipRef
+from backstop_mcp.features.data_hygiene.types import (
+    EntityRelationshipAttributes,
+    EntityRelationshipRef,
+    RelationshipTypeAttributes,
+)
+
+logger = logging.getLogger(__name__)
+
+type RelationshipResource = BackstopApiResource[EntityRelationshipAttributes]
+type RelationshipTypeResource = BackstopApiResource[RelationshipTypeAttributes]
 
 
 class EntityRelationships(TypedDict):
-    relationships: list[dict[str, object]]
-    relationship_types: list[dict[str, object]]
+    relationships: list[RelationshipResource]
+    relationship_types: list[RelationshipTypeResource]
+
+
+def _parse_resources[AttrT](
+    raw_items: list[dict[str, object]],
+    *,
+    schema: type[AttrT],
+    kind: str,
+) -> list[BackstopApiResource[AttrT]]:
+    parsed: list[BackstopApiResource[AttrT]] = []
+    for raw in raw_items:
+        try:
+            parsed.append(BackstopApiResource[schema].model_validate(raw))
+        except ValidationError as exc:
+            logger.warning(
+                "data_hygiene.side_load.unreadable",
+                extra={"kind": kind, "error": str(exc)},
+            )
+    return parsed
 
 
 def entity_relationships[AttrT](
@@ -25,8 +56,14 @@ def entity_relationships[AttrT](
 ) -> EntityRelationships:
     """`relationships` and `relationship_types` for an employment index, from one document."""
     return {
-        "relationships": follow_included(
-            document, document.data, EntityRelationshipRef.RELATIONSHIPS
+        "relationships": _parse_resources(
+            follow_included(document, document.data, EntityRelationshipRef.RELATIONSHIPS),
+            schema=EntityRelationshipAttributes,
+            kind="entityRelationships",
         ),
-        "relationship_types": included_by_type(document, EntityRelationshipRef.TYPES_RESOURCE),
+        "relationship_types": _parse_resources(
+            included_by_type(document, EntityRelationshipRef.TYPES_RESOURCE),
+            schema=RelationshipTypeAttributes,
+            kind="entity-relationship-types",
+        ),
     }

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
@@ -1,0 +1,32 @@
+"""Pull `entityRelationships` (+ nested types) out of a by-id JSON:API document.
+
+Relationships are followed from the primary resource's linkage; types are selected by resource
+type because a nested include leaves nothing on the primary pointing at them. Callers unpack the
+result into `EmploymentIndexFactory.index_for_person` / `index_for_organization`.
+"""
+
+from typing import TypedDict
+
+from backstop_mcp.backstop_client import (
+    BackstopApiResourceDocument,
+    follow_included,
+    included_by_type,
+)
+from backstop_mcp.features.data_hygiene.types import EntityRelationshipRef
+
+
+class EntityRelationships(TypedDict):
+    relationships: list[dict[str, object]]
+    relationship_types: list[dict[str, object]]
+
+
+def entity_relationships[AttrT](
+    document: BackstopApiResourceDocument[AttrT],
+) -> EntityRelationships:
+    """`relationships` and `relationship_types` for an employment index, from one document."""
+    return {
+        "relationships": follow_included(
+            document, document.data, EntityRelationshipRef.RELATIONSHIPS
+        ),
+        "relationship_types": included_by_type(document, EntityRelationshipRef.TYPES_RESOURCE),
+    }

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/entity_relationships.py
@@ -2,7 +2,7 @@
 
 Relationships are followed from the primary resource's linkage; types are selected by resource
 type because a nested include leaves nothing on the primary pointing at them. Callers unpack the
-result into `EmploymentIndexFactory.index_for_person` / `index_for_organization`.
+result into `EmploymentIndexFactory.index`.
 """
 
 import logging

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
@@ -1,7 +1,12 @@
 """Extract plain `as_of` provenance from Backstop resource attributes."""
 
-from backstop_mcp.coerce import as_clean_str, as_object_dict
+from collections.abc import Mapping
+from typing import cast
+
 from backstop_mcp.features.data_hygiene.types import AsOf, ProvenanceFields
+
+# Where an instance nests the actor object rather than sending a bare string.
+_ACTOR_NAME_KEYS = ("name", "displayName", "display_name", "id")
 
 
 def extract_as_of(attributes: ProvenanceFields | None) -> AsOf | None:
@@ -12,23 +17,28 @@ def extract_as_of(attributes: ProvenanceFields | None) -> AsOf | None:
     """
     if attributes is None:
         return None
-    modified_timestamp = as_clean_str(attributes.modified_timestamp)
     modified_by = _modified_by(attributes.modified_by)
-    if modified_timestamp is None and modified_by is None:
+    if attributes.modified_timestamp is None and modified_by is None:
         return None
-    return AsOf(modified_timestamp=modified_timestamp, modified_by=modified_by)
+    return AsOf(modified_timestamp=attributes.modified_timestamp, modified_by=modified_by)
 
 
 def _modified_by(value: object) -> str | None:
-    text = as_clean_str(value)
-    if text is not None:
-        return text
-    # Some instances nest the actor as `{name}` / `{id}` rather than a bare string.
-    nested = as_object_dict(value)
-    if nested is None:
+    """The actor as a name, whether Backstop sent a string or an object.
+
+    `AsOf.modified_by` cleans whatever this returns, so blank strings pulled out of a nested
+    actor are absence there rather than a check here.
+    """
+    if isinstance(value, str):
+        return value.strip() or None
+    if not isinstance(value, Mapping):
         return None
-    for key in ("name", "displayName", "display_name", "id"):
-        label = as_clean_str(nested.get(key))
-        if label is not None:
-            return label
-    return None
+    actor = cast("Mapping[str, object]", value)
+    return next(
+        (
+            text.strip()
+            for key in _ACTOR_NAME_KEYS
+            if isinstance(text := actor.get(key), str) and text.strip()
+        ),
+        None,
+    )

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
@@ -1,19 +1,19 @@
 """Extract plain `as_of` provenance from Backstop resource attributes."""
 
 from backstop_mcp.coerce import as_clean_str, as_object_dict
-from backstop_mcp.features.data_hygiene.types import AsOf
+from backstop_mcp.features.data_hygiene.types import AsOf, ProvenanceFields
 
 
-def extract_as_of(attributes: dict[str, object] | None) -> AsOf | None:
-    """Build provenance from `modifiedTimestamp` / `modifiedBy` when either is present.
+def extract_as_of(attributes: ProvenanceFields | None) -> AsOf | None:
+    """Build provenance from `modified_timestamp` / `modified_by` when either is present.
 
     Returns `None` when both are missing so callers can omit an empty envelope rather than
     echo `{null, null}`. No verdict is attached — age is left for the user to interpret.
     """
-    if not attributes:
+    if attributes is None:
         return None
-    modified_timestamp = as_clean_str(attributes.get("modifiedTimestamp"))
-    modified_by = _modified_by(attributes.get("modifiedBy"))
+    modified_timestamp = as_clean_str(attributes.modified_timestamp)
+    modified_by = _modified_by(attributes.modified_by)
     if modified_timestamp is None and modified_by is None:
         return None
     return AsOf(modified_timestamp=modified_timestamp, modified_by=modified_by)

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/provenance.py
@@ -1,0 +1,34 @@
+"""Extract plain `as_of` provenance from Backstop resource attributes."""
+
+from backstop_mcp.coerce import as_clean_str, as_object_dict
+from backstop_mcp.features.data_hygiene.types import AsOf
+
+
+def extract_as_of(attributes: dict[str, object] | None) -> AsOf | None:
+    """Build provenance from `modifiedTimestamp` / `modifiedBy` when either is present.
+
+    Returns `None` when both are missing so callers can omit an empty envelope rather than
+    echo `{null, null}`. No verdict is attached — age is left for the user to interpret.
+    """
+    if not attributes:
+        return None
+    modified_timestamp = as_clean_str(attributes.get("modifiedTimestamp"))
+    modified_by = _modified_by(attributes.get("modifiedBy"))
+    if modified_timestamp is None and modified_by is None:
+        return None
+    return AsOf(modified_timestamp=modified_timestamp, modified_by=modified_by)
+
+
+def _modified_by(value: object) -> str | None:
+    text = as_clean_str(value)
+    if text is not None:
+        return text
+    # Some instances nest the actor as `{name}` / `{id}` rather than a bare string.
+    nested = as_object_dict(value)
+    if nested is None:
+        return None
+    for key in ("name", "displayName", "display_name", "id"):
+        label = as_clean_str(nested.get(key))
+        if label is not None:
+            return label
+    return None

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
@@ -1,0 +1,54 @@
+"""Tool-facing echoes for provenance and departed-contact signals."""
+
+from pydantic import BaseModel, Field
+
+from backstop_mcp.features.data_hygiene.types import AsOf, DepartedEmployment, DepartureSignal
+
+
+class AsOfEcho(BaseModel):
+    """Plain provenance. Relay to the user; do not treat age as a staleness verdict."""
+
+    modified_timestamp: str | None = Field(default=None, description="Backstop modifiedTimestamp")
+    modified_by: str | None = Field(default=None, description="Backstop modifiedBy")
+
+
+class DepartedContactEcho(BaseModel):
+    """Hard signal that employment at an organization has ended. Always relay this flag."""
+
+    # Typed as the enum, not `str`, so the tool schema publishes the two possible values instead
+    # of a free-form string the caller has to read a description to interpret.
+    signal: DepartureSignal = Field(
+        description=(
+            "Which evidence this rests on: 'former_relationship_type' (the CRM links the person"
+            " to the organization as a past employee) or 'end_date_passed'."
+        )
+    )
+    organization_id: str
+    organization_type: str
+    end_date: str | None = Field(
+        default=None, description="Employment end date as YYYY-MM-DD, when the CRM records one"
+    )
+    relationship_type_id: str | None = None
+    relationship_type_name: str | None = None
+
+
+def as_of_echo(value: AsOf | None) -> AsOfEcho | None:
+    if value is None:
+        return None
+    return AsOfEcho(
+        modified_timestamp=value.modified_timestamp,
+        modified_by=value.modified_by,
+    )
+
+
+def departed_echo(value: DepartedEmployment | None) -> DepartedContactEcho | None:
+    if value is None:
+        return None
+    return DepartedContactEcho(
+        signal=value.signal,
+        organization_id=value.organization_id,
+        organization_type=value.organization_type,
+        end_date=value.end_date,
+        relationship_type_id=value.relationship_type_id,
+        relationship_type_name=value.relationship_type_name,
+    )

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
@@ -1,6 +1,7 @@
 """Tool-facing responses for provenance and departed-contact signals."""
 
 from datetime import date
+from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -10,7 +11,7 @@ from backstop_mcp.features.data_hygiene.types import AsOf, DepartedEmployment, D
 class DepartedContactResponse(BaseModel):
     """Hard signal that employment at an organization has ended. Always relay this flag."""
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
 
     # Typed as the enum, not `str`, so the tool schema publishes the two possible values instead
     # of a free-form string the caller has to read a description to interpret.

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/responses.py
@@ -1,19 +1,16 @@
-"""Tool-facing echoes for provenance and departed-contact signals."""
+"""Tool-facing responses for provenance and departed-contact signals."""
 
-from pydantic import BaseModel, Field
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from backstop_mcp.features.data_hygiene.types import AsOf, DepartedEmployment, DepartureSignal
 
 
-class AsOfEcho(BaseModel):
-    """Plain provenance. Relay to the user; do not treat age as a staleness verdict."""
-
-    modified_timestamp: str | None = Field(default=None, description="Backstop modifiedTimestamp")
-    modified_by: str | None = Field(default=None, description="Backstop modifiedBy")
-
-
-class DepartedContactEcho(BaseModel):
+class DepartedContactResponse(BaseModel):
     """Hard signal that employment at an organization has ended. Always relay this flag."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     # Typed as the enum, not `str`, so the tool schema publishes the two possible values instead
     # of a free-form string the caller has to read a description to interpret.
@@ -25,30 +22,18 @@ class DepartedContactEcho(BaseModel):
     )
     organization_id: str
     organization_type: str
-    end_date: str | None = Field(
+    end_date: date | None = Field(
         default=None, description="Employment end date as YYYY-MM-DD, when the CRM records one"
     )
     relationship_type_id: str | None = None
     relationship_type_name: str | None = None
 
 
-def as_of_echo(value: AsOf | None) -> AsOfEcho | None:
-    if value is None:
-        return None
-    return AsOfEcho(
-        modified_timestamp=value.modified_timestamp,
-        modified_by=value.modified_by,
-    )
+def as_of_response(as_of: AsOf | None) -> AsOf | None:
+    return as_of
 
 
-def departed_echo(value: DepartedEmployment | None) -> DepartedContactEcho | None:
-    if value is None:
+def departed_response(departure: DepartedEmployment | None) -> DepartedContactResponse | None:
+    if departure is None:
         return None
-    return DepartedContactEcho(
-        signal=value.signal,
-        organization_id=value.organization_id,
-        organization_type=value.organization_type,
-        end_date=value.end_date,
-        relationship_type_id=value.relationship_type_id,
-        relationship_type_name=value.relationship_type_name,
-    )
+    return DepartedContactResponse.model_validate(departure)

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
@@ -39,33 +39,18 @@ class EmploymentIndexFactory:
         """The vocabulary this factory was built with. Read-only; set once at composition."""
         return self._rules
 
-    def index_for_person(
+    def index(
         self,
         *,
         relationships: list[RelationshipResource],
         relationship_types: list[RelationshipTypeResource],
     ) -> EmploymentIndex:
-        """The `EmploymentIndex` for `entityRelationships` side-loaded off a person's own GET.
+        """Build an `EmploymentIndex` from `entityRelationships` side-loaded off a person or
+        organization GET.
 
-        Both arguments are side-loaded from the person's own GET — no second fetch of the person
-        and no per-relationship fetch of its type. Keyword-only because the two are the same type
-        and transposing them would silently misclassify every relationship.
-        """
-        return build_employment_index(
-            relationships=relationships,
-            relationship_types=relationship_types,
-            rules=self._rules,
-            today=self._clock(),
-        )
-
-    def index_for_organization(
-        self,
-        *,
-        relationships: list[RelationshipResource],
-        relationship_types: list[RelationshipTypeResource],
-    ) -> EmploymentIndex:
-        """The `EmploymentIndex` for `entityRelationships` side-loaded off an organization's own
-        GET. Mirrors `index_for_person`; see there for why both arguments are keyword-only.
+        Both arguments come from that GET's includes — no second fetch of the subject and no
+        per-relationship fetch of its type. Keyword-only because the two lists share a resource
+        shape and transposing them would silently misclassify every relationship.
         """
         return build_employment_index(
             relationships=relationships,

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
@@ -1,0 +1,95 @@
+from collections.abc import Callable, Sequence
+from datetime import date
+
+from backstop_mcp.features.data_hygiene.employment import (
+    EmploymentIndex,
+    build_organization_employment_index,
+    build_person_employment_index,
+)
+from backstop_mcp.features.data_hygiene.types import (
+    EmploymentRules,
+    TypeVocabulary,
+)
+
+
+class EmploymentIndexFactory:
+    """Owns the employment vocabulary and the clock; builds an `EmploymentIndex` per document.
+
+    The employment vocabulary is a constructor dependency and the relationship-type names arrive
+    side-loaded on the caller's own GET, so building an index needs no client, no cache and no
+    lock: it is synchronous, and every caller gets the same index for the same record.
+
+    Built by `create_employment_index_factory` in `create_app()` and reached via
+    `runtime.get_employment_index_factory()`.
+    """
+
+    def __init__(
+        self,
+        *,
+        rules: EmploymentRules,
+        clock: Callable[[], date] = date.today,
+    ) -> None:
+        self._rules: EmploymentRules = rules
+        self._clock: Callable[[], date] = clock
+
+    @property
+    def rules(self) -> EmploymentRules:
+        """The vocabulary this factory was built with. Read-only; set once at composition."""
+        return self._rules
+
+    def index_for_person(
+        self,
+        *,
+        relationships: list[dict[str, object]],
+        relationship_types: list[dict[str, object]],
+    ) -> EmploymentIndex:
+        """The `EmploymentIndex` for `entityRelationships` side-loaded off a person's own GET.
+
+        Both arguments are side-loaded from the person's own GET — no second fetch of the person
+        and no per-relationship fetch of its type. Keyword-only because the two are the same type
+        and transposing them would silently misclassify every relationship.
+        """
+        return build_person_employment_index(
+            relationships=relationships,
+            relationship_types=relationship_types,
+            rules=self._rules,
+            today=self._clock(),
+        )
+
+    def index_for_organization(
+        self,
+        *,
+        relationships: list[dict[str, object]],
+        relationship_types: list[dict[str, object]],
+    ) -> EmploymentIndex:
+        """The `EmploymentIndex` for `entityRelationships` side-loaded off an organization's own
+        GET. Mirrors `index_for_person`; see there for why both arguments are keyword-only.
+        """
+        return build_organization_employment_index(
+            relationships=relationships,
+            relationship_types=relationship_types,
+            rules=self._rules,
+            today=self._clock(),
+        )
+
+
+def create_employment_index_factory(
+    *,
+    employment_type_ids: Sequence[str],
+    employment_type_markers: Sequence[str],
+    former_type_ids: Sequence[str],
+    former_type_markers: Sequence[str],
+) -> EmploymentIndexFactory:
+    """Build the factory from configured values, translating them into the feature's own type."""
+    return EmploymentIndexFactory(
+        rules=EmploymentRules(
+            employment=TypeVocabulary(
+                type_ids=frozenset(employment_type_ids),
+                name_markers=frozenset(employment_type_markers),
+            ),
+            former=TypeVocabulary(
+                type_ids=frozenset(former_type_ids),
+                name_markers=frozenset(former_type_markers),
+            ),
+        ),
+    )

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/service.py
@@ -1,15 +1,17 @@
 from collections.abc import Callable, Sequence
 from datetime import date
 
-from backstop_mcp.features.data_hygiene.employment import (
-    EmploymentIndex,
-    build_organization_employment_index,
-    build_person_employment_index,
-)
+from backstop_mcp.backstop_client import BackstopApiResource
+from backstop_mcp.features.data_hygiene.employment import EmploymentIndex, build_employment_index
 from backstop_mcp.features.data_hygiene.types import (
     EmploymentRules,
+    EntityRelationshipAttributes,
+    RelationshipTypeAttributes,
     TypeVocabulary,
 )
+
+type RelationshipResource = BackstopApiResource[EntityRelationshipAttributes]
+type RelationshipTypeResource = BackstopApiResource[RelationshipTypeAttributes]
 
 
 class EmploymentIndexFactory:
@@ -40,8 +42,8 @@ class EmploymentIndexFactory:
     def index_for_person(
         self,
         *,
-        relationships: list[dict[str, object]],
-        relationship_types: list[dict[str, object]],
+        relationships: list[RelationshipResource],
+        relationship_types: list[RelationshipTypeResource],
     ) -> EmploymentIndex:
         """The `EmploymentIndex` for `entityRelationships` side-loaded off a person's own GET.
 
@@ -49,7 +51,7 @@ class EmploymentIndexFactory:
         and no per-relationship fetch of its type. Keyword-only because the two are the same type
         and transposing them would silently misclassify every relationship.
         """
-        return build_person_employment_index(
+        return build_employment_index(
             relationships=relationships,
             relationship_types=relationship_types,
             rules=self._rules,
@@ -59,13 +61,13 @@ class EmploymentIndexFactory:
     def index_for_organization(
         self,
         *,
-        relationships: list[dict[str, object]],
-        relationship_types: list[dict[str, object]],
+        relationships: list[RelationshipResource],
+        relationship_types: list[RelationshipTypeResource],
     ) -> EmploymentIndex:
         """The `EmploymentIndex` for `entityRelationships` side-loaded off an organization's own
         GET. Mirrors `index_for_person`; see there for why both arguments are keyword-only.
         """
-        return build_organization_employment_index(
+        return build_employment_index(
             relationships=relationships,
             relationship_types=relationship_types,
             rules=self._rules,

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
@@ -1,0 +1,192 @@
+"""Internal types for read-response provenance and departed-contact detection."""
+
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Which resource types can hold an employment relationship, as the canonical plurals that
+# `entity_types.normalize_entity_type` maps to — `departed.py` compares through it. Backstop
+# emits the API path segment (`people`, `organizations`) and an admin cannot rename those, so
+# this is product schema rather than tenant vocabulary and has no business being configurable:
+# a deployment cannot know the strings, and a typo would silently disable detection.
+PERSON_SIDE_TYPES: frozenset[str] = frozenset({"people", "contacts", "employees"})
+ORG_SIDE_TYPES: frozenset[str] = frozenset({"organizations"})
+
+
+class EntityRelationshipInclude(StrEnum):
+    """Backstop `?include=` values for side-loading employment relationships.
+
+    Nested hop is required: including `entityRelationships` alone leaves each
+    relationship's `entityRelationshipType` linkage empty.
+    """
+
+    ENTITY_RELATIONSHIPS = "entityRelationships"
+    ENTITY_RELATIONSHIP_TYPE = "entityRelationships.entityRelationshipType"
+
+    @classmethod
+    def for_employment(cls) -> str:
+        return f"{cls.ENTITY_RELATIONSHIPS},{cls.ENTITY_RELATIONSHIP_TYPE}"
+
+
+class EntityRelationshipRef(StrEnum):
+    """JSON:API names used when reading entity-relationship side-loads."""
+
+    RELATIONSHIPS = "entityRelationships"
+    TYPE = "entityRelationshipType"
+    TYPES_RESOURCE = "entity-relationship-types"
+
+
+class EntityRefAttributes(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+
+    resource_id: str | None = Field(default=None, alias="resourceId")
+    resource_type: str | None = Field(default=None, alias="resourceType")
+
+
+class EntityRelationshipAttributes(BaseModel):
+    """Sparse attributes used to decide whether a person→org employment has ended."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+
+    end_date: str | None = Field(default=None, alias="endDate")
+    start_date: str | None = Field(default=None, alias="startDate")
+    created_timestamp: str | None = Field(default=None, alias="createdTimestamp")
+    source_entity: EntityRefAttributes | None = Field(default=None, alias="sourceEntity")
+    destination_entity: EntityRefAttributes | None = Field(default=None, alias="destinationEntity")
+
+
+class RelationshipTypeAttributes(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class AsOf:
+    """Plain provenance from a Backstop record. No staleness verdict attached."""
+
+    modified_timestamp: str | None = None
+    modified_by: str | None = None
+
+
+class EmploymentStatus(StrEnum):
+    """What a relationship's type says about employment at the organization it links to.
+
+    Three outcomes, and `IRRELEVANT` is not a soft `FORMER`. A type that links a person to an
+    organization for some reason other than employment (`has portal access to`) must neither
+    raise a departure nor clear one — counting it as employment would let portal access vouch
+    for someone who has left. `CURRENT` and `FORMER` are both positive findings.
+
+    `StrEnum` so a member renders as a readable word in a log line or an assertion diff rather
+    than as an opaque ordinal.
+    """
+
+    CURRENT = "current"
+    FORMER = "former"
+    IRRELEVANT = "irrelevant"
+
+
+class DepartureSignal(StrEnum):
+    """Which evidence a departure rests on, so the answer can say why rather than just that."""
+
+    FORMER_TYPE = "former_relationship_type"
+    END_DATE = "end_date_passed"
+
+
+@dataclass(frozen=True)
+class DepartedEmployment:
+    """A hard signal that the person is no longer employed at an organization.
+
+    The organization is always identified: a relationship whose organization side carries no
+    `resourceId` is skipped rather than reported, because a departure nobody can attribute to a
+    company is not a usable answer — see `departed._employer_side`.
+    """
+
+    signal: DepartureSignal
+    organization_id: str
+    organization_type: str
+    end_date: str | None = None
+    relationship_type_id: str | None = None
+    relationship_type_name: str | None = None
+
+
+@dataclass(frozen=True)
+class TypeVocabulary:
+    """Which entity-relationship types a deployment puts in one bucket.
+
+    Two ways in, because a tenant can supply either. `type_ids` are exact but per-instance — an
+    admin's numeric ids mean nothing on another deployment. `name_markers` are substrings of the
+    type's own name and survive a re-install, at the cost of matching anything that contains
+    them. Both fields are required: a match must be a function of what was injected, never of
+    which default a call site happened to leave out.
+    """
+
+    type_ids: frozenset[str]
+    name_markers: frozenset[str]
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether this bucket can match anything at all."""
+        return not self.type_ids and not self.name_markers
+
+    def matches(self, *, type_id: str | None, type_name: str | None) -> bool:
+        if type_id is not None and type_id in self.type_ids:
+            return True
+        if type_name is None:
+            return False
+        lowered = type_name.casefold()
+        return any(marker.casefold() in lowered for marker in self.name_markers)
+
+
+@dataclass(frozen=True)
+class EmploymentEdge:
+    """One person→org relationship, normalised out of the raw Backstop payload.
+
+    `status` comes from `classify_employment` (`CURRENT` / `FORMER`; `IRRELEVANT` edges never
+    reach this shape at all). `effective_date` is whichever date on the relationship is
+    comparable across edges — a `None` here means the edge has no usable date and must sort
+    last rather than being mistaken for the oldest or newest edge. `evidence` reuses the
+    existing `DepartedEmployment` payload so tool responses keep their current shape even for a
+    `CURRENT` edge, where the payload describes the relationship rather than an actual departure.
+    """
+
+    person_id: str
+    organization_id: str
+    organization_type: str
+    status: EmploymentStatus
+    effective_date: date | None
+    evidence: DepartedEmployment
+
+
+@dataclass(frozen=True)
+class EmploymentRecord:
+    """The resolved answer for one person/organization pair, after edges are reduced to one."""
+
+    status: EmploymentStatus
+    departure: DepartedEmployment | None
+
+
+@dataclass(frozen=True)
+class EmploymentRules:
+    """Everything about reading a tenant's `entityRelationships` that a deployment can set.
+
+    Both halves are tenant vocabulary rather than anything Backstop guarantees. `employment`
+    decides which person→org types concern employment at all; `former` decides which of those
+    describe employment that has ended.
+
+    `former` is the half that does the work. A tenant models a departure as a *different
+    relationship type*, not as an end date — the instance this was built against carries
+    `is employee of` and `is a former employee of` side by side against the same organization
+    and fills in `endDate` on well under one percent of records. An empty `former` therefore
+    leaves `endDate` as the only signal and detects almost nothing.
+
+    An empty `employment` admits every person→org type, which over-reports in the one direction
+    that matters: `has portal access to` would count as employment and could clear a departure
+    that `is a former employee of` had correctly raised.
+    """
+
+    employment: TypeVocabulary
+    former: TypeVocabulary

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
@@ -1,11 +1,13 @@
 """Internal types for read-response provenance and departed-contact detection."""
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 from enum import StrEnum
-from typing import Annotated, ClassVar
+from typing import ClassVar
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from backstop_mcp.dates import LenientDate
 
 # Which resource types can hold an employment relationship, as the canonical plurals that
 # `entity_types.normalize_entity_type` maps to — `employment.py` compares through it. Backstop
@@ -14,32 +16,6 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 # a deployment cannot know the strings, and a typo would silently disable detection.
 PERSON_SIDE_TYPES: frozenset[str] = frozenset({"people", "contacts", "employees"})
 ORG_SIDE_TYPES: frozenset[str] = frozenset({"organizations"})
-
-
-def _lenient_date(value: object) -> date | None:
-    """Coerce Backstop date/timestamp spellings to a calendar day, or None if unparseable."""
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value.date()
-    if isinstance(value, date):
-        return value
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    try:
-        return date.fromisoformat(text[:10])
-    except ValueError:
-        pass
-    try:
-        return datetime.fromisoformat(text).date()
-    except ValueError:
-        return None
-
-
-_LenientDate = Annotated[date | None, BeforeValidator(_lenient_date)]
 
 
 class EntityRelationshipInclude(StrEnum):
@@ -77,9 +53,9 @@ class EntityRelationshipAttributes(BaseModel):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
 
-    end_date: _LenientDate = Field(default=None, alias="endDate")
-    start_date: _LenientDate = Field(default=None, alias="startDate")
-    created_timestamp: _LenientDate = Field(default=None, alias="createdTimestamp")
+    end_date: LenientDate = Field(default=None, alias="endDate")
+    start_date: LenientDate = Field(default=None, alias="startDate")
+    created_timestamp: LenientDate = Field(default=None, alias="createdTimestamp")
     source_entity: EntityRefAttributes | None = Field(default=None, alias="sourceEntity")
     destination_entity: EntityRefAttributes | None = Field(default=None, alias="destinationEntity")
 

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
@@ -3,11 +3,25 @@
 from dataclasses import dataclass
 from datetime import date
 from enum import StrEnum
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 from backstop_mcp.dates import LenientDate
+
+
+def _clean_or_none(value: object) -> object:
+    """Backstop sends `""` and `"  "` where it means "unset"; both are absence, not a value."""
+    return (value.strip() or None) if isinstance(value, str) else value
+
+
+# The one place the "stripped, non-empty, else absent" rule is written for this feature. Fields
+# carry it so readers get a value that is already clean, instead of every call site re-checking.
+#
+# Annotated on the *union*, not on the `str` arm: a `BeforeValidator` inside
+# `Annotated[str, ...] | None` still has its result checked against `str`, so returning None for
+# a blank fails validation rather than selecting the None arm.
+CleanStr = Annotated[str | None, BeforeValidator(_clean_or_none)]
 
 # Which resource types can hold an employment relationship, as the canonical plurals that
 # `entity_types.normalize_entity_type` maps to — `employment.py` compares through it. Backstop
@@ -44,7 +58,7 @@ class EntityRelationshipRef(StrEnum):
 class EntityRefAttributes(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
 
-    resource_id: str | None = Field(default=None, alias="resourceId")
+    resource_id: CleanStr = Field(default=None, alias="resourceId")
     resource_type: str | None = Field(default=None, alias="resourceType")
 
 
@@ -63,7 +77,7 @@ class EntityRelationshipAttributes(BaseModel):
 class RelationshipTypeAttributes(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
 
-    name: str | None = None
+    name: CleanStr = None
 
 
 class ProvenanceFields(BaseModel):
@@ -74,7 +88,7 @@ class ProvenanceFields(BaseModel):
     # parks the keys in `extra` when a subclass uses `extra="allow"`.
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore", populate_by_name=True)
 
-    modified_timestamp: str | None = Field(default=None, alias="modifiedTimestamp")
+    modified_timestamp: CleanStr = Field(default=None, alias="modifiedTimestamp")
     modified_by: object | None = Field(default=None, alias="modifiedBy")
 
 
@@ -83,8 +97,8 @@ class AsOf(BaseModel):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
-    modified_timestamp: str | None = None
-    modified_by: str | None = None
+    modified_timestamp: CleanStr = None
+    modified_by: CleanStr = None
 
 
 class EmploymentStatus(StrEnum):

--- a/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/data_hygiene/types.py
@@ -1,19 +1,45 @@
 """Internal types for read-response provenance and departed-contact detection."""
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from enum import StrEnum
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 # Which resource types can hold an employment relationship, as the canonical plurals that
-# `entity_types.normalize_entity_type` maps to — `departed.py` compares through it. Backstop
+# `entity_types.normalize_entity_type` maps to — `employment.py` compares through it. Backstop
 # emits the API path segment (`people`, `organizations`) and an admin cannot rename those, so
 # this is product schema rather than tenant vocabulary and has no business being configurable:
 # a deployment cannot know the strings, and a typo would silently disable detection.
 PERSON_SIDE_TYPES: frozenset[str] = frozenset({"people", "contacts", "employees"})
 ORG_SIDE_TYPES: frozenset[str] = frozenset({"organizations"})
+
+
+def _lenient_date(value: object) -> date | None:
+    """Coerce Backstop date/timestamp spellings to a calendar day, or None if unparseable."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(text).date()
+    except ValueError:
+        return None
+
+
+_LenientDate = Annotated[date | None, BeforeValidator(_lenient_date)]
 
 
 class EntityRelationshipInclude(StrEnum):
@@ -51,9 +77,9 @@ class EntityRelationshipAttributes(BaseModel):
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
 
-    end_date: str | None = Field(default=None, alias="endDate")
-    start_date: str | None = Field(default=None, alias="startDate")
-    created_timestamp: str | None = Field(default=None, alias="createdTimestamp")
+    end_date: _LenientDate = Field(default=None, alias="endDate")
+    start_date: _LenientDate = Field(default=None, alias="startDate")
+    created_timestamp: _LenientDate = Field(default=None, alias="createdTimestamp")
     source_entity: EntityRefAttributes | None = Field(default=None, alias="sourceEntity")
     destination_entity: EntityRefAttributes | None = Field(default=None, alias="destinationEntity")
 
@@ -64,9 +90,22 @@ class RelationshipTypeAttributes(BaseModel):
     name: str | None = None
 
 
-@dataclass(frozen=True)
-class AsOf:
+class ProvenanceFields(BaseModel):
+    """Shared `modifiedTimestamp` / `modifiedBy` attributes for as-of provenance."""
+
+    # `populate_by_name` so camelCase wire payloads and snake_case tool dumps both bind;
+    # without it, `tool_result`'s `by_alias=False` JSON leaves these fields at None and
+    # parks the keys in `extra` when a subclass uses `extra="allow"`.
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore", populate_by_name=True)
+
+    modified_timestamp: str | None = Field(default=None, alias="modifiedTimestamp")
+    modified_by: object | None = Field(default=None, alias="modifiedBy")
+
+
+class AsOf(BaseModel):
     """Plain provenance from a Backstop record. No staleness verdict attached."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     modified_timestamp: str | None = None
     modified_by: str | None = None
@@ -102,13 +141,13 @@ class DepartedEmployment:
 
     The organization is always identified: a relationship whose organization side carries no
     `resourceId` is skipped rather than reported, because a departure nobody can attribute to a
-    company is not a usable answer — see `departed._employer_side`.
+    company is not a usable answer — see `employment._employer_side`.
     """
 
     signal: DepartureSignal
     organization_id: str
     organization_type: str
-    end_date: str | None = None
+    end_date: date | None = None
     relationship_type_id: str | None = None
     relationship_type_name: str | None = None
 
@@ -148,17 +187,18 @@ class EmploymentEdge:
     `status` comes from `classify_employment` (`CURRENT` / `FORMER`; `IRRELEVANT` edges never
     reach this shape at all). `effective_date` is whichever date on the relationship is
     comparable across edges — a `None` here means the edge has no usable date and must sort
-    last rather than being mistaken for the oldest or newest edge. `evidence` reuses the
-    existing `DepartedEmployment` payload so tool responses keep their current shape even for a
-    `CURRENT` edge, where the payload describes the relationship rather than an actual departure.
+    last rather than being mistaken for the oldest or newest edge. `departure` is set only when
+    status is `FORMER`.
     """
 
     person_id: str
     organization_id: str
     organization_type: str
+    relationship_type_id: str | None
+    relationship_type_name: str | None
     status: EmploymentStatus
     effective_date: date | None
-    evidence: DepartedEmployment
+    departure: DepartedEmployment | None
 
 
 @dataclass(frozen=True)

--- a/services/backstop-mcp/src/backstop_mcp/features/party_resolver/search.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/party_resolver/search.py
@@ -34,6 +34,19 @@ _EMAIL_FIELDS: Mapping[SearchType, tuple[str, ...]] = {
     "employees": ("email", "email2", "email3"),
 }
 
+# Backstop's `/quick-search` rejects our lowercase `SearchType` outright (400
+# InvalidParameterException: valid options are [ALL, ACCOUNT, ..., ORGANIZATION,
+# PERSON_FIRST_NAME, PERSON_LAST_NAME, ..., EMAIL_ADDRESS, ...]) — these are the mapped values.
+# A name query might land in either the first- or last-name field, so people/contacts/employees
+# search both; `filter[searchTypes][eq]` takes a comma-joined multi-value the same way
+# `activityType` does elsewhere in this API.
+_BACKSTOP_SEARCH_TYPES: Mapping[SearchType, str] = {
+    "organizations": "ORGANIZATION",
+    "contacts": "PERSON_FIRST_NAME,PERSON_LAST_NAME",
+    "people": "PERSON_FIRST_NAME,PERSON_LAST_NAME",
+    "employees": "PERSON_FIRST_NAME,PERSON_LAST_NAME",
+}
+
 
 def normalized_email(value: str) -> str | None:
     """Return pydantic's normalized address, or `None` when `value` is not an email.
@@ -136,7 +149,7 @@ def _quick_search_params(
 ) -> dict[str, object]:
     params: dict[str, object] = {
         "filter[searchText][eq]": search,
-        "filter[searchTypes][eq]": search_type,
+        "filter[searchTypes][eq]": _backstop_search_types(search_type=search_type, search=search),
         "filter[limit][eq]": options.limit,
         "filter[showAll][eq]": options.show_all,
         "filter[enhanceSearchTypes][eq]": options.enhance_search_types,
@@ -154,6 +167,19 @@ def _quick_search_params(
         params["filter[filterType][eq]"] = options.filter_type
 
     return params
+
+
+def _backstop_search_types(*, search_type: SearchType, search: str) -> str:
+    """Map `search_type` to Backstop's uppercase `searchTypes` enum value(s).
+
+    When `search` itself looks like an email, `EMAIL_ADDRESS` is added to the person-shaped
+    mapping so a quick-search direct caller (unlike `resolve.py`'s `_resolve_one`, which routes
+    email-looking input to `search_by_email` instead) still matches on it.
+    """
+    base = _BACKSTOP_SEARCH_TYPES[search_type]
+    if search_type != "organizations" and looks_like_email(search):
+        return f"{base},EMAIL_ADDRESS"
+    return base
 
 
 def _merge_candidates(
@@ -174,6 +200,22 @@ def _candidates_from_document(
     )
 
 
+def _party_id(resource: _PartyResource) -> str:
+    """Extract the id usable in a follow-up `GET /{search_type}/{id}`.
+
+    Quick-search hits come back with a prefixed `id` (`organizations_341208613`), which
+    `NumberFormatException`s against the live API when interpolated as-is. `attributes.resourceId`
+    carries the real id when present; other party endpoints don't send that attribute, so fall
+    back to stripping the `{type}_` prefix off `id` (only when it's actually there).
+    """
+    if resource.attributes.resource_id is not None:
+        return resource.attributes.resource_id
+    prefix = f"{resource.type}_"
+    if resource.id.startswith(prefix):
+        return resource.id.removeprefix(prefix)
+    return resource.id
+
+
 def _candidate_from_resource(
     resource: _PartyResource, *, search_type: SearchType
 ) -> PartyCandidate:
@@ -189,8 +231,11 @@ def _candidate_from_resource(
     resolved_search_type = party_search_type(resource_type) or search_type
     name = resource.attributes.display_name()
     label = name if name is not None else f"{resource_type} #{resource.id}"
+    # `Candidate.key` stays `resource.id`: it's only a UI selection key for the elicitation
+    # flow, and the wire id is a fine, unique key even prefixed. `ResolvedParty.id` is what
+    # later gets interpolated into a Backstop path, so it needs the real, unprefixed id.
     return Candidate(
         key=resource.id,
         label=label,
-        value=ResolvedParty(id=resource.id, search_type=resolved_search_type, name=name),
+        value=ResolvedParty(id=_party_id(resource), search_type=resolved_search_type, name=name),
     )

--- a/services/backstop-mcp/src/backstop_mcp/features/party_resolver/types.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/party_resolver/types.py
@@ -49,6 +49,23 @@ class PartyAttributes(BaseModel):
     last_name: _StrippedStr | None = Field(
         default=None, validation_alias=AliasChoices("lastName", "last_name")
     )
+    # Quick-search's `id` comes back prefixed (`organizations_341208613`), unusable against
+    # `/organizations/{id}`; `resourceId` is the real id. Other party endpoints don't send this
+    # attribute, so it's optional and `search.py` falls back to stripping the `id` prefix.
+    # `_NonEmptyStr` (not `_StrippedStr`) so a blank/whitespace-only value can't bind to `""` and
+    # slip past `search.py`'s `is not None` check — that would return `""` as the id instead of
+    # falling through to the prefix-strip fallback. Needs the same blank→None coercion as
+    # `PartyResolveItem` since `_NonEmptyStr` alone rejects (rather than coerces) blank input.
+    resource_id: _NonEmptyStr | None = Field(
+        default=None, validation_alias=AliasChoices("resourceId", "resource_id")
+    )
+
+    @field_validator("resource_id", mode="before")
+    @classmethod
+    def _blank_resource_id_to_none(cls, value: object) -> object:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
     def display_name(self) -> str | None:
         if self.name:

--- a/services/backstop-mcp/src/backstop_mcp/server/runtime.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/runtime.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from backstop_mcp.backstop_client import BackstopClient, BackstopClientFactory
 from backstop_mcp.features.custom_fields import CustomFieldsService
+from backstop_mcp.features.data_hygiene import EmploymentIndexFactory
 
 
 @dataclass(frozen=True)
@@ -21,6 +22,7 @@ class Services:
 
     backstop: BackstopClientFactory
     custom_fields: CustomFieldsService
+    employment_index_factory: EmploymentIndexFactory
 
 
 _services: Services | None = None
@@ -67,3 +69,7 @@ async def get_backstop_client() -> BackstopClient:
 
 def get_custom_fields_service() -> CustomFieldsService:
     return get_services().custom_fields
+
+
+def get_employment_index_factory() -> EmploymentIndexFactory:
+    return get_services().employment_index_factory

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_organization.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_organization.py
@@ -8,12 +8,17 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from backstop_mcp.backstop_client import BackstopApiResourceDocument
 from backstop_mcp.features.custom_fields import glossary_meta
-from backstop_mcp.features.data_hygiene import AsOfEcho, as_of_echo, extract_as_of
+from backstop_mcp.features.data_hygiene import (
+    AsOf,
+    ProvenanceFields,
+    as_of_response,
+    extract_as_of,
+)
 from backstop_mcp.features.entity_types import EntityType
 from backstop_mcp.features.party_resolver import (
     PartyAmbiguousResponse,
-    ResolvedPartyEcho,
-    party_echo,
+    ResolvedPartyResponse,
+    party_response,
     resolve_party,
     unresolved_party_response,
 )
@@ -22,15 +27,14 @@ from backstop_mcp.server.runtime import get_backstop_client
 from backstop_mcp.server.tools.results import tool_result
 
 
-class OrganizationAttributes(BaseModel):
+class OrganizationAttributes(ProvenanceFields):
     """Shape of an organization resource's `attributes` in `get_organization`'s response.
 
-    `extra="allow"` so unrecognized Backstop fields (e.g. `status`, `modifiedTimestamp`)
-    survive the `model_dump(exclude_none=True)` round-trip that rebuilds the `organization`
-    dict — and so `extract_as_of` can read provenance from the same dump.
+    `extra="allow"` so unrecognized Backstop fields survive on the typed payload, and so
+    `extract_as_of` can read provenance from the model rather than string keys on a dump.
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow", populate_by_name=True)
 
     name: str | None = None
 
@@ -45,9 +49,9 @@ class OrganizationResolvedResponse(BaseModel):
     """
 
     status: Literal["resolved"] = "resolved"
-    organization: dict[str, object]
-    resolved: ResolvedPartyEcho
-    as_of: AsOfEcho | None = None
+    organization: OrganizationAttributes
+    resolved: ResolvedPartyResponse
+    as_of: AsOf | None = None
 
 
 type GetOrganizationResponse = (
@@ -71,7 +75,7 @@ async def get_organization(
         Field(
             description=(
                 "Trusted Backstop organization Party ID from a prior resolve echo "
-                "(`id` / `type` / `name`). Never invent or guess. Exactly one of "
+                "(`id` / `search_type` / `name`). Never invent or guess. Exactly one of "
                 "`party_id` or `search` must be provided."
             ),
         ),
@@ -89,7 +93,7 @@ async def get_organization(
     """Fetch one Backstop organization by trusted Party ID or by name/email search.
 
     Never invent or guess a party_id. Only pass a party_id that was previously returned
-    by this server's resolve echo (`id` / `type` / `name`). Otherwise pass `search`
+    by this server's resolve echo (`id` / `search_type` / `name`). Otherwise pass `search`
     (organization name or email) and let the server resolve it.
     Exactly one of party_id or search must be provided.
 
@@ -113,11 +117,13 @@ async def get_organization(
     party = result.value
     path = f"/organizations/{quote(party.id, safe='')}"
     document = await client.get(path, schema=BackstopApiResourceDocument[OrganizationAttributes])
-    attributes = document.data.attributes.model_dump(exclude_none=True)
+    attributes = document.data.attributes
     return tool_result(
         OrganizationResolvedResponse(
             organization=attributes,
-            resolved=party_echo(party, attributes=attributes),
-            as_of=as_of_echo(extract_as_of(attributes)),
+            resolved=party_response(
+                party, attributes=attributes.model_dump(by_alias=True, exclude_none=True)
+            ),
+            as_of=as_of_response(extract_as_of(attributes)),
         )
     )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_organization.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_organization.py
@@ -1,0 +1,123 @@
+from typing import Annotated, ClassVar, Literal
+from urllib.parse import quote
+
+from fastmcp import Context
+from fastmcp.tools import tool
+from mcp.types import CallToolResult, ToolAnnotations
+from pydantic import BaseModel, ConfigDict, Field
+
+from backstop_mcp.backstop_client import BackstopApiResourceDocument
+from backstop_mcp.features.custom_fields import glossary_meta
+from backstop_mcp.features.data_hygiene import AsOfEcho, as_of_echo, extract_as_of
+from backstop_mcp.features.entity_types import EntityType
+from backstop_mcp.features.party_resolver import (
+    PartyAmbiguousResponse,
+    ResolvedPartyEcho,
+    party_echo,
+    resolve_party,
+    unresolved_party_response,
+)
+from backstop_mcp.features.resolution import NotFoundResponse, Resolved
+from backstop_mcp.server.runtime import get_backstop_client
+from backstop_mcp.server.tools.results import tool_result
+
+
+class OrganizationAttributes(BaseModel):
+    """Shape of an organization resource's `attributes` in `get_organization`'s response.
+
+    `extra="allow"` so unrecognized Backstop fields (e.g. `status`, `modifiedTimestamp`)
+    survive the `model_dump(exclude_none=True)` round-trip that rebuilds the `organization`
+    dict — and so `extract_as_of` can read provenance from the same dump.
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    name: str | None = None
+
+
+class OrganizationResolvedResponse(BaseModel):
+    """`get_organization`'s response once the organization was found and fetched.
+
+    `organization` holds the record's own fields (the JSON:API resource's `attributes`) — not
+    the enclosing document, whose `type`/`id` are already echoed under `resolved`.
+    `as_of` is plain provenance (`modifiedTimestamp` / `modifiedBy`); relay it, do not treat
+    age as a staleness verdict.
+    """
+
+    status: Literal["resolved"] = "resolved"
+    organization: dict[str, object]
+    resolved: ResolvedPartyEcho
+    as_of: AsOfEcho | None = None
+
+
+type GetOrganizationResponse = (
+    PartyAmbiguousResponse | NotFoundResponse | OrganizationResolvedResponse
+)
+
+
+@tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    meta=glossary_meta(EntityType.ORGANIZATIONS),
+)
+async def get_organization(
+    ctx: Context,
+    party_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Trusted Backstop organization Party ID from a prior resolve echo "
+                "(`id` / `type` / `name`). Never invent or guess. Exactly one of "
+                "`party_id` or `search` must be provided."
+            ),
+        ),
+    ] = None,
+    search: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Organization name or email to resolve when no trusted `party_id` is "
+                "available. Exactly one of `party_id` or `search` must be provided."
+            ),
+        ),
+    ] = None,
+) -> CallToolResult:
+    """Fetch one Backstop organization by trusted Party ID or by name/email search.
+
+    Never invent or guess a party_id. Only pass a party_id that was previously returned
+    by this server's resolve echo (`id` / `type` / `name`). Otherwise pass `search`
+    (organization name or email) and let the server resolve it.
+    Exactly one of party_id or search must be provided.
+
+    Responses include `as_of` provenance when Backstop provides modifiedTimestamp/modifiedBy.
+    Relay that provenance to the user; do not treat record age as a staleness verdict.
+
+    When the custom-field glossary on this tool is truncated or missing, call
+    `list_custom_fields` with entity_type=organizations.
+    """
+    client = await get_backstop_client()
+    result = await resolve_party(
+        ctx,
+        client,
+        search_type="organizations",
+        party_id=party_id,
+        search=search,
+    )
+    if not isinstance(result, Resolved):
+        return tool_result(unresolved_party_response(result))
+
+    party = result.value
+    path = f"/organizations/{quote(party.id, safe='')}"
+    document = await client.get(path, schema=BackstopApiResourceDocument[OrganizationAttributes])
+    attributes = document.data.attributes.model_dump(exclude_none=True)
+    return tool_result(
+        OrganizationResolvedResponse(
+            organization=attributes,
+            resolved=party_echo(party, attributes=attributes),
+            as_of=as_of_echo(extract_as_of(attributes)),
+        )
+    )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
@@ -123,7 +123,9 @@ async def get_person(
         return tool_result(unresolved_party_response(result))
 
     party = result.value
-    path = f"/people/{quote(party.id, safe='')}"
+    # Quick-search for people uses the shared PERSON_* types, so a hit may be a
+    # contact/employee; follow `party.search_type` instead of hard-coding `/people`.
+    path = f"/{party.search_type}/{quote(party.id, safe='')}"
     document = await client.get(
         path,
         params={"include": EntityRelationshipInclude.for_employment()},

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
@@ -1,0 +1,152 @@
+from typing import Annotated, ClassVar, Literal
+from urllib.parse import quote
+
+from fastmcp import Context
+from fastmcp.tools import tool
+from mcp.types import CallToolResult, ToolAnnotations
+from pydantic import BaseModel, ConfigDict, Field
+
+from backstop_mcp.backstop_client import BackstopApiResourceDocument
+from backstop_mcp.features.custom_fields import glossary_meta
+from backstop_mcp.features.data_hygiene import (
+    AsOfEcho,
+    DepartedContactEcho,
+    EmploymentStatus,
+    EntityRelationshipInclude,
+    as_of_echo,
+    departed_echo,
+    entity_relationships,
+    extract_as_of,
+)
+from backstop_mcp.features.entity_types import EntityType
+from backstop_mcp.features.party_resolver import (
+    PartyAmbiguousResponse,
+    ResolvedPartyEcho,
+    party_echo,
+    resolve_party,
+    unresolved_party_response,
+)
+from backstop_mcp.features.resolution import NotFoundResponse, Resolved
+from backstop_mcp.server.runtime import get_backstop_client, get_employment_index_factory
+from backstop_mcp.server.tools.results import tool_result
+
+
+class PersonAttributes(BaseModel):
+    """Person resource attributes; extras preserved for the tool payload dump."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    name: str | None = None
+
+
+class PersonResolvedResponse(BaseModel):
+    """`get_person` once the person was found and fetched.
+
+    Always returns the person when resolved. When employment has ended anywhere, `departed` is
+    true and `departures` carries one entry per organization the person has left, each already
+    identifying its own `organization_id` — relay every entry to the user and do not present the
+    person as a current contact at any of those organizations unless they asked for historical
+    contacts.
+    """
+
+    status: Literal["resolved"] = "resolved"
+    person: dict[str, object]
+    resolved: ResolvedPartyEcho
+    as_of: AsOfEcho | None = None
+    departed: bool = False
+    departures: list[DepartedContactEcho] = Field(default_factory=list)
+
+
+type GetPersonResponse = PartyAmbiguousResponse | NotFoundResponse | PersonResolvedResponse
+
+
+@tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+    meta=glossary_meta(EntityType.PEOPLE),
+)
+async def get_person(
+    ctx: Context,
+    party_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Trusted Backstop person Party ID from a prior resolve echo "
+                "(`id` / `type` / `name`). Never invent or guess. Exactly one of "
+                "`party_id` or `search` must be provided."
+            ),
+        ),
+    ] = None,
+    search: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Person name or email to resolve when no trusted `party_id` is available. "
+                "Exactly one of `party_id` or `search` must be provided."
+            ),
+        ),
+    ] = None,
+) -> CallToolResult:
+    """Fetch one Backstop person by trusted Party ID or by name/email search.
+
+    Never invent or guess a party_id. Only pass a party_id that was previously returned
+    by this server's resolve echo (`id` / `type` / `name`). Otherwise pass `search`
+    (person name or email) and let the server resolve it.
+    Exactly one of party_id or search must be provided.
+
+    Side-loads entityRelationships and their relationship types on the same GET (no extra round
+    trip). When the CRM links the person to an organization as a past employee, or an employment
+    endDate has passed, `departed` is true — always relay `departed` / `departures` to the
+    user; do not present a departed person as a current contact unless they explicitly asked for
+    historical contacts.
+
+    `as_of` is plain provenance (modifiedTimestamp / modifiedBy). Relay it; do not treat
+    record age as a staleness verdict.
+
+    When the custom-field glossary on this tool is truncated or missing, call
+    `list_custom_fields` with entity_type=people.
+    """
+    client = await get_backstop_client()
+    result = await resolve_party(
+        ctx,
+        client,
+        search_type="people",
+        party_id=party_id,
+        search=search,
+    )
+    if not isinstance(result, Resolved):
+        return tool_result(unresolved_party_response(result))
+
+    party = result.value
+    path = f"/people/{quote(party.id, safe='')}"
+    document = await client.get(
+        path,
+        params={"include": EntityRelationshipInclude.for_employment()},
+        schema=BackstopApiResourceDocument[PersonAttributes],
+    )
+    attributes = document.data.attributes.model_dump(exclude_none=True)
+    index = get_employment_index_factory().index_for_person(
+        **entity_relationships(document),
+    )
+    departures: list[DepartedContactEcho] = []
+    for record in index.pairs(status=EmploymentStatus.FORMER):
+        assert record.departure is not None, (
+            "EmploymentIndex invariant: a FORMER record always carries departure evidence"
+        )
+        echo = departed_echo(record.departure)
+        assert echo is not None
+        departures.append(echo)
+
+    return tool_result(
+        PersonResolvedResponse(
+            person=attributes,
+            resolved=party_echo(party, attributes=attributes),
+            as_of=as_of_echo(extract_as_of(attributes)),
+            departed=bool(departures),
+            departures=departures,
+        )
+    )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
@@ -130,7 +130,7 @@ async def get_person(
         schema=BackstopApiResourceDocument[PersonAttributes],
     )
     attributes = document.data.attributes
-    index = get_employment_index_factory().index_for_person(
+    index = get_employment_index_factory().index(
         **entity_relationships(document),
     )
     departures: list[DepartedContactResponse] = []

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/get_person.py
@@ -9,20 +9,21 @@ from pydantic import BaseModel, ConfigDict, Field
 from backstop_mcp.backstop_client import BackstopApiResourceDocument
 from backstop_mcp.features.custom_fields import glossary_meta
 from backstop_mcp.features.data_hygiene import (
-    AsOfEcho,
-    DepartedContactEcho,
+    AsOf,
+    DepartedContactResponse,
     EmploymentStatus,
     EntityRelationshipInclude,
-    as_of_echo,
-    departed_echo,
+    ProvenanceFields,
+    as_of_response,
+    departed_response,
     entity_relationships,
     extract_as_of,
 )
 from backstop_mcp.features.entity_types import EntityType
 from backstop_mcp.features.party_resolver import (
     PartyAmbiguousResponse,
-    ResolvedPartyEcho,
-    party_echo,
+    ResolvedPartyResponse,
+    party_response,
     resolve_party,
     unresolved_party_response,
 )
@@ -31,10 +32,10 @@ from backstop_mcp.server.runtime import get_backstop_client, get_employment_inde
 from backstop_mcp.server.tools.results import tool_result
 
 
-class PersonAttributes(BaseModel):
-    """Person resource attributes; extras preserved for the tool payload dump."""
+class PersonAttributes(ProvenanceFields):
+    """Person resource attributes; extras preserved for the tool payload."""
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow", populate_by_name=True)
 
     name: str | None = None
 
@@ -50,11 +51,11 @@ class PersonResolvedResponse(BaseModel):
     """
 
     status: Literal["resolved"] = "resolved"
-    person: dict[str, object]
-    resolved: ResolvedPartyEcho
-    as_of: AsOfEcho | None = None
+    person: PersonAttributes
+    resolved: ResolvedPartyResponse
+    as_of: AsOf | None = None
     departed: bool = False
-    departures: list[DepartedContactEcho] = Field(default_factory=list)
+    departures: list[DepartedContactResponse] = Field(default_factory=list)
 
 
 type GetPersonResponse = PartyAmbiguousResponse | NotFoundResponse | PersonResolvedResponse
@@ -76,7 +77,7 @@ async def get_person(
         Field(
             description=(
                 "Trusted Backstop person Party ID from a prior resolve echo "
-                "(`id` / `type` / `name`). Never invent or guess. Exactly one of "
+                "(`id` / `search_type` / `name`). Never invent or guess. Exactly one of "
                 "`party_id` or `search` must be provided."
             ),
         ),
@@ -94,7 +95,7 @@ async def get_person(
     """Fetch one Backstop person by trusted Party ID or by name/email search.
 
     Never invent or guess a party_id. Only pass a party_id that was previously returned
-    by this server's resolve echo (`id` / `type` / `name`). Otherwise pass `search`
+    by this server's resolve echo (`id` / `search_type` / `name`). Otherwise pass `search`
     (person name or email) and let the server resolve it.
     Exactly one of party_id or search must be provided.
 
@@ -128,24 +129,26 @@ async def get_person(
         params={"include": EntityRelationshipInclude.for_employment()},
         schema=BackstopApiResourceDocument[PersonAttributes],
     )
-    attributes = document.data.attributes.model_dump(exclude_none=True)
+    attributes = document.data.attributes
     index = get_employment_index_factory().index_for_person(
         **entity_relationships(document),
     )
-    departures: list[DepartedContactEcho] = []
+    departures: list[DepartedContactResponse] = []
     for record in index.pairs(status=EmploymentStatus.FORMER):
         assert record.departure is not None, (
             "EmploymentIndex invariant: a FORMER record always carries departure evidence"
         )
-        echo = departed_echo(record.departure)
-        assert echo is not None
-        departures.append(echo)
+        response = departed_response(record.departure)
+        assert response is not None
+        departures.append(response)
 
     return tool_result(
         PersonResolvedResponse(
             person=attributes,
-            resolved=party_echo(party, attributes=attributes),
-            as_of=as_of_echo(extract_as_of(attributes)),
+            resolved=party_response(
+                party, attributes=attributes.model_dump(by_alias=True, exclude_none=True)
+            ),
+            as_of=as_of_response(extract_as_of(attributes)),
             departed=bool(departures),
             departures=departures,
         )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
@@ -4,7 +4,10 @@ from fastmcp.tools import tool
 from mcp.types import CallToolResult, ToolAnnotations
 from pydantic import BaseModel, Field
 
-from backstop_mcp.features.custom_fields import CustomFieldDefinitionEcho, definition_echo
+from backstop_mcp.features.custom_fields import (
+    CustomFieldDefinitionResponse,
+    definition_response,
+)
 from backstop_mcp.features.entity_types import EntityType
 from backstop_mcp.server.runtime import get_backstop_client, get_custom_fields_service
 from backstop_mcp.server.tools.results import tool_result
@@ -16,7 +19,7 @@ class ListCustomFieldsResponse(BaseModel):
     status: Literal["ok"] = "ok"
     entity_type: EntityType
     count: int
-    definitions: list[CustomFieldDefinitionEcho] = Field(default_factory=list)
+    definitions: list[CustomFieldDefinitionResponse] = Field(default_factory=list)
 
 
 @tool(
@@ -65,6 +68,6 @@ async def list_custom_fields(
         ListCustomFieldsResponse(
             entity_type=entity_type,
             count=len(definitions),
-            definitions=[definition_echo(definition) for definition in definitions],
+            definitions=[definition_response(definition) for definition in definitions],
         )
     )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
@@ -4,6 +4,7 @@ from fastmcp.tools import tool
 from mcp.types import CallToolResult, ToolAnnotations
 from pydantic import BaseModel, Field
 
+from backstop_mcp.features.auth import current_subject
 from backstop_mcp.features.custom_fields import (
     CustomFieldDefinitionResponse,
     definition_response,
@@ -58,12 +59,13 @@ async def list_custom_fields(
     """
     client = await get_backstop_client()
     service = get_custom_fields_service()
+    subject = current_subject()
     if refresh:
-        await service.refresh(client)
+        await service.refresh(client, subject=subject)
     else:
-        await service.ensure_fresh(client)
+        await service.ensure_fresh(client, subject=subject)
 
-    definitions = service.definitions_for(entity_type.value)
+    definitions = service.definitions_for(entity_type.value, subject=subject)
     return tool_result(
         ListCustomFieldsResponse(
             entity_type=entity_type,

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/list_custom_fields.py
@@ -1,0 +1,70 @@
+from typing import Annotated, Literal
+
+from fastmcp.tools import tool
+from mcp.types import CallToolResult, ToolAnnotations
+from pydantic import BaseModel, Field
+
+from backstop_mcp.features.custom_fields import CustomFieldDefinitionEcho, definition_echo
+from backstop_mcp.features.entity_types import EntityType
+from backstop_mcp.server.runtime import get_backstop_client, get_custom_fields_service
+from backstop_mcp.server.tools.results import tool_result
+
+
+class ListCustomFieldsResponse(BaseModel):
+    """Full custom-field catalog for one entity type."""
+
+    status: Literal["ok"] = "ok"
+    entity_type: EntityType
+    count: int
+    definitions: list[CustomFieldDefinitionEcho] = Field(default_factory=list)
+
+
+@tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+async def list_custom_fields(
+    entity_type: Annotated[
+        EntityType,
+        Field(
+            description=(
+                "Backstop entity type whose custom-field definitions to list: "
+                "organizations, people, contacts, employees, opportunities, or accounts."
+            ),
+        ),
+    ],
+    refresh: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, re-fetch custom-field definitions from Backstop into the cache "
+                "instead of using the cached catalog."
+            ),
+        ),
+    ] = False,
+) -> CallToolResult:
+    """List custom-field definitions for one Backstop entity type.
+
+    Use when a tool glossary is missing, truncated, or you need the full catalog (ids, types,
+    aliases, allowed values) for organizations, people, contacts, employees, opportunities, or
+    accounts. Pass refresh=true to re-fetch definitions from Backstop into the cache.
+    """
+    client = await get_backstop_client()
+    service = get_custom_fields_service()
+    if refresh:
+        await service.refresh(client)
+    else:
+        await service.ensure_fresh(client)
+
+    definitions = service.definitions_for(entity_type.value)
+    return tool_result(
+        ListCustomFieldsResponse(
+            entity_type=entity_type,
+            count=len(definitions),
+            definitions=[definition_echo(definition) for definition in definitions],
+        )
+    )

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/registry.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/registry.py
@@ -1,15 +1,24 @@
 """The single declaration of which tools this server exposes.
 
 Each entry is a `@tool`-decorated function (annotations / glossary meta live on the function).
-`create_app` registers from this list via `mcp.add_tool`. Empty for now — the client, auth, and
-party-resolver library land here across earlier PRs with nothing wired to MCP yet; the first
-tools land once `custom_fields` and the rest of the domain logic are in place.
+`create_app` registers from this list via `mcp.add_tool`. Glossary scopes are read from tool
+`meta` at tools/list time — not restated here.
 """
 
 from collections.abc import Awaitable, Callable
 
 from mcp.types import CallToolResult
 
+from backstop_mcp.server.tools.get_organization import get_organization
+from backstop_mcp.server.tools.get_person import get_person
+from backstop_mcp.server.tools.list_custom_fields import list_custom_fields
+from backstop_mcp.server.tools.system_info import get_system_info
+
 type ToolFunction = Callable[..., Awaitable[CallToolResult]]
 
-TOOLS: tuple[ToolFunction, ...] = ()
+TOOLS: tuple[ToolFunction, ...] = (
+    get_system_info,
+    get_organization,
+    get_person,
+    list_custom_fields,
+)

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/results.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/results.py
@@ -1,0 +1,22 @@
+"""MCP wire-shape helpers for tool returns.
+
+Tools keep domain Pydantic models internally and wrap them here so the MCP surface matches
+the Unique FastMCP pattern (`CallToolResult` + `TextContent`).
+"""
+
+from __future__ import annotations
+
+import json
+
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
+
+
+def tool_result(payload: BaseModel | dict[str, object]) -> CallToolResult:
+    """Serialize a domain payload as a single JSON text content block."""
+    text = payload.model_dump_json() if isinstance(payload, BaseModel) else json.dumps(payload)
+    return CallToolResult(content=[TextContent(type="text", text=text)])
+
+
+def tool_error(message: str) -> CallToolResult:
+    return CallToolResult(isError=True, content=[TextContent(type="text", text=message)])

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/results.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/results.py
@@ -6,16 +6,19 @@ the Unique FastMCP pattern (`CallToolResult` + `TextContent`).
 
 from __future__ import annotations
 
-import json
-
 from mcp.types import CallToolResult, TextContent
 from pydantic import BaseModel
 
 
-def tool_result(payload: BaseModel | dict[str, object]) -> CallToolResult:
-    """Serialize a domain payload as a single JSON text content block."""
-    text = payload.model_dump_json() if isinstance(payload, BaseModel) else json.dumps(payload)
-    return CallToolResult(content=[TextContent(type="text", text=text)])
+def tool_result(payload: BaseModel) -> CallToolResult:
+    """Serialize a domain payload as a single JSON text content block.
+
+    Uses Python field names (`by_alias=False`) so tool JSON matches the pydantic models the
+    server types against, not Backstop's camelCase wire aliases.
+    """
+    return CallToolResult(
+        content=[TextContent(type="text", text=payload.model_dump_json(by_alias=False))]
+    )
 
 
 def tool_error(message: str) -> CallToolResult:

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/system_info.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/system_info.py
@@ -1,0 +1,29 @@
+from fastmcp.tools import tool
+from mcp.types import CallToolResult, ToolAnnotations
+
+from backstop_mcp.server.runtime import get_backstop_client
+from backstop_mcp.server.tools.results import tool_result
+
+
+@tool(
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+async def get_system_info() -> CallToolResult:
+    """Fetch Backstop's system info for the currently connected user.
+
+    An example tool showing the full authenticated-call path end to end: FastMCP has
+    already validated the caller's MCP access token; `get_backstop_client` resolves *their*
+    stored Backstop credential (not a shared service account) and builds a `BackstopClient`
+    authenticated as them. That client auto-raises on any error response (a revoked credential
+    surfaces as `BackstopAuthError`; anything else as `BackstopApiError`/
+    `BackstopRateLimitError`), so this tool doesn't need to check status codes itself.
+    """
+    client = await get_backstop_client()
+    payload = await client.get("/system-info")
+    assert isinstance(payload, dict), "Backstop /system-info returns a JSON object"
+    return tool_result(payload)

--- a/services/backstop-mcp/src/backstop_mcp/server/tools/system_info.py
+++ b/services/backstop-mcp/src/backstop_mcp/server/tools/system_info.py
@@ -1,8 +1,17 @@
+from typing import ClassVar
+
 from fastmcp.tools import tool
 from mcp.types import CallToolResult, ToolAnnotations
+from pydantic import BaseModel, ConfigDict
 
 from backstop_mcp.server.runtime import get_backstop_client
 from backstop_mcp.server.tools.results import tool_result
+
+
+class SystemInfoResponse(BaseModel):
+    """Opaque Backstop `/system-info` payload; extras preserved for the instance's fields."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
 
 @tool(
@@ -24,6 +33,5 @@ async def get_system_info() -> CallToolResult:
     `BackstopRateLimitError`), so this tool doesn't need to check status codes itself.
     """
     client = await get_backstop_client()
-    payload = await client.get("/system-info")
-    assert isinstance(payload, dict), "Backstop /system-info returns a JSON object"
+    payload = await client.get("/system-info", schema=SystemInfoResponse)
     return tool_result(payload)

--- a/services/backstop-mcp/tests/features/custom_fields/test_values.py
+++ b/services/backstop-mcp/tests/features/custom_fields/test_values.py
@@ -97,6 +97,7 @@ class TestReadCustomFieldValue:
         )
 
         assert read.value == "Hot"
+        assert read.as_of is None
         sent_url = str(route.calls.last.request.url)
         assert "timeSeriesCustomFieldValues" in sent_url
         assert (
@@ -213,6 +214,7 @@ class TestReadCustomFieldValue:
         )
 
         assert read.value is None
+        assert read.as_of is None
 
     @pytest.mark.asyncio
     @respx.mock
@@ -240,3 +242,35 @@ class TestReadCustomFieldValue:
         )
 
         assert read.value is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_regular_path_extracts_as_of_from_same_get(self, client: BackstopClient) -> None:
+        respx.get(f"{BASE_URL}/organizations/o1").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "organizations",
+                        "id": "o1",
+                        "attributes": {
+                            "regularCustomFieldValues": [{"definitionId": "55", "value": "A"}],
+                            "modifiedTimestamp": "2024-06-01T12:00:00Z",
+                            "modifiedBy": "alice",
+                        },
+                    }
+                },
+            )
+        )
+
+        read = await read_custom_field_value(
+            client,
+            entity_type="organizations",
+            entity_id="o1",
+            definition=_definition("55", is_time_series=False),
+        )
+
+        assert read.value == "A"
+        assert read.as_of is not None
+        assert read.as_of.modified_timestamp == "2024-06-01T12:00:00Z"
+        assert read.as_of.modified_by == "alice"

--- a/services/backstop-mcp/tests/features/data_hygiene/helpers.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/helpers.py
@@ -1,0 +1,94 @@
+"""Side-loaded `entityRelationships` fixtures, shared by the feature tests and `get_person`'s.
+
+The type ids and names are the ones a real instance uses: `is employee of` and `is a former
+employee of` against the same organization, plus `has portal access to` as a person→org link that
+is not employment at all.
+
+The mirror types (`is employee of (mirror)` / `is a former employee of (mirror)`) are what an
+organization's own GET side-loads instead — same meaning, different ids and names, and pointing
+the other direction. `owns account` / `management company of` are org-side types the design doc
+cites as `IRRELEVANT`: person↔organization is not the shape at all (an org owning an account or
+managing another org), so they must drop out rather than count as employment either way.
+"""
+
+EMPLOYEE_TYPE = "456439"
+FORMER_TYPE = "459795"
+PORTAL_TYPE = "633147"
+EMPLOYEE_MIRROR_TYPE = "456441"
+FORMER_MIRROR_TYPE = "459797"
+OWNS_ACCOUNT_TYPE = "700001"
+MANAGEMENT_COMPANY_TYPE = "700002"
+
+TYPE_NAMES = {
+    EMPLOYEE_TYPE: "is employee of",
+    FORMER_TYPE: "is a former employee of",
+    PORTAL_TYPE: "has portal access to",
+    EMPLOYEE_MIRROR_TYPE: "is employee of (mirror)",
+    FORMER_MIRROR_TYPE: "is a former employee of (mirror)",
+    OWNS_ACCOUNT_TYPE: "owns account",
+    MANAGEMENT_COMPANY_TYPE: "management company of",
+}
+
+
+def relationship_types(*type_ids: str) -> list[dict[str, object]]:
+    """Side-loaded `entity-relationship-types` resources (id → name)."""
+    return [
+        {
+            "type": "entity-relationship-types",
+            "id": type_id,
+            "attributes": {"name": TYPE_NAMES[type_id]},
+        }
+        for type_id in type_ids
+    ]
+
+
+def person_org(
+    er_id: str,
+    *,
+    end_date: str | None = None,
+    start_date: str | None = None,
+    created_timestamp: str | None = None,
+    source_type: str | None = "people",
+    source_id: str | None = "p1",
+    dest_type: str | None = "organizations",
+    dest_id: str | None = "o1",
+    type_id: str | None = EMPLOYEE_TYPE,
+) -> dict[str, object]:
+    """One `entityRelationships` resource linking a person side to an org side.
+
+    A `None` id or type leaves that key off the side entirely, which is how Backstop returns a
+    side it did not resolve. `source_type`/`dest_type`/`source_id`/`dest_id` already suffice to
+    simulate an organization's own GET: pass the organization as `source_*` and the person as
+    `dest_*` (or vice versa) — `_employer_side`/`_person_id` match structurally by resource type,
+    not by literal JSON key, so no separate builder is needed for that payload shape.
+    """
+    attributes: dict[str, object] = {
+        "sourceEntity": _side(resource_id=source_id, resource_type=source_type),
+        "destinationEntity": _side(resource_id=dest_id, resource_type=dest_type),
+    }
+    if end_date is not None:
+        attributes["endDate"] = end_date
+    if start_date is not None:
+        attributes["startDate"] = start_date
+    if created_timestamp is not None:
+        attributes["createdTimestamp"] = created_timestamp
+    relationships: dict[str, object] = {}
+    if type_id is not None:
+        relationships["entityRelationshipType"] = {
+            "data": {"type": "entity-relationship-types", "id": type_id}
+        }
+    return {
+        "type": "entity-relationships",
+        "id": er_id,
+        "attributes": attributes,
+        "relationships": relationships,
+    }
+
+
+def _side(*, resource_id: str | None, resource_type: str | None) -> dict[str, object]:
+    side: dict[str, object] = {}
+    if resource_id is not None:
+        side["resourceId"] = resource_id
+    if resource_type is not None:
+        side["resourceType"] = resource_type
+    return side

--- a/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
@@ -1,0 +1,873 @@
+"""`EmploymentIndex` and its builders: one winner per `(person, organization)` pair, plus the
+type classification (`classify_employment`) and edge-parsing machinery (`_employment_edges` and
+its helpers) they rest on.
+
+Each test below is meant to read as a mini walkthrough:
+
+1. **Configure the checks** — which relationship types count as employment / former
+   employment (`EmploymentRules` / `TypeVocabulary`).
+2. **Prepare the side-loaded record** — `entityRelationships` plus their types, via
+   `helpers.person_org` / `helpers.relationship_types`.
+3. **Run verification** — `build_person_employment_index` / `build_organization_employment_index`
+   (what `EmploymentIndexFactory.index_for_person` / `index_for_organization` delegate to), then
+   query `status` / `departure` / `pairs` — or `classify_employment` directly for a single type.
+
+Numbered classes below cover the nine behavioural cases for `EmploymentIndex`. The remaining
+classes cover the parsing/gate/malformed-input edge cases of `_employment_edges` and
+`classify_employment` that predate `EmploymentIndex` and are unaffected by its
+single-winner-per-pair fold.
+"""
+
+from datetime import date
+
+import pytest
+
+from backstop_mcp.features.data_hygiene import DepartureSignal, EmploymentRules, TypeVocabulary
+from backstop_mcp.features.data_hygiene.employment import (
+    EmploymentIndex,
+    build_organization_employment_index,
+    build_person_employment_index,
+    classify_employment,
+)
+from backstop_mcp.features.data_hygiene.types import EmploymentStatus
+from tests.features.data_hygiene.helpers import (
+    EMPLOYEE_MIRROR_TYPE,
+    EMPLOYEE_TYPE,
+    FORMER_MIRROR_TYPE,
+    FORMER_TYPE,
+    MANAGEMENT_COMPANY_TYPE,
+    OWNS_ACCOUNT_TYPE,
+    PORTAL_TYPE,
+    TYPE_NAMES,
+    person_org,
+    relationship_types,
+)
+
+TODAY = date(2026, 8, 5)
+
+EMPTY_TYPE_IDS: frozenset[str] = frozenset()
+DEFAULT_EMPLOYMENT_MARKERS: frozenset[str] = frozenset({"employ"})
+DEFAULT_FORMER_MARKERS: frozenset[str] = frozenset({"former", "previous", "ex-", "no longer"})
+
+
+def configure_checks(
+    *,
+    employment_type_ids: frozenset[str] = EMPTY_TYPE_IDS,
+    employment_markers: frozenset[str] = DEFAULT_EMPLOYMENT_MARKERS,
+    former_type_ids: frozenset[str] = EMPTY_TYPE_IDS,
+    former_markers: frozenset[str] = DEFAULT_FORMER_MARKERS,
+) -> EmploymentRules:
+    """Build the vocabulary the index uses — same shape create_app injects."""
+    return EmploymentRules(
+        employment=TypeVocabulary(type_ids=employment_type_ids, name_markers=employment_markers),
+        former=TypeVocabulary(type_ids=former_type_ids, name_markers=former_markers),
+    )
+
+
+def person_index(
+    relationships: list[dict[str, object]],
+    *,
+    checks: EmploymentRules,
+    types: list[dict[str, object]] | None = None,
+    today: date = TODAY,
+) -> EmploymentIndex:
+    return build_person_employment_index(
+        relationships=relationships,
+        relationship_types=types if types is not None else relationship_types(*TYPE_NAMES),
+        rules=checks,
+        today=today,
+    )
+
+
+def organization_index(
+    relationships: list[dict[str, object]],
+    *,
+    checks: EmploymentRules,
+    types: list[dict[str, object]] | None = None,
+    today: date = TODAY,
+) -> EmploymentIndex:
+    return build_organization_employment_index(
+        relationships=relationships,
+        relationship_types=types if types is not None else relationship_types(*TYPE_NAMES),
+        rules=checks,
+        today=today,
+    )
+
+
+class TestSameOrgConflictPersonSide:
+    """Case 1/2 — person 341833933, org 341208613: the real ids from the design doc's Problem
+    section, a genuine tenant record where one person carries both a live and an ended
+    relationship to the same organization.
+    """
+
+    def test_a_later_current_type_beats_an_earlier_former_type(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=EMPLOYEE_TYPE,
+                source_id="341833933",
+                dest_id="341208613",
+                created_timestamp="2022-01-01",
+            ),
+            person_org(
+                "2",
+                type_id=FORMER_TYPE,
+                source_id="341833933",
+                dest_id="341208613",
+                created_timestamp="2021-01-01",
+            ),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert (
+            index.status(person_id="341833933", organization_id="341208613")
+            is EmploymentStatus.CURRENT
+        )
+        assert index.departure(person_id="341833933", organization_id="341208613") is None
+
+    def test_reversed_dates_flip_the_verdict_to_departed(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=EMPLOYEE_TYPE,
+                source_id="341833933",
+                dest_id="341208613",
+                created_timestamp="2021-01-01",
+            ),
+            person_org(
+                "2",
+                type_id=FORMER_TYPE,
+                source_id="341833933",
+                dest_id="341208613",
+                created_timestamp="2022-01-01",
+            ),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert (
+            index.status(person_id="341833933", organization_id="341208613")
+            is EmploymentStatus.FORMER
+        )
+        departed = index.departure(person_id="341833933", organization_id="341208613")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+
+
+class TestTwoFormerEdgesForTheSamePair:
+    """Two edges that both resolve to `FORMER` for one pair — a `FORMER_TYPE` record with no
+    date, and a `CURRENT`-typed record whose elapsed `endDate` rewrites it to `END_DATE` — still
+    need one winning `departure` to report. `EmploymentIndex` picks by date alone (any dated edge
+    outranks an undated one, regardless of which signal it carries), which differs from the old
+    `detect_departed_employment`'s signal-strength rule (`FORMER_TYPE` always won). Both edges
+    agree on `status`, so only `departure`'s exact evidence tells the two rules apart.
+    """
+
+    def test_the_dated_edge_wins_the_departure_evidence_even_over_an_undated_former_type(
+        self,
+    ) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=FORMER_TYPE, dest_id="oA"),
+            person_org("2", type_id=EMPLOYEE_TYPE, dest_id="oA", end_date="2020-01-01"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="oA") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="oA")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.END_DATE
+        assert departed.end_date == "2020-01-01"
+
+
+class TestElapsedEndDateOnACurrentType:
+    """Case 3/4 — rel 78305487: a `CURRENT`-typed relationship whose own `endDate` has already
+    passed is rewritten to a departure dated at that `endDate`.
+    """
+
+    def test_an_elapsed_end_date_is_a_departure_with_the_end_date_signal(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org("78305487", type_id=EMPLOYEE_TYPE, end_date="2022-12-31"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.END_DATE
+        assert departed.end_date == "2022-12-31"
+
+    def test_a_future_end_date_stays_current(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=EMPLOYEE_TYPE, end_date="2027-01-01")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+
+class TestStartDateBeatsCreatedTimestamp:
+    """Case 5 — a current edge's own `startDate` predates its own `createdTimestamp` (the record
+    was backfilled after the fact); a former edge dated between the two must still win, which only
+    happens if the current edge's effective date is read from `startDate`, not `createdTimestamp`.
+    """
+
+    def test_the_former_edge_dated_between_them_wins(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=EMPLOYEE_TYPE,
+                start_date="2020-01-01",
+                created_timestamp="2023-01-01",
+            ),
+            person_org("2", type_id=FORMER_TYPE, created_timestamp="2021-06-01"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+
+    def test_without_a_start_date_the_same_former_edge_loses_to_created_timestamp(self) -> None:
+        """Same former edge (2021-06-01) as the test above, but the current edge now carries only
+        `createdTimestamp` (2023-01-01), no `startDate`. That later date is read as its effective
+        date and outranks the former edge — proving the primary test's `FORMER` verdict really
+        does depend on `startDate` (2020) being read in preference to `createdTimestamp` (2023),
+        not on some other property of the fixture.
+        """
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=EMPLOYEE_TYPE, created_timestamp="2023-01-01"),
+            person_org("2", type_id=FORMER_TYPE, created_timestamp="2021-06-01"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+
+class TestMultiOrg:
+    """Case 6 — departed from A, current at B: both pairs are queryable independently, neither
+    collapses into the other the way a single-verdict-per-person scan would.
+    """
+
+    def test_both_organizations_are_queryable_independently(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=FORMER_TYPE, dest_id="orgA"),
+            person_org("2", type_id=EMPLOYEE_TYPE, dest_id="orgB"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="orgA") is EmploymentStatus.FORMER
+        assert index.status(person_id="p1", organization_id="orgB") is EmploymentStatus.CURRENT
+        departed_a = index.departure(person_id="p1", organization_id="orgA")
+        assert departed_a is not None
+        assert departed_a.organization_id == "orgA"
+        assert index.departure(person_id="p1", organization_id="orgB") is None
+
+    def test_pairs_lists_both_statuses_without_collapsing(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=FORMER_TYPE, dest_id="orgA"),
+            person_org("2", type_id=EMPLOYEE_TYPE, dest_id="orgB"),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        former_pairs = index.pairs(status=EmploymentStatus.FORMER)
+        current_pairs = index.pairs(status=EmploymentStatus.CURRENT)
+        assert len(former_pairs) == 1
+        assert len(current_pairs) == 1
+
+
+class TestOrganizationSideIndex:
+    """Case 7 — an organization's own GET side-loads mirror types (different ids/names, reversed
+    direction) that must classify identically to their person-side counterparts, while
+    `owns account` / `management company of` — org-side types that are not employment at all —
+    drop as `IRRELEVANT`.
+    """
+
+    def test_mirror_current_type_classifies_as_current(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=EMPLOYEE_MIRROR_TYPE,
+                source_type="organizations",
+                source_id="o1",
+                dest_type="people",
+                dest_id="p1",
+            )
+        ]
+        types = relationship_types(EMPLOYEE_MIRROR_TYPE)
+
+        index = organization_index(relationships, checks=checks, types=types)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_mirror_former_type_classifies_as_departed(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=FORMER_MIRROR_TYPE,
+                source_type="organizations",
+                source_id="o1",
+                dest_type="people",
+                dest_id="p1",
+            )
+        ]
+        types = relationship_types(FORMER_MIRROR_TYPE)
+
+        index = organization_index(relationships, checks=checks, types=types)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+
+    def test_owns_account_and_management_company_of_drop_as_irrelevant(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=OWNS_ACCOUNT_TYPE,
+                source_type="organizations",
+                source_id="o1",
+                dest_type="people",
+                dest_id="p1",
+            ),
+            person_org(
+                "2",
+                type_id=MANAGEMENT_COMPANY_TYPE,
+                source_type="organizations",
+                source_id="o1",
+                dest_type="people",
+                dest_id="p1",
+            ),
+        ]
+        types = relationship_types(OWNS_ACCOUNT_TYPE, MANAGEMENT_COMPANY_TYPE)
+
+        index = organization_index(relationships, checks=checks, types=types)
+
+        # No employment evidence at all for this pair: neither edge was admitted.
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.IRRELEVANT
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+
+class TestBothBuildersAgree:
+    """Case 8 — the same logical pair, fed through either payload shape (person's own GET vs.
+    organization's own GET), must resolve to the same `EmploymentRecord`. `person_org`'s
+    `source_type`/`dest_type` swap simulates the organization payload shape without a second
+    builder, per its own docstring.
+    """
+
+    def test_a_departure_resolves_the_same_from_either_side(self) -> None:
+        checks = configure_checks()
+        person_side = [person_org("1", type_id=FORMER_TYPE, source_id="p1", dest_id="o1")]
+        organization_side = [
+            person_org(
+                "1",
+                type_id=FORMER_MIRROR_TYPE,
+                source_type="organizations",
+                source_id="o1",
+                dest_type="people",
+                dest_id="p1",
+            )
+        ]
+
+        from_person = person_index(person_side, checks=checks)
+        from_organization = organization_index(
+            organization_side, checks=checks, types=relationship_types(FORMER_MIRROR_TYPE)
+        )
+
+        assert from_person.status(person_id="p1", organization_id="o1") == from_organization.status(
+            person_id="p1", organization_id="o1"
+        )
+        person_departed = from_person.departure(person_id="p1", organization_id="o1")
+        org_departed = from_organization.departure(person_id="p1", organization_id="o1")
+        assert person_departed is not None
+        assert org_departed is not None
+        assert person_departed.signal == org_departed.signal
+        assert person_departed.organization_id == org_departed.organization_id
+
+
+class TestMalformedInput:
+    """Case 9 — every malformed shape the index is built from is dropped rather than raised."""
+
+    def test_missing_resource_id_is_dropped(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, dest_id=None)]
+
+        index = person_index(relationships, checks=checks)
+
+        # No identifiable organization: nothing to key the pair on, so nothing is indexed.
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+    def test_unparseable_dates_fall_back_and_still_resolve(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=EMPLOYEE_TYPE,
+                start_date="not-a-date",
+                created_timestamp="also-not-a-date",
+            )
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        # No usable date anywhere on the edge: it still counts, as the sole edge for its pair.
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_unsideloaded_type_is_treated_as_untyped_and_stays_current(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+
+        index = person_index(relationships, checks=checks, types=[])
+
+        # The type resource never side-loaded, so `type_name` is None; `classify_employment`
+        # reads that as no signal at all, i.e. CURRENT, never an invented departure.
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+    def test_no_relationships_at_all(self) -> None:
+        checks = configure_checks()
+
+        index = person_index([], checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+        assert index.pairs(status=EmploymentStatus.CURRENT) == ()
+
+    def test_unreadable_relationship_is_skipped(self) -> None:
+        checks = configure_checks()
+        relationships: list[dict[str, object]] = [
+            {"type": "entity-relationships", "attributes": {}}
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+        assert index.pairs(status=EmploymentStatus.CURRENT) == ()
+
+    def test_untyped_relationship_neither_departs_nor_crashes(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=None)]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_untyped_relationship_keeps_its_end_date(self) -> None:
+        """The fallback: with no type to judge, `endDate` is the only evidence left."""
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=None, end_date="2020-01-01")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.END_DATE
+        assert departed.relationship_type_name is None
+
+    def test_unnamed_type_is_dropped(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+        types: list[dict[str, object]] = [
+            {"type": "entity-relationship-types", "id": FORMER_TYPE, "attributes": {}}
+        ]
+
+        index = person_index(relationships, checks=checks, types=types)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_unreadable_type_resource_is_dropped(self) -> None:
+        """No id to key the name under, so the relationship is left with no type signal."""
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+        types: list[dict[str, object]] = [
+            {"type": "entity-relationship-types", "attributes": {"name": TYPE_NAMES[FORMER_TYPE]}}
+        ]
+
+        index = person_index(relationships, checks=checks, types=types)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+
+class TestFormerRelationshipType:
+    """The signal that does the work: tenants model a departure as a different type."""
+
+    def test_former_employee_type_is_a_departure(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+        assert departed.organization_id == "o1"
+        assert departed.organization_type == "organizations"
+        assert departed.relationship_type_id == FORMER_TYPE
+        assert departed.relationship_type_name == "is a former employee of"
+        # No date was recorded; the type alone carried the signal.
+        assert departed.end_date is None
+
+    def test_current_employee_type_is_not(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=EMPLOYEE_TYPE)]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+    def test_former_wins_over_the_employment_marker_it_contains(self) -> None:
+        """`is a former employee of` contains `employee`; employment-first would clear it."""
+        checks = configure_checks(employment_markers=frozenset({"employee"}))
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+
+        index = person_index(relationships, checks=checks)
+
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+
+    def test_configured_ids_match_without_any_name(self) -> None:
+        checks = configure_checks(
+            former_type_ids=frozenset({FORMER_TYPE}),
+            former_markers=frozenset(),
+        )
+        relationships = [person_org("1", type_id=FORMER_TYPE)]
+        # No type names side-loaded — only the configured id can match.
+        types: list[dict[str, object]] = []
+
+        index = person_index(relationships, checks=checks, types=types)
+
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+
+    def test_a_former_type_with_a_date_reports_both(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, end_date="2022-12-31")]
+
+        index = person_index(relationships, checks=checks)
+
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+        assert departed.end_date == "2022-12-31"
+
+    def test_no_former_vocabulary_leaves_only_end_date(self) -> None:
+        checks = configure_checks(former_markers=frozenset())
+        former_only = [person_org("1", type_id=FORMER_TYPE)]
+        former_with_date = [person_org("1", type_id=FORMER_TYPE, end_date="2020-01-01")]
+
+        assert (
+            person_index(former_only, checks=checks).status(person_id="p1", organization_id="o1")
+            is EmploymentStatus.CURRENT
+        )
+        assert (
+            person_index(former_with_date, checks=checks).status(
+                person_id="p1", organization_id="o1"
+            )
+            is EmploymentStatus.FORMER
+        )
+
+
+class TestPortalAccessIsNotEmployment:
+    """`has portal access to` is person→org but not employment: it must not vouch for, nor stand
+    in for, an ended employment at the same organization.
+    """
+
+    def test_portal_access_cannot_vouch_for_a_departed_person(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=FORMER_TYPE),
+            person_org("2", type_id=PORTAL_TYPE),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+
+    def test_portal_access_alone_is_not_a_departure_either(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=PORTAL_TYPE, end_date="2020-01-01")]
+
+        index = person_index(relationships, checks=checks)
+
+        # `has portal access to` classifies IRRELEVANT, so the edge is dropped before it ever
+        # reaches an end-date check: no evidence for the pair at all, not a cleared departure.
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.IRRELEVANT
+
+
+class TestEndDateParsing:
+    """`endDate` shapes an instance can send, on an otherwise-current relationship."""
+
+    def test_past_end_date_is_a_departure(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", end_date="2022-12-31T00:00:00.000-0500")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.signal is DepartureSignal.END_DATE
+        # Normalised: the CRM writes a full timestamp for what the API documents as a date.
+        assert departed.end_date == "2022-12-31"
+
+    def test_future_end_date_is_not(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", end_date="2027-01-01")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_today_is_not_yet_departed(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", end_date=TODAY.isoformat())]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_unparseable_end_date_is_ignored(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", end_date="not-a-date")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_blank_end_date_is_ignored(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", end_date="   ")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+
+    def test_a_compact_timestamp_still_parses(self) -> None:
+        """Not the shape this instance writes, but its date part isn't the leading ten chars."""
+        checks = configure_checks()
+        relationships = [person_org("1", end_date="20221231T101530")]
+
+        index = person_index(relationships, checks=checks)
+
+        departed = index.departure(person_id="p1", organization_id="o1")
+        assert departed is not None
+        assert departed.end_date == "2022-12-31"
+
+
+class TestPersonToOrgGate:
+    def test_reversed_sides_still_match(self) -> None:
+        checks = configure_checks()
+        relationships = [
+            person_org(
+                "1",
+                type_id=FORMER_TYPE,
+                source_type="organizations",
+                source_id="o9",
+                dest_type="people",
+                dest_id="p1",
+            )
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        departed = index.departure(person_id="p1", organization_id="o9")
+        assert departed is not None
+        assert departed.organization_id == "o9"
+
+    def test_contacts_count_as_person_side(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, source_type="contacts")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.FORMER
+
+    def test_non_org_destination_is_skipped(self) -> None:
+        """A person→fund-product link is not employment however its type is named."""
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, dest_type="hedge-fund-products")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+    def test_person_to_person_link_is_skipped(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, dest_type="people")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+    def test_missing_side_is_skipped(self) -> None:
+        checks = configure_checks()
+        relationships: list[dict[str, object]] = [
+            {
+                "type": "entity-relationships",
+                "id": "1",
+                "attributes": {
+                    "sourceEntity": {"resourceId": "p1", "resourceType": "people"},
+                },
+                "relationships": {
+                    "entityRelationshipType": {
+                        "data": {"type": "entity-relationship-types", "id": FORMER_TYPE}
+                    }
+                },
+            }
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+    def test_a_side_without_a_type_is_skipped(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, dest_type=None)]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+
+class TestUnidentifiableOrganization:
+    """An org side with no `resourceId` names no company, so it decides nothing.
+
+    (A missing `resourceId` entirely is covered by
+    `TestMalformedInput.test_missing_resource_id_is_dropped`.)
+    """
+
+    def test_a_blank_organization_id_counts_as_none(self) -> None:
+        checks = configure_checks()
+        relationships = [person_org("1", type_id=FORMER_TYPE, dest_id="   ")]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.pairs(status=EmploymentStatus.FORMER) == ()
+
+    def test_one_cannot_clear_a_departure_from_another_company(self) -> None:
+        """Keyed on a shared placeholder, this employment would vouch for a person who left
+        somewhere else entirely."""
+        checks = configure_checks()
+        relationships = [
+            person_org("1", type_id=FORMER_TYPE, dest_id="oA"),
+            person_org("2", type_id=EMPLOYEE_TYPE, dest_id=None),
+        ]
+
+        index = person_index(relationships, checks=checks)
+
+        assert index.status(person_id="p1", organization_id="oA") is EmploymentStatus.FORMER
+        departed = index.departure(person_id="p1", organization_id="oA")
+        assert departed is not None
+        assert departed.organization_id == "oA"
+
+
+class TestClassifyEmployment:
+    """Single-type classification the scan calls for each person→org relationship."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("is employee of", EmploymentStatus.CURRENT),
+            ("is a former employee of", EmploymentStatus.FORMER),
+            ("has portal access to", EmploymentStatus.IRRELEVANT),
+        ],
+    )
+    def test_the_vocabulary_a_real_instance_uses(
+        self, name: str, expected: EmploymentStatus
+    ) -> None:
+        checks = configure_checks(
+            employment_markers=frozenset({"employ"}),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id="9", type_name=name, rules=checks)
+
+        assert status is expected
+
+    def test_former_is_tested_before_employment(self) -> None:
+        """Both markers match `is a former employee of`; the departure one has to win."""
+        checks = configure_checks(
+            employment_markers=frozenset({"employee"}),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id="9", type_name="is a former employee of", rules=checks)
+
+        assert status is EmploymentStatus.FORMER
+
+    def test_configured_ids_decide_without_a_name(self) -> None:
+        checks = configure_checks(
+            employment_markers=frozenset({"employ"}),
+            former_type_ids=frozenset({"459795"}),
+            former_markers=frozenset(),
+        )
+
+        status = classify_employment(type_id="459795", type_name=None, rules=checks)
+
+        assert status is EmploymentStatus.FORMER
+
+    def test_no_type_signal_falls_back_to_current(self) -> None:
+        """With nothing to judge, the person→org gate is the only evidence — never invent a
+        departure, and keep `endDate` in play."""
+        checks = configure_checks(
+            employment_markers=frozenset({"employ"}),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id=None, type_name=None, rules=checks)
+
+        assert status is EmploymentStatus.CURRENT
+
+    def test_an_id_whose_type_did_not_side_load_is_also_no_signal(self) -> None:
+        """Same fallback as a record with no type at all — not a positive `IRRELEVANT` finding,
+        which would drop the record and lose its `endDate`."""
+        checks = configure_checks(
+            employment_markers=frozenset({"employ"}),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id="9", type_name=None, rules=checks)
+
+        assert status is EmploymentStatus.CURRENT
+
+    def test_empty_employment_vocabulary_admits_every_person_to_org_type(self) -> None:
+        checks = configure_checks(
+            employment_markers=frozenset(),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id="9", type_name="has portal access to", rules=checks)
+
+        assert status is EmploymentStatus.CURRENT
+
+    def test_markers_are_case_insensitive(self) -> None:
+        checks = configure_checks(
+            employment_markers=frozenset({"employ"}),
+            former_markers=frozenset({"former"}),
+        )
+
+        status = classify_employment(type_id="9", type_name="Is A Former Employee Of", rules=checks)
+
+        assert status is EmploymentStatus.FORMER

--- a/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
@@ -8,8 +8,8 @@ Each test below is meant to read as a mini walkthrough:
    employment (`EmploymentRules` / `TypeVocabulary`).
 2. **Prepare the side-loaded record** — `entityRelationships` plus their types, via
    `helpers.person_org` / `helpers.relationship_types`.
-3. **Run verification** — `build_employment_index` / `build_employment_index`
-   (what `EmploymentIndexFactory.index_for_person` / `index_for_organization` delegate to), then
+3. **Run verification** — `build_employment_index`
+   (what `EmploymentIndexFactory.index` delegates to), then
    query `status` / `departure` / `pairs` — or `classify_employment` directly for a single type.
 
 Numbered classes below cover the nine behavioural cases for `EmploymentIndex`. The remaining

--- a/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_employment.py
@@ -8,7 +8,7 @@ Each test below is meant to read as a mini walkthrough:
    employment (`EmploymentRules` / `TypeVocabulary`).
 2. **Prepare the side-loaded record** — `entityRelationships` plus their types, via
    `helpers.person_org` / `helpers.relationship_types`.
-3. **Run verification** — `build_person_employment_index` / `build_organization_employment_index`
+3. **Run verification** — `build_employment_index` / `build_employment_index`
    (what `EmploymentIndexFactory.index_for_person` / `index_for_organization` delegate to), then
    query `status` / `departure` / `pairs` — or `classify_employment` directly for a single type.
 
@@ -21,15 +21,20 @@ single-winner-per-pair fold.
 from datetime import date
 
 import pytest
+from pydantic import ValidationError
 
+from backstop_mcp.backstop_client import BackstopApiResource
 from backstop_mcp.features.data_hygiene import DepartureSignal, EmploymentRules, TypeVocabulary
 from backstop_mcp.features.data_hygiene.employment import (
     EmploymentIndex,
-    build_organization_employment_index,
-    build_person_employment_index,
+    build_employment_index,
     classify_employment,
 )
-from backstop_mcp.features.data_hygiene.types import EmploymentStatus
+from backstop_mcp.features.data_hygiene.types import (
+    EmploymentStatus,
+    EntityRelationshipAttributes,
+    RelationshipTypeAttributes,
+)
 from tests.features.data_hygiene.helpers import (
     EMPLOYEE_MIRROR_TYPE,
     EMPLOYEE_TYPE,
@@ -48,6 +53,30 @@ TODAY = date(2026, 8, 5)
 EMPTY_TYPE_IDS: frozenset[str] = frozenset()
 DEFAULT_EMPLOYMENT_MARKERS: frozenset[str] = frozenset({"employ"})
 DEFAULT_FORMER_MARKERS: frozenset[str] = frozenset({"former", "previous", "ex-", "no longer"})
+
+
+def _typed_relationships(
+    relationships: list[dict[str, object]],
+) -> list[BackstopApiResource[EntityRelationshipAttributes]]:
+    parsed: list[BackstopApiResource[EntityRelationshipAttributes]] = []
+    for raw in relationships:
+        try:
+            parsed.append(BackstopApiResource[EntityRelationshipAttributes].model_validate(raw))
+        except ValidationError:
+            continue
+    return parsed
+
+
+def _typed_types(
+    types: list[dict[str, object]],
+) -> list[BackstopApiResource[RelationshipTypeAttributes]]:
+    parsed: list[BackstopApiResource[RelationshipTypeAttributes]] = []
+    for raw in types:
+        try:
+            parsed.append(BackstopApiResource[RelationshipTypeAttributes].model_validate(raw))
+        except ValidationError:
+            continue
+    return parsed
 
 
 def configure_checks(
@@ -71,9 +100,11 @@ def person_index(
     types: list[dict[str, object]] | None = None,
     today: date = TODAY,
 ) -> EmploymentIndex:
-    return build_person_employment_index(
-        relationships=relationships,
-        relationship_types=types if types is not None else relationship_types(*TYPE_NAMES),
+    return build_employment_index(
+        relationships=_typed_relationships(relationships),
+        relationship_types=_typed_types(
+            types if types is not None else relationship_types(*TYPE_NAMES)
+        ),
         rules=checks,
         today=today,
     )
@@ -86,9 +117,11 @@ def organization_index(
     types: list[dict[str, object]] | None = None,
     today: date = TODAY,
 ) -> EmploymentIndex:
-    return build_organization_employment_index(
-        relationships=relationships,
-        relationship_types=types if types is not None else relationship_types(*TYPE_NAMES),
+    return build_employment_index(
+        relationships=_typed_relationships(relationships),
+        relationship_types=_typed_types(
+            types if types is not None else relationship_types(*TYPE_NAMES)
+        ),
         rules=checks,
         today=today,
     )
@@ -181,7 +214,7 @@ class TestTwoFormerEdgesForTheSamePair:
         departed = index.departure(person_id="p1", organization_id="oA")
         assert departed is not None
         assert departed.signal is DepartureSignal.END_DATE
-        assert departed.end_date == "2020-01-01"
+        assert departed.end_date == date(2020, 1, 1)
 
 
 class TestElapsedEndDateOnACurrentType:
@@ -201,7 +234,7 @@ class TestElapsedEndDateOnACurrentType:
         departed = index.departure(person_id="p1", organization_id="o1")
         assert departed is not None
         assert departed.signal is DepartureSignal.END_DATE
-        assert departed.end_date == "2022-12-31"
+        assert departed.end_date == date(2022, 12, 31)
 
     def test_a_future_end_date_stays_current(self) -> None:
         checks = configure_checks()
@@ -429,15 +462,15 @@ class TestMalformedInput:
         # No usable date anywhere on the edge: it still counts, as the sole edge for its pair.
         assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
 
-    def test_unsideloaded_type_is_treated_as_untyped_and_stays_current(self) -> None:
+    def test_unsideloaded_type_is_dropped_as_irrelevant(self) -> None:
         checks = configure_checks()
         relationships = [person_org("1", type_id=FORMER_TYPE)]
 
         index = person_index(relationships, checks=checks, types=[])
 
-        # The type resource never side-loaded, so `type_name` is None; `classify_employment`
-        # reads that as no signal at all, i.e. CURRENT, never an invented departure.
-        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        # Type id present but name never side-loaded: not employment evidence (must not clear a
+        # real departure elsewhere). Edge is dropped before indexing.
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.IRRELEVANT
         assert index.departure(person_id="p1", organization_id="o1") is None
 
     def test_no_relationships_at_all(self) -> None:
@@ -489,10 +522,10 @@ class TestMalformedInput:
 
         index = person_index(relationships, checks=checks, types=types)
 
-        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.IRRELEVANT
 
     def test_unreadable_type_resource_is_dropped(self) -> None:
-        """No id to key the name under, so the relationship is left with no type signal."""
+        """No id to key the name under, so the relationship is left with no type name."""
         checks = configure_checks()
         relationships = [person_org("1", type_id=FORMER_TYPE)]
         types: list[dict[str, object]] = [
@@ -501,7 +534,7 @@ class TestMalformedInput:
 
         index = person_index(relationships, checks=checks, types=types)
 
-        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.CURRENT
+        assert index.status(person_id="p1", organization_id="o1") is EmploymentStatus.IRRELEVANT
 
 
 class TestFormerRelationshipType:
@@ -568,7 +601,7 @@ class TestFormerRelationshipType:
         departed = index.departure(person_id="p1", organization_id="o1")
         assert departed is not None
         assert departed.signal is DepartureSignal.FORMER_TYPE
-        assert departed.end_date == "2022-12-31"
+        assert departed.end_date == date(2022, 12, 31)
 
     def test_no_former_vocabulary_leaves_only_end_date(self) -> None:
         checks = configure_checks(former_markers=frozenset())
@@ -630,7 +663,7 @@ class TestEndDateParsing:
         assert departed is not None
         assert departed.signal is DepartureSignal.END_DATE
         # Normalised: the CRM writes a full timestamp for what the API documents as a date.
-        assert departed.end_date == "2022-12-31"
+        assert departed.end_date == date(2022, 12, 31)
 
     def test_future_end_date_is_not(self) -> None:
         checks = configure_checks()
@@ -673,7 +706,7 @@ class TestEndDateParsing:
 
         departed = index.departure(person_id="p1", organization_id="o1")
         assert departed is not None
-        assert departed.end_date == "2022-12-31"
+        assert departed.end_date == date(2022, 12, 31)
 
 
 class TestPersonToOrgGate:
@@ -840,9 +873,12 @@ class TestClassifyEmployment:
 
         assert status is EmploymentStatus.CURRENT
 
-    def test_an_id_whose_type_did_not_side_load_is_also_no_signal(self) -> None:
-        """Same fallback as a record with no type at all — not a positive `IRRELEVANT` finding,
-        which would drop the record and lose its `endDate`."""
+    def test_an_id_whose_type_did_not_side_load_is_irrelevant(self) -> None:
+        """Id known but name missing: not employment evidence when vocabulary is configured.
+
+        A portal-style edge must not classify as CURRENT and clear a real FORMER winner.
+        Truly untyped (`type_id is None`) still falls back to CURRENT so `endDate` applies.
+        """
         checks = configure_checks(
             employment_markers=frozenset({"employ"}),
             former_markers=frozenset({"former"}),
@@ -850,7 +886,7 @@ class TestClassifyEmployment:
 
         status = classify_employment(type_id="9", type_name=None, rules=checks)
 
-        assert status is EmploymentStatus.CURRENT
+        assert status is EmploymentStatus.IRRELEVANT
 
     def test_empty_employment_vocabulary_admits_every_person_to_org_type(self) -> None:
         checks = configure_checks(

--- a/services/backstop-mcp/tests/features/data_hygiene/test_entity_relationships.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_entity_relationships.py
@@ -1,0 +1,56 @@
+"""`entity_relationships`: pull employment side-loads out of a by-id document."""
+
+from pydantic import BaseModel
+
+from backstop_mcp.backstop_client import BackstopApiResourceDocument
+from backstop_mcp.features.data_hygiene import entity_relationships
+
+
+class _Attrs(BaseModel):
+    name: str
+
+
+class TestEntityRelationships:
+    def test_follows_relationships_and_selects_types_by_resource_type(self) -> None:
+        document = BackstopApiResourceDocument[_Attrs].model_validate(
+            {
+                "data": {
+                    "id": "1",
+                    "type": "people",
+                    "attributes": {"name": "Jane"},
+                    "relationships": {
+                        "entityRelationships": {
+                            "data": [
+                                {"type": "entity-relationships", "id": "er2"},
+                                {"type": "entity-relationships", "id": "er1"},
+                            ]
+                        }
+                    },
+                },
+                "included": [
+                    {"type": "entity-relationships", "id": "er1", "attributes": {}},
+                    {
+                        "type": "entity-relationship-types",
+                        "id": "t1",
+                        "attributes": {"name": "is employee of"},
+                    },
+                    {"type": "entity-relationships", "id": "er2", "attributes": {}},
+                    {
+                        "type": "people",
+                        "id": "other",
+                        "attributes": {"name": "noise"},
+                    },
+                ],
+            }
+        )
+
+        result = entity_relationships(document)
+
+        assert [item["id"] for item in result["relationships"]] == ["er2", "er1"]
+        assert result["relationship_types"] == [
+            {
+                "type": "entity-relationship-types",
+                "id": "t1",
+                "attributes": {"name": "is employee of"},
+            }
+        ]

--- a/services/backstop-mcp/tests/features/data_hygiene/test_entity_relationships.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_entity_relationships.py
@@ -46,11 +46,6 @@ class TestEntityRelationships:
 
         result = entity_relationships(document)
 
-        assert [item["id"] for item in result["relationships"]] == ["er2", "er1"]
-        assert result["relationship_types"] == [
-            {
-                "type": "entity-relationship-types",
-                "id": "t1",
-                "attributes": {"name": "is employee of"},
-            }
-        ]
+        assert [item.id for item in result["relationships"]] == ["er2", "er1"]
+        assert [item.id for item in result["relationship_types"]] == ["t1"]
+        assert result["relationship_types"][0].attributes.name == "is employee of"

--- a/services/backstop-mcp/tests/features/data_hygiene/test_provenance.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_provenance.py
@@ -1,34 +1,38 @@
 import pytest
 
-from backstop_mcp.features.data_hygiene import AsOf, extract_as_of
+from backstop_mcp.features.data_hygiene import AsOf, ProvenanceFields, extract_as_of
+
+
+def _attrs(payload: dict[str, object]) -> ProvenanceFields:
+    return ProvenanceFields.model_validate(payload)
 
 
 class TestExtractAsOf:
     def test_returns_none_when_both_missing(self) -> None:
-        assert extract_as_of({}) is None
+        assert extract_as_of(_attrs({})) is None
         assert extract_as_of(None) is None
-        assert extract_as_of({"name": "Acme"}) is None
+        assert extract_as_of(_attrs({"name": "Acme"})) is None
 
     def test_extracts_timestamp_and_by(self) -> None:
         assert extract_as_of(
-            {"modifiedTimestamp": "2024-01-01T00:00:00Z", "modifiedBy": "alice"}
+            _attrs({"modifiedTimestamp": "2024-01-01T00:00:00Z", "modifiedBy": "alice"})
         ) == AsOf(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
 
     def test_timestamp_alone_is_enough(self) -> None:
-        assert extract_as_of({"modifiedTimestamp": "2024-01-01"}) == AsOf(
+        assert extract_as_of(_attrs({"modifiedTimestamp": "2024-01-01"})) == AsOf(
             modified_timestamp="2024-01-01", modified_by=None
         )
 
     def test_actor_alone_is_enough(self) -> None:
-        assert extract_as_of({"modifiedBy": "alice"}) == AsOf(
+        assert extract_as_of(_attrs({"modifiedBy": "alice"})) == AsOf(
             modified_timestamp=None, modified_by="alice"
         )
 
     def test_blank_values_count_as_missing(self) -> None:
-        assert extract_as_of({"modifiedTimestamp": "  ", "modifiedBy": ""}) is None
+        assert extract_as_of(_attrs({"modifiedTimestamp": "  ", "modifiedBy": ""})) is None
 
     def test_values_are_stripped(self) -> None:
-        assert extract_as_of({"modifiedTimestamp": " 2024-01-01 "}) == AsOf(
+        assert extract_as_of(_attrs({"modifiedTimestamp": " 2024-01-01 "})) == AsOf(
             modified_timestamp="2024-01-01", modified_by=None
         )
 
@@ -48,12 +52,12 @@ class TestNestedModifiedBy:
         ],
     )
     def test_the_first_readable_label_wins(self, actor: dict[str, str], expected: str) -> None:
-        assert extract_as_of({"modifiedBy": actor}) == AsOf(
+        assert extract_as_of(_attrs({"modifiedBy": actor})) == AsOf(
             modified_timestamp=None, modified_by=expected
         )
 
     def test_an_object_with_no_readable_label_is_dropped(self) -> None:
-        assert extract_as_of({"modifiedBy": {"href": "/users/7"}}) is None
+        assert extract_as_of(_attrs({"modifiedBy": {"href": "/users/7"}})) is None
 
     def test_a_non_string_non_object_actor_is_dropped(self) -> None:
-        assert extract_as_of({"modifiedBy": 7}) is None
+        assert extract_as_of(_attrs({"modifiedBy": 7})) is None

--- a/services/backstop-mcp/tests/features/data_hygiene/test_provenance.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_provenance.py
@@ -1,0 +1,59 @@
+import pytest
+
+from backstop_mcp.features.data_hygiene import AsOf, extract_as_of
+
+
+class TestExtractAsOf:
+    def test_returns_none_when_both_missing(self) -> None:
+        assert extract_as_of({}) is None
+        assert extract_as_of(None) is None
+        assert extract_as_of({"name": "Acme"}) is None
+
+    def test_extracts_timestamp_and_by(self) -> None:
+        assert extract_as_of(
+            {"modifiedTimestamp": "2024-01-01T00:00:00Z", "modifiedBy": "alice"}
+        ) == AsOf(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
+
+    def test_timestamp_alone_is_enough(self) -> None:
+        assert extract_as_of({"modifiedTimestamp": "2024-01-01"}) == AsOf(
+            modified_timestamp="2024-01-01", modified_by=None
+        )
+
+    def test_actor_alone_is_enough(self) -> None:
+        assert extract_as_of({"modifiedBy": "alice"}) == AsOf(
+            modified_timestamp=None, modified_by="alice"
+        )
+
+    def test_blank_values_count_as_missing(self) -> None:
+        assert extract_as_of({"modifiedTimestamp": "  ", "modifiedBy": ""}) is None
+
+    def test_values_are_stripped(self) -> None:
+        assert extract_as_of({"modifiedTimestamp": " 2024-01-01 "}) == AsOf(
+            modified_timestamp="2024-01-01", modified_by=None
+        )
+
+
+class TestNestedModifiedBy:
+    """Some instances nest the actor as an object rather than a bare string."""
+
+    @pytest.mark.parametrize(
+        ("actor", "expected"),
+        [
+            ({"name": "bob"}, "bob"),
+            ({"displayName": "Bob Smith"}, "Bob Smith"),
+            ({"display_name": "Bob Smith"}, "Bob Smith"),
+            ({"id": "u-7"}, "u-7"),
+            # A name beats the id it sits next to.
+            ({"id": "u-7", "name": "bob"}, "bob"),
+        ],
+    )
+    def test_the_first_readable_label_wins(self, actor: dict[str, str], expected: str) -> None:
+        assert extract_as_of({"modifiedBy": actor}) == AsOf(
+            modified_timestamp=None, modified_by=expected
+        )
+
+    def test_an_object_with_no_readable_label_is_dropped(self) -> None:
+        assert extract_as_of({"modifiedBy": {"href": "/users/7"}}) is None
+
+    def test_a_non_string_non_object_actor_is_dropped(self) -> None:
+        assert extract_as_of({"modifiedBy": 7}) is None

--- a/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
@@ -5,8 +5,8 @@ user would still never hear about it — so each response is asserted whole.
 """
 
 from datetime import date
+from typing import cast
 
-from backstop_mcp.coerce import as_object_dict, as_object_list
 from backstop_mcp.features.data_hygiene import (
     AsOf,
     DepartedContactResponse,
@@ -70,12 +70,14 @@ class TestDepartedResponse:
     def test_the_schema_publishes_the_possible_signals(self) -> None:
         """Typed as the enum, so a caller reads the two values off the tool schema."""
         schema: dict[str, object] = DepartedContactResponse.model_json_schema()
-        definitions = as_object_dict(schema.get("$defs"))
-        assert definitions is not None
-        signal = as_object_dict(definitions.get("DepartureSignal"))
-        assert signal is not None
+        definitions = schema["$defs"]
+        assert isinstance(definitions, dict)
+        signal = cast("dict[str, object]", definitions)["DepartureSignal"]
+        assert isinstance(signal, dict)
+        values = cast("dict[str, object]", signal)["enum"]
+        assert isinstance(values, list)
 
-        assert set(as_object_list(signal.get("enum"))) == {
+        assert set(cast("list[object]", values)) == {
             "former_relationship_type",
             "end_date_passed",
         }

--- a/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
@@ -1,0 +1,80 @@
+"""The tool-facing echoes: every field of the internal signal has to survive the hop.
+
+A dropped field here is invisible to the feature tests — the scan would still be right and the
+user would still never hear about it — so each echo is asserted whole.
+"""
+
+from backstop_mcp.coerce import as_object_dict, as_object_list
+from backstop_mcp.features.data_hygiene import (
+    AsOf,
+    AsOfEcho,
+    DepartedContactEcho,
+    DepartedEmployment,
+    DepartureSignal,
+    as_of_echo,
+    departed_echo,
+)
+
+
+class TestAsOfEcho:
+    def test_nothing_to_echo_stays_none(self) -> None:
+        assert as_of_echo(None) is None
+
+    def test_both_fields_are_carried(self) -> None:
+        assert as_of_echo(
+            AsOf(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
+        ) == AsOfEcho(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
+
+    def test_a_partial_signal_is_carried_as_is(self) -> None:
+        assert as_of_echo(AsOf(modified_timestamp="2024-01-01")) == AsOfEcho(
+            modified_timestamp="2024-01-01", modified_by=None
+        )
+
+
+class TestDepartedEcho:
+    def test_a_current_person_has_nothing_to_echo(self) -> None:
+        assert departed_echo(None) is None
+
+    def test_every_field_is_carried(self) -> None:
+        departed = DepartedEmployment(
+            signal=DepartureSignal.FORMER_TYPE,
+            organization_id="o1",
+            organization_type="organizations",
+            end_date="2022-12-31",
+            relationship_type_id="459795",
+            relationship_type_name="is a former employee of",
+        )
+
+        assert departed_echo(departed) == DepartedContactEcho(
+            signal=DepartureSignal.FORMER_TYPE,
+            organization_id="o1",
+            organization_type="organizations",
+            end_date="2022-12-31",
+            relationship_type_id="459795",
+            relationship_type_name="is a former employee of",
+        )
+
+    def test_the_signal_serializes_as_the_word_the_user_sees(self) -> None:
+        echo = departed_echo(
+            DepartedEmployment(
+                signal=DepartureSignal.END_DATE,
+                organization_id="o1",
+                organization_type="organizations",
+            )
+        )
+
+        assert echo is not None
+        assert echo.model_dump()["signal"] == "end_date_passed"
+
+    def test_the_schema_publishes_the_possible_signals(self) -> None:
+        """Typed as the enum, so a caller reads the two values off the tool schema."""
+        schema: dict[str, object] = DepartedContactEcho.model_json_schema()
+        definitions = as_object_dict(schema.get("$defs"))
+        assert definitions is not None
+        signal = as_object_dict(definitions.get("DepartureSignal"))
+        assert signal is not None
+
+        assert set(as_object_list(signal.get("enum"))) == {
+            "former_relationship_type",
+            "end_date_passed",
+        }

--- a/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_responses.py
@@ -1,61 +1,62 @@
-"""The tool-facing echoes: every field of the internal signal has to survive the hop.
+"""The tool-facing responses: every field of the internal signal has to survive the hop.
 
 A dropped field here is invisible to the feature tests — the scan would still be right and the
-user would still never hear about it — so each echo is asserted whole.
+user would still never hear about it — so each response is asserted whole.
 """
+
+from datetime import date
 
 from backstop_mcp.coerce import as_object_dict, as_object_list
 from backstop_mcp.features.data_hygiene import (
     AsOf,
-    AsOfEcho,
-    DepartedContactEcho,
+    DepartedContactResponse,
     DepartedEmployment,
     DepartureSignal,
-    as_of_echo,
-    departed_echo,
+    as_of_response,
+    departed_response,
 )
 
 
-class TestAsOfEcho:
+class TestAsOf:
     def test_nothing_to_echo_stays_none(self) -> None:
-        assert as_of_echo(None) is None
+        assert as_of_response(None) is None
 
     def test_both_fields_are_carried(self) -> None:
-        assert as_of_echo(
+        assert as_of_response(
             AsOf(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
-        ) == AsOfEcho(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
+        ) == AsOf(modified_timestamp="2024-01-01T00:00:00Z", modified_by="alice")
 
     def test_a_partial_signal_is_carried_as_is(self) -> None:
-        assert as_of_echo(AsOf(modified_timestamp="2024-01-01")) == AsOfEcho(
+        assert as_of_response(AsOf(modified_timestamp="2024-01-01")) == AsOf(
             modified_timestamp="2024-01-01", modified_by=None
         )
 
 
-class TestDepartedEcho:
+class TestDepartedResponse:
     def test_a_current_person_has_nothing_to_echo(self) -> None:
-        assert departed_echo(None) is None
+        assert departed_response(None) is None
 
     def test_every_field_is_carried(self) -> None:
         departed = DepartedEmployment(
             signal=DepartureSignal.FORMER_TYPE,
             organization_id="o1",
             organization_type="organizations",
-            end_date="2022-12-31",
+            end_date=date(2022, 12, 31),
             relationship_type_id="459795",
             relationship_type_name="is a former employee of",
         )
 
-        assert departed_echo(departed) == DepartedContactEcho(
+        assert departed_response(departed) == DepartedContactResponse(
             signal=DepartureSignal.FORMER_TYPE,
             organization_id="o1",
             organization_type="organizations",
-            end_date="2022-12-31",
+            end_date=date(2022, 12, 31),
             relationship_type_id="459795",
             relationship_type_name="is a former employee of",
         )
 
     def test_the_signal_serializes_as_the_word_the_user_sees(self) -> None:
-        echo = departed_echo(
+        response = departed_response(
             DepartedEmployment(
                 signal=DepartureSignal.END_DATE,
                 organization_id="o1",
@@ -63,12 +64,12 @@ class TestDepartedEcho:
             )
         )
 
-        assert echo is not None
-        assert echo.model_dump()["signal"] == "end_date_passed"
+        assert response is not None
+        assert response.model_dump()["signal"] == "end_date_passed"
 
     def test_the_schema_publishes_the_possible_signals(self) -> None:
         """Typed as the enum, so a caller reads the two values off the tool schema."""
-        schema: dict[str, object] = DepartedContactEcho.model_json_schema()
+        schema: dict[str, object] = DepartedContactResponse.model_json_schema()
         definitions = as_object_dict(schema.get("$defs"))
         assert definitions is not None
         signal = as_object_dict(definitions.get("DepartureSignal"))

--- a/services/backstop-mcp/tests/features/data_hygiene/test_service.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_service.py
@@ -1,4 +1,4 @@
-"""`EmploymentIndexFactory`: what the composition root hands it, and what `index_for_person` no
+"""`EmploymentIndexFactory`: what the composition root hands it, and what `index` no
 longer needs to be passed.
 
 The scan and classifier it delegates to are covered in `test_employment.py`.
@@ -68,7 +68,7 @@ def _factory(
 
 class TestCreateEmploymentIndexFactory:
     def test_configured_markers_reach_the_verdict(self) -> None:
-        index = _factory().index_for_person(
+        index = _factory().index(
             relationships=_typed_relationships([person_org("er1", type_id=FORMER_TYPE)]),
             relationship_types=_typed_types(relationship_types(FORMER_TYPE)),
         )
@@ -81,7 +81,7 @@ class TestCreateEmploymentIndexFactory:
     def test_configured_ids_decide_when_no_type_side_loaded(self) -> None:
         factory = _factory(former_type_ids=("custom-7",), former_type_markers=())
 
-        index = factory.index_for_person(
+        index = factory.index(
             relationships=_typed_relationships([person_org("er1", type_id="custom-7")]),
             relationship_types=[],
         )
@@ -96,9 +96,9 @@ class TestCreateEmploymentIndexFactory:
         assert factory.rules.former.type_ids == frozenset({"x"})
 
 
-class TestIndexForPerson:
+class TestIndex:
     def test_a_person_with_no_relationships_is_not_departed(self) -> None:
-        index = _factory().index_for_person(
+        index = _factory().index(
             relationships=[],
             relationship_types=_typed_types(relationship_types(FORMER_TYPE)),
         )
@@ -106,7 +106,7 @@ class TestIndexForPerson:
         assert index.departure(person_id="p1", organization_id="o1") is None
 
     def test_a_current_employee_is_not_departed(self) -> None:
-        index = _factory().index_for_person(
+        index = _factory().index(
             relationships=_typed_relationships([person_org("er1", type_id=EMPLOYEE_TYPE)]),
             relationship_types=_typed_types(relationship_types(EMPLOYEE_TYPE)),
         )
@@ -115,7 +115,7 @@ class TestIndexForPerson:
 
     def test_the_clock_defaults_to_today(self) -> None:
         """A real deployment gets `date.today`; only tests pin it."""
-        index = _factory().index_for_person(
+        index = _factory().index(
             relationships=_typed_relationships(
                 [person_org("er1", type_id=None, end_date="2000-01-01")]
             ),
@@ -130,7 +130,7 @@ class TestIndexForPerson:
         # Days rather than `replace(year=...)`, which raises on a leap day.
         next_year = (date.today() + timedelta(days=366)).isoformat()
 
-        index = _factory().index_for_person(
+        index = _factory().index(
             relationships=_typed_relationships(
                 [person_org("er1", type_id=None, end_date=next_year)]
             ),
@@ -144,7 +144,7 @@ class TestIndexForPerson:
             rules=_factory().rules,
             clock=lambda: date(2020, 1, 1),
         )
-        index = factory.index_for_person(
+        index = factory.index(
             relationships=_typed_relationships(
                 [person_org("er1", type_id=None, end_date="2019-12-31")]
             ),

--- a/services/backstop-mcp/tests/features/data_hygiene/test_service.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_service.py
@@ -7,10 +7,17 @@ The scan and classifier it delegates to are covered in `test_employment.py`.
 from collections.abc import Sequence
 from datetime import date, timedelta
 
+from pydantic import ValidationError
+
+from backstop_mcp.backstop_client import BackstopApiResource
 from backstop_mcp.features.data_hygiene import (
     DepartureSignal,
     EmploymentIndexFactory,
     create_employment_index_factory,
+)
+from backstop_mcp.features.data_hygiene.types import (
+    EntityRelationshipAttributes,
+    RelationshipTypeAttributes,
 )
 from tests.features.data_hygiene.helpers import (
     EMPLOYEE_TYPE,
@@ -18,6 +25,30 @@ from tests.features.data_hygiene.helpers import (
     person_org,
     relationship_types,
 )
+
+
+def _typed_relationships(
+    relationships: list[dict[str, object]],
+) -> list[BackstopApiResource[EntityRelationshipAttributes]]:
+    parsed: list[BackstopApiResource[EntityRelationshipAttributes]] = []
+    for raw in relationships:
+        try:
+            parsed.append(BackstopApiResource[EntityRelationshipAttributes].model_validate(raw))
+        except ValidationError:
+            continue
+    return parsed
+
+
+def _typed_types(
+    types: list[dict[str, object]],
+) -> list[BackstopApiResource[RelationshipTypeAttributes]]:
+    parsed: list[BackstopApiResource[RelationshipTypeAttributes]] = []
+    for raw in types:
+        try:
+            parsed.append(BackstopApiResource[RelationshipTypeAttributes].model_validate(raw))
+        except ValidationError:
+            continue
+    return parsed
 
 
 def _factory(
@@ -38,8 +69,8 @@ def _factory(
 class TestCreateEmploymentIndexFactory:
     def test_configured_markers_reach_the_verdict(self) -> None:
         index = _factory().index_for_person(
-            relationships=[person_org("er1", type_id=FORMER_TYPE)],
-            relationship_types=relationship_types(FORMER_TYPE),
+            relationships=_typed_relationships([person_org("er1", type_id=FORMER_TYPE)]),
+            relationship_types=_typed_types(relationship_types(FORMER_TYPE)),
         )
         departed = index.departure(person_id="p1", organization_id="o1")
 
@@ -51,7 +82,8 @@ class TestCreateEmploymentIndexFactory:
         factory = _factory(former_type_ids=("custom-7",), former_type_markers=())
 
         index = factory.index_for_person(
-            relationships=[person_org("er1", type_id="custom-7")], relationship_types=[]
+            relationships=_typed_relationships([person_org("er1", type_id="custom-7")]),
+            relationship_types=[],
         )
         departed = index.departure(person_id="p1", organization_id="o1")
 
@@ -67,15 +99,16 @@ class TestCreateEmploymentIndexFactory:
 class TestIndexForPerson:
     def test_a_person_with_no_relationships_is_not_departed(self) -> None:
         index = _factory().index_for_person(
-            relationships=[], relationship_types=relationship_types(FORMER_TYPE)
+            relationships=[],
+            relationship_types=_typed_types(relationship_types(FORMER_TYPE)),
         )
 
         assert index.departure(person_id="p1", organization_id="o1") is None
 
     def test_a_current_employee_is_not_departed(self) -> None:
         index = _factory().index_for_person(
-            relationships=[person_org("er1", type_id=EMPLOYEE_TYPE)],
-            relationship_types=relationship_types(EMPLOYEE_TYPE),
+            relationships=_typed_relationships([person_org("er1", type_id=EMPLOYEE_TYPE)]),
+            relationship_types=_typed_types(relationship_types(EMPLOYEE_TYPE)),
         )
 
         assert index.departure(person_id="p1", organization_id="o1") is None
@@ -83,34 +116,41 @@ class TestIndexForPerson:
     def test_the_clock_defaults_to_today(self) -> None:
         """A real deployment gets `date.today`; only tests pin it."""
         index = _factory().index_for_person(
-            relationships=[person_org("er1", type_id=None, end_date="2000-01-01")],
+            relationships=_typed_relationships(
+                [person_org("er1", type_id=None, end_date="2000-01-01")]
+            ),
             relationship_types=[],
         )
         departed = index.departure(person_id="p1", organization_id="o1")
 
         assert departed is not None
-        assert departed.end_date == "2000-01-01"
+        assert departed.end_date == date(2000, 1, 1)
 
     def test_an_end_date_after_today_is_not_departed(self) -> None:
         # Days rather than `replace(year=...)`, which raises on a leap day.
         next_year = (date.today() + timedelta(days=366)).isoformat()
 
         index = _factory().index_for_person(
-            relationships=[person_org("er1", type_id=None, end_date=next_year)],
+            relationships=_typed_relationships(
+                [person_org("er1", type_id=None, end_date=next_year)]
+            ),
             relationship_types=[],
         )
 
         assert index.departure(person_id="p1", organization_id="o1") is None
 
     def test_an_injected_clock_decides_whether_an_end_date_has_passed(self) -> None:
-        rules = _factory().rules
-        relationships = [person_org("er1", type_id=None, end_date="2026-08-05")]
+        factory = EmploymentIndexFactory(
+            rules=_factory().rules,
+            clock=lambda: date(2020, 1, 1),
+        )
+        index = factory.index_for_person(
+            relationships=_typed_relationships(
+                [person_org("er1", type_id=None, end_date="2019-12-31")]
+            ),
+            relationship_types=[],
+        )
+        departed = index.departure(person_id="p1", organization_id="o1")
 
-        before = EmploymentIndexFactory(rules=rules, clock=lambda: date(2026, 8, 4))
-        after = EmploymentIndexFactory(rules=rules, clock=lambda: date(2026, 8, 6))
-
-        before_index = before.index_for_person(relationships=relationships, relationship_types=[])
-        after_index = after.index_for_person(relationships=relationships, relationship_types=[])
-
-        assert before_index.departure(person_id="p1", organization_id="o1") is None
-        assert after_index.departure(person_id="p1", organization_id="o1") is not None
+        assert departed is not None
+        assert departed.signal is DepartureSignal.END_DATE

--- a/services/backstop-mcp/tests/features/data_hygiene/test_service.py
+++ b/services/backstop-mcp/tests/features/data_hygiene/test_service.py
@@ -1,0 +1,116 @@
+"""`EmploymentIndexFactory`: what the composition root hands it, and what `index_for_person` no
+longer needs to be passed.
+
+The scan and classifier it delegates to are covered in `test_employment.py`.
+"""
+
+from collections.abc import Sequence
+from datetime import date, timedelta
+
+from backstop_mcp.features.data_hygiene import (
+    DepartureSignal,
+    EmploymentIndexFactory,
+    create_employment_index_factory,
+)
+from tests.features.data_hygiene.helpers import (
+    EMPLOYEE_TYPE,
+    FORMER_TYPE,
+    person_org,
+    relationship_types,
+)
+
+
+def _factory(
+    *,
+    employment_type_ids: Sequence[str] = (),
+    employment_type_markers: Sequence[str] = ("employ",),
+    former_type_ids: Sequence[str] = (),
+    former_type_markers: Sequence[str] = ("former",),
+) -> EmploymentIndexFactory:
+    return create_employment_index_factory(
+        employment_type_ids=employment_type_ids,
+        employment_type_markers=employment_type_markers,
+        former_type_ids=former_type_ids,
+        former_type_markers=former_type_markers,
+    )
+
+
+class TestCreateEmploymentIndexFactory:
+    def test_configured_markers_reach_the_verdict(self) -> None:
+        index = _factory().index_for_person(
+            relationships=[person_org("er1", type_id=FORMER_TYPE)],
+            relationship_types=relationship_types(FORMER_TYPE),
+        )
+        departed = index.departure(person_id="p1", organization_id="o1")
+
+        assert departed is not None
+        assert departed.signal is DepartureSignal.FORMER_TYPE
+        assert departed.relationship_type_name == "is a former employee of"
+
+    def test_configured_ids_decide_when_no_type_side_loaded(self) -> None:
+        factory = _factory(former_type_ids=("custom-7",), former_type_markers=())
+
+        index = factory.index_for_person(
+            relationships=[person_org("er1", type_id="custom-7")], relationship_types=[]
+        )
+        departed = index.departure(person_id="p1", organization_id="o1")
+
+        assert departed is not None
+        assert departed.relationship_type_id == "custom-7"
+
+    def test_rules_are_exposed_read_only(self) -> None:
+        factory = _factory(former_type_ids=("x",))
+
+        assert factory.rules.former.type_ids == frozenset({"x"})
+
+
+class TestIndexForPerson:
+    def test_a_person_with_no_relationships_is_not_departed(self) -> None:
+        index = _factory().index_for_person(
+            relationships=[], relationship_types=relationship_types(FORMER_TYPE)
+        )
+
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+    def test_a_current_employee_is_not_departed(self) -> None:
+        index = _factory().index_for_person(
+            relationships=[person_org("er1", type_id=EMPLOYEE_TYPE)],
+            relationship_types=relationship_types(EMPLOYEE_TYPE),
+        )
+
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+    def test_the_clock_defaults_to_today(self) -> None:
+        """A real deployment gets `date.today`; only tests pin it."""
+        index = _factory().index_for_person(
+            relationships=[person_org("er1", type_id=None, end_date="2000-01-01")],
+            relationship_types=[],
+        )
+        departed = index.departure(person_id="p1", organization_id="o1")
+
+        assert departed is not None
+        assert departed.end_date == "2000-01-01"
+
+    def test_an_end_date_after_today_is_not_departed(self) -> None:
+        # Days rather than `replace(year=...)`, which raises on a leap day.
+        next_year = (date.today() + timedelta(days=366)).isoformat()
+
+        index = _factory().index_for_person(
+            relationships=[person_org("er1", type_id=None, end_date=next_year)],
+            relationship_types=[],
+        )
+
+        assert index.departure(person_id="p1", organization_id="o1") is None
+
+    def test_an_injected_clock_decides_whether_an_end_date_has_passed(self) -> None:
+        rules = _factory().rules
+        relationships = [person_org("er1", type_id=None, end_date="2026-08-05")]
+
+        before = EmploymentIndexFactory(rules=rules, clock=lambda: date(2026, 8, 4))
+        after = EmploymentIndexFactory(rules=rules, clock=lambda: date(2026, 8, 6))
+
+        before_index = before.index_for_person(relationships=relationships, relationship_types=[])
+        after_index = after.index_for_person(relationships=relationships, relationship_types=[])
+
+        assert before_index.departure(person_id="p1", organization_id="o1") is None
+        assert after_index.departure(person_id="p1", organization_id="o1") is not None

--- a/services/backstop-mcp/tests/features/party_resolver/test_resolve.py
+++ b/services/backstop-mcp/tests/features/party_resolver/test_resolve.py
@@ -13,6 +13,7 @@ from backstop_mcp.features.party_resolver import (
     unresolved_parties_response,
     unresolved_party_response,
 )
+from backstop_mcp.features.party_resolver.search import quick_search
 from backstop_mcp.features.resolution import (
     Ambiguous,
     BatchAmbiguous,
@@ -193,7 +194,7 @@ class TestQuickSearch:
         assert result.value.id == "o1"
         params = route.calls.last.request.url.params
         assert params["filter[searchText][eq]"] == "Capstone"
-        assert params["filter[searchTypes][eq]"] == "organizations"
+        assert params["filter[searchTypes][eq]"] == "ORGANIZATION"
         assert params["filter[limit][eq]"] == "10"
         assert params["filter[showAll][eq]"] == "false"
         assert params["filter[enhanceSearchTypes][eq]"] == "false"
@@ -345,6 +346,200 @@ class TestQuickSearch:
 
         assert exc_info.value.path == "/quick-search"
         assert exc_info.value.schema_name == "BackstopApiCollectionDocument[PartyAttributes]"
+
+
+class TestSearchTypeMapping:
+    """`/quick-search` rejects our lowercase `SearchType` outright (400 InvalidParameterException);
+    it wants its own uppercase enum. Exercised via `quick_search` directly (not `resolve_party`)
+    since `_resolve_one` routes email-looking `search` values to `search_by_email` instead,
+    never reaching `quick_search`.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_organizations_maps_to_organization(self, client: BackstopClient) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="organizations", search="Capstone")
+
+        assert route.calls.last.request.url.params["filter[searchTypes][eq]"] == "ORGANIZATION"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_people_maps_to_first_and_last_name(self, client: BackstopClient) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="people", search="Ada Lovelace")
+
+        params = route.calls.last.request.url.params
+        assert params["filter[searchTypes][eq]"] == "PERSON_FIRST_NAME,PERSON_LAST_NAME"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_contacts_maps_to_first_and_last_name(self, client: BackstopClient) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="contacts", search="Ada Lovelace")
+
+        params = route.calls.last.request.url.params
+        assert params["filter[searchTypes][eq]"] == "PERSON_FIRST_NAME,PERSON_LAST_NAME"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_employees_maps_to_first_and_last_name(self, client: BackstopClient) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="employees", search="Ada Lovelace")
+
+        params = route.calls.last.request.url.params
+        assert params["filter[searchTypes][eq]"] == "PERSON_FIRST_NAME,PERSON_LAST_NAME"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_email_shaped_search_adds_email_address_for_people(
+        self, client: BackstopClient
+    ) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="people", search="ada@example.com")
+
+        params = route.calls.last.request.url.params
+        assert (
+            params["filter[searchTypes][eq]"] == "PERSON_FIRST_NAME,PERSON_LAST_NAME,EMAIL_ADDRESS"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_email_shaped_search_does_not_add_email_address_for_organizations(
+        self, client: BackstopClient
+    ) -> None:
+        route = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        await quick_search(client, search_type="organizations", search="ops@capstone.com")
+
+        assert route.calls.last.request.url.params["filter[searchTypes][eq]"] == "ORGANIZATION"
+
+
+class TestPartyIdFromResourceId:
+    """UN-23680: quick-search's `id` (e.g. `organizations_341208613`) is not a usable party id —
+    the follow-up `GET /organizations/{id}` needs the raw id from `attributes.resourceId`.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_prefers_resource_id_attribute_over_prefixed_id(
+        self, client: BackstopClient
+    ) -> None:
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(
+                    resource(
+                        "organizations_341208613",
+                        "organizations",
+                        name="Capstone",
+                        resourceId="341208613",
+                    )
+                ),
+            )
+        )
+
+        result = await resolve_party(
+            ctx_never_elicit(),
+            client,
+            search_type="organizations",
+            search="Capstone",
+        )
+
+        assert isinstance(result, Resolved)
+        assert result.value.id == "341208613"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_falls_back_to_stripping_type_prefix_when_resource_id_is_absent(
+        self, client: BackstopClient
+    ) -> None:
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(
+                    resource("organizations_341208613", "organizations", name="Capstone")
+                ),
+            )
+        )
+
+        result = await resolve_party(
+            ctx_never_elicit(),
+            client,
+            search_type="organizations",
+            search="Capstone",
+        )
+
+        assert isinstance(result, Resolved)
+        assert result.value.id == "341208613"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_id_without_type_prefix_is_used_as_is_when_resource_id_is_absent(
+        self, client: BackstopClient
+    ) -> None:
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(resource("o1", "organizations", name="Capstone")),
+            )
+        )
+
+        result = await resolve_party(
+            ctx_never_elicit(),
+            client,
+            search_type="organizations",
+            search="Capstone",
+        )
+
+        assert isinstance(result, Resolved)
+        assert result.value.id == "o1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_falls_back_to_stripping_type_prefix_when_resource_id_is_blank(
+        self, client: BackstopClient
+    ) -> None:
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(
+                    resource(
+                        "organizations_341208613",
+                        "organizations",
+                        name="Capstone",
+                        resourceId="   ",
+                    )
+                ),
+            )
+        )
+
+        result = await resolve_party(
+            ctx_never_elicit(),
+            client,
+            search_type="organizations",
+            search="Capstone",
+        )
+
+        assert isinstance(result, Resolved)
+        assert result.value.id == "341208613"
 
 
 class TestHitCounts:

--- a/services/backstop-mcp/tests/helpers.py
+++ b/services/backstop-mcp/tests/helpers.py
@@ -1,20 +1,39 @@
 """Shared test construction helpers.
 
 Mirrors what `create_app()` does, minus the web layer: build one `BackstopClientFactory`, and
-install it in the single `runtime.Services` holder. Tests that need a client go through the
-factory exactly as production does, so the concurrency gate and config injection under test are
-the real ones.
+install it (plus a `CustomFieldsService`) in the single `runtime.Services` holder. Tests that
+need a client go through the factory exactly as production does, so the concurrency gate and
+config injection under test are the real ones.
 """
 
+from collections.abc import Sequence
+from datetime import date
+
 from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from backstop_mcp.app import retry_settings, transport_settings
 from backstop_mcp.backstop_client.credential import BackstopCredentialSecret
 from backstop_mcp.backstop_client.factory import BackstopClientFactory
 from backstop_mcp.config import BackstopConfig
 from backstop_mcp.features.auth.context import BackstopAuthContext
+from backstop_mcp.features.custom_fields import (
+    CustomFieldsService,
+    FieldOverride,
+    create_custom_fields_service,
+)
+from backstop_mcp.features.data_hygiene import (
+    EmploymentIndexFactory,
+    EmploymentRules,
+    TypeVocabulary,
+)
+from backstop_mcp.server.runtime import Services, configure_services
 
 BASE_URL = "https://example.backstopsolutions.com"
+
+# Fixed "today" for departed-contact detection, so an end date in a fixture never becomes
+# past-or-future depending on when the suite runs.
+FIXED_TODAY = date(2026, 8, 5)
 
 
 def credential(username: str = "bob.smith", token: str = "token") -> BackstopCredentialSecret:
@@ -45,6 +64,73 @@ def client_factory(
     """
     config = backstop_config(base_url, **overrides)
     return BackstopClientFactory(transport_settings(config), retry_settings(config), auth=auth)
+
+
+def install_services(
+    *,
+    backstop: BackstopClientFactory,
+    custom_fields: CustomFieldsService,
+    employment_index_factory: EmploymentIndexFactory | None = None,
+) -> Services:
+    services = Services(
+        backstop=backstop,
+        custom_fields=custom_fields,
+        employment_index_factory=employment_index_factory or build_employment_index_factory(),
+    )
+    configure_services(services)
+    return services
+
+
+def build_employment_index_factory(
+    *,
+    employment_type_ids: Sequence[str] = (),
+    employment_markers: Sequence[str] | None = None,
+    former_type_ids: Sequence[str] = (),
+    former_markers: Sequence[str] | None = None,
+    today: date = FIXED_TODAY,
+) -> EmploymentIndexFactory:
+    """A factory with the configured defaults and a fixed clock.
+
+    Markers default to `BackstopConfig`'s rather than to empty, so a test that doesn't tune them
+    exercises what a deployment actually runs.
+    """
+    config = backstop_config()
+    return EmploymentIndexFactory(
+        rules=EmploymentRules(
+            employment=TypeVocabulary(
+                type_ids=frozenset(employment_type_ids),
+                name_markers=frozenset(
+                    config.employment_relationship_type_markers
+                    if employment_markers is None
+                    else employment_markers
+                ),
+            ),
+            former=TypeVocabulary(
+                type_ids=frozenset(former_type_ids),
+                name_markers=frozenset(
+                    config.former_employment_relationship_type_markers
+                    if former_markers is None
+                    else former_markers
+                ),
+            ),
+        ),
+        clock=lambda: today,
+    )
+
+
+def custom_fields_service(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    base_url: str = BASE_URL,
+    overrides: dict[str, FieldOverride] | None = None,
+    ttl_minutes: int = 60,
+) -> CustomFieldsService:
+    return create_custom_fields_service(
+        session_factory=session_factory,
+        base_url=base_url,
+        overrides=overrides or {},
+        ttl_minutes=ttl_minutes,
+    )
 
 
 def resource(id: str, type: str, name: str | None = None, **attrs: object) -> dict[str, object]:

--- a/services/backstop-mcp/tests/server/middleware/test_custom_field_glossary.py
+++ b/services/backstop-mcp/tests/server/middleware/test_custom_field_glossary.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import cast
 
 import httpx
 import pytest
@@ -21,6 +22,7 @@ from backstop_mcp.features.custom_fields import (
     FieldOverride,
     create_custom_fields_service,
     glossary_meta,
+    parse_glossary_entities,
 )
 from backstop_mcp.features.custom_fields.store import save_snapshot
 from backstop_mcp.features.custom_fields.types import CustomFieldDefinition
@@ -329,3 +331,37 @@ class TestGlossaryMiddleware:
         org_tool = next(t for t in tools if t.name == "get_organization")
         assert org_tool.description is not None
         assert "is1" in org_tool.description
+
+
+class TestGlossaryScopesComeFromToolMeta:
+    def test_registered_tools_declare_scopes_on_meta(self) -> None:
+        from fastmcp.tools.function_tool import ToolMeta
+
+        from backstop_mcp.server.tools.get_organization import get_organization
+        from backstop_mcp.server.tools.get_person import get_person
+        from backstop_mcp.server.tools.list_custom_fields import list_custom_fields
+        from backstop_mcp.server.tools.registry import TOOLS
+        from backstop_mcp.server.tools.system_info import get_system_info
+
+        assert (get_system_info, get_organization, get_person, list_custom_fields) == TOOLS
+
+        org_meta = getattr(get_organization, "__fastmcp__", None)
+        assert isinstance(org_meta, ToolMeta)
+        assert parse_glossary_entities(_as_object_dict(org_meta.meta)) == (
+            EntityType.ORGANIZATIONS,
+        )
+
+        person_meta = getattr(get_person, "__fastmcp__", None)
+        assert isinstance(person_meta, ToolMeta)
+        assert parse_glossary_entities(_as_object_dict(person_meta.meta)) == (EntityType.PEOPLE,)
+
+        list_meta = getattr(list_custom_fields, "__fastmcp__", None)
+        assert isinstance(list_meta, ToolMeta)
+        assert parse_glossary_entities(_as_object_dict(list_meta.meta)) == ()
+
+
+def _as_object_dict(meta: object) -> dict[str, object] | None:
+    if meta is None:
+        return None
+    assert isinstance(meta, dict)
+    return cast(dict[str, object], meta)

--- a/services/backstop-mcp/tests/server/tools/conftest.py
+++ b/services/backstop-mcp/tests/server/tools/conftest.py
@@ -5,11 +5,11 @@ production, so these fixtures install a real `Services` — one `BackstopClientF
 auth context pointed at the test database) plus one `CustomFieldsService`.
 """
 
-import os
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 
 import pytest
+from cryptography.fernet import Fernet
 from mcp.server.auth.provider import AccessToken
 from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -52,7 +52,7 @@ async def connect_user(
         base_url: str = BASE_URL,
         overrides: dict[str, FieldOverride] | None = None,
     ) -> ConnectedUser:
-        key = os.urandom(32)
+        key = Fernet.generate_key()
 
         async def _noop_revoke(_subject: str) -> None:
             return None

--- a/services/backstop-mcp/tests/server/tools/conftest.py
+++ b/services/backstop-mcp/tests/server/tools/conftest.py
@@ -1,0 +1,91 @@
+"""Wiring shared by the tool tests.
+
+A tool reaches its collaborators through `runtime.get_services()`, exactly as it does in
+production, so these fixtures install a real `Services` — one `BackstopClientFactory` (with an
+auth context pointed at the test database) plus one `CustomFieldsService`.
+"""
+
+import os
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass
+
+import pytest
+from mcp.server.auth.provider import AccessToken
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from backstop_mcp.backstop_client import BackstopClientFactory
+from backstop_mcp.backstop_client.credential import BackstopCredentialSecret
+from backstop_mcp.features.auth.context import BackstopAuthContext
+from backstop_mcp.features.auth.credential_store import save_credential
+from backstop_mcp.features.custom_fields import CustomFieldsService, FieldOverride
+from tests.helpers import BASE_URL, client_factory, custom_fields_service, install_services
+
+type DatabaseFixture = tuple[AsyncEngine, async_sessionmaker[AsyncSession]]
+
+
+@dataclass(frozen=True)
+class ConnectedUser:
+    """A logged-in caller whose tools will resolve their own stored Backstop credential."""
+
+    subject: str
+    custom_fields: CustomFieldsService
+    clients: BackstopClientFactory
+
+
+type ConnectUser = Callable[..., "AsyncGenerator[ConnectedUser] | object"]
+
+
+@pytest.fixture
+async def connect_user(
+    db: DatabaseFixture, monkeypatch: pytest.MonkeyPatch
+) -> AsyncGenerator[Callable[..., object]]:
+    """Return a coroutine factory that stores a credential and installs the runtime services."""
+    _, session_factory = db
+    built: list[BackstopClientFactory] = []
+
+    async def connect(
+        subject: str,
+        username: str,
+        api_token: str = "token",
+        *,
+        base_url: str = BASE_URL,
+        overrides: dict[str, FieldOverride] | None = None,
+    ) -> ConnectedUser:
+        key = os.urandom(32)
+
+        async def _noop_revoke(_subject: str) -> None:
+            return None
+
+        async with session_factory() as session:
+            await save_credential(
+                session,
+                subject,
+                BackstopCredentialSecret(username=username, api_token=SecretStr(api_token)),
+                key,
+            )
+            await session.commit()
+
+        monkeypatch.setattr(
+            "backstop_mcp.features.auth.context.get_access_token",
+            lambda: AccessToken(
+                token="access-token", client_id="client-1", scopes=[], subject=subject
+            ),
+        )
+
+        factory = client_factory(
+            base_url,
+            auth=BackstopAuthContext(
+                session_factory=session_factory,
+                encryption_key=key,
+                revoke_tokens_for_subject=_noop_revoke,
+            ),
+        )
+        built.append(factory)
+        service = custom_fields_service(session_factory, base_url=base_url, overrides=overrides)
+        install_services(backstop=factory, custom_fields=service)
+        return ConnectedUser(subject=subject, custom_fields=service, clients=factory)
+
+    yield connect
+    for factory in built:
+        await factory.aclose()

--- a/services/backstop-mcp/tests/server/tools/helpers.py
+++ b/services/backstop-mcp/tests/server/tools/helpers.py
@@ -1,0 +1,29 @@
+"""Helpers for asserting MCP `CallToolResult` payloads in tool tests."""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel, TypeAdapter
+
+
+def tool_payload(result: CallToolResult) -> dict[str, object]:
+    assert isinstance(result, CallToolResult)
+    assert result.isError is not True
+    assert result.content, "expected non-empty CallToolResult.content"
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    payload = cast(object, json.loads(block.text))
+    assert isinstance(payload, dict)
+    return cast(dict[str, object], payload)
+
+
+def tool_model[T: BaseModel](result: CallToolResult, model: type[T]) -> T:
+    return model.model_validate(tool_payload(result))
+
+
+def tool_model_union(result: CallToolResult, union: object) -> BaseModel:
+    """Validate against a PEP 604 / typing union of response models."""
+    return cast(BaseModel, TypeAdapter(union).validate_python(tool_payload(result)))

--- a/services/backstop-mcp/tests/server/tools/test_custom_field_tools.py
+++ b/services/backstop-mcp/tests/server/tools/test_custom_field_tools.py
@@ -1,0 +1,94 @@
+from collections.abc import Callable
+
+import httpx
+import pytest
+import respx
+
+from backstop_mcp.features.custom_fields import FieldOverride
+from backstop_mcp.features.entity_types import EntityType
+from backstop_mcp.server.tools.list_custom_fields import (
+    ListCustomFieldsResponse,
+    list_custom_fields,
+)
+from tests.features.party_resolver.helpers import BASE_URL, resource
+from tests.server.tools.helpers import tool_model
+
+type ConnectUser = Callable[..., object]
+
+_OVERRIDES: dict[str, FieldOverride] = {
+    "organizations:is1": FieldOverride(
+        display_name="Investor Status",
+        aliases=("investor status",),
+    )
+}
+
+
+def tenant(name: str) -> str:
+    """A distinct Backstop base URL per test.
+
+    Schema snapshots are keyed by base URL and the test Postgres persists for the whole
+    session, so sharing one URL would let an earlier test's snapshot satisfy a later test's
+    `ensure_fresh` and skip the fetch under test.
+    """
+    return f"{BASE_URL}/{name}"
+
+
+def _lov_entries_route(base_url: str) -> respx.Route:
+    return respx.get(f"{base_url}/lov-entries").mock(
+        return_value=httpx.Response(200, json={"data": [], "links": {"next": None}})
+    )
+
+
+def _definitions_route(base_url: str, *definitions: dict[str, object]) -> respx.Route:
+    _lov_entries_route(base_url)
+    return respx.get(f"{base_url}/custom-field-definitions").mock(
+        return_value=httpx.Response(200, json={"data": list(definitions), "links": {"next": None}})
+    )
+
+
+def _investor_status(**extra: object) -> dict[str, object]:
+    return resource(
+        "99",
+        "custom-field-definitions",
+        name="is1",
+        entityType="Organization",
+        fieldType="picklist",
+        isTimeSeries=False,
+        **extra,
+    )
+
+
+class TestListCustomFieldsTool:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_lists_definitions_for_entity_type(self, connect_user: ConnectUser) -> None:
+        base_url = tenant("cf-list")
+        await connect_user("user-cf-list-1", "cf-list-bob", base_url=base_url, overrides=_OVERRIDES)  # pyright: ignore[reportGeneralTypeIssues]
+        _definitions_route(base_url, _investor_status(selectOptions=[{"label": "Active"}]))
+
+        result = tool_model(
+            await list_custom_fields(entity_type=EntityType.ORGANIZATIONS, refresh=True),
+            ListCustomFieldsResponse,
+        )
+
+        assert result.entity_type == EntityType.ORGANIZATIONS
+        assert result.count == 1
+        assert result.definitions[0].definition_id == "99"
+        assert result.definitions[0].display_name == "Investor Status"
+        assert result.definitions[0].allowed_values[0].label == "Active"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_entity_type_returns_empty_catalog(self, connect_user: ConnectUser) -> None:
+        base_url = tenant("cf-list-empty")
+        await connect_user("user-cf-list-2", "cf-list-carol", base_url=base_url)  # pyright: ignore[reportGeneralTypeIssues]
+        _definitions_route(base_url, _investor_status())
+
+        result = tool_model(
+            await list_custom_fields(entity_type=EntityType.PEOPLE, refresh=True),
+            ListCustomFieldsResponse,
+        )
+
+        assert result.entity_type == EntityType.PEOPLE
+        assert result.count == 0
+        assert result.definitions == []

--- a/services/backstop-mcp/tests/server/tools/test_get_organization.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_organization.py
@@ -69,11 +69,15 @@ class TestGetOrganization:
 
         # `organization` is the record's own fields, not the enclosing JSON:API document —
         # `type`/`id` are already echoed under `resolved`.
-        assert result.organization == OrganizationAttributes(
-            name="Capstone",
-            status="active",
-            modified_timestamp="2025-03-01T10:00:00Z",
-            modified_by="ops",
+        # `model_validate`, not kwargs: `status` is an `extra="allow"` passthrough and the
+        # provenance fields bind by alias, neither of which the synthesized `__init__` knows.
+        assert result.organization == OrganizationAttributes.model_validate(
+            {
+                "name": "Capstone",
+                "status": "active",
+                "modified_timestamp": "2025-03-01T10:00:00Z",
+                "modified_by": "ops",
+            }
         )
         assert result.resolved == ResolvedPartyResponse(
             id="o42", search_type="organizations", name="Capstone"

--- a/services/backstop-mcp/tests/server/tools/test_get_organization.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_organization.py
@@ -1,0 +1,233 @@
+from collections.abc import Callable
+
+import httpx
+import pytest
+import respx
+
+from backstop_mcp.backstop_client import BackstopResponseSchemaError
+from backstop_mcp.features.data_hygiene import AsOfEcho
+from backstop_mcp.features.party_resolver import (
+    PartyAmbiguousResponse,
+    PartyCandidateEcho,
+    ResolvedPartyEcho,
+)
+from backstop_mcp.features.resolution import NotFoundResponse
+from backstop_mcp.server.tools.get_organization import (
+    GetOrganizationResponse,
+    OrganizationResolvedResponse,
+    get_organization,
+)
+from tests.features.party_resolver.helpers import (
+    BASE_URL,
+    collection,
+    ctx_decline,
+    ctx_never_elicit,
+    resource,
+)
+from tests.server.tools.helpers import tool_model, tool_model_union
+
+type ConnectUser = Callable[..., object]
+
+
+class TestGetOrganization:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unique_search_fetches_organization_and_echoes_resolved(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-org-1", "org-bob.smith")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(resource("o42", "organizations", name="Capstone")),
+            )
+        )
+        respx.get(f"{BASE_URL}/organizations/o42").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "organizations",
+                        "id": "o42",
+                        "attributes": {
+                            "name": "Capstone",
+                            "status": "active",
+                            "modifiedTimestamp": "2025-03-01T10:00:00Z",
+                            "modifiedBy": "ops",
+                        },
+                    }
+                },
+            )
+        )
+
+        result = tool_model(
+            await get_organization(ctx_never_elicit(), search="Capstone"),
+            OrganizationResolvedResponse,
+        )
+
+        # `organization` is the record's own fields, not the enclosing JSON:API document —
+        # `type`/`id` are already echoed under `resolved`.
+        assert result.organization == {
+            "name": "Capstone",
+            "status": "active",
+            "modifiedTimestamp": "2025-03-01T10:00:00Z",
+            "modifiedBy": "ops",
+        }
+        assert result.resolved == ResolvedPartyEcho(id="o42", type="organizations", name="Capstone")
+        assert result.as_of == AsOfEcho(
+            modified_timestamp="2025-03-01T10:00:00Z", modified_by="ops"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ambiguous_search_returns_candidates_without_org_get(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-org-2", "org-carol.diaz")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(
+                    resource("o1", "organizations", name="Capstone A"),
+                    resource("o2", "organizations", name="Capstone B"),
+                ),
+            )
+        )
+        org_get = respx.get(url__regex=rf"{BASE_URL}/organizations/\w+").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        result = tool_model(
+            await get_organization(ctx_decline(), search="Capstone"),
+            PartyAmbiguousResponse,
+        )
+
+        assert result == PartyAmbiguousResponse(
+            query="Capstone",
+            scope="organizations",
+            candidates=[
+                PartyCandidateEcho(key="o1", label="Capstone A", id="o1", name="Capstone A"),
+                PartyCandidateEcho(key="o2", label="Capstone B", id="o2", name="Capstone B"),
+            ],
+        )
+        assert org_get.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_trusted_party_id_fetches_organization(self, connect_user: ConnectUser) -> None:
+        await connect_user("user-org-3", "org-dave.lee")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/organizations/trusted-9").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "organizations",
+                        "id": "trusted-9",
+                        "attributes": {"name": "From Body"},
+                    }
+                },
+            )
+        )
+        quick = respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        result = tool_model(
+            await get_organization(ctx_never_elicit(), party_id="trusted-9"),
+            OrganizationResolvedResponse,
+        )
+
+        # The name is backfilled from the organization fetch this tool makes anyway, so no
+        # extra `confirm_name` request is needed to satisfy the echo requirement.
+        assert result.resolved == ResolvedPartyEcho(
+            id="trusted-9", type="organizations", name="From Body"
+        )
+        assert quick.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_trusted_party_id_is_percent_encoded_in_request_path(
+        self, connect_user: ConnectUser
+    ) -> None:
+        # Defense in depth alongside the '/' rejection in resolve.py: any character that
+        # could otherwise change the request's structure (here, a space) must be encoded
+        # rather than interpolated raw into the path.
+        await connect_user("user-org-5", "org-frank.oz")  # pyright: ignore[reportGeneralTypeIssues]
+
+        org_get = respx.get(f"{BASE_URL}/organizations/trusted%209").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "organizations",
+                        "id": "trusted 9",
+                        "attributes": {"name": "From Body"},
+                    }
+                },
+            )
+        )
+
+        result = tool_model(
+            await get_organization(ctx_never_elicit(), party_id="trusted 9"),
+            OrganizationResolvedResponse,
+        )
+
+        assert isinstance(result, OrganizationResolvedResponse)
+        assert org_get.call_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_trusted_party_id_containing_slash_is_rejected(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-org-6", "org-grace.hopper")  # pyright: ignore[reportGeneralTypeIssues]
+
+        with pytest.raises(ValueError, match="must not contain '/'"):
+            await get_organization(ctx_never_elicit(), party_id="../admin")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_malformed_organization_body_raises_schema_error(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-org-4", "org-erin.ng")  # pyright: ignore[reportGeneralTypeIssues]
+
+        # `id` is entirely absent from the organization resource — fails
+        # `BackstopApiResourceDocument[OrganizationAttributes]` schema validation outright.
+        respx.get(f"{BASE_URL}/organizations/trusted-9").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"type": "organizations", "attributes": {"name": "From Body"}}},
+            )
+        )
+
+        with pytest.raises(BackstopResponseSchemaError) as exc_info:
+            await get_organization(ctx_never_elicit(), party_id="trusted-9")
+
+        assert exc_info.value.path == "/organizations/trusted-9"
+        assert exc_info.value.schema_name == "BackstopApiResourceDocument[OrganizationAttributes]"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_not_found_search_returns_the_query_it_used(
+        self, connect_user: ConnectUser
+    ) -> None:
+        """Policy step 5: name the exact term searched for, so a typo is correctable."""
+        await connect_user("user-org-7", "org-hank.p")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(200, json=collection())
+        )
+
+        result = tool_model_union(
+            await get_organization(ctx_never_elicit(), search="Capstoen"),
+            GetOrganizationResponse,
+        )
+
+        assert isinstance(result, NotFoundResponse)
+        assert result.status == "not_found"
+        assert getattr(result, "query", None) == "Capstoen"
+        assert getattr(result, "scope", None) == "organizations"

--- a/services/backstop-mcp/tests/server/tools/test_get_organization.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_organization.py
@@ -5,15 +5,16 @@ import pytest
 import respx
 
 from backstop_mcp.backstop_client import BackstopResponseSchemaError
-from backstop_mcp.features.data_hygiene import AsOfEcho
+from backstop_mcp.features.data_hygiene import AsOf
 from backstop_mcp.features.party_resolver import (
     PartyAmbiguousResponse,
-    PartyCandidateEcho,
-    ResolvedPartyEcho,
+    PartyCandidateResponse,
+    ResolvedPartyResponse,
 )
 from backstop_mcp.features.resolution import NotFoundResponse
 from backstop_mcp.server.tools.get_organization import (
     GetOrganizationResponse,
+    OrganizationAttributes,
     OrganizationResolvedResponse,
     get_organization,
 )
@@ -68,16 +69,16 @@ class TestGetOrganization:
 
         # `organization` is the record's own fields, not the enclosing JSON:API document —
         # `type`/`id` are already echoed under `resolved`.
-        assert result.organization == {
-            "name": "Capstone",
-            "status": "active",
-            "modifiedTimestamp": "2025-03-01T10:00:00Z",
-            "modifiedBy": "ops",
-        }
-        assert result.resolved == ResolvedPartyEcho(id="o42", type="organizations", name="Capstone")
-        assert result.as_of == AsOfEcho(
-            modified_timestamp="2025-03-01T10:00:00Z", modified_by="ops"
+        assert result.organization == OrganizationAttributes(
+            name="Capstone",
+            status="active",
+            modified_timestamp="2025-03-01T10:00:00Z",
+            modified_by="ops",
         )
+        assert result.resolved == ResolvedPartyResponse(
+            id="o42", search_type="organizations", name="Capstone"
+        )
+        assert result.as_of == AsOf(modified_timestamp="2025-03-01T10:00:00Z", modified_by="ops")
 
     @pytest.mark.asyncio
     @respx.mock
@@ -108,8 +109,8 @@ class TestGetOrganization:
             query="Capstone",
             scope="organizations",
             candidates=[
-                PartyCandidateEcho(key="o1", label="Capstone A", id="o1", name="Capstone A"),
-                PartyCandidateEcho(key="o2", label="Capstone B", id="o2", name="Capstone B"),
+                PartyCandidateResponse(key="o1", label="Capstone A", id="o1", name="Capstone A"),
+                PartyCandidateResponse(key="o2", label="Capstone B", id="o2", name="Capstone B"),
             ],
         )
         assert org_get.call_count == 0
@@ -142,8 +143,8 @@ class TestGetOrganization:
 
         # The name is backfilled from the organization fetch this tool makes anyway, so no
         # extra `confirm_name` request is needed to satisfy the echo requirement.
-        assert result.resolved == ResolvedPartyEcho(
-            id="trusted-9", type="organizations", name="From Body"
+        assert result.resolved == ResolvedPartyResponse(
+            id="trusted-9", search_type="organizations", name="From Body"
         )
         assert quick.call_count == 0
 

--- a/services/backstop-mcp/tests/server/tools/test_get_organization.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_organization.py
@@ -113,8 +113,20 @@ class TestGetOrganization:
             query="Capstone",
             scope="organizations",
             candidates=[
-                PartyCandidateResponse(key="o1", label="Capstone A", id="o1", name="Capstone A"),
-                PartyCandidateResponse(key="o2", label="Capstone B", id="o2", name="Capstone B"),
+                PartyCandidateResponse(
+                    key="o1",
+                    label="Capstone A",
+                    id="o1",
+                    search_type="organizations",
+                    name="Capstone A",
+                ),
+                PartyCandidateResponse(
+                    key="o2",
+                    label="Capstone B",
+                    id="o2",
+                    search_type="organizations",
+                    name="Capstone B",
+                ),
             ],
         )
         assert org_get.call_count == 0

--- a/services/backstop-mcp/tests/server/tools/test_get_person.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_person.py
@@ -4,11 +4,11 @@ import httpx
 import pytest
 import respx
 
-from backstop_mcp.features.data_hygiene import AsOfEcho
+from backstop_mcp.features.data_hygiene import AsOf
 from backstop_mcp.features.party_resolver import (
     PartyAmbiguousResponse,
-    PartyCandidateEcho,
-    ResolvedPartyEcho,
+    PartyCandidateResponse,
+    ResolvedPartyResponse,
 )
 from backstop_mcp.server.tools.get_person import PersonResolvedResponse, get_person
 from tests.features.data_hygiene.helpers import (
@@ -87,7 +87,9 @@ class TestGetPerson:
             PersonResolvedResponse,
         )
 
-        assert result.resolved == ResolvedPartyEcho(id="p9", type="people", name="Jane Doe")
+        assert result.resolved == ResolvedPartyResponse(
+            id="p9", search_type="people", name="Jane Doe"
+        )
         assert result.departed is True
         assert len(result.departures) == 1
         departure = result.departures[0]
@@ -96,7 +98,7 @@ class TestGetPerson:
         assert departure.organization_id == "o1"
         # The type carried the signal; this tenant recorded no date.
         assert departure.end_date is None
-        assert result.as_of == AsOfEcho(
+        assert result.as_of == AsOf(
             modified_timestamp="2023-01-01T00:00:00Z", modified_by="crm-admin"
         )
         # The nested hop is what populates each relationship's own type linkage, and it has to
@@ -161,8 +163,8 @@ class TestGetPerson:
             query="Jane",
             scope="people",
             candidates=[
-                PartyCandidateEcho(key="p1", label="Jane A", id="p1", name="Jane A"),
-                PartyCandidateEcho(key="p2", label="Jane B", id="p2", name="Jane B"),
+                PartyCandidateResponse(key="p1", label="Jane A", id="p1", name="Jane A"),
+                PartyCandidateResponse(key="p2", label="Jane B", id="p2", name="Jane B"),
             ],
         )
         assert person_get.call_count == 0

--- a/services/backstop-mcp/tests/server/tools/test_get_person.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_person.py
@@ -138,6 +138,49 @@ class TestGetPerson:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_fetches_resolved_collection_when_hit_is_not_people(
+        self, connect_user: ConnectUser
+    ) -> None:
+        """Name search uses shared PERSON_* types; a contact hit must GET /contacts/{id}."""
+        await connect_user("user-person-4", "person-erin")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(resource("c9", "contacts", name="Jane Contact")),
+            )
+        )
+        contact_get = respx.get(f"{BASE_URL}/contacts/c9").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "contacts",
+                        "id": "c9",
+                        "attributes": {"name": "Jane Contact"},
+                        "relationships": {"entityRelationships": {"data": []}},
+                    },
+                    "included": [],
+                },
+            )
+        )
+        people_get = respx.get(url__regex=rf"{BASE_URL}/people/\w+").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        result = tool_model(
+            await get_person(ctx_never_elicit(), search="Jane Contact"),
+            PersonResolvedResponse,
+        )
+
+        assert result.resolved == ResolvedPartyResponse(
+            id="c9", search_type="contacts", name="Jane Contact"
+        )
+        assert contact_get.call_count == 1
+        assert people_get.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_ambiguous_search_skips_person_get(self, connect_user: ConnectUser) -> None:
         await connect_user("user-person-2", "person-carol")  # pyright: ignore[reportGeneralTypeIssues]
 

--- a/services/backstop-mcp/tests/server/tools/test_get_person.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_person.py
@@ -163,8 +163,20 @@ class TestGetPerson:
             query="Jane",
             scope="people",
             candidates=[
-                PartyCandidateResponse(key="p1", label="Jane A", id="p1", name="Jane A"),
-                PartyCandidateResponse(key="p2", label="Jane B", id="p2", name="Jane B"),
+                PartyCandidateResponse(
+                    key="p1",
+                    label="Jane A",
+                    id="p1",
+                    search_type="people",
+                    name="Jane A",
+                ),
+                PartyCandidateResponse(
+                    key="p2",
+                    label="Jane B",
+                    id="p2",
+                    search_type="people",
+                    name="Jane B",
+                ),
             ],
         )
         assert person_get.call_count == 0

--- a/services/backstop-mcp/tests/server/tools/test_get_person.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_person.py
@@ -1,0 +1,173 @@
+from collections.abc import Callable
+
+import httpx
+import pytest
+import respx
+
+from backstop_mcp.features.data_hygiene import AsOfEcho
+from backstop_mcp.features.party_resolver import (
+    PartyAmbiguousResponse,
+    PartyCandidateEcho,
+    ResolvedPartyEcho,
+)
+from backstop_mcp.server.tools.get_person import PersonResolvedResponse, get_person
+from tests.features.data_hygiene.helpers import (
+    EMPLOYEE_TYPE,
+    FORMER_TYPE,
+    person_org,
+    relationship_types,
+)
+from tests.features.party_resolver.helpers import (
+    BASE_URL,
+    collection,
+    ctx_decline,
+    ctx_never_elicit,
+    resource,
+)
+from tests.server.tools.helpers import tool_model
+
+type ConnectUser = Callable[..., object]
+
+
+def _person_document(*type_ids: str) -> dict[str, object]:
+    """A person GET shaped like the real nested-include response.
+
+    One relationship per type id, all pointing at the same organization, with each type's own
+    resource side-loaded alongside them — which is where the type name comes from now.
+    """
+    relationships = [
+        person_org(f"er{index}", type_id=type_id, source_id="p9")
+        for index, type_id in enumerate(type_ids)
+    ]
+    types = relationship_types(*dict.fromkeys(type_ids))
+    return {
+        "data": {
+            "type": "people",
+            "id": "p9",
+            "attributes": {
+                "name": "Jane Doe",
+                "modifiedTimestamp": "2023-01-01T00:00:00Z",
+                "modifiedBy": "crm-admin",
+            },
+            "relationships": {
+                "entityRelationships": {
+                    "data": [
+                        {"type": "entity-relationships", "id": item["id"]} for item in relationships
+                    ]
+                }
+            },
+        },
+        "included": [*relationships, *types],
+    }
+
+
+class TestGetPerson:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unique_search_fetches_person_and_flags_departed(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-person-1", "person-bob")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(resource("p9", "people", name="Jane Doe")),
+            )
+        )
+        person_get = respx.get(f"{BASE_URL}/people/p9").mock(
+            return_value=httpx.Response(200, json=_person_document(FORMER_TYPE))
+        )
+        types_get = respx.get(f"{BASE_URL}/entity-relationship-types").mock(
+            return_value=httpx.Response(200, json={"data": [], "links": {}})
+        )
+
+        result = tool_model(
+            await get_person(ctx_never_elicit(), search="Jane Doe"),
+            PersonResolvedResponse,
+        )
+
+        assert result.resolved == ResolvedPartyEcho(id="p9", type="people", name="Jane Doe")
+        assert result.departed is True
+        assert len(result.departures) == 1
+        departure = result.departures[0]
+        assert departure.signal == "former_relationship_type"
+        assert departure.relationship_type_name == "is a former employee of"
+        assert departure.organization_id == "o1"
+        # The type carried the signal; this tenant recorded no date.
+        assert departure.end_date is None
+        assert result.as_of == AsOfEcho(
+            modified_timestamp="2023-01-01T00:00:00Z", modified_by="crm-admin"
+        )
+        # The nested hop is what populates each relationship's own type linkage, and it has to
+        # arrive on this one GET: without it the detector has no type id to classify.
+        sent = str(person_get.calls.last.request.url).replace("%3D", "=").replace("%2C", ",")
+        assert "include=entityRelationships,entityRelationships.entityRelationshipType" in sent
+        assert types_get.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_undated_tie_at_the_same_org_breaks_toward_departed(
+        self, connect_user: ConnectUser
+    ) -> None:
+        """A person carrying both `is a former employee of` and `is employee of` against one
+        organization, neither dated: `EmploymentIndex`'s winner-per-pair fold breaks an undated
+        tie toward `FORMER` — under-reporting a departure is the costlier error."""
+        await connect_user("user-person-3", "person-dave")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(resource("p9", "people", name="Jane Doe")),
+            )
+        )
+        respx.get(f"{BASE_URL}/people/p9").mock(
+            return_value=httpx.Response(200, json=_person_document(FORMER_TYPE, EMPLOYEE_TYPE))
+        )
+
+        result = tool_model(
+            await get_person(ctx_never_elicit(), search="Jane Doe"),
+            PersonResolvedResponse,
+        )
+
+        assert result.departed is True
+        assert len(result.departures) == 1
+        assert result.departures[0].organization_id == "o1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ambiguous_search_skips_person_get(self, connect_user: ConnectUser) -> None:
+        await connect_user("user-person-2", "person-carol")  # pyright: ignore[reportGeneralTypeIssues]
+
+        respx.get(f"{BASE_URL}/quick-search").mock(
+            return_value=httpx.Response(
+                200,
+                json=collection(
+                    resource("p1", "people", name="Jane A"),
+                    resource("p2", "people", name="Jane B"),
+                ),
+            )
+        )
+        person_get = respx.get(url__regex=rf"{BASE_URL}/people/\w+").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        result = tool_model(
+            await get_person(ctx_decline(), search="Jane"),
+            PartyAmbiguousResponse,
+        )
+
+        assert result == PartyAmbiguousResponse(
+            query="Jane",
+            scope="people",
+            candidates=[
+                PartyCandidateEcho(key="p1", label="Jane A", id="p1", name="Jane A"),
+                PartyCandidateEcho(key="p2", label="Jane B", id="p2", name="Jane B"),
+            ],
+        )
+        assert person_get.call_count == 0
+
+    def test_docstring_instructs_model_to_relay_departed_flag(self) -> None:
+        doc = get_person.__doc__ or ""
+        assert "departed" in doc
+        assert "relay" in doc.lower()

--- a/services/backstop-mcp/tests/server/tools/test_system_info.py
+++ b/services/backstop-mcp/tests/server/tools/test_system_info.py
@@ -1,0 +1,116 @@
+import os
+from collections.abc import Callable
+
+import httpx
+import pytest
+import respx
+from mcp.server.auth.provider import AccessToken
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from backstop_mcp.backstop_client import BackstopAuthError
+from backstop_mcp.backstop_client.credential import BackstopCredentialSecret
+from backstop_mcp.features.auth.context import BackstopAuthContext, NotConnectedError
+from backstop_mcp.features.auth.credential_store import save_credential
+from backstop_mcp.server.tools.system_info import get_system_info
+from tests.helpers import BASE_URL, client_factory, custom_fields_service, install_services
+from tests.server.tools.helpers import tool_payload
+
+type DatabaseFixture = tuple[AsyncEngine, async_sessionmaker[AsyncSession]]
+type ConnectUser = Callable[..., object]
+
+
+def _fake_access_token(subject: str) -> AccessToken:
+    return AccessToken(token="access-token", client_id="client-1", scopes=[], subject=subject)
+
+
+class TestGetSystemInfo:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_backstop_response_for_connected_user(
+        self, connect_user: ConnectUser
+    ) -> None:
+        await connect_user("user-tool-1", "tool-bob.smith")  # pyright: ignore[reportGeneralTypeIssues]
+        respx.get(f"{BASE_URL}/system-info").mock(
+            return_value=httpx.Response(200, json={"version": "1.0"})
+        )
+
+        result = tool_payload(await get_system_info())
+
+        assert result == {"version": "1.0"}
+
+    @pytest.mark.asyncio
+    async def test_raises_not_connected_when_no_credential(
+        self, db: DatabaseFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, session_factory = db
+
+        async def _noop_revoke(_subject: str) -> None:
+            return None
+
+        factory = client_factory(
+            BASE_URL,
+            auth=BackstopAuthContext(
+                session_factory=session_factory,
+                encryption_key=os.urandom(32),
+                revoke_tokens_for_subject=_noop_revoke,
+            ),
+        )
+        install_services(backstop=factory, custom_fields=custom_fields_service(session_factory))
+        monkeypatch.setattr(
+            "backstop_mcp.features.auth.context.get_access_token",
+            lambda: _fake_access_token("user-never-connected"),
+        )
+
+        try:
+            with pytest.raises(NotConnectedError):
+                await get_system_info()
+        finally:
+            await factory.aclose()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_backstop_auth_error_when_credential_revoked(
+        self, db: DatabaseFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mid-session Backstop 401 revokes the caller's MCP tokens, forcing a re-login."""
+        revoked_subjects: list[str] = []
+
+        async def _record_revoke(subject: str) -> None:
+            revoked_subjects.append(subject)
+
+        _, session_factory = db
+        key = os.urandom(32)
+        async with session_factory() as session:
+            await save_credential(
+                session,
+                "user-tool-2",
+                BackstopCredentialSecret(
+                    username="tool-carol.diaz", api_token=SecretStr("revoked-token")
+                ),
+                key,
+            )
+            await session.commit()
+
+        factory = client_factory(
+            BASE_URL,
+            auth=BackstopAuthContext(
+                session_factory=session_factory,
+                encryption_key=key,
+                revoke_tokens_for_subject=_record_revoke,
+            ),
+        )
+        install_services(backstop=factory, custom_fields=custom_fields_service(session_factory))
+        monkeypatch.setattr(
+            "backstop_mcp.features.auth.context.get_access_token",
+            lambda: _fake_access_token("user-tool-2"),
+        )
+        respx.get(f"{BASE_URL}/system-info").mock(return_value=httpx.Response(401))
+
+        try:
+            with pytest.raises(BackstopAuthError):
+                await get_system_info()
+        finally:
+            await factory.aclose()
+
+        assert revoked_subjects == ["user-tool-2"]

--- a/services/backstop-mcp/tests/server/tools/test_system_info.py
+++ b/services/backstop-mcp/tests/server/tools/test_system_info.py
@@ -1,9 +1,9 @@
-import os
 from collections.abc import Callable
 
 import httpx
 import pytest
 import respx
+from cryptography.fernet import Fernet
 from mcp.server.auth.provider import AccessToken
 from pydantic import SecretStr
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -52,7 +52,7 @@ class TestGetSystemInfo:
             BASE_URL,
             auth=BackstopAuthContext(
                 session_factory=session_factory,
-                encryption_key=os.urandom(32),
+                encryption_key=Fernet.generate_key(),
                 revoke_tokens_for_subject=_noop_revoke,
             ),
         )
@@ -80,7 +80,7 @@ class TestGetSystemInfo:
             revoked_subjects.append(subject)
 
         _, session_factory = db
-        key = os.urandom(32)
+        key = Fernet.generate_key()
         async with session_factory() as session:
             await save_credential(
                 session,

--- a/services/backstop-mcp/tests/test_app.py
+++ b/services/backstop-mcp/tests/test_app.py
@@ -39,8 +39,8 @@ def _as_str(value: object) -> str | None:
 
 
 # `starlette.testclient` returns httpx responses that this repo's strict type-checking sees as
-# partially unknown. Narrowed once here, so every assertion below is checked rather than
-# silently `Any`.
+# partially unknown. Narrowed once here, the same way `features/resolution.py` narrows FastMCP's
+# request context, so every assertion below is checked rather than silently `Any`.
 class _HttpResponse(Protocol):
     @property
     def status_code(self) -> int: ...
@@ -134,6 +134,40 @@ class TestWiring:
         """A second `BackstopConfig()` read from the environment would silently ignore the knobs."""
         _ = app_client
         assert get_services().backstop.settings.base_url == _BASE_URL
+
+    def test_the_departed_detector_owns_the_employment_types_create_app_was_given(
+        self, postgres_container: PostgresContainer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`get_person` used to build `BackstopConfig()` itself, discarding what was injected.
+
+        Same failure as `test_the_factory_owns_the_settings_create_app_was_given`, and just as
+        silent: a tenant's configured relationship types would be ignored while the env-parsed
+        defaults quietly took over. The env var is set to something else entirely so a re-read
+        would produce a visibly different answer.
+        """
+        monkeypatch.setenv("BACKSTOP_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "from the environment")
+        monkeypatch.setenv(
+            "BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "from the environment"
+        )
+        configs = {
+            **_configs(postgres_container),
+            "backstop_config": BackstopConfig(
+                base_url=_BASE_URL,
+                employment_relationship_type_ids=("ert-9",),
+                employment_relationship_type_markers=("placement at",),
+                former_employment_relationship_type_ids=("ert-10",),
+                former_employment_relationship_type_markers=("placement ended",),
+            ),
+        }
+        app = create_app(**configs)  # pyright: ignore[reportArgumentType]
+
+        with TestClient(app):
+            rules = get_services().employment_index_factory.rules
+
+        assert rules.employment.type_ids == frozenset({"ert-9"})
+        assert rules.employment.name_markers == frozenset({"placement at"})
+        assert rules.former.type_ids == frozenset({"ert-10"})
+        assert rules.former.name_markers == frozenset({"placement ended"})
 
     def test_services_are_installed_for_tools_to_reach(self, app_client: TestClient) -> None:
         _ = app_client
@@ -241,9 +275,12 @@ class TestToolRegistration:
 
         assert response.status_code == 401
 
-    def test_no_tools_are_registered_yet(self) -> None:
-        """`TOOLS` is empty until the first tool lands in a later PR."""
-        assert TOOLS == ()
+    def test_every_registered_tool_has_a_distinct_name(self) -> None:
+        """`create_app` registers by iterating TOOLS, so a duplicate name would shadow."""
+        names = [fn.__name__ for fn in TOOLS]
+
+        assert len(names) == len(set(names))
+        assert names
 
 
 class TestConfigTranslation:

--- a/services/backstop-mcp/tests/test_config.py
+++ b/services/backstop-mcp/tests/test_config.py
@@ -2,7 +2,7 @@ import ssl
 from datetime import timedelta
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from backstop_mcp.config import (
     AppConfig,
@@ -78,6 +78,17 @@ class TestBackstopConfigDefaults:
         assert config.max_retry_wait_ms == 30_000
         assert config.default_page_size == 100
         assert config.report_page_size == 500
+        assert config.custom_field_overrides == {}
+        assert config.custom_field_schema_ttl_minutes == 7 * 24 * 60
+        assert config.employment_relationship_type_ids == ()
+        assert config.employment_relationship_type_markers == ("employ",)
+        assert config.former_employment_relationship_type_ids == ()
+        assert config.former_employment_relationship_type_markers == (
+            "former",
+            "previous",
+            "ex-",
+            "no longer",
+        )
 
     def test_strips_trailing_slash_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("BACKSTOP_BASE_URL", "https://tenant.backstopsolutions.com/")
@@ -111,9 +122,37 @@ class TestBackstopConfigDefaults:
         assert config.default_page_size == 50
         assert config.report_page_size == 250
 
+    def test_employment_relationship_types_parse_csv(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BACKSTOP_EMPLOYMENT_RELATIONSHIP_TYPE_IDS", "1, 2,3")
+        monkeypatch.setenv("BACKSTOP_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "Employment, Works At")
+        monkeypatch.setenv("BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_IDS", "9")
+        monkeypatch.setenv("BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "Used To Work")
+
+        config = BackstopConfig()
+
+        assert config.employment_relationship_type_ids == ("1", "2", "3")
+        assert config.employment_relationship_type_markers == ("Employment", "Works At")
+        assert config.former_employment_relationship_type_ids == ("9",)
+        assert config.former_employment_relationship_type_markers == ("Used To Work",)
+
+    def test_configured_markers_replace_the_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A tenant's phrasing is the whole vocabulary; an empty value leaves ids to decide."""
+        monkeypatch.setenv(
+            "BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "Placement Ended"
+        )
+        assert BackstopConfig().former_employment_relationship_type_markers == ("Placement Ended",)
+
+        monkeypatch.setenv("BACKSTOP_FORMER_EMPLOYMENT_RELATIONSHIP_TYPE_MARKERS", "")
+        assert BackstopConfig().former_employment_relationship_type_markers == ()
+
     def test_report_page_size_rejects_values_over_500(self) -> None:
         with pytest.raises(ValueError, match="report_page_size"):
             BackstopConfig(report_page_size=501)
+
+    def test_schema_ttl_rejects_zero(self) -> None:
+        """A zero TTL would refetch the whole schema on every call."""
+        with pytest.raises(ValueError, match="custom_field_schema_ttl_minutes"):
+            BackstopConfig(custom_field_schema_ttl_minutes=0)
 
 
 class TestAuthConfig:
@@ -146,6 +185,33 @@ class TestAuthConfig:
         """A zero interval would spin the sweep loop without ever sleeping."""
         with pytest.raises(ValueError, match="cleanup_interval_hours"):
             AuthConfig(cleanup_interval_hours=0)
+
+
+class TestBackstopServiceAccount:
+    def test_absent_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BACKSTOP_SERVICE_USERNAME", raising=False)
+        monkeypatch.delenv("BACKSTOP_SERVICE_API_TOKEN", raising=False)
+        config = BackstopConfig()
+
+        assert config.service_username is None
+        assert config.service_api_token is None
+
+    def test_reads_both_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BACKSTOP_SERVICE_USERNAME", "svc-bot")
+        monkeypatch.setenv("BACKSTOP_SERVICE_API_TOKEN", "svc-token")
+        config = BackstopConfig()
+
+        assert config.service_username == "svc-bot"
+        assert config.service_api_token is not None
+        assert config.service_api_token.get_secret_value() == "svc-token"
+
+    def test_rejects_username_without_token(self) -> None:
+        with pytest.raises(ValueError, match="must be set together"):
+            BackstopConfig(service_username="svc-bot")
+
+    def test_rejects_token_without_username(self) -> None:
+        with pytest.raises(ValueError, match="must be set together"):
+            BackstopConfig(service_api_token=SecretStr("svc-token"))
 
 
 class TestPublicBaseUrl:

--- a/services/backstop-mcp/tests/test_layering.py
+++ b/services/backstop-mcp/tests/test_layering.py
@@ -24,7 +24,7 @@
 4. **A package is entered through its `__init__`, never through its modules.** From outside,
    `from backstop_mcp.features.data_hygiene import EmploymentIndexFactory` — not
    `...data_hygiene.service import ...`, and certainly not `...data_hygiene.employment import
-   build_person_employment_index`. Each package's `__all__` is then the whole of what it promises,
+   build_employment_index`. Each package's `__all__` is then the whole of what it promises,
    and everything else is free to move.
 
    This is what makes a package able to say "call it this way". `data_hygiene/employment.py`

--- a/services/backstop-mcp/tests/test_layering.py
+++ b/services/backstop-mcp/tests/test_layering.py
@@ -192,16 +192,16 @@ class TestTheDetectionItself:
         ]
 
     def test_catches_the_violation_the_internals_rule_exists_for(self) -> None:
-        # Verbatim shape of the import `get_person.py` used to carry, alongside a
-        # `BackstopConfig()` it built itself.
+        # The shape `get_person.py` would carry if it reached past the package front door
+        # instead of importing `features.data_hygiene` itself.
         assert _internal_imports(
-            "from backstop_mcp.features.data_hygiene.departed import detect_departed_employment",
+            "from backstop_mcp.features.data_hygiene.service import DataHygieneService",
             _SRC / "server" / "tools",
-        ) == [("backstop_mcp.features.data_hygiene.departed", 1)]
+        ) == [("backstop_mcp.features.data_hygiene.service", 1)]
 
     def test_the_same_import_is_fine_inside_the_feature(self) -> None:
         assert not _internal_imports(
-            "from backstop_mcp.features.data_hygiene.departed import detect_departed_employment",
+            "from backstop_mcp.features.data_hygiene.service import DataHygieneService",
             _package_directory("backstop_mcp.features.data_hygiene"),
         )
 

--- a/services/backstop-mcp/tests/test_layering.py
+++ b/services/backstop-mcp/tests/test_layering.py
@@ -17,15 +17,22 @@
    `BackstopTransportSettings`/`RetrySettings` — its own frozen types, translated from
    `BackstopConfig` by `create_app`. It used to take the `pydantic-settings` model directly, which
    coupled the layer to the env-parsing shape and to every knob on it, including the ones it has
-   no business seeing (the service account, the custom-field overrides — both land in a later
-   PR). `features/` is deliberately *not* subject to this rule: it may read config freely (see
-   `features/__init__.py`), because a feature is allowed to be configured — a transport is only
-   allowed to be told.
+   no business seeing (the service account, the custom-field overrides). `features/` is
+   deliberately *not* subject to this rule: it may read config freely (see `features/__init__.py`),
+   because a feature is allowed to be configured — a transport is only allowed to be told.
 
 4. **A package is entered through its `__init__`, never through its modules.** From outside,
-   `from backstop_mcp.features.party_resolver import resolve_party` — not
-   `...party_resolver.resolve import ...`. Each package's `__all__` is then the whole of what it
-   promises, and everything else is free to move.
+   `from backstop_mcp.features.data_hygiene import EmploymentIndexFactory` — not
+   `...data_hygiene.service import ...`, and certainly not `...data_hygiene.employment import
+   build_person_employment_index`. Each package's `__all__` is then the whole of what it promises,
+   and everything else is free to move.
+
+   This is what makes a package able to say "call it this way". `data_hygiene/employment.py`
+   decides nothing until it is handed an employment vocabulary, the side-loaded relationship
+   types and a clock; `EmploymentIndexFactory` supplies all three, from configuration, once.
+   Reaching past it is how the original bug happened — `get_person` assembled its own vocabulary
+   with `BackstopConfig()`, so whatever `create_app` had been given was silently ignored.
+   `__all__` alone is only a convention; this rule is what makes it hold.
 
    Applies to the packages listed in `_PUBLIC_SURFACE_PACKAGES`. `features/` and `server/` are
    not among them: they are groupings whose `__init__` is documentation, so `features.resolution`
@@ -51,13 +58,13 @@ _CONFIG_MODULE = "backstop_mcp.config"
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
 # directly testable without being callable from production code that should go through the front
-# door. A new package belongs here as soon as its `__init__` exports anything (`data_hygiene`
-# lands in a later PR and joins this list then).
+# door. A new package belongs here as soon as its `__init__` exports anything.
 _PUBLIC_SURFACE_PACKAGES: tuple[str, ...] = (
     "backstop_mcp.backstop_client",
     "backstop_mcp.db",
     "backstop_mcp.features.auth",
     "backstop_mcp.features.custom_fields",
+    "backstop_mcp.features.data_hygiene",
     "backstop_mcp.features.party_resolver",
     "backstop_mcp.server.middleware",
     "backstop_mcp.server.tools",
@@ -77,7 +84,7 @@ def _imported_modules(tree: ast.AST) -> list[tuple[str, int]]:
 
 
 def _source_id(source: pathlib.Path) -> str:
-    """Test id for one module: `features/party_resolver/resolve.py`, not an absolute path."""
+    """Test id for one module: `features/custom_fields/service.py`, not an absolute path."""
     return str(source.relative_to(_SRC))
 
 
@@ -115,7 +122,7 @@ def _declares_dunder_all(node: ast.AST) -> bool:
 
 
 def _package_directory(package: str) -> pathlib.Path:
-    """`backstop_mcp.features.party_resolver` → the directory that package's modules live in."""
+    """`backstop_mcp.features.data_hygiene` → the directory that package's modules live in."""
     return _SRC.joinpath(*package.split(".")[1:])
 
 
@@ -173,7 +180,7 @@ class TestTheDetectionItself:
     def test_does_not_fire_on_permitted_imports(self) -> None:
         assert not _imports_under(
             "from backstop_mcp.backstop_client.client import BackstopClient\n"
-            + "from backstop_mcp.features.party_resolver.resolve import resolve_party\n"
+            + "from backstop_mcp.features.custom_fields.service import CustomFieldsService\n"
             + "from backstop_mcp.logging import configure_logging\n",
             _SERVER_PREFIX,
         )
@@ -185,15 +192,17 @@ class TestTheDetectionItself:
         ]
 
     def test_catches_the_violation_the_internals_rule_exists_for(self) -> None:
+        # Verbatim shape of the import `get_person.py` used to carry, alongside a
+        # `BackstopConfig()` it built itself.
         assert _internal_imports(
-            "from backstop_mcp.features.party_resolver.resolve import resolve_party",
+            "from backstop_mcp.features.data_hygiene.departed import detect_departed_employment",
             _SRC / "server" / "tools",
-        ) == [("backstop_mcp.features.party_resolver.resolve", 1)]
+        ) == [("backstop_mcp.features.data_hygiene.departed", 1)]
 
     def test_the_same_import_is_fine_inside_the_feature(self) -> None:
         assert not _internal_imports(
-            "from backstop_mcp.features.party_resolver.resolve import resolve_party",
-            _package_directory("backstop_mcp.features.party_resolver"),
+            "from backstop_mcp.features.data_hygiene.departed import detect_departed_employment",
+            _package_directory("backstop_mcp.features.data_hygiene"),
         )
 
     def test_catches_reaching_past_the_init_for_a_service_too(self) -> None:
@@ -205,7 +214,7 @@ class TestTheDetectionItself:
 
     def test_does_not_fire_on_the_package_root(self) -> None:
         assert not _internal_imports(
-            "from backstop_mcp.features.party_resolver import resolve_party\n"
+            "from backstop_mcp.features.data_hygiene import EmploymentIndexFactory\n"
             + "from backstop_mcp.server.runtime import get_services\n"
             + "from backstop_mcp.features.resolution import Resolved\n",
             _SRC / "server" / "tools",
@@ -285,10 +294,10 @@ class TestPackagesAreEnteredThroughTheirInit:
 
     def test_a_package_still_composes_its_own_modules(self) -> None:
         """The rule is only meaningful if something inside the package assembles the parts."""
-        init = _package_directory("backstop_mcp.features.party_resolver") / "__init__.py"
-        imported = {module for module, _line in _imported_modules(ast.parse(init.read_text()))}
+        service = _package_directory("backstop_mcp.features.data_hygiene") / "service.py"
+        imported = {module for module, _line in _imported_modules(ast.parse(service.read_text()))}
 
-        assert "backstop_mcp.features.party_resolver.resolve" in imported
+        assert "backstop_mcp.features.data_hygiene.employment" in imported
 
     @pytest.mark.parametrize("source", sorted(_SRC.rglob("*.py")), ids=_source_id)
     def test_no_module_reaches_past_another_packages_init(self, source: pathlib.Path) -> None:
@@ -296,7 +305,8 @@ class TestPackagesAreEnteredThroughTheirInit:
         assert not violations, (
             "import the package, not a module inside it — a package's __all__ is the whole of "
             + "what it promises, and reaching past it means assembling collaborators the package "
-            + "is responsible for assembling. Export the name from that package's __init__ and "
-            + "import it from there:\n  "
+            + "is responsible for assembling (which is how a tool came to re-read "
+            + "BackstopConfig() and ignore what create_app was given). Export the name from that "
+            + "package's __init__ and import it from there:\n  "
             + "\n  ".join(violations)
         )


### PR DESCRIPTION
## Summary

- Data hygiene: departed-contact detection via employment relationship index + `as_of` provenance on reads ([UN-23678](https://unique-ch.atlassian.net/browse/UN-23678))
- Registers the MCP tool surface that composes the stacked libraries:
  - `get_system_info`
  - `get_organization` (party resolve → fetch + glossary meta + `as_of`)
  - `get_person` (party resolve → fetch + departed flag + `as_of`)
  - `list_custom_fields`
- Final tip of this stack matches the pre-split backup tree (`backstop-mcp/feat/UN-22647--scafolding-backup-20260806`)

## Stack

1. Scaffolding (#716)
2. Client + Auth (#748)
3. Party resolver (#749)
4. Custom fields (#750) ← base
5. **This PR (#751)** — data hygiene + all tools

## Review focus

- Employment index / former-employment markers vs ids
- `as_of` provenance (no staleness verdict)
- How tools compose party + custom fields + hygiene

## Test plan

- [ ] `cd services/backstop-mcp && uv sync && uv run ruff check . && uv run basedpyright && uv run pytest`
- [ ] `get_organization` with fuzzy name and trusted `party_id`
- [ ] Ambiguous name elicits a choice (or structured ambiguous payload)
- [ ] `list_custom_fields` / glossary on `tools/list`
- [ ] `get_person` reports departed contacts when former employment is present

[UN-23678]: https://unique-ch.atlassian.net/browse/UN-23678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ