### PR TITLE
build(confluence-connector,outlook-semantic-mcp,sharepoint-connector,teams-mcp): upgrade AzureRM provider to v5

### DIFF
--- a/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
+++ b/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
   }
 }

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
     time = {
       source  = "hashicorp/time"

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
     random = {
       source  = "hashicorp/random"

--- a/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
+++ b/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
     time = {
       source  = "hashicorp/time"

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4"
+      version = "~> 5"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary
- Upgrade the AzureRM provider constraint from v4 to v5 across the Confluence, Outlook, SharePoint, and Teams Azure deployments.

## Changes
- Update secret deployment provider constraints for all four connectors.
- Update Entra application provider constraints for Outlook and Teams.

## Test plan
- [x] Run `terraform fmt -check` on all six changed `versions.tf` files.
- [x] Verify the PR title type and scopes against `.gitcommitizen` and the changed paths.

## Risk / rollout
- AzureRM v5 contains breaking provider changes; review generated Terraform plans before applying.
- Roll back by restoring the v4 provider constraints.

Refs: [UN-24043](https://unique-ag.atlassian.net/browse/UN-24043)

Made with [Cursor](https://cursor.com)

[UN-24043]: https://unique-ch.atlassian.net/browse/UN-24043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