### PR TITLE
feat(teams-mcp): surface clear error when Graph transcript access is disabled

### DIFF
--- a/services/teams-mcp/src/transcript/subscription-create.service.ts
+++ b/services/teams-mcp/src/transcript/subscription-create.service.ts
@@ -8,6 +8,10 @@ import { MAIN_EXCHANGE } from '~/amqp/amqp.constants';
 import { DRIZZLE, type DrizzleDatabase, subscriptions, userProfiles } from '~/drizzle';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import {
+  GraphTranscriptAccessDisabledException,
+  isGraphAccessToTranscriptsDisabled,
+} from '~/utils/graph-transcript-access';
+import {
   CreateSubscriptionRequestSchema,
   Subscription,
   SubscriptionRequestedEventDto,
@@ -227,7 +231,17 @@ export class SubscriptionCreateService {
     );
 
     const client = this.graphClientFactory.createClientForUser(userProfileId.toString());
-    const graphResponse = (await client.api('/subscriptions').post(payload)) as unknown;
+    let graphResponse: unknown;
+    try {
+      graphResponse = (await client.api('/subscriptions').post(payload)) as unknown;
+    } catch (error) {
+      if (isGraphAccessToTranscriptsDisabled(error)) {
+        throw new GraphTranscriptAccessDisabledException(
+          error instanceof Error ? error.message : undefined,
+        );
+      }
+      throw error;
+    }
     const graphSubscription = await Subscription.parseAsync(graphResponse);
 
     span?.setAttribute('graph_subscription.id', graphSubscription.id);

--- a/services/teams-mcp/src/transcript/subscription-reauthorize.service.ts
+++ b/services/teams-mcp/src/transcript/subscription-reauthorize.service.ts
@@ -7,6 +7,10 @@ import { MAIN_EXCHANGE } from '~/amqp/amqp.constants';
 import { DRIZZLE, type DrizzleDatabase, subscriptions } from '~/drizzle';
 import { GraphClientFactory } from '~/msgraph/graph-client.factory';
 import {
+  GraphTranscriptAccessDisabledException,
+  isGraphAccessToTranscriptsDisabled,
+} from '~/utils/graph-transcript-access';
+import {
   ReauthorizationRequiredEventDto,
   Subscription,
   UpdateSubscriptionRequestSchema,
@@ -121,9 +125,17 @@ export class SubscriptionReauthorizeService {
     );
 
     const client = this.graphClientFactory.createClientForUser(subscription.userProfileId);
-    const graphResponse = (await client
-      .api(`/subscriptions/${subscriptionId}`)
-      .patch(payload)) as unknown;
+    let graphResponse: unknown;
+    try {
+      graphResponse = (await client.api(`/subscriptions/${subscriptionId}`).patch(payload)) as unknown;
+    } catch (error) {
+      if (isGraphAccessToTranscriptsDisabled(error)) {
+        throw new GraphTranscriptAccessDisabledException(
+          error instanceof Error ? error.message : undefined,
+        );
+      }
+      throw error;
+    }
     const graphSubscription = await Subscription.parseAsync(graphResponse);
 
     span?.addEvent('Graph API subscription updated', {

--- a/services/teams-mcp/src/transcript/subscription-reauthorize.service.ts
+++ b/services/teams-mcp/src/transcript/subscription-reauthorize.service.ts
@@ -127,7 +127,9 @@ export class SubscriptionReauthorizeService {
     const client = this.graphClientFactory.createClientForUser(subscription.userProfileId);
     let graphResponse: unknown;
     try {
-      graphResponse = (await client.api(`/subscriptions/${subscriptionId}`).patch(payload)) as unknown;
+      graphResponse = (await client
+        .api(`/subscriptions/${subscriptionId}`)
+        .patch(payload)) as unknown;
     } catch (error) {
       if (isGraphAccessToTranscriptsDisabled(error)) {
         throw new GraphTranscriptAccessDisabledException(

--- a/services/teams-mcp/src/utils/graph-error.filter.ts
+++ b/services/teams-mcp/src/utils/graph-error.filter.ts
@@ -7,6 +7,11 @@ import {
   Logger,
 } from '@nestjs/common';
 import type { Response } from 'express';
+import {
+  GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED,
+  GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE,
+  isGraphAccessToTranscriptsDisabled,
+} from './graph-transcript-access';
 
 /**
  * MS Graph SDK bug: `.getStream()` error responses leave `GraphError.body` as
@@ -57,6 +62,11 @@ export class GraphErrorFilter implements ExceptionFilter {
 
     await hydrateStreamBody(exception);
 
+    const transcriptAccessDisabled = isGraphAccessToTranscriptsDisabled(exception);
+    const clientMessage = transcriptAccessDisabled
+      ? GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE
+      : exception.message;
+
     const formattedCode = exception.code ? `[${exception.code ?? ''}] ` : ' ';
     this.logger.error(
       {
@@ -66,8 +76,9 @@ export class GraphErrorFilter implements ExceptionFilter {
         date: exception.date,
         body: exception.body,
         message: exception.message,
+        transcriptAccessDisabled,
       },
-      `${formattedCode}Microsoft Graph API: ${exception.message}`,
+      `${formattedCode}Microsoft Graph API: ${clientMessage}`,
     );
 
     // Pass through the Graph API status code so MCP clients can react appropriately —
@@ -78,8 +89,8 @@ export class GraphErrorFilter implements ExceptionFilter {
     const statusCode = isValidHttpStatus ? exception.statusCode : HttpStatus.INTERNAL_SERVER_ERROR;
     response.status(statusCode).json({
       error: 'Microsoft Graph API Error',
-      code: exception.code,
-      message: exception.message,
+      code: transcriptAccessDisabled ? GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED : exception.code,
+      message: clientMessage,
       requestId: exception.requestId,
       timestamp: exception.date?.toISOString(),
     });

--- a/services/teams-mcp/src/utils/graph-transcript-access.spec.ts
+++ b/services/teams-mcp/src/utils/graph-transcript-access.spec.ts
@@ -1,0 +1,84 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED,
+  GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE,
+  GraphTranscriptAccessDisabledException,
+  isGraphAccessToTranscriptsDisabled,
+} from './graph-transcript-access';
+
+function graphErrorWithBody(partial: {
+  statusCode: number;
+  code?: string | null;
+  message: string;
+  body?: string | null;
+}): GraphError {
+  const error = new GraphError(partial.statusCode, partial.message);
+  error.code = partial.code ?? null;
+  error.body = partial.body ?? null;
+  return error;
+}
+
+describe('graph-transcript-access', () => {
+  describe('isGraphAccessToTranscriptsDisabled', () => {
+    it('returns true when innerError.code is GraphAccessToTranscriptsDisabled', () => {
+      const error = graphErrorWithBody({
+        statusCode: 403,
+        code: 'Forbidden',
+        message: 'Graph API access to transcripts is disabled for this tenant.',
+        body: JSON.stringify({
+          code: 'Forbidden',
+          message: 'Graph API access to transcripts is disabled for this tenant.',
+          innerError: { code: GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED },
+        }),
+      });
+
+      expect(isGraphAccessToTranscriptsDisabled(error)).toBe(true);
+    });
+
+    it('returns true when body is missing but status and message match', () => {
+      const error = graphErrorWithBody({
+        statusCode: 403,
+        code: 'Forbidden',
+        message: 'Graph API access to transcripts is disabled for this tenant.',
+      });
+
+      expect(isGraphAccessToTranscriptsDisabled(error)).toBe(true);
+    });
+
+    it('returns false for other 403 Graph errors', () => {
+      const error = graphErrorWithBody({
+        statusCode: 403,
+        code: 'Forbidden',
+        message: 'Access denied',
+        body: JSON.stringify({
+          code: 'Forbidden',
+          message: 'Access denied',
+          innerError: { code: 'AccessDenied' },
+        }),
+      });
+
+      expect(isGraphAccessToTranscriptsDisabled(error)).toBe(false);
+    });
+
+    it('returns false for non-GraphError values', () => {
+      expect(isGraphAccessToTranscriptsDisabled(new Error('boom'))).toBe(false);
+      expect(isGraphAccessToTranscriptsDisabled(null)).toBe(false);
+    });
+  });
+
+  describe('GraphTranscriptAccessDisabledException', () => {
+    it('includes actionable guidance and optional Graph cause', () => {
+      const exception = new GraphTranscriptAccessDisabledException(
+        'Graph API access to transcripts is disabled for this tenant.',
+      );
+
+      expect(exception).toBeInstanceOf(GraphTranscriptAccessDisabledException);
+      expect(exception.message).toContain(GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE);
+      expect(exception.message).toContain(
+        'Graph API access to transcripts is disabled for this tenant.',
+      );
+      expect(exception.message).toContain('Unique cannot enable this setting via OAuth');
+    });
+  });
+});

--- a/services/teams-mcp/src/utils/graph-transcript-access.ts
+++ b/services/teams-mcp/src/utils/graph-transcript-access.ts
@@ -1,0 +1,76 @@
+import { GraphError } from '@microsoft/microsoft-graph-client';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+/** Microsoft Graph `innerError.code` when tenant transcript API access is off. */
+export const GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED = 'GraphAccessToTranscriptsDisabled';
+
+/**
+ * Actionable guidance when Graph returns {@link GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED}.
+ * Re-consent will not fix this.
+ */
+export const GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE =
+  'Microsoft Graph access to meeting transcripts is disabled for this tenant. ' +
+  'Entra admin consent alone is not enough — a Teams or Global admin must enable ' +
+  'Microsoft Graph access under Teams admin center → Meetings → Meeting settings → ' +
+  'Transcript API access (or run: Set-CsTeamsMeetingConfiguration -Identity Global ' +
+  '-EnableGraphTranscriptAccess $true). Optionally enable speaker attribution ' +
+  '(-EnableAttributedTranscripts $true). After enabling, wait a few minutes, then call ' +
+  'start_kb_integration again and confirm with verify_kb_integration_status. ' +
+  'Unique cannot enable this setting via OAuth.';
+
+/**
+ * Thrown when Graph returns `GraphAccessToTranscriptsDisabled` so MCP clients get a
+ * clear JSON-RPC error instead of a generic consent / re-auth hint.
+ */
+export class GraphTranscriptAccessDisabledException extends McpError {
+  public constructor(cause?: string) {
+    const message = cause
+      ? `${GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE} (Graph: ${cause})`
+      : GRAPH_TRANSCRIPT_ACCESS_DISABLED_MESSAGE;
+    super(ErrorCode.InternalError, message);
+    this.name = 'GraphTranscriptAccessDisabledException';
+  }
+}
+
+function getGraphInnerErrorCode(error: GraphError): string | undefined {
+  if (typeof error.body !== 'string' || error.body.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(error.body);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return undefined;
+    }
+
+    const innerError = (parsed as { innerError?: unknown }).innerError;
+    if (typeof innerError !== 'object' || innerError === null) {
+      return undefined;
+    }
+
+    const code = (innerError as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Detects the tenant-wide Teams Graph transcript access toggle being off.
+ * Prefer `innerError.code`; fall back to status + message when body is missing.
+ */
+export function isGraphAccessToTranscriptsDisabled(error: unknown): boolean {
+  if (!(error instanceof GraphError)) {
+    return false;
+  }
+
+  if (getGraphInnerErrorCode(error) === GRAPH_ACCESS_TO_TRANSCRIPTS_DISABLED) {
+    return true;
+  }
+
+  return (
+    error.statusCode === 403 &&
+    typeof error.message === 'string' &&
+    error.message.toLowerCase().includes('graph api access to transcripts is disabled')
+  );
+}


### PR DESCRIPTION
## Summary
- Detects Microsoft Graph `GraphAccessToTranscriptsDisabled` (tenant `EnableGraphTranscriptAccess` off) and throws `GraphTranscriptAccessDisabledException` with actionable Teams admin / PowerShell guidance.
- Applies on transcript subscription create and renew, and enriches HTTP `GraphErrorFilter` responses so clients are not steered toward re-consent.
- Docs for the toggle live in a separate PR: https://github.com/Unique-AG/connectors/pull/761

Related to UN-23713 (nice-to-have error messaging).

## Test plan
- [ ] Unit tests for `isGraphAccessToTranscriptsDisabled` / exception message pass
- [ ] With Graph transcript access off, `start_kb_integration` returns the actionable error (not a generic consent/re-auth hint)
- [ ] With access on, subscription create/renew unchanged
- [ ] HTTP Graph 403 for this code surfaces `GraphAccessToTranscriptsDisabled` and the guidance message


Made with [Cursor](https://cursor.com)