### PR TITLE
fix(teams-mcp): allow azurerm v4 or v5 (>= 4, < 6) in entra module

### DIFF
--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
@@ -6,8 +6,12 @@ terraform {
       version = "~> 3"
     }
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4 — the infrastructure identity stack pins
+      # azurerm ~> 4.15 — so keep it compatible with both until the estate migrates.
+      version = ">= 4, < 6"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## What

Change the teams-mcp entra-application Terraform module's `azurerm` provider constraint from `~> 5` to `>= 4, < 6` (allow v4 **or** v5, exclude v6+).

## Why

`teams-mcp@0.4.3` bumped this module's `azurerm` requirement to `~> 5` (Dependabot #744). `~> 5` **excludes** v4, so any consuming stack still on azurerm v4 can no longer resolve providers. The infrastructure identity stack pins `azurerm ~> 4.15`, so pinning that stack's `teams_mcp` module to `0.4.3` makes `terraform init` fail:

```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/azurerm:
no available releases match the given constraints ~> 4.0, ~> 5.0
```

This surfaced on infrastructure PR [#3504](https://github.com/Unique-AG/infrastructure/pull/3504) (the UN-23436 ingestion-only app), which pins `teams-mcp@0.4.3`.

The module uses azurerm **only** for `azurerm_key_vault_secret`, whose schema is identical across v4 and v5. Allowing both majors keeps it consumable by the current estate (v4.15, where the constraint intersects to a v4.x) and by a future v5 migration — without forcing either.

## Verification

- `terraform init -backend=false` (clean `.terraform`) ✅ → `>= 4.0.0, < 6.0.0` resolves; intersects to azurerm v4.x inside the v4.15-pinned identity stack
- `terraform validate` ✅ · `terraform fmt -check` ✅

## Follow-up

- Once released (patch → `teams-mcp@0.4.4`), infrastructure #3504 repins from `0.4.3` to `0.4.4`.
- Sibling connectors modules (outlook-semantic-mcp, sharepoint-connector) are still `~> 4`; applying the same `>= 4, < 6` range there would pre-empt the same break when Dependabot bumps them (out of scope here).
