### PR TITLE
fix(confluence-connector): keep credentials on redirects and trim whitespace from secrets

### DIFF
--- a/services/confluence-connector/src/utils/__tests__/rate-limited-http-client.spec.ts
+++ b/services/confluence-connector/src/utils/__tests__/rate-limited-http-client.spec.ts
@@ -4,11 +4,11 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 vi.mock('undici', () => ({
   Agent: class MockAgent {
-    public compose() {
-      return {};
+    public compose(composed: string[]) {
+      return { composed };
     }
   },
-  interceptors: { redirect: () => ({}), retry: () => ({}) },
+  interceptors: { redirect: () => 'redirect', retry: () => 'retry' },
   request: vi.fn(),
 }));
 
@@ -39,6 +39,7 @@ function mockUndiciResponse(
     body: {
       json: vi.fn().mockResolvedValue(body),
       text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+      dump: vi.fn().mockResolvedValue(undefined),
     },
   } as unknown as Dispatcher.ResponseData;
 }
@@ -88,6 +89,48 @@ describe('RateLimitedHttpClient', () => {
 
       await expect(client.rateLimitedRequest('https://example.com', {})).rejects.toThrow(/500/);
     });
+
+    it('follows same-origin redirects with the credentials intact', async () => {
+      mockedRequest
+        .mockResolvedValueOnce(
+          mockUndiciResponse(302, '', { location: '/confluence/rest/api/content' }),
+        )
+        .mockResolvedValueOnce(mockUndiciResponse(200, { data: 'value' }));
+
+      const result = await client.rateLimitedRequest('https://example.com/rest/api/content', {
+        Authorization: 'Basic dXNlcjpwYXNz',
+      });
+
+      expect(result).toEqual({ data: 'value' });
+      expect(mockedRequest).toHaveBeenLastCalledWith(
+        'https://example.com/confluence/rest/api/content',
+        expect.objectContaining({ headers: { Authorization: 'Basic dXNlcjpwYXNz' } }),
+      );
+    });
+
+    it('rejects a cross-origin redirect instead of continuing unauthenticated', async () => {
+      mockedRequest.mockResolvedValueOnce(
+        mockUndiciResponse(302, '', { location: 'https://other.example.com/rest/api/content' }),
+      );
+
+      await expect(
+        client.rateLimitedRequest('https://example.com/rest/api/content', {
+          Authorization: 'Basic dXNlcjpwYXNz',
+        }),
+      ).rejects.toThrow(/redirected to a different origin \(https:\/\/other\.example\.com\)/);
+
+      expect(mockedRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a scheme-only redirect because it also drops credentials', async () => {
+      mockedRequest.mockResolvedValueOnce(
+        mockUndiciResponse(301, '', { location: 'https://example.com/rest/api/content' }),
+      );
+
+      await expect(
+        client.rateLimitedRequest('http://example.com/rest/api/content', {}),
+      ).rejects.toThrow(/redirected to a different origin/);
+    });
   });
 
   describe('rateLimitedStreamRequest', () => {
@@ -133,6 +176,19 @@ describe('RateLimitedHttpClient', () => {
       await expect(
         client.rateLimitedStreamRequest('https://example.com/download', {}),
       ).rejects.toThrow(/Error response from/);
+    });
+
+    // Cloud attachment downloads redirect to a presigned media URL on another origin, which only
+    // works when undici follows the redirect and drops the Authorization header.
+    it('uses the redirect-following dispatcher', async () => {
+      mockedRequest.mockResolvedValueOnce(mockUndiciResponse(200, new Readable({ read() {} })));
+
+      await client.rateLimitedStreamRequest('https://example.com/download', {});
+
+      expect(mockedRequest).toHaveBeenCalledWith(
+        'https://example.com/download',
+        expect.objectContaining({ dispatcher: { composed: ['redirect', 'retry'] } }),
+      );
     });
   });
 

