### PR TITLE
fix(kb-mcp): return ToolResult and wire [sourceN] references [UN-24212]

### DIFF
--- a/services/kb-mcp/src/kb_mcp/main.py
+++ b/services/kb-mcp/src/kb_mcp/main.py
@@ -8,7 +8,7 @@ from unique_mcp.monitoring import setup_ops
 from unique_toolkit.monitoring import configure_tracing
 
 from kb_mcp.auth import build_auth
-from kb_mcp.references import SERVER_CITATION_INSTRUCTIONS
+from kb_mcp.references import SERVER_INSTRUCTIONS_CITATION_GUIDANCE
 from kb_mcp.settings import ENV_FILE, get_settings
 
 
@@ -27,7 +27,7 @@ def main() -> None:
 
     mcp = FastMCP(
         "Knowledge Base Search",
-        instructions=SERVER_CITATION_INSTRUCTIONS,
+        instructions=SERVER_INSTRUCTIONS_CITATION_GUIDANCE,
         auth=oidc_proxy,
         providers=[FileSystemProvider(Path(__file__).parent / "tools")],
     )

--- a/services/kb-mcp/src/kb_mcp/references.py
+++ b/services/kb-mcp/src/kb_mcp/references.py
@@ -89,14 +89,12 @@ TOOL_DESCRIPTION_CITATION_GUIDANCE = (
     "Never alter unique:// or https:// URLs from the result headers."
 )
 
