### PR TITLE
fix(confluence-connector,outlook-semantic-mcp,sharepoint-connector,teams-mcp): allow azurerm v4 or v5 (>= 4, < 6) in remaining modules

### DIFF
--- a/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
+++ b/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
@@ -2,11 +2,7 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4, so keep it compatible with both until
-      # the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
   }

--- a/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
+++ b/services/confluence-connector/deploy/terraform/azure/confluence-connector-secrets/versions.tf
@@ -2,8 +2,12 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4, so keep it compatible with both until
+      # the estate migrates.
+      version = ">= 4, < 6"
     }
   }
 }

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
@@ -6,8 +6,12 @@ terraform {
       version = "~> 3"
     }
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4 — the infrastructure identity stack pins
+      # azurerm ~> 4.15 — so keep it compatible with both until the estate migrates.
+      version = ">= 4, < 6"
     }
     time = {
       source  = "hashicorp/time"

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-entra-application/versions.tf
@@ -6,11 +6,7 @@ terraform {
       version = "~> 3"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4 — the infrastructure identity stack pins
-      # azurerm ~> 4.15 — so keep it compatible with both until the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
     time = {

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
@@ -2,11 +2,7 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4, so keep it compatible with both until
-      # the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
     random = {

--- a/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
+++ b/services/outlook-semantic-mcp/deploy/terraform/azure/outlook-semantic-mcp-secrets/versions.tf
@@ -2,8 +2,12 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4, so keep it compatible with both until
+      # the estate migrates.
+      version = ">= 4, < 6"
     }
     random = {
       source  = "hashicorp/random"

--- a/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
+++ b/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
@@ -2,8 +2,12 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4, so keep it compatible with both until
+      # the estate migrates.
+      version = ">= 4, < 6"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
+++ b/services/sharepoint-connector/deploy/terraform/azure/sharepoint-connector-secrets/versions.tf
@@ -2,11 +2,7 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4, so keep it compatible with both until
-      # the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
     tls = {

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-entra-application/versions.tf
@@ -6,11 +6,7 @@ terraform {
       version = "~> 3"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4 — the infrastructure identity stack pins
-      # azurerm ~> 4.15 — so keep it compatible with both until the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
     time = {

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
@@ -2,11 +2,7 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
-      # whose schema is stable across both majors. A hard `~> 5` made the module
-      # unconsumable by stacks still on v4, so keep it compatible with both until
-      # the estate migrates.
+      source  = "hashicorp/azurerm"
       version = ">= 4, < 6"
     }
     random = {

--- a/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
+++ b/services/teams-mcp/deploy/terraform/azure/teams-mcp-secrets/versions.tf
@@ -2,8 +2,12 @@ terraform {
   required_version = "~> 1.10"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 5"
+      source = "hashicorp/azurerm"
+      # Allow v4 or v5 (not v6+): this module only uses azurerm_key_vault_secret,
+      # whose schema is stable across both majors. A hard `~> 5` made the module
+      # unconsumable by stacks still on v4, so keep it compatible with both until
+      # the estate migrates.
+      version = ">= 4, < 6"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary
- Relax the AzureRM provider constraint from a hard `~> 5` to `>= 4, < 6` in the five remaining Terraform modules bumped in #759, matching the fix already applied to the teams-mcp Entra module in #764.
- These modules only use `azurerm_key_vault_secret`, whose schema is stable across v4 and v5, so a hard v5 pin made them unconsumable by stacks still on azurerm v4 (e.g. the infrastructure identity stack pins `~> 4.15`).
- Also drops the rationale comment that #764 added to the teams-mcp Entra module, keeping all six modules uniform.

## Changes
- `confluence-connector-secrets`, `outlook-semantic-mcp-entra-application`, `outlook-semantic-mcp-secrets`, `sharepoint-connector-secrets`, `teams-mcp-secrets`: `version = ">= 4, < 6"`.
- `teams-mcp-entra-application`: remove constraint rationale comment.

## Test plan
- [x] `terraform fmt -check` passes on all changed `versions.tf` files.
- [x] PR title scopes verified against `.gitcommitizen` and the changed paths.

Refs: [UN-24043](https://unique-ag.atlassian.net/browse/UN-24043)

Made with [Cursor](https://cursor.com)

[UN-24043]: https://unique-ch.atlassian.net/browse/UN-24043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