--- a/services/confluence-connector/src/utils/__tests__/zod.util.spec.ts
+++ b/services/confluence-connector/src/utils/__tests__/zod.util.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  envRequiredPlainSchema,
+  envRequiredSecretSchema,
+  redactedNonEmptyStringSchema,
+  requiredStringSchema,
+} from '../zod.util';
+
+const ENV_VAR = 'ZOD_UTIL_SPEC_SECRET';
+
+describe('credential schemas', () => {
+  afterEach(() => {
+    delete process.env[ENV_VAR];
+  });
+
+  it('strips the trailing newline a Kubernetes secret adds to a password', () => {
+    process.env[ENV_VAR] = 'sup3r-s3cret\n';
+
+    const password = envRequiredSecretSchema.parse(`os.environ/${ENV_VAR}`);
+
+    expect(password.value).toBe('sup3r-s3cret');
+  });
+
+  it('strips surrounding whitespace from an inline secret', () => {
+    expect(envRequiredSecretSchema.parse('  sup3r-s3cret  ').value).toBe('sup3r-s3cret');
+    expect(envRequiredPlainSchema.parse('  plain-value\n')).toBe('plain-value');
+    expect(redactedNonEmptyStringSchema.parse(' proxy-pass\n').value).toBe('proxy-pass');
+  });
+
+  it('strips surrounding whitespace from a username', () => {
+    expect(requiredStringSchema.parse(' technical-user\n')).toBe('technical-user');
+  });
+
+  it('rejects a whitespace-only secret', () => {
+    expect(() => envRequiredSecretSchema.parse('   ')).toThrow();
+  });
+});

--- a/services/confluence-connector/src/utils/rate-limited-http-client.ts
+++ b/services/confluence-connector/src/utils/rate-limited-http-client.ts
@@ -7,6 +7,8 @@ import type { Metrics } from '../metrics';
 import { handleErrorStatus } from './http-util';
 
 const API_PATH_START = /\/(rest\/api|api\/v2)\//;
