### PR TITLE
fix(confluence-connector): resolve basic auth username from env references

### DIFF
--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/values.additional.schema.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/values.additional.schema.json
@@ -119,7 +119,7 @@
                           },
                           "username": {
                             "type": "string",
-                            "description": "Confluence username for Basic auth"
+                            "description": "Confluence username for Basic auth. Use \"os.environ/ENV_VAR_NAME\" to read from environment variable at runtime."
                           },
                           "password": {
                             "type": "string",

--- a/services/confluence-connector/deploy/helm-charts/confluence-connector/values.schema.json
+++ b/services/confluence-connector/deploy/helm-charts/confluence-connector/values.schema.json
@@ -2147,7 +2147,7 @@
                           },
                           "username": {
                             "type": "string",
-                            "description": "Confluence username for Basic auth"
+                            "description": "Confluence username for Basic auth. Use \"os.environ/ENV_VAR_NAME\" to read from environment variable at runtime."
                           },
                           "password": {
                             "type": "string",

--- a/services/confluence-connector/src/auth/confluence-auth/__tests__/confluence-auth.factory.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/__tests__/confluence-auth.factory.spec.ts
@@ -96,7 +96,7 @@ describe('ConfluenceAuthFactory', () => {
         instanceType: 'data-center',
         auth: {
           mode: AuthMode.Basic,
-          username: 'alice',
+          username: new Redacted('alice'),
           password: new Redacted('s3cret'),
         },
       };

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/basic-auth.strategy.spec.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/__tests__/basic-auth.strategy.spec.ts
@@ -16,7 +16,7 @@ describe('BasicAuthStrategy', () => {
   it('returns a Basic authorization header with base64(user:password)', async () => {
     const strategy = new BasicAuthStrategy({
       mode: AuthMode.Basic,
-      username: 'alice',
+      username: new Redacted('alice'),
       password: new Redacted('s3cret'),
     });
 
@@ -28,7 +28,7 @@ describe('BasicAuthStrategy', () => {
   it('returns the same header on multiple calls', async () => {
     const strategy = new BasicAuthStrategy({
       mode: AuthMode.Basic,
-      username: 'bob',
+      username: new Redacted('bob'),
       password: new Redacted('p@ssw0rd'),
     });
 
@@ -41,7 +41,7 @@ describe('BasicAuthStrategy', () => {
   it('correctly encodes credentials containing non-ASCII characters', async () => {
     const strategy = new BasicAuthStrategy({
       mode: AuthMode.Basic,
-      username: 'üser',
+      username: new Redacted('üser'),
       password: new Redacted('päss:wörd'),
     });
 

--- a/services/confluence-connector/src/auth/confluence-auth/strategies/basic-auth.strategy.ts
+++ b/services/confluence-connector/src/auth/confluence-auth/strategies/basic-auth.strategy.ts
@@ -8,7 +8,7 @@ export class BasicAuthStrategy extends ConfluenceAuth {
 
   public constructor(authConfig: BasicAuthConfig) {
     super();
-    const credentials = `${authConfig.username}:${authConfig.password.value}`;
+    const credentials = `${authConfig.username.value}:${authConfig.password.value}`;
     this.header = `Basic ${Buffer.from(credentials, 'utf8').toString('base64')}`;
   }
 

--- a/services/confluence-connector/src/config/__tests__/confluence.schema.spec.ts
+++ b/services/confluence-connector/src/config/__tests__/confluence.schema.spec.ts
@@ -138,5 +138,26 @@ describe('ConfluenceConfigSchema', () => {
 
       delete process.env.TEST_CONFLUENCE_SECRET;
     });
+
+    it('resolves os.environ/ prefix for the basic auth username', () => {
+      process.env.TEST_CONFLUENCE_USERNAME = 'resolved-user';
+
+      const result = ConfluenceConfigSchema.parse({
+        ...baseDataCenterInput,
+        auth: {
+          mode: 'basic',
+          username: 'os.environ/TEST_CONFLUENCE_USERNAME',
+          password: 'my-password',
+        },
+      });
+
+      if (result.auth.mode === 'basic') {
+        expect(result.auth.username.value).toBe('resolved-user');
+        expect(String(result.auth.username)).toBe('[Redacted]');
+        expect(result.auth.password.value).toBe('my-password');
+      }
+
+      delete process.env.TEST_CONFLUENCE_USERNAME;
+    });
   });
 });

--- a/services/confluence-connector/src/config/confluence.schema.ts
+++ b/services/confluence-connector/src/config/confluence.schema.ts
@@ -25,7 +25,7 @@ const patAuth = z.object({
 
 const basicAuth = z.object({
   mode: z.literal(AuthMode.Basic).describe('HTTP Basic username/password (Data Center only)'),
-  username: requiredStringSchema,
+  username: envRequiredSecretSchema,
   password: envRequiredSecretSchema,
 });
 

--- a/services/confluence-connector/src/utils/__tests__/zod.util.spec.ts
+++ b/services/confluence-connector/src/utils/__tests__/zod.util.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  envRequiredPlainSchema,
+  envRequiredSecretSchema,
+  redactedNonEmptyStringSchema,
+} from '../zod.util';
+
+const ENV_VAR = 'ZOD_UTIL_SPEC_SECRET';
+
+describe('credential schemas', () => {
+  afterEach(() => {
+    delete process.env[ENV_VAR];
+  });
+
+  it('strips the trailing newline a Kubernetes secret adds to a password', () => {
+    process.env[ENV_VAR] = 'sup3r-s3cret\n';
+
+    const password = envRequiredSecretSchema.parse(`os.environ/${ENV_VAR}`);
+
+    expect(password.value).toBe('sup3r-s3cret');
+  });
+
+  it('strips surrounding whitespace from an inline secret', () => {
+    expect(envRequiredSecretSchema.parse('  sup3r-s3cret  ').value).toBe('sup3r-s3cret');
+    expect(envRequiredPlainSchema.parse('  plain-value\n')).toBe('plain-value');
+    expect(redactedNonEmptyStringSchema.parse(' proxy-pass\n').value).toBe('proxy-pass');
+  });
+
+  it('rejects a whitespace-only secret', () => {
+    expect(() => envRequiredSecretSchema.parse('   ')).toThrow();
+  });
+});

--- a/services/confluence-connector/src/utils/zod.util.ts
+++ b/services/confluence-connector/src/utils/zod.util.ts
@@ -22,12 +22,13 @@ const envResolvableStringSchema = z.string().transform((val) => {
 });
 
 export const envRequiredSecretSchema = envResolvableStringSchema
-  .pipe(z.string().nonempty())
+  .pipe(z.string().trim().nonempty())
   .transform((val) => new Redacted(val));
 
-export const envRequiredPlainSchema = envResolvableStringSchema.pipe(z.string().nonempty());
+export const envRequiredPlainSchema = envResolvableStringSchema.pipe(z.string().trim().nonempty());
 
 export const redactedNonEmptyStringSchema = z
   .string()
+  .trim()
   .nonempty()
   .transform((val) => new Redacted(val));


### PR DESCRIPTION
Basic auth `username` only accepted a plain string, so `os.environ/VAR` was passed through literally and authentication failed. It now uses `envRequiredSecretSchema`, the same env-resolvable, log-redacted schema as the other credentials.

Also trims surrounding whitespace from credentials, since secrets injected from Kubernetes secrets or `.env` files routinely carry a trailing newline that Confluence rejects with a bare 401.