-# Unique-host only (`unique.app/tool-format-information`). Mirrors the
-# emphatic tone of Internal Search's own format info
-# (unique_internal_search.prompts.DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT),
-# which has no competing citation text elsewhere. kb-mcp's description still
-# carries TOOL_DESCRIPTION_CITATION_GUIDANCE, so this has to be at least as
-# forceful to win out for Unique AI. Wording is deliberately verbatim-close
-# to Internal Search's own — proven reliable there; keep it that way rather
-# than tuning it further (see UN-24212 history for what didn't work).
+# Unique-host only (`unique.app/tool-format-information`). Kept verbatim-close
+# to Internal Search's own format info
+# (unique_internal_search.prompts.DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT)
+# — that wording is proven reliable there, and edits here (e.g. loosening it
+# for other tools) have measurably regressed search's own citation rate, so
+# don't tune this without re-testing search specifically.
 UNIQUE_AI_TOOL_FORMAT_INFORMATION = (
     "Whenever you use information retrieved with this search tool, you must "
     "adhere to strict reference guidelines. You must strictly reference each "
@@ -146,13 +144,11 @@ UNIQUE_AI_RESULT_CITATION_INSTRUCTION = (
     "markers as clickable references automatically."
 )
 
-# Server-wide `instructions` field — static, sent to every client regardless
-# of who's calling, so (like TOOL_DESCRIPTION_CITATION_GUIDANCE) it must defer
-# to a stronger, client-specific instruction when one exists. Also the only
-# citation guidance content_tree and read_file get (their own descriptions
-# just have a casual one-liner) — search additionally reinforces this
-# per-call via citation_instruction_content, so keep this tool-neutral
-# rather than search-flavored.
+# Server-wide `instructions` field — static, sent to every client, so (like
+# TOOL_DESCRIPTION_CITATION_GUIDANCE) it must defer to a stronger,
+# client-specific instruction when one exists. It's also the only citation
+# guidance content_tree/read_file get (their descriptions just have a casual
+# one-liner), so keep this tool-neutral rather than search-flavored.
 SERVER_INSTRUCTIONS_CITATION_GUIDANCE = (
     "If your system prompt or a tool result instructs you to cite with "
     "'[source<number>]' markers instead, follow that guidance — it takes "

--- a/services/kb-mcp/src/kb_mcp/references.py
+++ b/services/kb-mcp/src/kb_mcp/references.py
@@ -94,9 +94,11 @@ TOOL_DESCRIPTION_CITATION_GUIDANCE = (
 # (unique_internal_search.prompts.DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT),
 # which has no competing citation text elsewhere. kb-mcp's description still
 # carries TOOL_DESCRIPTION_CITATION_GUIDANCE, so this has to be at least as
-# forceful to win out for Unique AI.
+# forceful to win out for Unique AI. Wording is deliberately verbatim-close
+# to Internal Search's own — proven reliable there; keep it that way rather
+# than tuning it further (see UN-24212 history for what didn't work).
 UNIQUE_AI_TOOL_FORMAT_INFORMATION = (
-    "Whenever you use information retrieved with this tool, you must "
+    "Whenever you use information retrieved with this search tool, you must "
     "adhere to strict reference guidelines. You must strictly reference each "
     "fact used with the `source_number` of the corresponding passage, in the "
     "following format: '[source<source_number>]'.\n\n"
@@ -105,13 +107,6 @@ UNIQUE_AI_TOOL_FORMAT_INFORMATION = (
     "- The policy requires dual approval [source2][source3].\n\n"
     "A fact is preferably referenced by ONLY ONE source, e.g [sourceX], which "
     "should be the most relevant source for the fact.\n"
-    "This applies even when the tool call response contains only a single "
-    "source_number — cite it too; a single source is not a reason to skip "
-    "citation.\n"
-    "This also applies when you summarize an entire document rather than "
-    "listing individual facts: still include that source_number at least "
-    "once, e.g. in your first sentence — a summary is not a reason to skip "
-    "citation either.\n"
     "Follow these guidelines closely and be sure to use the proper "
     "`source_number` when referencing facts.\n"
     "Make sure that your reference follows the format [sourceX] and that the "

--- a/services/kb-mcp/src/kb_mcp/references.py
+++ b/services/kb-mcp/src/kb_mcp/references.py
@@ -14,16 +14,23 @@ Referencing style
      when the frontend base URL and scope id are known.
    - Otherwise fall back to ``unique://content/{contentId}`` (resolved by the
      Unique platform frontend).
-2. **Text layer** (for the LLM): each result is prefixed with a ready-to-use
-   markdown citation link
+2. **Text layer** (generic MCP clients): each result is prefixed with a
+   ready-to-use markdown citation link
 
        [Quarterly Report 2025.pdf](https://<identifier>.unique.app/knowledge-upload/…?file=…)
        (pages 12-14)
 
    so models can paste the link inline instead of inventing ``[sourceN]`` tags.
+   Surfaced via MCP ``description``, result headers, and trailing citation
+   instruction.
 3. **Structured layer** (``search`` only): each content item carries a
    ``unique.app/reference`` entry in its ``_meta``, always using the
-   ``unique://content/{id}`` scheme for KB docs.
+   ``unique://content/{id}`` scheme for KB docs. Unique AI rehydrates these
+   into ``content_chunks`` / ``[sourceN]`` markers.
+4. **Unique-host format info** (``unique.app/tool-format-information``, i.e.
+   ``UNIQUE_AI_TOOL_FORMAT_INFORMATION``): teaches Unique AI to cite with
+   ``[sourceN]`` from tool results — not markdown deep links. MCP
+   ``description`` stays on the generic path.
 """
 
 from __future__ import annotations
@@ -32,16 +39,45 @@ import logging
 from typing import Any, cast
 from urllib.parse import quote
 
+from fastmcp.server.dependencies import get_context
 from mcp.types import TextContent
 from unique_toolkit.content.schemas import ContentChunk
 
 _LOGGER = logging.getLogger(__name__)
 
+# Set by node-chat's own MCP client (see ExtendedMcpServer.connect). This is
+# the core MCP `initialize` field `clientInfo.name`, not a namespaced `_meta`
+# extra, so it's a reliable way to tell Unique AI apart from a generic client
+# (Claude Desktop/Code, MCP Inspector) without needing per-server admin config.
+_UNIQUE_AI_CLIENT_NAME_PREFIX = "unique-ai-mcp-client-module-"
+
+
+def is_unique_ai_client() -> bool:
+    """True when the connected MCP client is node-chat's own client."""
+    try:
+        ctx = get_context()
+    except (RuntimeError, LookupError):
+        return False
+    if ctx is None:
+        return False
+    client_params = ctx.session.client_params
+    if client_params is None:
+        return False
+    return client_params.clientInfo.name.startswith(_UNIQUE_AI_CLIENT_NAME_PREFIX)
+
+
 REFERENCE_META_KEY = "unique.app/reference"
 
-# Surfaced via tool meta, description, and a trailing result block.
-REFERENCE_FORMAT_INFORMATION = (
-    "Each search result starts with a markdown citation link of the form "
+# Injected into the tool `description`, seen by every client. The opening
+# deferral clause is required: without it, this flatly contradicts
+# UNIQUE_AI_TOOL_FORMAT_INFORMATION for Unique AI's own calls, and its
+# "do NOT use [sourceN]" prohibition would win by being the text closest to
+# where the model decides how to call the tool.
+TOOL_DESCRIPTION_CITATION_GUIDANCE = (
+    "If your system prompt or the tool result instructs you to cite with "
+    "'[source<number>]' markers instead, follow that guidance — it takes "
+    "precedence over everything below. Otherwise: each search result starts "
+    "with a markdown citation link of the form "
     "'[<document name>](<document URL>)' (optional page range on the next line). "
     "When you use information from a result, cite it inline by pasting that "
     "exact markdown link immediately after the claim — for example "
@@ -53,18 +89,84 @@ REFERENCE_FORMAT_INFORMATION = (
     "Never alter unique:// or https:// URLs from the result headers."
 )
 
-CITATION_RESULT_INSTRUCTION = (
+# Unique-host only (`unique.app/tool-format-information`). Mirrors the
+# emphatic tone of Internal Search's own format info
+# (unique_internal_search.prompts.DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT),
+# which has no competing citation text elsewhere. kb-mcp's description still
+# carries TOOL_DESCRIPTION_CITATION_GUIDANCE, so this has to be at least as
+# forceful to win out for Unique AI.
+UNIQUE_AI_TOOL_FORMAT_INFORMATION = (
+    "Whenever you use information retrieved with this tool, you must "
+    "adhere to strict reference guidelines. You must strictly reference each "
+    "fact used with the `source_number` of the corresponding passage, in the "
+    "following format: '[source<source_number>]'.\n\n"
+    "Example:\n"
+    "- Revenue grew 10% [source0] and headcount doubled [source1].\n"
+    "- The policy requires dual approval [source2][source3].\n\n"
+    "A fact is preferably referenced by ONLY ONE source, e.g [sourceX], which "
+    "should be the most relevant source for the fact.\n"
+    "This applies even when the tool call response contains only a single "
+    "source_number — cite it too; a single source is not a reason to skip "
+    "citation.\n"
+    "This also applies when you summarize an entire document rather than "
+    "listing individual facts: still include that source_number at least "
+    "once, e.g. in your first sentence — a summary is not a reason to skip "
+    "citation either.\n"
+    "Follow these guidelines closely and be sure to use the proper "
+    "`source_number` when referencing facts.\n"
+    "Make sure that your reference follows the format [sourceX] and that the "
+    "source number is correct. Source is written in singular form and the "
+    "number is written in digits.\n\n"
+    "IT IS VERY IMPORTANT TO FOLLOW THESE GUIDELINES!!\n"
+    "NEVER CITE A source_number THAT YOU DON'T SEE IN THE TOOL CALL "
+    "RESPONSE!!!\n"
+    "The source_number in old assistant messages are no longer valid — this "
+    "has to be the number you find in the message with role 'tool'.\n"
+    "Do not paste knowledge-upload or unique:// URLs into the answer and do "
+    "not add a Sources list — the platform resolves [sourceN] markers to "
+    "clickable references automatically."
+)
+
+SEARCH_SYSTEM_PROMPT = (
+    "Use this tool to search the Unique knowledge base for passages that answer "
+    "the user's question. Prefer it when the answer may live in company "
+    "documents, policies, or uploaded files. Pass a focused search_string; "
+    "split distinct facts into separate calls when needed."
+)
+
+# Trailing content block, generic clients (Claude Desktop/Code, Inspector —
+# anything without Unique's chat-side [sourceN] → reference resolution).
+GENERIC_RESULT_CITATION_INSTRUCTION = (
     "How to cite: paste the exact [<document name>](<url>) markdown links from "
     "the result headers inline after each claim. Do not write [sourceN] or other "
     "bracket placeholders. End with a Sources list using those same markdown links."
 )
 
-SERVER_CITATION_INSTRUCTIONS = (
-    "This server searches the Unique knowledge base. When answering from search "
-    "results, cite sources inline by pasting the exact markdown links "
-    "[document name](url) provided in each result header. Never use [sourceN] "
-    "placeholders. End with a Sources section listing the cited documents as "
-    "those same markdown links."
+# Same trailing block, selected instead when is_unique_ai_client() is true.
+UNIQUE_AI_RESULT_CITATION_INSTRUCTION = (
+    "How to cite: reference each result using its `source_number` as "
+    "'[source<source_number>]' immediately after the claim it supports. Do "
+    "not paste document names, markdown links, or URLs into your answer, and "
+    "do not add a separate Sources list — the platform renders [sourceN] "
+    "markers as clickable references automatically."
+)
+
+# Server-wide `instructions` field — static, sent to every client regardless
+# of who's calling, so (like TOOL_DESCRIPTION_CITATION_GUIDANCE) it must defer
+# to a stronger, client-specific instruction when one exists. Also the only
+# citation guidance content_tree and read_file get (their own descriptions
+# just have a casual one-liner) — search additionally reinforces this
+# per-call via citation_instruction_content, so keep this tool-neutral
+# rather than search-flavored.
+SERVER_INSTRUCTIONS_CITATION_GUIDANCE = (
+    "If your system prompt or a tool result instructs you to cite with "
+    "'[source<number>]' markers instead, follow that guidance — it takes "
+    "precedence over the rest of this. Otherwise: this server gives access "
+    "to the Unique knowledge base (search, browse, and read files). When "
+    "answering using content from any of its tools, cite sources inline by "
+    "pasting the exact markdown links [document name](url) provided in "
+    "each result header. End with a Sources section listing the cited "
+    "documents as those same markdown links."
 )
 
 
@@ -227,6 +329,17 @@ def chunk_to_text_content(
     )
 
 
-def citation_instruction_content() -> TextContent:
-    """Trailing block that steers the LLM to cite the results above."""
-    return TextContent(type="text", text=CITATION_RESULT_INSTRUCTION)
+def citation_instruction_content(*, is_unique_ai_chat: bool = False) -> TextContent:
+    """Trailing block that steers the LLM to cite the results above.
+
+    ``is_unique_ai_chat`` selects the [sourceN] convention Unique AI's own
+    chat pipeline resolves to clickable references; generic MCP clients
+    (Claude Desktop/Code, Inspector) get the markdown-link instruction
+    instead, since they have no such resolution.
+    """
+    text = (
+        UNIQUE_AI_RESULT_CITATION_INSTRUCTION
+        if is_unique_ai_chat
+        else GENERIC_RESULT_CITATION_INSTRUCTION
+    )
+    return TextContent(type="text", text=text)

--- a/services/kb-mcp/src/kb_mcp/references.py
+++ b/services/kb-mcp/src/kb_mcp/references.py
@@ -58,8 +58,6 @@ def is_unique_ai_client() -> bool:
         ctx = get_context()
     except (RuntimeError, LookupError):
         return False
-    if ctx is None:
-        return False
     client_params = ctx.session.client_params
     if client_params is None:
         return False

--- a/services/kb-mcp/src/kb_mcp/tools/content_tree/tool.py
+++ b/services/kb-mcp/src/kb_mcp/tools/content_tree/tool.py
@@ -9,8 +9,8 @@ import logging
 from typing import Annotated, Literal
 
 from fastmcp.dependencies import Depends
-from fastmcp.tools import tool
-from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from fastmcp.tools import ToolResult, tool
+from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 from unique_mcp import (
     ConfigSchemaMeta,
@@ -162,7 +162,7 @@ async def content_tree(
         ),
     ] = False,
     config: ContentTreeToolConfig = Depends(get_tool_config(ContentTreeToolConfig)),
-) -> CallToolResult:
+) -> ToolResult:
     """Browse the knowledge base's visible file/folder structure. Pick a
     `mode`; only that mode's args below apply, rest ignored. '*' = required.
     - mode='tree': max_depth — first orientation view of folders/files.
@@ -182,8 +182,8 @@ async def content_tree(
     cid: str | None = None
     try:
         if mode == "search" and not query:
-            return CallToolResult(
-                isError=True,
+            return ToolResult(
+                is_error=True,
                 content=[
                     TextContent(
                         type="text",
@@ -224,7 +224,7 @@ async def content_tree(
                 max_concurrent_scope_lookups=config.max_concurrent_scope_lookups,
             )
             _LOGGER.info("content_tree complete correlation_id=%s mode=%s", cid, mode)
-            return CallToolResult(content=[TextContent(type="text", text=text)])
+            return ToolResult(content=[TextContent(type="text", text=text)])
 
         if mode == "list":
             rows = await tree_svc.resolve_visible_file_paths_async(
@@ -257,7 +257,7 @@ async def content_tree(
                 mode,
                 len(rows),
             )
-            return CallToolResult(content=[TextContent(type="text", text=text)])
+            return ToolResult(content=[TextContent(type="text", text=text)])
 
         assert query is not None and mode == "search"
         matches = await tree_svc.search_visible_files_fuzzy_async(
@@ -286,7 +286,7 @@ async def content_tree(
             mode,
             len(matches),
         )
-        return CallToolResult(content=[TextContent(type="text", text=text)])
+        return ToolResult(content=[TextContent(type="text", text=text)])
     except Exception as exc:
         _LOGGER.exception(
             "content_tree error correlation_id=%s mode=%s error_type=%s",
@@ -294,6 +294,6 @@ async def content_tree(
             mode,
             type(exc).__name__,
         )
-        return CallToolResult(
-            isError=True, content=[TextContent(type="text", text=str(exc))]
+        return ToolResult(
+            is_error=True, content=[TextContent(type="text", text=str(exc))]
         )

--- a/services/kb-mcp/src/kb_mcp/tools/content_tree/tool.py
+++ b/services/kb-mcp/src/kb_mcp/tools/content_tree/tool.py
@@ -77,8 +77,12 @@ _META = merge_tool_meta(
     {
         "unique.app/icon": "folder-tree",
         "unique.app/system-prompt": (
-            "Choose this tool to browse or locate files/folders in the "
-            "knowledge base before reading one with the read_file tool."
+            "Choose this tool to browse the knowledge base's folder "
+            "structure, list files, or find a file by its name/path before "
+            "reading it with read_file. Its own mode='search' only "
+            "fuzzy-matches file names/paths — for questions about what a "
+            "document says (a topic, a fact, 'search about X'), use the "
+            "search tool instead, not this one."
         ),
     },
     ContextRequirements(

--- a/services/kb-mcp/src/kb_mcp/tools/read_file/tool.py
+++ b/services/kb-mcp/src/kb_mcp/tools/read_file/tool.py
@@ -11,8 +11,8 @@ from typing import Annotated
 
 import tiktoken
 from fastmcp.dependencies import Depends
-from fastmcp.tools import tool
-from mcp.types import CallToolResult, TextContent, ToolAnnotations
+from fastmcp.tools import ToolResult, tool
+from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field, RootModel, field_validator
 from unique_mcp import (
     ConfigSchemaMeta,
@@ -27,12 +27,12 @@ from unique_toolkit.content.functions import (
     download_content_to_bytes_async,
     search_contents_async,
 )
-from unique_toolkit.content.schemas import Content, ContentChunk
+from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.content.utils import sort_content_chunks
 
 from kb_mcp.correlation import correlation_id
 from kb_mcp.references import file_reference_url, markdown_citation_link
-from kb_mcp.settings import Settings, get_settings
+from kb_mcp.settings import get_settings
 from kb_mcp.tools.read_file.config import ReadFileToolConfig
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,41 +72,15 @@ _META = merge_tool_meta(
 )
 
 
-def _error(text: str) -> CallToolResult:
-    return CallToolResult(isError=True, content=[TextContent(type="text", text=text)])
-
-
-def _with_reference_header(
-    result: CallToolResult, content: Content, settings: Settings
-) -> CallToolResult:
-    """Prefix successful reads with a markdown link that opens the file."""
-    if result.isError or not result.content:
-        return result
-    first = result.content[0]
-    if not isinstance(first, TextContent):
-        return result
-    url = file_reference_url(
-        content.id,
-        metadata=content.metadata,
-        frontend_base_url=settings.frontend_base_url_str(),
-    )
-    header = markdown_citation_link(content.title or content.key, url)
-    prefixed = TextContent(type="text", text=f"{header}\n\n{first.text}")
-    return result.model_copy(update={"content": [prefixed, *result.content[1:]]})
-
-
-def _ok(text: str) -> CallToolResult:
-    return CallToolResult(content=[TextContent(type="text", text=text)])
-
-
 def _render_chunked(
     chunks: list[ContentChunk],
     start_page: int | None,
     end_page: int | None,
     max_tokens_per_call: int,
-) -> CallToolResult:
+) -> tuple[bool, str]:
+    """Return ``(is_error, text)``."""
     if not chunks:
-        return _error("this file hasn't finished processing yet")
+        return True, "this file hasn't finished processing yet"
 
     total_pages = max((c.end_page or c.start_page or 0) for c in chunks)
     if total_pages == 0:
@@ -118,8 +92,8 @@ def _render_chunked(
         full_text = "\n".join(c.text for c in chunks)
         total_tokens = count_tokens(full_text)
         if total_tokens <= max_tokens_per_call:
-            return _ok(_render_with_page_markers(chunks))
-        return _error(
+            return False, _render_with_page_markers(chunks)
+        return True, (
             f"file has ~{total_tokens} tokens across {total_pages} pages; "
             "specify start_page/end_page to read a portion."
         )
@@ -127,7 +101,7 @@ def _render_chunked(
     s = start_page if start_page is not None else 1
     e = end_page if end_page is not None else total_pages
     if s < 1 or s > e or s > total_pages:
-        return _error(
+        return True, (
             f"file has {total_pages} pages; requested range {s}-{e} is out of bounds."
         )
 
@@ -137,7 +111,7 @@ def _render_chunked(
         if (c.start_page or 0) <= e and (c.end_page or c.start_page or 0) >= s
     ]
     if not selected:
-        return _error(
+        return True, (
             f"no content found in pages {s}-{e}; the file's page numbering "
             "may have gaps — try a wider range."
         )
@@ -147,12 +121,12 @@ def _render_chunked(
     if s < e:
         selected_tokens = count_tokens(text)
         if selected_tokens > max_tokens_per_call:
-            return _error(
+            return True, (
                 f"pages {s}-{e} span ~{selected_tokens} tokens, over the "
                 f"{max_tokens_per_call}-token per-call limit; request a "
                 "narrower range (a single page is always allowed)."
             )
-    return _ok(text)
+    return False, text
 
 
 def _render_with_page_markers(chunks: list[ContentChunk]) -> str:
@@ -171,14 +145,15 @@ def _render_text(
     start_page: int | None,
     end_page: int | None,
     max_tokens_per_call: int,
-) -> CallToolResult:
+) -> tuple[bool, str]:
+    """Return ``(is_error, text)``."""
     total_tokens = count_tokens(full_text)
     total_pages = max(1, math.ceil(total_tokens / max_tokens_per_call))
 
     if start_page is None and end_page is None:
         if total_tokens <= max_tokens_per_call:
-            return _ok(full_text)
-        return _error(
+            return False, full_text
+        return True, (
             f"file has ~{total_tokens} tokens (~{total_pages} pages of "
             f"{max_tokens_per_call} tokens each); specify start_page/end_page "
             "to read a portion."
@@ -187,12 +162,12 @@ def _render_text(
     s = start_page if start_page is not None else 1
     e = end_page if end_page is not None else total_pages
     if s < 1 or s > e or s > total_pages:
-        return _error(
+        return True, (
             f"file has {total_pages} pages; requested range {s}-{e} is out of bounds."
         )
     # Virtual pages are sized to max_tokens_per_call, so multi-page ranges overflow.
     if s < e:
-        return _error(
+        return True, (
             f"each virtual page is {max_tokens_per_call} tokens (the per-call "
             f"limit); read one page per call. File has {total_pages} pages."
         )
@@ -200,7 +175,7 @@ def _render_text(
     token_start, token_end = _virtual_page_token_bounds(s, e, max_tokens_per_call)
     slice_text = _slice_by_token_count(full_text, token_start, token_end)
     prefix = f"showing tokens {token_start}-{token_end} of {total_tokens} total"
-    return _ok(f"{prefix}\n\n{slice_text}")
+    return False, f"{prefix}\n\n{slice_text}"
 
 
 def _slice_by_token_count(text: str, token_start: int, token_end: int) -> str:
@@ -246,7 +221,7 @@ async def read_file(
         Field(description="Last page to return (1-indexed), inclusive."),
     ] = None,
     config: ReadFileToolConfig = Depends(get_tool_config(ReadFileToolConfig)),
-) -> CallToolResult:
+) -> ToolResult:
     """Read a specific knowledge-base file's text content. Requires
     `content_id` (from a prior content_tree 'list'/'search' call).
     For large files, pass `start_page`/`end_page` to read a portion — for
@@ -283,7 +258,14 @@ async def read_file(
                 cid,
                 content_id,
             )
-            return _error(f"no content found for content_id={content_id}")
+            return ToolResult(
+                content=[
+                    TextContent(
+                        type="text", text=f"no content found for content_id={content_id}"
+                    )
+                ],
+                is_error=True,
+            )
         content = contents[0]
 
         try:
@@ -296,11 +278,19 @@ async def read_file(
                 cid,
                 content_id,
             )
-            return _error(f"unsupported file type for read_file: {suffix}")
+            return ToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text=f"unsupported file type for read_file: {suffix}",
+                    )
+                ],
+                is_error=True,
+            )
 
         if ext.is_chunked:
             chunks = sort_content_chunks(list(content.chunks))
-            result = _render_chunked(
+            is_error, text = _render_chunked(
                 chunks, start_page, end_page, config.max_tokens_per_call
             )
         else:
@@ -311,17 +301,30 @@ async def read_file(
                 chat_id=None,
             )
             full_text = raw_bytes.decode("utf-8", errors="replace")
-            result = _render_text(
+            is_error, text = _render_text(
                 full_text, start_page, end_page, config.max_tokens_per_call
             )
-        result = _with_reference_header(result, content, kb_settings)
+
         _LOGGER.info(
             "read_file complete correlation_id=%s content_id=%s is_error=%s",
             cid,
             content_id,
-            result.isError,
+            is_error,
         )
-        return result
+        if is_error:
+            return ToolResult(
+                content=[TextContent(type="text", text=text)], is_error=True
+            )
+
+        url = file_reference_url(
+            content.id,
+            metadata=content.metadata,
+            frontend_base_url=kb_settings.frontend_base_url_str(),
+        )
+        header = markdown_citation_link(content.title or content.key, url)
+        return ToolResult(
+            content=[TextContent(type="text", text=f"{header}\n\n{text}")]
+        )
     except Exception as exc:
         _LOGGER.exception(
             "read_file error correlation_id=%s content_id=%s error_type=%s",
@@ -329,6 +332,6 @@ async def read_file(
             content_id,
             type(exc).__name__,
         )
-        return CallToolResult(
-            isError=True, content=[TextContent(type="text", text=str(exc))]
+        return ToolResult(
+            content=[TextContent(type="text", text=str(exc))], is_error=True
         )

--- a/services/kb-mcp/src/kb_mcp/tools/read_file/tool.py
+++ b/services/kb-mcp/src/kb_mcp/tools/read_file/tool.py
@@ -261,7 +261,8 @@ async def read_file(
             return ToolResult(
                 content=[
                     TextContent(
-                        type="text", text=f"no content found for content_id={content_id}"
+                        type="text",
+                        text=f"no content found for content_id={content_id}",
                     )
                 ],
                 is_error=True,

--- a/services/kb-mcp/src/kb_mcp/tools/search/tool.py
+++ b/services/kb-mcp/src/kb_mcp/tools/search/tool.py
@@ -10,11 +10,11 @@ Separation of concerns:
 """
 
 import logging
-from typing import Annotated, cast
+from typing import Annotated
 
 from fastmcp.dependencies import Depends
-from fastmcp.tools import tool
-from mcp.types import CallToolResult, ContentBlock, TextContent, ToolAnnotations
+from fastmcp.tools import ToolResult, tool
+from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 from unique_mcp import (
     ConfigSchemaMeta,
@@ -31,9 +31,12 @@ from unique_toolkit.experimental.components.internal_search import (
 
 from kb_mcp.correlation import correlation_id
 from kb_mcp.references import (
-    REFERENCE_FORMAT_INFORMATION,
+    SEARCH_SYSTEM_PROMPT,
+    TOOL_DESCRIPTION_CITATION_GUIDANCE,
+    UNIQUE_AI_TOOL_FORMAT_INFORMATION,
     chunk_to_text_content,
     citation_instruction_content,
+    is_unique_ai_client,
 )
 from kb_mcp.settings import get_settings
 from kb_mcp.tools.search.config import SearchToolConfig
@@ -44,11 +47,8 @@ _LOGGER = logging.getLogger(__name__)
 _META = merge_tool_meta(
     {
         "unique.app/icon": "search",
-        "unique.app/system-prompt": (
-            "Choose this tool if you need to search in the knowledge base. "
-            + REFERENCE_FORMAT_INFORMATION
-        ),
-        "unique.app/tool-format-information": REFERENCE_FORMAT_INFORMATION,
+        "unique.app/system-prompt": SEARCH_SYSTEM_PROMPT,
+        "unique.app/tool-format-information": UNIQUE_AI_TOOL_FORMAT_INFORMATION,
     },
     ContextRequirements(
         required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
@@ -59,11 +59,11 @@ _META = merge_tool_meta(
 
 @tool(
     name="search",
-    # Not the docstring: this reuses REFERENCE_FORMAT_INFORMATION (also in
-    # _META below), and a literal docstring can't reference a module constant.
+    # Not the docstring: this reuses TOOL_DESCRIPTION_CITATION_GUIDANCE, and a
+    # literal docstring can't reference a module constant.
     description=(
         "Search the knowledge base for the given query and return relevant "
-        "chunks. " + REFERENCE_FORMAT_INFORMATION
+        "chunks. " + TOOL_DESCRIPTION_CITATION_GUIDANCE
     ),
     meta=_META,
     annotations=ToolAnnotations(
@@ -79,7 +79,7 @@ async def search(
         Field(description="The query to search for in the knowledge base."),
     ],
     config: SearchToolConfig = Depends(get_tool_config(SearchToolConfig)),
-) -> CallToolResult:
+) -> ToolResult:
     """Search the knowledge base using ``SearchToolConfig`` from the config meta key."""
     kb_settings = get_settings()
     cid: str | None = None
@@ -108,8 +108,8 @@ async def search(
         _LOGGER.exception(
             "search error correlation_id=%s error_type=%s", cid, type(exc).__name__
         )
-        return CallToolResult(
-            isError=True, content=[TextContent(type="text", text=str(exc))]
+        return ToolResult(
+            content=[TextContent(type="text", text=str(exc))], is_error=True
         )
 
     frontend_base_url = kb_settings.frontend_base_url_str()
@@ -134,7 +134,9 @@ async def search(
         for i, chunk in enumerate(chunks, start=1)
     ]
     if content:
-        content.append(citation_instruction_content())
+        content.append(
+            citation_instruction_content(is_unique_ai_chat=is_unique_ai_client())
+        )
 
     _LOGGER.info("search complete correlation_id=%s result_count=%d", cid, len(chunks))
-    return CallToolResult(content=cast(list[ContentBlock], content))
+    return ToolResult(content=content)

--- a/services/kb-mcp/tests/test_content_tree_tool.py
+++ b/services/kb-mcp/tests/test_content_tree_tool.py
@@ -4,7 +4,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from mcp.types import CallToolResult
+from fastmcp.tools import ToolResult
 from pydantic import SecretStr
 from unique_toolkit.experimental.components.content_tree.schemas import (
     MatchTarget as ServiceMatchTarget,
@@ -100,7 +100,7 @@ async def test_mode_tree_returns_tree_view_only():
             config=ContentTreeToolConfig(),
         )
 
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     text = result.content[0].text  # type: ignore[union-attr]
     assert text == "TREE VIEW"
     assert "list-result" not in text
@@ -133,7 +133,7 @@ async def test_mode_list_returns_list_view_only():
             config=ContentTreeToolConfig(),
         )
 
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     text = result.content[0].text  # type: ignore[union-attr]
     assert "[LIST/VIEW](unique://content/list-result) (content_id=list-result)" in text
     assert "TREE VIEW" not in text
@@ -150,7 +150,7 @@ async def test_mode_search_returns_search_view_only():
             config=ContentTreeToolConfig(),
         )
 
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     text = result.content[0].text  # type: ignore[union-attr]
     assert (
         "[SEARCH/VIEW](unique://content/search-result) "
@@ -169,8 +169,8 @@ async def test_mode_search_without_query_returns_error_without_calling_service()
             config=ContentTreeToolConfig(),
         )
 
-    assert isinstance(result, CallToolResult)
-    assert result.isError is True
+    assert isinstance(result, ToolResult)
+    assert result.is_error is True
     assert result.content[0].text == "query is required when mode='search'"  # type: ignore[union-attr]
     mock_cls.assert_not_called()
 
@@ -286,7 +286,7 @@ async def test_refresh_true_invalidates_caller_cache_only():
 
     mock_tree.invalidate_cache.assert_called_once_with()
     mock_tree.render_visible_tree_async.assert_called_once()
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     assert result.content[0].text == "tree output"  # type: ignore[union-attr]
 
 
@@ -388,7 +388,7 @@ async def test_identity_refusal_surfaces_as_tool_error(identity):
     identity.side_effect = ValueError("Refusing UNIQUE_AUTH_* env fallback")
     result = await content_tree(mode="tree", config=ContentTreeToolConfig())
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "UNIQUE_AUTH_" in result.content[0].text  # type: ignore[union-attr]
 
 

--- a/services/kb-mcp/tests/test_read_file_tool.py
+++ b/services/kb-mcp/tests/test_read_file_tool.py
@@ -69,7 +69,7 @@ async def test_unsupported_extension_returns_error_without_downstream_calls():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "unsupported file type for read_file: .xlsx" in result.content[0].text  # type: ignore[union-attr]
     mock_download.assert_not_called()
 
@@ -90,7 +90,7 @@ async def test_no_content_found_returns_error_without_downstream_calls():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "no content found for content_id=cont_missing" in result.content[0].text  # type: ignore[union-attr]
     mock_download.assert_not_called()
 
@@ -128,7 +128,7 @@ async def test_chunked_small_doc_returns_full_text_with_page_markers():
     mock_search.assert_awaited_once()
     _, kwargs = mock_search.call_args
     assert kwargs["where"] == {"id": {"equals": "cont_abc"}}
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "--- page 1 ---" in text
     assert "--- page 2 ---" in text
@@ -146,7 +146,7 @@ async def test_chunked_oversized_no_range_returns_informative_error():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "tokens" in text
     assert "100 pages" in text
@@ -169,7 +169,7 @@ async def test_chunked_multi_page_range_over_cap_returns_error():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "narrower range" in text
     assert "per-call limit" in text
@@ -192,7 +192,7 @@ async def test_chunked_single_page_request_exempt_from_cap():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "word" in text
     assert "short intro" not in text
@@ -210,7 +210,7 @@ async def test_chunked_start_page_zero_is_out_of_bounds():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "out of bounds" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -229,7 +229,7 @@ async def test_chunked_page_gap_range_returns_no_content_error():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "no content found in pages 2-3" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -248,7 +248,7 @@ async def test_chunked_without_page_metadata_falls_back_to_virtual_paging():
             config=ReadFileToolConfig(max_tokens_per_call=8_000),
         )
 
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "alpha beta" in text
     assert "gamma delta" in text
@@ -266,7 +266,7 @@ async def test_chunked_out_of_bounds_range_returns_short_error():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "5 pages" in text
     assert "500-510" in text
@@ -282,7 +282,7 @@ async def test_chunked_empty_chunks_returns_not_finished_processing_error():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "hasn't finished processing yet" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -298,7 +298,7 @@ async def test_text_small_doc_returns_full_text_no_markers_no_page_language():
             config=ReadFileToolConfig(max_tokens_per_call=8_000),
         )
 
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert text == (
         "[notes.md](unique://content/cont_abc)\n\n"
@@ -320,7 +320,7 @@ async def test_text_oversized_no_range_returns_virtual_page_error():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "tokens" in text
     assert "pages of 10 tokens each" in text
@@ -342,7 +342,7 @@ async def test_text_range_given_returns_token_boundary_slice_with_prefix():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert text.startswith("[notes.txt](unique://content/cont_abc)\n\n")
     assert "showing tokens 0-10 of" in text
@@ -363,7 +363,7 @@ async def test_text_out_of_bounds_range_returns_short_error():
             config=ReadFileToolConfig(max_tokens_per_call=8_000),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "out of bounds" in text
 
@@ -383,7 +383,7 @@ async def test_text_start_page_zero_is_out_of_bounds():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "out of bounds" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -402,7 +402,7 @@ async def test_text_multi_page_range_returns_one_page_per_call_error():
             config=ReadFileToolConfig(max_tokens_per_call=10),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "one page per call" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -418,7 +418,7 @@ async def test_text_non_utf8_bytes_degrade_instead_of_failing():
             config=ReadFileToolConfig(),
         )
 
-    assert result.isError is not True
+    assert result.is_error is not True
     text = result.content[0].text  # type: ignore[union-attr]
     assert "caf" in text and "ol" in text
 
@@ -431,7 +431,7 @@ async def test_identity_refusal_surfaces_as_tool_error(monkeypatch):
     )
     result = await read_file(content_id="cont_abc", config=ReadFileToolConfig())
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "UNIQUE_AUTH_" in result.content[0].text  # type: ignore[union-attr]
 
 

--- a/services/kb-mcp/tests/test_search_tool.py
+++ b/services/kb-mcp/tests/test_search_tool.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from mcp.types import CallToolResult
+from fastmcp.tools import ToolResult
 from unique_mcp.meta.rjsf import ConfigSchemaMeta
 from unique_toolkit.content.schemas import ContentChunk, ContentMetadata
 from unique_toolkit.experimental.components.internal_search import (
@@ -13,11 +13,15 @@ from unique_toolkit.experimental.components.internal_search import (
 )
 
 from kb_mcp.references import (
-    CITATION_RESULT_INSTRUCTION,
-    REFERENCE_FORMAT_INFORMATION,
+    GENERIC_RESULT_CITATION_INSTRUCTION,
     REFERENCE_META_KEY,
+    SEARCH_SYSTEM_PROMPT,
+    TOOL_DESCRIPTION_CITATION_GUIDANCE,
+    UNIQUE_AI_RESULT_CITATION_INSTRUCTION,
+    UNIQUE_AI_TOOL_FORMAT_INFORMATION,
     chunk_to_text_content,
     frontend_document_url,
+    is_unique_ai_client,
     markdown_citation_link,
     reference_url,
     scope_id_from_folder_id_path,
@@ -55,7 +59,16 @@ def test_tool_description_includes_citation_rules():
     description = search.__fastmcp__.description
     assert description is not None
     assert "Do NOT invent placeholders like [source1]" in description
-    assert REFERENCE_FORMAT_INFORMATION in description
+    assert TOOL_DESCRIPTION_CITATION_GUIDANCE in description
+
+
+def test_tool_meta_uses_unique_ai_format_and_slim_system_prompt():
+    meta = search.__fastmcp__.meta or {}
+    assert meta["unique.app/tool-format-information"] == UNIQUE_AI_TOOL_FORMAT_INFORMATION
+    assert "[source" in meta["unique.app/tool-format-information"]
+    assert "Do NOT invent placeholders" not in meta["unique.app/tool-format-information"]
+    assert meta["unique.app/system-prompt"] == SEARCH_SYSTEM_PROMPT
+    assert TOOL_DESCRIPTION_CITATION_GUIDANCE not in meta["unique.app/system-prompt"]
 
 
 def _make_chunk(text: str, **kwargs) -> ContentChunk:
@@ -90,6 +103,11 @@ def _patch_identity():
         "kb_mcp.tools.search.tool.get_unique_settings_async",
         new=AsyncMock(return_value=_make_identity()),
     )
+
+
+def _patch_is_unique_ai_client(value: bool):
+    """Stub node-chat-vs-generic-client detection (see is_unique_ai_client)."""
+    return patch("kb_mcp.tools.search.tool.is_unique_ai_client", return_value=value)
 
 
 def _patch_kb_settings(base_url: str | None = None, lookup_concurrency: int = 8):
@@ -133,7 +151,7 @@ async def test_search_string_becomes_the_search_query():
     # backend itself is mocked out here — this is the resulting query state,
     # not an assertion on which collaborator got called.
     assert mock_service.state.search_queries == ["test query"]
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     # result chunks + trailing citation instruction
     assert len(result.content) == 2
 
@@ -190,7 +208,7 @@ async def test_search_uses_defaults_when_no_config_provided():
             config=SearchToolConfig(),
         )
 
-    assert isinstance(result, CallToolResult)
+    assert isinstance(result, ToolResult)
     assert mock_service.state.search_queries == ["fallback query"]
 
 
@@ -208,7 +226,7 @@ async def test_search_returns_error_result_on_service_failure():
             config=SearchToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "KB unavailable" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -238,7 +256,7 @@ async def test_search_returns_error_result_on_post_processor_failure():
             config=SearchToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "post-processor failed" in result.content[0].text  # type: ignore[union-attr]
 
 
@@ -253,8 +271,34 @@ async def test_search_returns_error_when_identity_unresolvable():
             config=SearchToolConfig(),
         )
 
-    assert result.isError is True
+    assert result.is_error is True
     assert "UNIQUE_AUTH_" in result.content[0].text  # type: ignore[union-attr]
+
+
+def test_is_unique_ai_client_true_for_node_chats_own_client_name():
+    ctx = MagicMock()
+    ctx.session.client_params.clientInfo.name = "unique-ai-mcp-client-module-kb-mcp"
+    with patch("kb_mcp.references.get_context", return_value=ctx):
+        assert is_unique_ai_client() is True
+
+
+def test_is_unique_ai_client_false_for_generic_client_name():
+    ctx = MagicMock()
+    ctx.session.client_params.clientInfo.name = "claude-code"
+    with patch("kb_mcp.references.get_context", return_value=ctx):
+        assert is_unique_ai_client() is False
+
+
+def test_is_unique_ai_client_false_when_no_context():
+    with patch("kb_mcp.references.get_context", side_effect=RuntimeError):
+        assert is_unique_ai_client() is False
+
+
+def test_is_unique_ai_client_false_when_client_params_missing():
+    ctx = MagicMock()
+    ctx.session.client_params = None
+    with patch("kb_mcp.references.get_context", return_value=ctx):
+        assert is_unique_ai_client() is False
 
 
 def test_scope_id_from_folder_id_path_takes_leaf():
@@ -414,7 +458,42 @@ async def test_search_results_are_numbered_sequentially_and_include_citation_blo
     assert "](unique://content/" in texts[0]
     assert "](unique://content/" in texts[1]
     assert "[source" not in texts[0]
-    assert texts[2] == CITATION_RESULT_INSTRUCTION
+    assert texts[2] == GENERIC_RESULT_CITATION_INSTRUCTION
+
+
+@pytest.mark.asyncio
+async def test_search_uses_sourceN_citation_instruction_when_called_via_unique_ai_chat():
+    """Generic MCP clients (Claude Desktop/Code, Inspector) get the
+    markdown-link instruction above; a call relayed through node-chat (its
+    own MCP `clientInfo`, per is_unique_ai_client) must get the [sourceN]
+    instruction instead — that's the only form the platform's
+    citation-badge rendering resolves.
+    """
+    chunks = [_make_chunk("first"), _make_chunk("second")]
+    mock_service = MagicMock()
+    mock_service.bind_settings.return_value = mock_service
+    mock_service.state = MagicMock()
+    mock_service.run = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "kb_mcp.tools.search.tool.KnowledgeBaseInternalSearchService.from_config",
+            return_value=mock_service,
+        ),
+        _patch_post_processor(chunks),
+        _patch_identity(),
+        _patch_kb_settings(None),
+        _patch_resolve_scope_ids(),
+        _patch_is_unique_ai_client(True),
+    ):
+        result = await search(
+            search_string="query",
+            config=SearchToolConfig(),
+        )
+
+    texts = [c.text for c in result.content]  # type: ignore[union-attr]
+    assert texts[2] == UNIQUE_AI_RESULT_CITATION_INSTRUCTION
+    assert texts[2] != GENERIC_RESULT_CITATION_INSTRUCTION
 
 
 @pytest.mark.asyncio

--- a/services/kb-mcp/tests/test_search_tool.py
+++ b/services/kb-mcp/tests/test_search_tool.py
@@ -64,9 +64,13 @@ def test_tool_description_includes_citation_rules():
 
 def test_tool_meta_uses_unique_ai_format_and_slim_system_prompt():
     meta = search.__fastmcp__.meta or {}
-    assert meta["unique.app/tool-format-information"] == UNIQUE_AI_TOOL_FORMAT_INFORMATION
+    assert (
+        meta["unique.app/tool-format-information"] == UNIQUE_AI_TOOL_FORMAT_INFORMATION
+    )
     assert "[source" in meta["unique.app/tool-format-information"]
-    assert "Do NOT invent placeholders" not in meta["unique.app/tool-format-information"]
+    assert (
+        "Do NOT invent placeholders" not in meta["unique.app/tool-format-information"]
+    )
     assert meta["unique.app/system-prompt"] == SEARCH_SYSTEM_PROMPT
     assert TOOL_DESCRIPTION_CITATION_GUIDANCE not in meta["unique.app/system-prompt"]
 

--- a/services/kb-mcp/uv.lock
+++ b/services/kb-mcp/uv.lock
@@ -1117,7 +1117,7 @@ wheels = [
 
 [[package]]
 name = "kb-mcp"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- `search`, `content_tree`, and `read_file` returned `mcp.types.CallToolResult`, which FastMCP's `convert_result()` doesn't special-case — every content item got JSON-serialized into a single `TextContent` blob instead of staying a proper multi-item list. Fixed by returning `fastmcp.tools.ToolResult` instead.
- `search` now attaches `unique.app/reference` metadata to each result, letting Unique AI resolve `[sourceN]` citations to clickable reference chips.
- Generic MCP clients (Claude Desktop/Code, MCP Inspector, Cursor) keep getting plain markdown-link citations via the tool description and a trailing per-call instruction, selected per-client via `is_unique_ai_client()` (based on the MCP `clientInfo.name` node-chat's own client sets).
- `content_tree`/`read_file` get only the `ToolResult` fix — no structured-reference wiring, since `read_file`'s reference wiring didn't reliably get the model to cite (a prompt-engineering problem, not a correctness one) and `content_tree`'s output is navigational links rather than answer-supporting content.

## Test plan
- [x] Full `kb-mcp` test suite passes (99 tests)
- [x] `ruff check` clean
- [x] Verified live end-to-end via node-chat/Unique AI: `search` reliably renders `[sourceN]` reference chips
- [x] Verified live via Cursor (generic MCP client): markdown-link citations render correctly, no `[sourceN]` leakage
- [x] Verified live: `content_tree`/`read_file` no longer collapse into a single JSON blob