+const MAX_REDIRECTS = 10;
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
 /**
  * Extracts a short, normalized endpoint from a full Confluence URL.
@@ -38,14 +40,17 @@ export class RateLimitedHttpClient {
   private readonly logger = new Logger(RateLimitedHttpClient.name);
   private readonly limiter: Bottleneck;
   private readonly dispatcher: Dispatcher;
+  private readonly redirectDispatcher: Dispatcher;
 
   public constructor(
     ratePerMinute: number,
     private readonly metrics: Metrics,
     dispatcher?: Dispatcher,
   ) {
-    this.dispatcher = (dispatcher ?? new Agent()).compose([
-      interceptors.redirect({ maxRedirections: 10 }),
+    const baseDispatcher = dispatcher ?? new Agent();
+    this.dispatcher = baseDispatcher.compose([interceptors.retry()]);
+    this.redirectDispatcher = baseDispatcher.compose([
+      interceptors.redirect({ maxRedirections: MAX_REDIRECTS }),
       interceptors.retry(),
     ]);
 
@@ -59,7 +64,9 @@ export class RateLimitedHttpClient {
   }
 
   public async rateLimitedRequest(url: string, headers: Record<string, string>): Promise<unknown> {
-    const body = await this.executeRequest(url, headers);
+    const body = await this.executeRequest(url, (target) =>
+      this.sendFollowingSameOriginRedirects(target, headers),
+    );
     return body.json();
   }
 
@@ -67,12 +74,51 @@ export class RateLimitedHttpClient {
     url: string,
     headers: Record<string, string>,
   ): Promise<Readable> {
-    return this.executeRequest(url, headers);
+    return this.executeRequest(url, (target) =>
+      request(target, { method: 'GET', headers, dispatcher: this.redirectDispatcher }),
+    );
+  }
+
+  // Undici's redirect interceptor drops the Authorization header whenever a redirect changes origin,
+  // which silently downgrades an authenticated API call to an anonymous one instead of failing.
+  // Same-origin redirects keep the header and are common on context-path deployments, so we follow
+  // those ourselves and surface a cross-origin one as a configuration error.
+  private async sendFollowingSameOriginRedirects(
+    url: string,
+    headers: Record<string, string>,
+  ): Promise<Dispatcher.ResponseData> {
+    let currentUrl = url;
+
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+      const response = await request(currentUrl, {
+        method: 'GET',
+        headers,
+        dispatcher: this.dispatcher,
+      });
+
+      const { location } = response.headers;
+      if (!REDIRECT_STATUS_CODES.has(response.statusCode) || typeof location !== 'string') {
+        return response;
+      }
+
+      const target = new URL(location, currentUrl);
+      if (target.origin !== new URL(currentUrl).origin) {
+        await response.body.dump();
+        throw new Error(
+          `${currentUrl} redirected to a different origin (${target.origin}). Credentials cannot be forwarded across origins, so the request would run unauthenticated. Point the configured baseUrl at ${target.origin} instead.`,
+        );
+      }
+
+      await response.body.dump();
+      currentUrl = target.toString();
+    }
+
+    throw new Error(`${url} exceeded ${MAX_REDIRECTS} redirects`);
   }
 
   private async executeRequest(
     url: string,
-    headers: Record<string, string>,
+    send: (url: string) => Promise<Dispatcher.ResponseData>,
   ): Promise<Dispatcher.ResponseData['body']> {
     return this.limiter.schedule(async () => {
       const startTime = Date.now();
@@ -80,11 +126,7 @@ export class RateLimitedHttpClient {
       let statusCode: number | undefined;
 
       try {
-        const response = await request(url, {
-          method: 'GET',
-          headers,
-          dispatcher: this.dispatcher,
-        });
+        const response = await send(url);
 
         statusCode = response.statusCode;
         await handleErrorStatus(response.statusCode, response.body, url);

--- a/services/confluence-connector/src/utils/zod.util.ts
+++ b/services/confluence-connector/src/utils/zod.util.ts
@@ -21,13 +21,16 @@ const envResolvableStringSchema = z.string().transform((val) => {
   return process.env[varName] ?? '';
 });
 
+// Secrets injected through Kubernetes secrets or `.env` files routinely carry a trailing newline,
+// which is invisible in config but makes Confluence reject the credentials with a bare 401.
 export const envRequiredSecretSchema = envResolvableStringSchema
-  .pipe(z.string().nonempty())
+  .pipe(z.string().trim().nonempty())
   .transform((val) => new Redacted(val));
 
-export const envRequiredPlainSchema = envResolvableStringSchema.pipe(z.string().nonempty());
+export const envRequiredPlainSchema = envResolvableStringSchema.pipe(z.string().trim().nonempty());
 
 export const redactedNonEmptyStringSchema = z
   .string()
+  .trim()
   .nonempty()
   .transform((val) => new Redacted(val));


### PR DESCRIPTION
Found while investigating UN-23909 (client sync failing with `401 AUTHENTICATED_FAILED`).

## Credentials were silently dropped across redirects

Undici's redirect interceptor drops `Authorization` on any origin change, including a bare scheme or port change. The request then continued **anonymously instead of failing**, so against an instance with anonymous access enabled we would ingest whatever the anonymous user can see rather than error out.

Reproduced against a local Confluence DC 8.5.18 behind a redirector: the request arrived as `{"type":"anonymous"}` while `curl -L -u` stayed authenticated.

JSON API calls now follow same-origin redirects themselves (context-path deployments rely on these) and fail with an actionable message on a cross-origin one. Attachment streaming keeps the interceptor, because Cloud downloads redirect to a presigned media URL on another origin where stripping the header is required.

## Secrets kept their trailing newline

`envRequiredSecretSchema` did not trim, so a Kubernetes secret created with `--from-file` or a heredoc carried a `\n` into the Basic header. Confluence rejects that with `AUTHENTICATED_FAILED`, identical to a wrong password and invisible in config. Usernames were already trimmed; passwords, tokens and the proxy password now are too.

Verified end to end against a live Confluence DC.
