### PR TITLE
refactor(office-mcp): make the four tools read as one server

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,9 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes three tools
-so far — `whoami`, `list_chats` and `search_messages` — and more land in later PRs, stacked on top
-of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes four tools
+so far — `whoami`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
+stacked on top of this one.
 
 ## Layout
 
@@ -15,7 +15,7 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats, search)
+  features/              what the connector does — one module per slice (identity, chats, messages)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -30,8 +30,9 @@ The layering rules are that **nothing under `features/` may import from `server/
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
 is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
 imports neither `features/` nor `config`**, taking its own frozen `GraphSettings` instead, that
-**`server/` does not import the Graph SDK**, since a tool declares and exposes while the request
-belongs to a feature, and that
+**`server/` does not import the Graph SDK** — nor the `kiota_*`/`msgraph_core` request layer
+underneath it, which is how a Graph call gets shaped without ever spelling `msgraph` — since a tool
+declares and exposes while the request belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
 environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
 and grows as each package arrives.
@@ -75,8 +76,8 @@ consented to, which is why sign-in has to ask for it:
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
 | `User.Read` | Delegated | No | `whoami` |
-| `Chat.Read` | Delegated | No | `list_chats`, `search_messages` |
-| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages` |
+| `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` (chats) |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages`, `read_message` (channels) |
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
@@ -86,7 +87,9 @@ enough for Graph to *accept* a `chatMessage` search, but Microsoft documents tha
 returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
 `ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
 missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
-than serve half an answer per query. It is also what the message reader in the next PR needs.
+than serve half an answer per query. It is also what `read_message` needs for a channel message —
+Graph's permissions for a message read are per surface, so that tool's own 403 names whichever one
+the handle it was given required.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -132,6 +135,7 @@ gets that string onto the wire.
 | `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
+| `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
 all are described to the model in prose that names the traps rather than only the fields — `mail` is
@@ -174,6 +178,34 @@ Decisions worth knowing:
   than the advertised schema. It is the only constraint of that kind here: nothing else about
   Microsoft's KQL scope terms makes two of these parameters genuinely incompatible, so nothing else
   is invented.
+- **The reader is `read_message`, not a polymorphic `read_resource`.** It takes a URI handle, which
+  pairs with a search that returns one, but its name says only what it reads. Two reasons, and the
+  second is the load-bearing one. A tool called `read_resource` that serves Teams messages alone
+  invites `mail:///`, `site:///` and `drive:///` — the connector we compared against exposes exactly
+  that one polymorphic reader over every M365 entity — and every one of those is a failure a model
+  could not have predicted from the name. More importantly, a message read's permission is per
+  surface (`Chat.Read` in a chat, `ChannelMessage.Read.All` in a channel) and a token is exchanged
+  per tool, so one reader over every entity type would have to redeem the union of every read
+  permission on every call: a tenant unwilling to grant meeting-transcript access would break
+  reading a chat message. Transcripts (which Microsoft addresses by a join-URL-derived handle) and
+  recordings therefore arrive as their own handle-taking readers rather than as new schemes here.
+- **A message body is normalised, never passed through as Teams HTML.** Wrapper divs, `<at>`
+  mentions, `<emoji alt="👀">`, hostedContents `<img>`, `<attachment>` placeholders and adaptive-card
+  JSON all become readable text (`@Name`, the emoji itself, `[image]`, `[attachment: name]`,
+  `[card]`), and `mentions` / `attachments` come back resolved so the placeholders have a key. This
+  is `services/teams-mcp`'s normaliser ported, not a second attempt at it.
+- **A message with no text says why.** Microsoft Graph has no rendered text for a system event
+  message — `from` is null and the body is the literal `<systemEventMessage/>`, because Teams writes
+  "Ada joined the chat" in the client — so a read that lands on one reports the event named from
+  `eventDetail` (`members joined`, `chat renamed`) and a null `text`. A deleted message reports
+  `deleted_at` and a null `text` rather than a tombstone's leftovers. Both are the difference
+  between "no content" and "they said nothing".
+- **`read_message` keeps three failures distinct.** A malformed handle is ours to explain, so its
+  error shows both readable shapes and says where a handle comes from; Graph's 404 on a well-formed
+  handle says the message could not be read and explicitly *not* that it never existed (Graph
+  answers deleted, invisible and absent identically); a 403 names the one permission that surface
+  needs. The generic "check the id came from a tool response verbatim" advice is suppressed for the
+  404 here, because the handle did come from one — that is `graph_tool_errors(..., not_found=...)`.
 - **A search query is never logged.** Not in a message, not as a structured field, not as a span
   attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
   to remove query terms from its spans and logs after the fact; a test here asserts they never

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,8 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes no MCP
-tools yet: the feature packages and the tools that use the Graph client land in later PRs, stacked
-on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes two tools so
+far — `whoami` and `list_chats` — and more land in later PRs, stacked on top of this one.
 
 ## Layout
 
@@ -15,19 +14,24 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — empty until the first feature lands
-  server/                how it's exposed over MCP — the /ready probe today, tools when they land
+  features/              what the connector does — one module per slice (identity, chats)
+  server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
 This service owns no database schema and has no ORM, no engine and no migrations. Its only table
 (`oauth_kv`) belongs to the OAuth state store, which creates it itself — see **State** below.
 
+A feature module owns three things that belong together: the Graph request it makes, the shape it
+answers with, and the delegated Graph permission that request needs. `server/tools.py` declares the
+MCP tools over them and is the only place that knows about MCP.
+
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — that **`graph_client/` imports neither `features/`
-nor `config`**, taking its own frozen `GraphSettings` instead, and that **only `create_app`
-constructs a config**, so nothing downstream can quietly re-read the environment and disagree with
-the app it runs in. `tests/test_layering.py` enforces all of them, and grows as each package
-arrives.
+nor `config`**, taking its own frozen `GraphSettings` instead, that **`server/` does not import the
+Graph SDK**, since a tool declares and exposes while the request belongs to a feature, and that
+**only `create_app` constructs a config**, so nothing downstream can quietly re-read the
+environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
+and grows as each package arrives.
 
 ## Auth
 
@@ -59,7 +63,19 @@ all of these hold:
   the provider validates every token against one issuer derived from that value, so a
   multi-tenant authority would reject all of them rather than accept all tenants.
 
-Graph permissions are deliberately not requested yet — they belong to the tools that need them.
+**Graph permissions** belong to the tools that need them, and `create_app` passes their union to
+the provider as `additional_authorize_scopes`. They ride the authorize request only — Entra issues
+one token per resource, so the code exchange asks for this API's own scope and each tool redeems a
+Graph one per call via On-Behalf-Of. That redemption can only succeed for a permission already
+consented to, which is why sign-in has to ask for it:
+
+| Permission | Type | Admin consent | Used by |
+| --- | --- | --- | --- |
+| `User.Read` | Delegated | No | `whoami` |
+| `Chat.Read` | Delegated | No | `list_chats` |
+
+`Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
+`$expand=lastMessagePreview`, and a message preview is a message.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -97,6 +113,32 @@ gets that string onto the wire.
 - **The caller's token goes to `graph.microsoft.com` and nowhere else.** The SDK's bearer provider
   does not check its own allowed-hosts validator, so a redirect or an off-Graph `nextLink` would
   otherwise be handed a user's delegated credential.
+
+## Tools
+
+| Tool | What it answers | Graph |
+| --- | --- | --- |
+| `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
+| `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
+
+Both are read-only, both take their caller's identity from the token rather than from a parameter,
+and both are described to the model in prose that names the traps rather than only the fields —
+`mail` is null for guests (use `user_principal_name`, which may be on a different domain), and a
+chat's recency is its last message, not the `lastUpdatedDateTime` that Graph moves on a rename.
+
+Three decisions worth knowing:
+
+- **Every result has a declared output schema.** So `truncated` and `members_truncated` are typed
+  fields rather than prose or, worse, an extra object appended to the results array that a model can
+  mistake for a result.
+- **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
+  collection) is a window on the most recent chats, and `truncated` says when there are more. A
+  cursor over a collection that reorders itself on every message returns duplicates and gaps, and
+  the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+- **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
+  model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
+  named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
+  rides along, because that is what Microsoft support asks for.
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -128,9 +128,9 @@ chat's recency is its last message, not the `lastUpdatedDateTime` that Graph mov
 
 Three decisions worth knowing:
 
-- **Every result has a declared output schema.** So `truncated` and `members_truncated` are typed
-  fields rather than prose or, worse, an extra object appended to the results array that a model can
-  mistake for a result.
+- **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
+  typed fields rather than prose or, worse, an extra object appended to the results array that a
+  model can mistake for a result.
 - **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
@@ -138,7 +138,10 @@ Three decisions worth knowing:
 - **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
   model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
   named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
-  rides along, because that is what Microsoft support asks for.
+  rides along, because that is what Microsoft support asks for. A permission that was never
+  consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
+  FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
+  exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,8 +2,9 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes two tools so
-far — `whoami` and `list_chats` — and more land in later PRs, stacked on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes three tools
+so far — `whoami`, `list_chats` and `search_messages` — and more land in later PRs, stacked on top
+of this one.
 
 ## Layout
 
@@ -14,7 +15,7 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats)
+  features/              what the connector does — one module per slice (identity, chats, search)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -22,13 +23,15 @@ This service owns no database schema and has no ORM, no engine and no migrations
 (`oauth_kv`) belongs to the OAuth state store, which creates it itself — see **State** below.
 
 A feature module owns three things that belong together: the Graph request it makes, the shape it
-answers with, and the delegated Graph permission that request needs. `server/tools.py` declares the
+answers with, and the delegated Graph permissions that request needs. `server/tools.py` declares the
 MCP tools over them and is the only place that knows about MCP.
 
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
-wires features together, never the reverse — that **`graph_client/` imports neither `features/`
-nor `config`**, taking its own frozen `GraphSettings` instead, that **`server/` does not import the
-Graph SDK**, since a tool declares and exposes while the request belongs to a feature, and that
+wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
+is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
+imports neither `features/` nor `config`**, taking its own frozen `GraphSettings` instead, that
+**`server/` does not import the Graph SDK**, since a tool declares and exposes while the request
+belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
 environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
 and grows as each package arrives.
@@ -72,10 +75,18 @@ consented to, which is why sign-in has to ask for it:
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
 | `User.Read` | Delegated | No | `whoami` |
-| `Chat.Read` | Delegated | No | `list_chats` |
+| `Chat.Read` | Delegated | No | `list_chats`, `search_messages` |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages` |
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
+
+`ChannelMessage.Read.All` is the broad one, and it is requested deliberately. `Chat.Read` alone is
+enough for Graph to *accept* a `chatMessage` search, but Microsoft documents that a search never
+returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
+`ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
+missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
+than serve half an answer per query. It is also what the message reader in the next PR needs.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -120,13 +131,15 @@ gets that string onto the wire.
 | --- | --- | --- |
 | `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
+| `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
 
-Both are read-only, both take their caller's identity from the token rather than from a parameter,
-and both are described to the model in prose that names the traps rather than only the fields —
-`mail` is null for guests (use `user_principal_name`, which may be on a different domain), and a
-chat's recency is its last message, not the `lastUpdatedDateTime` that Graph moves on a rename.
+All are read-only, all take their caller's identity from the token rather than from a parameter, and
+all are described to the model in prose that names the traps rather than only the fields — `mail` is
+null for guests (use `user_principal_name`, which may be on a different domain), a chat's recency is
+its last message rather than the `lastUpdatedDateTime` that Graph moves on a rename, and a search
+hit's `summary` is a snippet rather than the message.
 
-Three decisions worth knowing:
+Decisions worth knowing:
 
 - **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
   typed fields rather than prose or, worse, an extra object appended to the results array that a
@@ -135,6 +148,36 @@ Three decisions worth knowing:
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
   the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+- **`search_messages` is one Graph request, always.** No fan-out, and specifically no per-chat scan
+  when a date filter is set or a permission is missing — which is what the connector this replaces
+  falls back to, up to 50 chats × 50 messages. Graph's read budget is "one request per second per
+  app per tenant … on a given channel or chat", and *per app* means one user's sweep degrades every
+  other user in the tenant; the connector we compared against returned zero results and a rate-limit
+  note from that path in a live tenant. Date bounds go into the query string as `sent>=` / `sent<=`
+  instead, where Microsoft's index applies them — inclusive, and covering channels as well as chats.
+- **`search_messages` reports no result total,** because Graph does not give one: for Teams messages
+  the `total` it returns is the count on the page. `more_results_available` plus `next_offset` are
+  the whole of the paging contract, and a page can be shorter than `size` because system messages
+  (`from: null`, a body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
+- **`query` is words, not a phrase.** Multi-word free text reaches Microsoft's index as separate
+  terms, which KQL ANDs: every word must appear, anywhere in the message and in any order. Wrapping
+  the whole query in the quotes that guard a *filter value* would make it an exact-adjacency phrase
+  and silently drop every match whose words are not side by side — the recall loss a caller cannot
+  see, since the tool answers with fewer messages than exist and says nothing. A caller who wants
+  adjacency quotes the words themselves, and that phrase is passed through as one. The injection
+  guard is unweakened, only moved: it now runs a word at a time, so `from:ceo`, `sent>2026-01-01`,
+  `(`, `*`, a leading `-` and a bare `OR` are each quoted into literal text rather than obeyed —
+  `services/teams-mcp`'s guard, applied where a scope term's *value* is built and per word where
+  the caller's own text is.
+- **"At least one search criterion" is in the schema,** as an `anyOf` of one-element `required`
+  lists, and re-checked at the tool boundary because FastMCP validates against the signature rather
+  than the advertised schema. It is the only constraint of that kind here: nothing else about
+  Microsoft's KQL scope terms makes two of these parameters genuinely incompatible, so nothing else
+  is invented.
+- **A search query is never logged.** Not in a message, not as a structured field, not as a span
+  attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
+  to remove query terms from its spans and logs after the fact; a test here asserts they never
+  arrive.
 - **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
   model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
   named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
@@ -142,6 +185,12 @@ Three decisions worth knowing:
   consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
   FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
   exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".
+  Both paths name *every* permission the call was made under, which for `search_messages` is
+  `Chat.Read` and `ChannelMessage.Read.All` both: neither Graph's 403 nor Entra's AADSTS65001 says
+  which of the two was missing, and an administrator handed one name may grant the one that was
+  already there. So the tenant that grants `Chat.Read` and withholds `ChannelMessage.Read.All` gets
+  a refusal of this connector's own wording, naming both permissions and the remedy — not
+  azure-identity's stack trace.
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -3,7 +3,7 @@
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
 Users sign in with their own Microsoft account and the server acts as them. It exposes four tools
-so far — `whoami`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
+so far — `get_me`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
 stacked on top of this one.
 
 ## Layout
@@ -26,6 +26,13 @@ A feature module owns three things that belong together: the Graph request it ma
 answers with, and the delegated Graph permissions that request needs. `server/tools.py` declares the
 MCP tools over them and is the only place that knows about MCP.
 
+Where two features answer about the same thing, the shared vocabulary lives in one of them rather
+than in both: `message_search` owns the `teams:///` message handle — its two shapes, its parser and
+which permission each surface is read under — and the sender shape, and `message_read` imports both.
+Search is where a handle and a search-shaped sender are minted, and two modules that each knew how
+to spell a handle would be free to disagree; the disagreement would surface as a search result that
+cannot be read.
+
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
 is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
@@ -34,8 +41,10 @@ imports neither `features/` nor `config`**, taking its own frozen `GraphSettings
 underneath it, which is how a Graph call gets shaped without ever spelling `msgraph` — since a tool
 declares and exposes while the request belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
-environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
-and grows as each package arrives.
+environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them, and
+each rule is paired with a guard that fails if the rule has gone vacuous — an empty tree to walk, a
+missing file to forbid reaching past. None of them is conditional on a package that has yet to land,
+because they all have now: a rule that stops running is a failure there and not a skip.
 
 ## Auth
 
@@ -75,7 +84,7 @@ consented to, which is why sign-in has to ask for it:
 
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
-| `User.Read` | Delegated | No | `whoami` |
+| `User.Read` | Delegated | No | `get_me` |
 | `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` (chats) |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages`, `read_message` (channels) |
 
@@ -132,26 +141,40 @@ gets that string onto the wire.
 
 | Tool | What it answers | Graph |
 | --- | --- | --- |
-| `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
+| `get_me` | Who the signed-in user is: `user_id`, `display_name`, `email`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
 | `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
-all are described to the model in prose that names the traps rather than only the fields — `mail` is
+all are described to the model in prose that names the traps rather than only the fields — `email` is
 null for guests (use `user_principal_name`, which may be on a different domain), a chat's recency is
 its last message rather than the `lastUpdatedDateTime` that Graph moves on a rename, and a search
 hit's `summary` is a snippet rather than the message.
 
 Decisions worth knowing:
 
+- **The four tools are one surface, and the conventions are asserted, not just intended.** A name is
+  `verb_noun` — which is why the identity tool is `get_me` and not `whoami`, the shell idiom having
+  made the odd one out of the tool a model calls first (Microsoft's own M365 connector landed on
+  `get_me` too). A result field is snake_case, and one thing has one name across every tool: a
+  person's Entra id is `user_id` wherever it appears, an address is `email`, a time is `…_at`. Every
+  tool whose answer is a list says "there is more" with the same word, `truncated`, and says in its
+  own description how to get the rest — a wider `limit` where there is no cursor, `next_offset` where
+  there is. `tests/test_mcp_tools.py` checks all of that against the live schemas, because a
+  convention nothing enforces is how the fifth tool comes out different from the first four.
 - **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
   typed fields rather than prose or, worse, an extra object appended to the results array that a
   model can mistake for a result.
 - **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
-  the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+  the window is what "recent chats" means; `services/teams-mcp` ships the same shape. What the
+  `chat_id` it returns is *for* is naming: it is the same id `search_messages` puts on every chat
+  message it finds, so the list is how a found message gets a topic and a set of participants. No
+  tool here takes a chat id as an argument, a search cannot be narrowed to one chat, and a handle
+  cannot be assembled out of one — so the description says all three rather than promising a
+  chat-scoped tool that does not exist.
 - **`search_messages` is one Graph request, always.** No fan-out, and specifically no per-chat scan
   when a date filter is set or a permission is missing — which is what the connector this replaces
   falls back to, up to 50 chats × 50 messages. Graph's read budget is "one request per second per
@@ -160,9 +183,9 @@ Decisions worth knowing:
   note from that path in a live tenant. Date bounds go into the query string as `sent>=` / `sent<=`
   instead, where Microsoft's index applies them — inclusive, and covering channels as well as chats.
 - **`search_messages` reports no result total,** because Graph does not give one: for Teams messages
-  the `total` it returns is the count on the page. `more_results_available` plus `next_offset` are
-  the whole of the paging contract, and a page can be shorter than `size` because system messages
-  (`from: null`, a body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
+  the `total` it returns is the count on the page. `truncated` plus `next_offset` are the whole of the
+  paging contract, and a page can be shorter than `size` because system messages (`from: null`, a
+  body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
 - **`query` is words, not a phrase.** Multi-word free text reaches Microsoft's index as separate
   terms, which KQL ANDs: every word must appear, anywhere in the message and in any order. Wrapping
   the whole query in the quotes that guard a *filter value* would make it an exact-adjacency phrase
@@ -210,10 +233,14 @@ Decisions worth knowing:
   attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
   to remove query terms from its spans and logs after the fact; a test here asserts they never
   arrive.
-- **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
-  model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
-  named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
-  rides along, because that is what Microsoft support asks for. A permission that was never
+- **A refusal names its remedy, in one voice.** `server/errors.py` maps each Graph failure onto the
+  one thing a model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator
+  for *this named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. Every one of
+  them is written to the same shape, because a model reads them all as one server: "Microsoft 365"
+  is what refused and is named first (not "Microsoft Graph", which is an API the caller is not
+  calling), then the remedy and whether retrying could possibly help, then the diagnostics in a
+  parenthesis at the end. The Graph request id rides along there, because that is what Microsoft
+  support asks for, by that name. A permission that was never
   consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
   FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
   exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".

--- a/services/office-mcp/pyproject.toml
+++ b/services/office-mcp/pyproject.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Microsoft 365 (Office) FastMCP server"
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp==3.4.5",
+    # The `azure` extra (azure-identity, pyjwt) is what FastMCP's On-Behalf-Of exchange needs —
+    # `EntraOBOToken` raises ImportError without it, and every tool goes through it. Both packages
+    # also arrive transitively via `msgraph-sdk`, which is precisely why this is declared: the day
+    # the Graph SDK stops depending on them, OBO must not break silently.
+    "fastmcp[azure]==3.4.5",
     # fastmcp already depends on py-key-value-aio[filetree,keyring,memory]; declared here for
     # the postgresql extra and because auth.py imports it directly (OAuth state store).
     "py-key-value-aio[postgresql]==0.4.5",

--- a/services/office-mcp/src/office_mcp/app.py
+++ b/services/office-mcp/src/office_mcp/app.py
@@ -11,9 +11,10 @@ from unique_mcp.monitoring import setup_ops
 
 from office_mcp.auth import build_auth, build_oauth_storage
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
+from office_mcp.graph_client import GraphSettings, create_graph_transport
 from office_mcp.logging import configure_logging
 from office_mcp.metrics import configure_metrics
-from office_mcp.server import ready_response
+from office_mcp.server import GRAPH_SCOPES, ready_response, register_tools
 
 
 def create_app(
@@ -24,9 +25,9 @@ def create_app(
     """The composition root.
 
     Every config object and every long-lived collaborator is built exactly once here and then
-    injected. Nothing downstream re-reads the environment. The Microsoft Graph client and the
-    tools that use it land in later PRs, wired in here the same way — so the MCP endpoint below
-    authenticates callers but exposes no tools yet.
+    injected. Nothing downstream re-reads the environment: `graph_client` in particular is handed
+    its own frozen `GraphSettings` rather than being allowed to read config, and the tools are
+    handed the one HTTP transport built from it.
     """
     config = config or AppConfig()
     database_config = database_config or DatabaseConfig()
@@ -42,19 +43,31 @@ def create_app(
     # rather than inside `build_auth` so that one object serves both consumers: the auth
     # provider that depends on it, and the readiness probe that has to prove it works.
     oauth_storage = build_oauth_storage(entra_config, database_config)
-    auth = build_auth(entra_config, base_url=config.issuer, client_storage=oauth_storage)
+    auth = build_auth(
+        entra_config,
+        base_url=config.issuer,
+        client_storage=oauth_storage,
+        graph_scopes=GRAPH_SCOPES,
+    )
+    # `GraphSettings`' defaults are what this service wants (see its docstring: interactive-call
+    # timeouts, the SDK's own retry count). It is still built here rather than inside
+    # `graph_client`, because the composition root is where a knob would have to be mapped from
+    # `AppConfig` the day an operator needs a different value.
+    graph_transport = create_graph_transport(GraphSettings())
 
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncGenerator[None, None]:
         try:
             yield
         finally:
-            # One On-Behalf-Of credential is cached per signed-in user, each holding an open
-            # HTTP transport of its own. The OAuth state store is deliberately not closed here:
-            # its asyncpg pool dies with the process, and the wrapper chain `oauth_storage`
-            # names publishes get/put/delete only — no close — so shutting the pool down would
-            # mean reaching through the encryption wrapper for a store the process is about to
-            # drop anyway.
+            # The Graph transport is a connection pool shared by every tool call, and one
+            # On-Behalf-Of credential is cached per signed-in user, each holding an open HTTP
+            # transport of its own. The OAuth state store is deliberately not closed here: its
+            # asyncpg pool dies with the process, and the wrapper chain `oauth_storage` names
+            # publishes get/put/delete only — no close — so shutting the pool down would mean
+            # reaching through the encryption wrapper for a store the process is about to drop
+            # anyway.
+            await graph_transport.aclose()
             await auth.close_obo_credentials()
 
     mcp = FastMCP(
@@ -64,6 +77,7 @@ def create_app(
         middleware=[],
         lifespan=lifespan,
     )
+    register_tools(mcp, graph_transport)
 
     # Mounts /probe, /health, /metrics and returns HTTP request-metrics middleware.
     ops_middleware = setup_ops(mcp)

--- a/services/office-mcp/src/office_mcp/auth.py
+++ b/services/office-mcp/src/office_mcp/auth.py
@@ -5,15 +5,17 @@ OAuth 2.1 proxy — it presents a DCR-capable authorization server to MCP client
 onto the Entra app registration, so the authorize endpoint, PKCE (enforced on both hops), the
 redirect callback, the consent screen, refresh-token rotation and the On-Behalf-Of exchange that
 turns a user's token into a Microsoft Graph one are all its own. What is left for this service to
-decide is the two things the library cannot know: which app registration to use, and where the
-resulting state is kept.
+decide is the three things the library cannot know: which app registration to use, which Graph
+permissions its tools will need, and where the resulting state is kept.
 
-The second one is not a preference. Every token FastMCP issues is a reference token that is
+The last one is not a preference. Every token FastMCP issues is a reference token that is
 re-validated against this store on every single request, and the default store is an encrypted
 file tree under the *process's own* home directory — so on Kubernetes it would log every user out
 on each pod restart and fail outright as soon as a second replica served a request. Postgres,
 which this service already runs, is what makes the deployment horizontally scalable.
 """
+
+from collections.abc import Sequence
 
 from fastmcp.server.auth.providers.azure import AzureProvider
 from key_value.aio.protocols import AsyncKeyValue
@@ -30,8 +32,7 @@ _OAUTH_TABLE_NAME = "oauth_kv"
 # The custom scope the app registration exposes under its Application ID URI, which is what
 # gates access to *this* server. `AzureProvider` refuses to start without at least one non-OIDC
 # scope here, because Entra omits OIDC scopes from the `scp` claim and they therefore cannot be
-# enforced. Graph permissions are a separate channel and are not listed here: they are requested
-# by the tools that need them, via the On-Behalf-Of exchange, and none exist yet.
+# enforced. Graph permissions are the separate channel below.
 _REQUIRED_SCOPES = ("access_as_user",)
 
 _ENCRYPTION_SALT = "office-mcp-oauth-storage"
@@ -63,7 +64,12 @@ def build_oauth_storage(entra: EntraConfig, database: DatabaseConfig) -> AsyncKe
     )
 
 
-def build_auth(entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue) -> AzureProvider:
+def build_auth(
+    entra: EntraConfig,
+    base_url: str,
+    client_storage: AsyncKeyValue,
+    graph_scopes: Sequence[str],
+) -> AzureProvider:
     """The auth provider — `create_app` is its only caller.
 
     `base_url` must be the externally-reachable URL of this service: the OAuth metadata clients
@@ -75,12 +81,21 @@ def build_auth(entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue)
     built here: the readiness probe answers by reading through the very same object, so that a
     200 means *this* provider's store can reach Postgres and not merely that some second
     connection resembling it could.
+
+    `graph_scopes` are the Microsoft Graph permissions the tools need, which is why they arrive
+    from outside rather than being listed here — the tools decide them. They ride the authorize
+    request only: Entra issues one token per resource (AADSTS28000), so the code exchange asks
+    only for this API's own scope, and the Graph ones are redeemed later, per tool call, by the
+    On-Behalf-Of exchange. Sending them at authorize time is what makes that possible at all —
+    OBO can only redeem a permission the user or an administrator has already consented to, and
+    a permission that is never requested is never consented to.
     """
     return AzureProvider(
         client_id=entra.client_id,
         client_secret=entra.client_secret.get_secret_value(),
         tenant_id=entra.tenant_id,
         required_scopes=list(_REQUIRED_SCOPES),
+        additional_authorize_scopes=list(graph_scopes),
         base_url=base_url,
         client_storage=client_storage,
     )

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,9 +1,9 @@
 """Feature implementations: what this connector actually does.
 
 One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
-chats) and `message_search` (finding a Teams message) so far. Each owns three things that belong
-together: the Graph request it makes, the shape it answers with, and the delegated Graph
-permissions that request needs.
+chats), `message_search` (finding a Teams message) and `message_read` (reading one) so far. Each
+owns three things that belong together: the Graph request it makes, the shape it answers with, and
+the delegated Graph permissions that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,8 +1,9 @@
 """Feature implementations: what this connector actually does.
 
-One module per slice of Microsoft 365 — `identity` (who the caller is) and `chats` (their Teams
-chats) so far. Each owns three things that belong together: the Graph request it makes, the shape
-it answers with, and the delegated Graph permission that request needs.
+One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
+chats) and `message_search` (finding a Teams message) so far. Each owns three things that belong
+together: the Graph request it makes, the shape it answers with, and the delegated Graph
+permissions that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,7 +1,8 @@
 """Feature implementations: what this connector actually does.
 
-Empty for now — the Microsoft Graph client, Entra auth, and the Microsoft 365 domain logic land
-in later PRs, stacked on top of this scaffolding.
+One module per slice of Microsoft 365 — `identity` (who the caller is) and `chats` (their Teams
+chats) so far. Each owns three things that belong together: the Graph request it makes, the shape
+it answers with, and the delegated Graph permission that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -12,8 +12,10 @@ Three Graph facts shape everything here, all from the list-chats reference
   `@odata.nextLink` still set — so filling a window needs the page walk `collect_pages` does, and
   a short first page is not evidence that there are no more chats.
 * `$expand=members` returns at most 25 members per chat "even if a larger `$top` value is
-  specified". That truncation is silent, which is exactly how a model comes to summarise a
-  200-person chat from 25 names, so it is reported as a field.
+  specified". The cap is silent and Graph sends no member total on this collection, which is
+  exactly how a model comes to summarise a 200-person chat from 25 names. So a list that arrives
+  full to the cap is reported as *possibly* incomplete — which is the whole of what is known: a
+  chat with exactly 25 members and one with 200 come back identical.
 """
 
 from datetime import datetime
@@ -95,11 +97,14 @@ class ChatSummary(BaseModel):
             + "has no members."
         )
     )
-    members_truncated: bool = Field(
+    members_may_be_incomplete: bool = Field(
         description=(
-            f"True when `members` hit Microsoft Graph's cap of {MEMBERS_PER_CHAT} members per "
-            + "chat on this endpoint, so people are missing from the list. Always false when "
-            + "`members` is null."
+            f"True when `members` came back full to Microsoft Graph's cap of {MEMBERS_PER_CHAT} "
+            + "members per chat on this endpoint, so the chat may have members that were not "
+            + "returned. It is not proof that any were: Graph sends no member total here, so a "
+            + f"chat with exactly {MEMBERS_PER_CHAT} members is indistinguishable from one with "
+            + 'hundreds. Either way, do not answer "who is in this chat" from a list this is '
+            + "set on. Always false when `members` is null."
         )
     )
 
@@ -158,7 +163,7 @@ def _summarise(chat: Chat, include_member_emails: bool) -> ChatSummary:
         last_message_at=preview.created_date_time if preview is not None else None,
         created_at=chat.created_date_time,
         members=members,
-        members_truncated=members is not None and len(members) >= MEMBERS_PER_CHAT,
+        members_may_be_incomplete=members is not None and len(members) >= MEMBERS_PER_CHAT,
     )
 
 

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -1,0 +1,179 @@
+"""The signed-in user's Microsoft Teams chats, most recently active first.
+
+Three Graph facts shape everything here, all from the list-chats reference
+(https://learn.microsoft.com/en-us/graph/api/chat-list):
+
+* `lastMessagePreview/createdDateTime desc` is the **only** ordering Graph will apply to this
+  collection, and it is the one that means "recently active". The chat's own
+  `lastUpdatedDateTime` looks like activity and is not: Graph documents it as when the chat was
+  renamed or its membership last changed. `services/teams-mcp` reached the same conclusion the
+  hard way ("order list_chats by recency").
+* `$top` may be at most 50, and Graph warns that a page can come back short of `$top` with an
+  `@odata.nextLink` still set — so filling a window needs the page walk `collect_pages` does, and
+  a short first page is not evidence that there are no more chats.
+* `$expand=members` returns at most 25 members per chat "even if a larger `$top` value is
+  specified". That truncation is silent, which is exactly how a model comes to summarise a
+  200-person chat from 25 names, so it is reported as a field.
+"""
+
+from datetime import datetime
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.aad_user_conversation_member import AadUserConversationMember
+from msgraph.generated.models.chat import Chat
+from msgraph.generated.users.item.chats.chats_request_builder import ChatsRequestBuilder
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import collect_pages, graph_errors
+
+# Reading a chat's `lastMessagePreview` is reading a message, which `Chat.ReadBasic` — "read the
+# names and members of chats" — does not cover; `Chat.Read` is the least privilege that does.
+GRAPH_PERMISSION = "Chat.Read"
+
+# Graph's documented `$top` ceiling on this collection. The tool's schema derives its `limit`
+# maximum from this, so the bound a caller sees is the bound Graph actually enforces.
+MAX_CHATS = 50
+
+# Graph's documented cap on `$expand=members`, per chat.
+MEMBERS_PER_CHAT = 25
+
+_RECENCY = "lastMessagePreview/createdDateTime desc"
+
+type _ChatsQuery = ChatsRequestBuilder.ChatsRequestBuilderGetQueryParameters
+
+
+class ChatMember(BaseModel):
+    display_name: str | None = Field(
+        description="The member's name as Teams shows it. Null for some external participants."
+    )
+    email: str | None = Field(
+        default=None,
+        description=(
+            "The member's email address, present only when `include_member_emails` was set. Null "
+            + "for a participant Graph has no address for, such as a room or a phone dial-in."
+        ),
+    )
+
+
+class ChatSummary(BaseModel):
+    chat_id: str = Field(
+        description=(
+            "The chat's Graph id, e.g. `19:...@thread.v2`. Pass it verbatim to any tool that "
+            + "takes a chat id; it cannot be reconstructed from a topic or a member's name."
+        )
+    )
+    chat_type: str = Field(
+        description=(
+            "`oneOnOne`, `group` or `meeting` — a meeting chat is the conversation attached to a "
+            + "Teams meeting. `unknown` if Graph reported a type this connector predates."
+        )
+    )
+    topic: str | None = Field(
+        description=(
+            "The chat's name. Null for every oneOnOne chat and for group chats nobody named — "
+            + "those are identified by `members` instead."
+        )
+    )
+    last_message_at: datetime | None = Field(
+        description=(
+            "When the last message in this chat was sent. This is the value the list is ordered "
+            + "by, and the only 'recent activity' Microsoft Graph exposes for a chat. Null when "
+            + "nobody has posted in the chat yet."
+        )
+    )
+    created_at: datetime | None = Field(
+        description=(
+            "When the chat was created (Graph `createdDateTime`) — useful to tell apart chats "
+            + "that share a topic."
+        )
+    )
+    members: list[ChatMember] | None = Field(
+        description=(
+            "Who is in the chat. Returned only for chats with no `topic`, where the people are "
+            + "the only way to name the chat; null otherwise, which is not a claim that the chat "
+            + "has no members."
+        )
+    )
+    members_truncated: bool = Field(
+        description=(
+            f"True when `members` hit Microsoft Graph's cap of {MEMBERS_PER_CHAT} members per "
+            + "chat on this endpoint, so people are missing from the list. Always false when "
+            + "`members` is null."
+        )
+    )
+
+
+class ChatList(BaseModel):
+    chats: list[ChatSummary] = Field(
+        description="The signed-in user's chats, most recently active first."
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the user has more chats than the `limit` returned here. There is no "
+            + f"cursor: raise `limit` (up to {MAX_CHATS}) to widen the window. Chats less recent "
+            + "than the window are not reachable from this tool."
+        )
+    )
+
+
+async def list_recent_chats(
+    client: GraphServiceClient, *, limit: int, include_member_emails: bool
+) -> ChatList:
+    """The `limit` most recently active chats, and whether the user has more than that."""
+    assert 1 <= limit <= MAX_CHATS, f"limit must be within 1..{MAX_CHATS}, got {limit}"
+
+    configuration = RequestConfiguration[_ChatsQuery](
+        query_parameters=ChatsRequestBuilder.ChatsRequestBuilderGetQueryParameters(
+            # `$select` is rejected on this collection as an unsupported parameter, so the
+            # expansions are what bring back the fields below.
+            expand=["members", "lastMessagePreview"],
+            orderby=[_RECENCY],
+            top=limit,
+        )
+    )
+    with graph_errors():
+        first_page = await client.me.chats.get(request_configuration=configuration)
+        assert first_page is not None, "Graph answered GET /me/chats with no collection"
+        collected = await collect_pages(first_page, client, limit=limit)
+
+    return ChatList(
+        chats=[_summarise(chat, include_member_emails) for chat in collected.items],
+        truncated=collected.truncated,
+    )
+
+
+def _summarise(chat: Chat, include_member_emails: bool) -> ChatSummary:
+    assert chat.id is not None, "Graph returned a chat with no id"
+    preview = chat.last_message_preview
+    members = _members(chat, include_member_emails) if chat.topic is None else None
+    # `ChatType` subclasses `str`, so the member *is* its wire value ("group") and pydantic
+    # narrows it to a plain `str` on the way in. Its `.value` would be the obvious thing to reach
+    # for and is typed as a one-tuple, because the generated members carry trailing commas
+    # (`OneOnOne = "oneOnOne",`).
+    return ChatSummary(
+        chat_id=chat.id,
+        chat_type=chat.chat_type if chat.chat_type is not None else "unknown",
+        topic=chat.topic,
+        last_message_at=preview.created_date_time if preview is not None else None,
+        created_at=chat.created_date_time,
+        members=members,
+        members_truncated=members is not None and len(members) >= MEMBERS_PER_CHAT,
+    )
+
+
+def _members(chat: Chat, include_emails: bool) -> list[ChatMember]:
+    """The chat's expanded members.
+
+    Only `aadUserConversationMember` carries an email; a room, a phone participant or an
+    anonymous meeting guest is a different subtype with a display name and nothing to match on.
+    """
+    return [
+        ChatMember(
+            display_name=member.display_name,
+            email=member.email
+            if include_emails and isinstance(member, AadUserConversationMember)
+            else None,
+        )
+        for member in chat.members or []
+    ]

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -61,8 +61,11 @@ class ChatMember(BaseModel):
 class ChatSummary(BaseModel):
     chat_id: str = Field(
         description=(
-            "The chat's Graph id, e.g. `19:...@thread.v2`. Pass it verbatim to any tool that "
-            + "takes a chat id; it cannot be reconstructed from a topic or a member's name."
+            "The chat's Graph id, e.g. `19:...@thread.v2`. It is the same id search_messages "
+            + "reports as `chat_id` on a chat message, so it is how to tell which of these chats a "
+            + "found message came from. No tool here takes a chat id as an argument — a message is "
+            + "read by the `uri` handle search_messages emits, which this id cannot be assembled "
+            + "into — and it cannot be reconstructed from a topic or a member's name either."
         )
     )
     chat_type: str = Field(
@@ -115,9 +118,10 @@ class ChatList(BaseModel):
     )
     truncated: bool = Field(
         description=(
-            "True when the user has more chats than the `limit` returned here. There is no "
-            + f"cursor: raise `limit` (up to {MAX_CHATS}) to widen the window. Chats less recent "
-            + "than the window are not reachable from this tool."
+            "True when the user has more chats than this `limit` holds — the same 'there is more' "
+            + "flag every list-shaped tool here reports. There is no cursor to page with: raise "
+            + f"`limit` (up to {MAX_CHATS}) to widen the window. Chats less recent than the window "
+            + "are not reachable from this tool."
         )
     )
 

--- a/services/office-mcp/src/office_mcp/features/identity.py
+++ b/services/office-mcp/src/office_mcp/features/identity.py
@@ -27,19 +27,23 @@ class SignedInUser(BaseModel):
 
     Field names are snake_case here and in every other tool payload, which is the one place this
     connector deliberately does not echo Graph's spelling — the field descriptions name the Graph
-    property wherever the two differ.
+    property wherever the two differ. Two of them differ by more than case, so that one thing has
+    one name across this server's whole surface: a person's Entra object id is `user_id` here as it
+    is on a message's sender and on a mention, and an email address is `email` here as it is on a
+    sender and on a chat member. Graph calls them `id` and `mail`.
     """
 
-    id: str = Field(
+    user_id: str = Field(
         description=(
-            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier "
-            + "safe to compare against user ids from other tools; names and addresses change."
+            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier safe "
+            + "to compare against the `user_id` of a message's sender or of a mention; names and "
+            + "addresses change."
         )
     )
     display_name: str | None = Field(
         description="The user's name as Microsoft 365 shows it. Null only on incomplete accounts."
     )
-    mail: str | None = Field(
+    email: str | None = Field(
         description=(
             "The canonical primary SMTP address (Graph `mail`), and the right thing to match a "
             + "sender or recipient address against. Null for guest and unlicensed accounts — "
@@ -50,7 +54,7 @@ class SignedInUser(BaseModel):
         description=(
             "The sign-in name (Graph `userPrincipalName`). Usually looks like an email address "
             + "but is not guaranteed to be one: a tenant may issue it on a different domain than "
-            + "`mail`, so treat it as an identifier rather than an address unless `mail` is null."
+            + "`email`, so treat it as an identifier rather than an address unless `email` is null."
         )
     )
     job_title: str | None = Field(
@@ -71,9 +75,9 @@ async def get_signed_in_user(client: GraphServiceClient) -> SignedInUser:
     assert user is not None, "Graph answered GET /me with no user object"
     assert user.id is not None, "Graph answered GET /me with a user that has no id"
     return SignedInUser(
-        id=user.id,
+        user_id=user.id,
         display_name=user.display_name,
-        mail=user.mail,
+        email=user.mail,
         user_principal_name=user.user_principal_name,
         job_title=user.job_title,
     )

--- a/services/office-mcp/src/office_mcp/features/identity.py
+++ b/services/office-mcp/src/office_mcp/features/identity.py
@@ -1,0 +1,79 @@
+"""Who the caller is, according to Microsoft Graph.
+
+Every other feature answers questions about "my" mail, "my" chats or "my" meetings, and each of
+them is answered as the signed-in user. This module is how a model finds out who that is.
+"""
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.users.item.user_item_request_builder import UserItemRequestBuilder
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_errors
+
+# The delegated Microsoft Graph permission this module's one call needs. Declared beside the call
+# rather than in the server layer so that the permission and the request that requires it cannot
+# drift apart: `server/` both requests it at sign-in and names it when Graph refuses.
+GRAPH_PERMISSION = "User.Read"
+
+# `/me` returns a large default projection; these are the five properties the model is told about.
+_SELECT = ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
+
+type _MeQuery = UserItemRequestBuilder.UserItemRequestBuilderGetQueryParameters
+
+
+class SignedInUser(BaseModel):
+    """The signed-in user's own profile, as the MCP client sees it.
+
+    Field names are snake_case here and in every other tool payload, which is the one place this
+    connector deliberately does not echo Graph's spelling — the field descriptions name the Graph
+    property wherever the two differ.
+    """
+
+    id: str = Field(
+        description=(
+            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier "
+            + "safe to compare against user ids from other tools; names and addresses change."
+        )
+    )
+    display_name: str | None = Field(
+        description="The user's name as Microsoft 365 shows it. Null only on incomplete accounts."
+    )
+    mail: str | None = Field(
+        description=(
+            "The canonical primary SMTP address (Graph `mail`), and the right thing to match a "
+            + "sender or recipient address against. Null for guest and unlicensed accounts — "
+            + "fall back to user_principal_name."
+        )
+    )
+    user_principal_name: str | None = Field(
+        description=(
+            "The sign-in name (Graph `userPrincipalName`). Usually looks like an email address "
+            + "but is not guaranteed to be one: a tenant may issue it on a different domain than "
+            + "`mail`, so treat it as an identifier rather than an address unless `mail` is null."
+        )
+    )
+    job_title: str | None = Field(
+        description="The user's job title, when the directory records one."
+    )
+
+
+async def get_signed_in_user(client: GraphServiceClient) -> SignedInUser:
+    """`GET /me`, projected onto the five properties this connector promises."""
+    configuration = RequestConfiguration[_MeQuery](
+        query_parameters=UserItemRequestBuilder.UserItemRequestBuilderGetQueryParameters(
+            select=_SELECT
+        )
+    )
+    with graph_errors():
+        user = await client.me.get(request_configuration=configuration)
+
+    assert user is not None, "Graph answered GET /me with no user object"
+    assert user.id is not None, "Graph answered GET /me with a user that has no id"
+    return SignedInUser(
+        id=user.id,
+        display_name=user.display_name,
+        mail=user.mail,
+        user_principal_name=user.user_principal_name,
+        job_title=user.job_title,
+    )

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -21,7 +21,10 @@ What a read has to survive, all of it documented and none of it optional:
 * **The body is Teams HTML.** `itemBody.contentType` is `html` or `text`, and the HTML is wrapper
   divs, `<at>` mention tags, `<emoji alt="👀">`, hostedContents `<img>` and `<attachment>`
   placeholders. Handing that to a model is a quality bug, so it is normalised to text here — the
-  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented.
+  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented, with one
+  deliberate divergence: that port decides a message is an adaptive card when its *text* starts
+  with `{` and contains `"type"`, which discards any message somebody pasted JSON into. The card
+  signal here is attachment metadata instead, per `_is_card` below.
 * **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
   (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
   *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
@@ -35,13 +38,17 @@ What a read has to survive, all of it documented and none of it optional:
   properties of `chatMessage`; a tombstone must not be presented as live content.
 * **`mentions[]` and `attachments[]` are the key to the body.** The body carries `<at id="0">` and
   `<attachment id="…">` placeholders whose meaning is in those collections, so both are returned
-  resolved.
+  resolved. A *card* is one of those attachments and nothing else: Graph marks it by the
+  attachment's `contentType`, so that — never the shape of the body text — is what says a message
+  is a card here.
 """
 
 import html
+import json
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from typing import cast
 from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -120,9 +127,11 @@ class MessageAttachment(BaseModel):
     content_type: str | None = Field(
         description=(
             "Microsoft's `contentType`: `reference` for a link to a file, "
-            + "`forwardedMessageReference` for a forwarded message, "
-            + "`application/vnd.microsoft.card.codesnippet` for a code snippet, or a Bot Framework "
-            + "card type. It says what the attachment is, not what format the file is in."
+            + "`forwardedMessageReference` for a forwarded message, or a card type such as "
+            + "`application/vnd.microsoft.card.adaptive` for an adaptive card and "
+            + "`application/vnd.microsoft.card.codesnippet` for a code snippet. It says what the "
+            + "attachment is, not what format the file is in — and it is the only thing that says "
+            + "a message carries a card, which is why `[card]` in `text` comes from here."
         )
     )
     url: str | None = Field(
@@ -169,10 +178,12 @@ class TeamsMessage(BaseModel):
         description=(
             "The message, as plain text. Teams HTML is normalised: mentions read as `@Name`, list "
             + "items as `- `, emoji as themselves, an inline image as `[image]`, an attachment as "
-            + "`[attachment: name]` and an adaptive card as `[card]`, with every remaining tag "
-            + "removed and every HTML entity decoded. Null when the message has no text of its "
-            + "own — a system event, a deleted message, or a post that was only an image or a "
-            + "card. This is the full body, not search's `summary` snippet."
+            + "`[attachment: name]` and a card as `[card]`, with every remaining tag removed and "
+            + "every HTML entity decoded. Null when the message has no text of its own — a system "
+            + "event, a deleted message, or a post that was only an image or a card. This is the "
+            + "whole message, never abridged: text that happens to look like JSON or code is a "
+            + "person's own words and is reported verbatim, and `[card]` appears only where "
+            + "`attachments` names a card. This is the full body, not search's `summary` snippet."
         )
     )
     event: str | None = Field(
@@ -440,9 +451,30 @@ _IMAGE = re.compile(r"<img[^>]*>", re.IGNORECASE)
 _ANY_TAG = re.compile(r"<[^>]*>")
 _BLANK_LINES = re.compile(r"\n{3,}")
 
-# An adaptive card whose JSON Teams put in the body rather than in `attachments`. Dumping it would
-# spend a model's context on layout; `services/teams-mcp` found this the hard way.
+_ATTACHMENT = "[attachment]"
 _CARD = "[card]"
+
+# A card is *attachment metadata*, not something to sniff out of body text. Graph names it in
+# `attachments[].contentType` — "If the attachment is a rich card, set the property to the rich card
+# object" of `content` — and the documented value for an adaptive card is
+# `application/vnd.microsoft.card.adaptive`, one of two card namespaces Teams publishes
+# (https://learn.microsoft.com/en-us/graph/api/resources/chatmessageattachment,
+# https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference):
+#
+#     application/vnd.microsoft.card.adaptive              an adaptive card
+#     application/vnd.microsoft.card.hero                  a hero card
+#     application/vnd.microsoft.card.thumbnail             a thumbnail card
+#     application/vnd.microsoft.card.receipt               a receipt card
+#     application/vnd.microsoft.card.signin                a sign-in card
+#     application/vnd.microsoft.card.codesnippet           a code snippet
+#     application/vnd.microsoft.card.announcement          an announcement header
+#     application/vnd.microsoft.teams.card.list            a list card
+#     application/vnd.microsoft.teams.card.o365connector   a connector card for Microsoft 365 Groups
+#
+# The two prefixes are matched rather than those nine values enumerated, for the same reason
+# `_EVENT_TYPE` reads an event's name instead of tabulating the 31 subtypes that exist today: the
+# namespace is the documented shape, and Teams keeps adding card types to it.
+_CARD_CONTENT_TYPES = ("application/vnd.microsoft.card.", "application/vnd.microsoft.teams.card.")
 
 
 def _text(
@@ -475,8 +507,10 @@ def _from_html(
     mention_texts = {
         mention.id: mention.mention_text for mention in mentions if mention.id is not None
     }
-    names = {
-        attachment.id: attachment.name for attachment in attachments if attachment.id is not None
+    markers = {
+        attachment.id: _attachment_marker(attachment)
+        for attachment in attachments
+        if attachment.id is not None
     }
 
     text = _PARAGRAPH_END.sub("\n", content)
@@ -485,16 +519,14 @@ def _from_html(
     text = _LIST_ITEM.sub("- ", text)
     text = _MENTION_TAG.sub(lambda tag: _mention_text(tag, mention_texts), text)
     text = _EMOJI.sub(lambda tag: tag.group(1), text)
-    text = _ATTACHMENT_TAG.sub(lambda tag: _attachment_text(tag, names), text)
+    text = _ATTACHMENT_TAG.sub(lambda tag: markers.get(tag.group(1), _ATTACHMENT), text)
     text = _IMAGE.sub("[image]", text)
     text = _ANY_TAG.sub("", text)
     # A non-breaking space is what Teams puts between pasted words; a model reads it as a word
     # joiner rather than as the space it is meant to be.
     text = html.unescape(text).replace("\xa0", " ")
     text = _BLANK_LINES.sub("\n\n", text).strip()
-    if text.startswith("{") and '"type"' in text:
-        return _CARD
-    return text
+    return _CARD if _is_card_payload(text, attachments) else text
 
 
 def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> str:
@@ -511,6 +543,46 @@ def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> s
     return f"@{name}" if name else "[mention]"
 
 
-def _attachment_text(tag: re.Match[str], names: dict[str, str | None]) -> str:
-    name = names.get(tag.group(1))
-    return f"[attachment: {name}]" if name else "[attachment]"
+def _attachment_marker(attachment: ChatMessageAttachment) -> str:
+    """How one attachment reads where the body's `<attachment id="…">` placeholder sat.
+
+    Teams gives a card no `name`, so a card would otherwise read as an anonymous `[attachment]`.
+    Its `contentType` is what says it is a card, and that is where `[card]` comes from.
+    """
+    if attachment.name:
+        return f"[attachment: {attachment.name}]"
+    return _CARD if _is_card(attachment) else _ATTACHMENT
+
+
+def _is_card(attachment: ChatMessageAttachment) -> bool:
+    """Whether Graph marked this attachment as a card, by the only property that says so."""
+    return (attachment.content_type or "").lower().startswith(_CARD_CONTENT_TYPES)
+
+
+def _is_card_payload(text: str, attachments: list[ChatMessageAttachment]) -> bool:
+    """Whether `text` is nothing but the payload of a card this message already carries.
+
+    Teams sometimes leaves a card's own JSON in `body.content` instead of the
+    `<attachment id="…">` placeholder, and handing a model a screenful of layout JSON spends its
+    context on nothing. But *looking* like JSON is not evidence of a card — a developer pasting a
+    config fragment or an API response into Teams writes a brace-and-`"type"` object too, and a
+    guard that went by the shape of the text silently threw those messages away, in the one tool
+    that is the only route to a message's text. So a body is only dropped when the message carries
+    a card attachment whose `content` *is* that payload, compared parsed so that indentation and
+    escaping do not decide it. Everything else is what somebody wrote, and is returned in full.
+    """
+    payload = _json(text)
+    if payload is None:
+        return False
+    cards = (attachment for attachment in attachments if _is_card(attachment))
+    return any(_json(card.content) == payload for card in cards)
+
+
+def _json(value: str | None) -> object | None:
+    """`value` parsed, or None when it is not a JSON object or array to begin with."""
+    if value is None or not value.lstrip().startswith(("{", "[")):
+        return None
+    try:
+        return cast("object", json.loads(value))
+    except ValueError:
+        return None

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -6,15 +6,11 @@ properties defined in chatMessage. You can use the Teams API to retrieve more de
 single message" (https://learn.microsoft.com/en-us/graph/search-concept-chat-messages) — so a hit
 is metadata plus a handle, and this is the module that turns the handle back into a message.
 
-The handle is `message_search`'s contract, and exactly two shapes exist because Graph addresses a
-Teams message two ways (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
-
-    teams:///chats/{chatId}/messages/{messageId}
-    teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
-
-Nothing else is accepted. `mail:///`, `site:///` and friends are not "not yet implemented" — this
-connector is scoped to Teams, and a reader that advertises schemes it cannot serve teaches a model
-to ask for things that will always fail.
+The handle is `message_search`'s contract, so `MessageHandle` and its parser live there, with the
+search that mints them, and this module takes them from there rather than spelling the two shapes a
+second time. `MessageSender` and `sender_of` arrive the same way and for the same reason: a message
+means the same thing whichever of the two tools produced it, and that is a property of there being
+one definition rather than of two agreeing.
 
 What a read has to survive, all of it documented and none of it optional:
 
@@ -28,8 +24,8 @@ What a read has to survive, all of it documented and none of it optional:
 * **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
   (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
   *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
-  `emailAddress`. Both go through `message_search.sender_of`, so a sender means the same thing
-  whichever tool produced it.
+  `emailAddress`. Both go through `sender_of`, which is why a `sender` here has the same three
+  fields as a search hit's, with different ones filled in.
 * **System / event messages have no text anywhere.** `from` is null and `body.content` is the
   literal `<systemEventMessage/>`; the "Ada joined the chat" sentence is rendered by the Teams
   client and Graph never sends it (https://learn.microsoft.com/en-us/graph/system-messages). Search
@@ -46,10 +42,8 @@ What a read has to survive, all of it documented and none of it optional:
 import html
 import json
 import re
-from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
-from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
 from kiota_abstractions.headers_collection import HeadersCollection
@@ -67,19 +61,20 @@ from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
-from office_mcp.features.message_search import MessageSender, sender_of
+from office_mcp.features.message_search import (
+    CHANNEL_PERMISSION,
+    CHAT_PERMISSION,
+    MessageHandle,
+    MessageSender,
+    sender_of,
+)
 from office_mcp.graph_client import graph_errors
 
-# Reading a message is `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the
-# permissions are per surface (https://learn.microsoft.com/en-us/graph/api/chatmessage-get), and a
-# handle says which surface it addresses. That is why `MessageHandle.permission` exists: a 403 on a
-# chat read can only be about `Chat.Read`, and naming the other one alongside it would send an
-# administrator after a permission that was never missing.
-CHAT_PERMISSION = "Chat.Read"
-CHANNEL_PERMISSION = "ChannelMessage.Read.All"
-
-# What the token exchange has to ask for. Both, because the exchange happens before the tool sees
-# its argument and so before anything knows which surface this call will read.
+# What the token exchange has to ask for: both, because the exchange happens before the tool sees
+# its argument and so before anything knows which surface this call will read. Reading a message is
+# `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the permissions are per surface
+# (https://learn.microsoft.com/en-us/graph/api/chatmessage-get) — and `MessageHandle.permission` is
+# what names the one a given read was actually made under.
 GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
 
 # `messageType` is an evolvable enum: without this header Graph answers `systemEventMessage` as
@@ -107,10 +102,10 @@ class MessageMention(BaseModel):
     )
     user_id: str | None = Field(
         description=(
-            "The mentioned person's Microsoft Entra object id, comparable against `id` from whoami "
-            + "and the `mentions` parameter of search_messages. Null when the mention was not a "
-            + "person — Teams also mentions teams, channels, chats, tags and everyone at once — so "
-            + "a null here is not a failure to resolve a user."
+            "The mentioned person's Microsoft Entra object id, comparable against `user_id` from "
+            + "get_me and the `mentions` parameter of search_messages. Null when the mention was "
+            + "not a person — Teams also mentions teams, channels, chats, tags and everyone at "
+            + "once — so a null here is not a failure to resolve a user."
         )
     )
 
@@ -242,71 +237,6 @@ class TeamsMessage(BaseModel):
             + "not unpacked."
         )
     )
-
-
-@dataclass(frozen=True, slots=True)
-class MessageHandle:
-    """A parsed `teams:///` handle: which message, and under which permission it is read."""
-
-    message_id: str
-    chat_id: str | None = None
-    team_id: str | None = None
-    channel_id: str | None = None
-
-    @property
-    def permission(self) -> str:
-        """The one delegated Graph permission the read this handle addresses is made under."""
-        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
-
-    @property
-    def uri(self) -> str:
-        """The handle again, canonically — identical to the `uri` a search hit carried."""
-        if self.chat_id is not None:
-            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
-        assert self.team_id is not None and self.channel_id is not None, (
-            "a handle addresses either a chat or a team channel"
-        )
-        return (
-            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
-            + f"/messages/{_segment(self.message_id)}"
-        )
-
-
-# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
-# `message_search` percent-encodes each one — a Teams id is full of `:` and `@` and would otherwise
-# be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was already
-# readable exactly as it is, so a handle a caller copied out of a log still resolves.
-_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
-_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
-
-
-def message_handle(uri: str) -> MessageHandle | None:
-    """`uri` as a handle, or None if it is not one this connector can read.
-
-    None rather than an exception with a message: what to tell the caller about a malformed handle
-    is the tool boundary's business, and this module is not allowed to speak MCP.
-    """
-    chat = _CHAT_HANDLE.match(uri)
-    if chat is not None:
-        chat_id, message_id = (unquote(part) for part in chat.groups())
-        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
-    channel = _CHANNEL_HANDLE.match(uri)
-    if channel is not None:
-        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
-        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
-    return None
-
-
-def _handle(handle: MessageHandle) -> MessageHandle | None:
-    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
-    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
-    if any(value is not None and not value.strip() for value in ids):
-        return None
-    return handle
-
-
-def _segment(value: str) -> str:
-    return quote(value, safe="")
 
 
 async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> TeamsMessage:

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -1,0 +1,516 @@
+"""Reading one Microsoft Teams message, from the handle a search result carries.
+
+`message_search` cannot answer "what did they actually say". Graph's search index returns a
+reduced `chatMessage` projection with **no `body`** — "The search Teams API doesn't return all
+properties defined in chatMessage. You can use the Teams API to retrieve more details about any
+single message" (https://learn.microsoft.com/en-us/graph/search-concept-chat-messages) — so a hit
+is metadata plus a handle, and this is the module that turns the handle back into a message.
+
+The handle is `message_search`'s contract, and exactly two shapes exist because Graph addresses a
+Teams message two ways (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
+
+    teams:///chats/{chatId}/messages/{messageId}
+    teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+
+Nothing else is accepted. `mail:///`, `site:///` and friends are not "not yet implemented" — this
+connector is scoped to Teams, and a reader that advertises schemes it cannot serve teaches a model
+to ask for things that will always fail.
+
+What a read has to survive, all of it documented and none of it optional:
+
+* **The body is Teams HTML.** `itemBody.contentType` is `html` or `text`, and the HTML is wrapper
+  divs, `<at>` mention tags, `<emoji alt="👀">`, hostedContents `<img>` and `<attachment>`
+  placeholders. Handing that to a model is a quality bug, so it is normalised to text here — the
+  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented.
+* **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
+  (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
+  *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
+  `emailAddress`. Both go through `message_search.sender_of`, so a sender means the same thing
+  whichever tool produced it.
+* **System / event messages have no text anywhere.** `from` is null and `body.content` is the
+  literal `<systemEventMessage/>`; the "Ada joined the chat" sentence is rendered by the Teams
+  client and Graph never sends it (https://learn.microsoft.com/en-us/graph/system-messages). Search
+  drops these; a read that lands on one has to say what the event *was*, from `eventDetail`.
+* **Deleted and edited messages exist.** `deletedDateTime` and `lastEditedDateTime` are read-only
+  properties of `chatMessage`; a tombstone must not be presented as live content.
+* **`mentions[]` and `attachments[]` are the key to the body.** The body carries `<at id="0">` and
+  `<attachment id="…">` placeholders whose meaning is in those collections, so both are returned
+  resolved.
+"""
+
+import html
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import quote, unquote
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from kiota_abstractions.headers_collection import HeadersCollection
+from msgraph.generated.chats.item.messages.item.chat_message_item_request_builder import (
+    ChatMessageItemRequestBuilder as ChatMessageRequestBuilder,
+)
+from msgraph.generated.models.body_type import BodyType
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.models.chat_message_attachment import ChatMessageAttachment
+from msgraph.generated.models.chat_message_mention import ChatMessageMention
+from msgraph.generated.models.chat_message_type import ChatMessageType
+from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_request_builder import (  # noqa: E501
+    ChatMessageItemRequestBuilder as ChannelMessageRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.features.message_search import MessageSender, sender_of
+from office_mcp.graph_client import graph_errors
+
+# Reading a message is `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the
+# permissions are per surface (https://learn.microsoft.com/en-us/graph/api/chatmessage-get), and a
+# handle says which surface it addresses. That is why `MessageHandle.permission` exists: a 403 on a
+# chat read can only be about `Chat.Read`, and naming the other one alongside it would send an
+# administrator after a permission that was never missing.
+CHAT_PERMISSION = "Chat.Read"
+CHANNEL_PERMISSION = "ChannelMessage.Read.All"
+
+# What the token exchange has to ask for. Both, because the exchange happens before the tool sees
+# its argument and so before anything knows which surface this call will read.
+GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
+
+# `messageType` is an evolvable enum: without this header Graph answers `systemEventMessage` as
+# `unknownFutureValue` (https://learn.microsoft.com/en-us/graph/api/resources/chatmessage). Nothing
+# below *depends* on the type — a null `from` and a populated `eventDetail` identify a system
+# message either way — but `chatEvent` and `typing` carry neither, and the type is the only thing
+# that names them.
+_PREFER_UNKNOWN_ENUMS = ("Prefer", "include-unknown-enum-members")
+
+type _ChatMessageQuery = ChatMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
+type _ChannelMessageQuery = (
+    ChannelMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
+)
+
+
+class MessageMention(BaseModel):
+    """One @-mention, resolved: the body only carries an `<at id="N">` placeholder."""
+
+    text: str | None = Field(
+        description=(
+            "How the mention reads in the message, e.g. a person's display name or a team's name. "
+            + "This is Microsoft's `mentionText`, and it is what the `@…` in `text` was rendered "
+            + "from."
+        )
+    )
+    user_id: str | None = Field(
+        description=(
+            "The mentioned person's Microsoft Entra object id, comparable against `id` from whoami "
+            + "and the `mentions` parameter of search_messages. Null when the mention was not a "
+            + "person — Teams also mentions teams, channels, chats, tags and everyone at once — so "
+            + "a null here is not a failure to resolve a user."
+        )
+    )
+
+
+class MessageAttachment(BaseModel):
+    """One attachment. The body only carries an `<attachment id="…">` placeholder."""
+
+    name: str | None = Field(
+        description=(
+            "The attachment's name, which is what `[attachment: …]` in `text` shows. Null for "
+            + "attachments Teams gives no name, such as an adaptive card or a forwarded message."
+        )
+    )
+    content_type: str | None = Field(
+        description=(
+            "Microsoft's `contentType`: `reference` for a link to a file, "
+            + "`forwardedMessageReference` for a forwarded message, "
+            + "`application/vnd.microsoft.card.codesnippet` for a code snippet, or a Bot Framework "
+            + "card type. It says what the attachment is, not what format the file is in."
+        )
+    )
+    url: str | None = Field(
+        description=(
+            "Where the attachment's content lives, when Microsoft gave a URL. This connector does "
+            + "not download attachments, and the URL may need Microsoft 365 credentials to open, "
+            + "so treat it as a reference to show a person rather than something to fetch."
+        )
+    )
+
+
+class TeamsMessage(BaseModel):
+    """One Teams message, as fully as Microsoft Graph will describe it."""
+
+    uri: str = Field(
+        description=(
+            "The handle this message was read from, in the canonical form search_messages emits. "
+            + "Echoed so a message can be quoted, cached or re-read without reassembling it."
+        )
+    )
+    message_id: str = Field(
+        description=(
+            "The message's Graph `id`. Unique only within its own chat, channel or reply thread, "
+            + "so identify a message by `uri` rather than by this."
+        )
+    )
+    chat_id: str | None = Field(
+        description="The chat this message is in. Null for a channel message."
+    )
+    team_id: str | None = Field(description="The team, for a channel message. Null in a chat.")
+    channel_id: str | None = Field(
+        description="The channel, for a channel message. Null in a chat."
+    )
+    sender: MessageSender | None = Field(
+        description=(
+            "Who wrote the message, in the same shape search_messages reports. Null only when "
+            + "nobody wrote it: Microsoft Graph sends no author for a system event message, which "
+            + "`event` then describes. A read identifies a sender by Entra object id rather than "
+            + "by email — the Teams identity Graph answers a read with carries no email address at "
+            + "all — so `email` is normally null here even though search fills it in."
+        )
+    )
+    text: str | None = Field(
+        description=(
+            "The message, as plain text. Teams HTML is normalised: mentions read as `@Name`, list "
+            + "items as `- `, emoji as themselves, an inline image as `[image]`, an attachment as "
+            + "`[attachment: name]` and an adaptive card as `[card]`, with every remaining tag "
+            + "removed and every HTML entity decoded. Null when the message has no text of its "
+            + "own — a system event, a deleted message, or a post that was only an image or a "
+            + "card. This is the full body, not search's `summary` snippet."
+        )
+    )
+    event: str | None = Field(
+        description=(
+            "What happened, when this is a system event message rather than something a person "
+            + "wrote: `members joined`, `chat renamed`, `call ended` and so on, from Microsoft's "
+            + "`eventDetail` type. Null for an ordinary message. Microsoft Graph does not send the "
+            + "sentence Teams displays for these ('Ada joined the chat') — the Teams client writes "
+            + "it — so this naming of the event is all there is, and there is no text to quote. "
+            + "Who took part in the event is not returned by this connector."
+        )
+    )
+    created_at: datetime | None = Field(description="When the message was sent.")
+    last_edited_at: datetime | None = Field(
+        description=(
+            "When the message was last edited by its author, or null if it never was — this is "
+            + "Microsoft's `lastEditedDateTime`, the property behind the 'Edited' flag in Teams. "
+            + "Unlike `lastModifiedDateTime` it does not move when somebody adds a reaction."
+        )
+    )
+    deleted_at: datetime | None = Field(
+        description=(
+            "When the message was deleted, or null if it is still live. When this is set, `text` "
+            + "is null and the message's content is gone: say the message was deleted rather than "
+            + "reporting it as empty."
+        )
+    )
+    reply_to_id: str | None = Field(
+        description=(
+            "The id of the channel post this message replies to, for a reply in a channel thread; "
+            + "null for a root post and for every chat message, which Teams does not thread."
+        )
+    )
+    subject: str | None = Field(
+        description="The message subject. Usually null: Teams sets one only on some channel posts."
+    )
+    importance: str | None = Field(
+        description="`normal`, `high` or `urgent`, as the sender marked the message."
+    )
+    web_url: str | None = Field(
+        description=(
+            "A link that opens the message in Microsoft Teams. Populated for channel messages; "
+            + "Graph gives chat messages no such link, so it is null there."
+        )
+    )
+    mentions: list[MessageMention] = Field(
+        description=(
+            "Everyone and everything this message @-mentions, in the order Microsoft lists them. "
+            + "Empty when it mentions nobody."
+        )
+    )
+    attachments: list[MessageAttachment] = Field(
+        description=(
+            "What was attached: files, cards, code snippets, forwarded messages. Empty when "
+            + "nothing was. The contents are not downloaded and a forwarded message's own body is "
+            + "not unpacked."
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MessageHandle:
+    """A parsed `teams:///` handle: which message, and under which permission it is read."""
+
+    message_id: str
+    chat_id: str | None = None
+    team_id: str | None = None
+    channel_id: str | None = None
+
+    @property
+    def permission(self) -> str:
+        """The one delegated Graph permission the read this handle addresses is made under."""
+        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
+
+    @property
+    def uri(self) -> str:
+        """The handle again, canonically — identical to the `uri` a search hit carried."""
+        if self.chat_id is not None:
+            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
+        assert self.team_id is not None and self.channel_id is not None, (
+            "a handle addresses either a chat or a team channel"
+        )
+        return (
+            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+            + f"/messages/{_segment(self.message_id)}"
+        )
+
+
+# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
+# `message_search` percent-encodes each one — a Teams id is full of `:` and `@` and would otherwise
+# be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was already
+# readable exactly as it is, so a handle a caller copied out of a log still resolves.
+_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
+_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+
+
+def message_handle(uri: str) -> MessageHandle | None:
+    """`uri` as a handle, or None if it is not one this connector can read.
+
+    None rather than an exception with a message: what to tell the caller about a malformed handle
+    is the tool boundary's business, and this module is not allowed to speak MCP.
+    """
+    chat = _CHAT_HANDLE.match(uri)
+    if chat is not None:
+        chat_id, message_id = (unquote(part) for part in chat.groups())
+        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    channel = _CHANNEL_HANDLE.match(uri)
+    if channel is not None:
+        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
+        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
+    return None
+
+
+def _handle(handle: MessageHandle) -> MessageHandle | None:
+    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
+    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    if any(value is not None and not value.strip() for value in ids):
+        return None
+    return handle
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
+
+
+async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> TeamsMessage:
+    """The message `handle` addresses. One Graph request, whichever surface it lives on.
+
+    `chatmessage-get` "doesn't support the OData query parameters", so there is no `$select` to
+    narrow it with and no `$expand` to widen it: mentions and attachments arrive with the message.
+    """
+    with graph_errors():
+        message = await _get(client, handle)
+
+    assert message is not None, "Graph answered a message read with no message"
+    return _message(message, handle)
+
+
+async def _get(client: GraphServiceClient, handle: MessageHandle) -> ChatMessage | None:
+    if handle.chat_id is not None:
+        return await (
+            client.chats.by_chat_id(handle.chat_id)
+            .messages.by_chat_message_id(handle.message_id)
+            .get(request_configuration=RequestConfiguration[_ChatMessageQuery](headers=_headers()))
+        )
+    assert handle.team_id is not None and handle.channel_id is not None, (
+        "a handle addresses either a chat or a team channel"
+    )
+    return await (
+        client.teams.by_team_id(handle.team_id)
+        .channels.by_channel_id(handle.channel_id)
+        .messages.by_chat_message_id(handle.message_id)
+        .get(request_configuration=RequestConfiguration[_ChannelMessageQuery](headers=_headers()))
+    )
+
+
+def _headers() -> HeadersCollection:
+    """A `HeadersCollection` of our own, carrying the `Prefer` header.
+
+    Built per request on purpose: `RequestConfiguration.headers` defaults to a single
+    `HeadersCollection` instance shared by every configuration in the process, so adding a header
+    to the default would add it to every other Graph request this connector makes.
+    """
+    headers = HeadersCollection()
+    headers.add(*_PREFER_UNKNOWN_ENUMS)
+    return headers
+
+
+def _message(message: ChatMessage, handle: MessageHandle) -> TeamsMessage:
+    mentions = message.mentions or []
+    attachments = message.attachments or []
+    return TeamsMessage(
+        uri=handle.uri,
+        message_id=message.id or handle.message_id,
+        chat_id=handle.chat_id,
+        team_id=handle.team_id,
+        channel_id=handle.channel_id,
+        sender=sender_of(message.from_),
+        text=_text(message, mentions=mentions, attachments=attachments),
+        event=_event(message),
+        created_at=message.created_date_time,
+        last_edited_at=message.last_edited_date_time,
+        deleted_at=message.deleted_date_time,
+        reply_to_id=message.reply_to_id,
+        subject=message.subject,
+        # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
+        importance=message.importance,
+        web_url=message.web_url,
+        mentions=[_mention(mention) for mention in mentions],
+        attachments=[_attachment(attachment) for attachment in attachments],
+    )
+
+
+def _mention(mention: ChatMessageMention) -> MessageMention:
+    mentioned = mention.mentioned
+    user = mentioned.user if mentioned is not None else None
+    return MessageMention(text=mention.mention_text, user_id=user.id if user is not None else None)
+
+
+def _attachment(attachment: ChatMessageAttachment) -> MessageAttachment:
+    return MessageAttachment(
+        name=attachment.name,
+        content_type=attachment.content_type,
+        # `content` and `contentUrl` are documented as mutually exclusive, and `content` is a card
+        # payload or a forwarded message's JSON rather than a location — so only the URL is a URL.
+        url=attachment.content_url,
+    )
+
+
+# Every `eventMessageDetail` subtype is named `<what happened>EventMessageDetail`, and Microsoft
+# lists all 31 (https://learn.microsoft.com/en-us/graph/system-messages) — so the `@odata.type` of
+# the one Graph sent *is* the event. Reading the name is what makes this cover the subtypes
+# Microsoft adds next as well as the ones that exist today; a table of the 31 would answer
+# "unknown event" for the 32nd.
+_EVENT_TYPE = re.compile(r"\A#?microsoft\.graph\.(.+?)EventMessageDetail\Z")
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+# What Teams renders itself and Graph describes to nobody: `chatEvent` and `typing` messages carry
+# no `eventDetail`, and a `systemEventMessage` whose detail Graph omitted carries nothing either.
+_UNDESCRIBED_EVENT = "a system event Microsoft Graph sent no detail for"
+
+
+def _event(message: ChatMessage) -> str | None:
+    """What this message is an event *of*, or None if a person wrote it.
+
+    Three independent signals, because no one of them is reliable alone: `eventDetail` is only
+    populated for `systemEventMessage`, `messageType` needs the `Prefer` header above to be legible
+    at all, and a null `from` is what Graph actually sends for every one of them.
+    """
+    detail = message.event_detail
+    if detail is not None:
+        return _event_name(detail.odata_type) or _UNDESCRIBED_EVENT
+    if message.from_ is None or (
+        message.message_type is not None and message.message_type != ChatMessageType.Message
+    ):
+        return _UNDESCRIBED_EVENT
+    return None
+
+
+def _event_name(odata_type: str | None) -> str | None:
+    """`#microsoft.graph.membersJoinedEventMessageDetail` → `members joined`."""
+    if odata_type is None:
+        return None
+    matched = _EVENT_TYPE.match(odata_type)
+    if matched is None:
+        return None
+    return _CAMEL_BOUNDARY.sub(" ", matched.group(1)).lower()
+
+
+# Teams HTML, in the order it has to be unwound. Everything here is a documented shape rather than
+# a defensive guess: `services/teams-mcp` ships this same pipeline merged, and Microsoft's own
+# examples are where the `<emoji alt>`, hostedContents `<img>` and `<attachment>` placeholder cases
+# come from (https://learn.microsoft.com/en-us/graph/api/resources/chatmessage).
+_PARAGRAPH_END = re.compile(r"</p\s*>", re.IGNORECASE)
+_LINE_BREAK = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_LIST_ITEM_END = re.compile(r"</li\s*>", re.IGNORECASE)
+_LIST_ITEM = re.compile(r"<li[^>]*>", re.IGNORECASE)
+_MENTION_TAG = re.compile(r"<at([^>]*)>(.*?)</at\s*>", re.IGNORECASE | re.DOTALL)
+_MENTION_INDEX = re.compile(r'\bid="(\d+)"', re.IGNORECASE)
+# `<emoji id="1f440_eyes" alt="👀" title="Eyes">` — the character is in the attribute, so stripping
+# the tag without reading it deletes the emoji from the message.
+_EMOJI = re.compile(r'<(?:custom)?emoji[^>]*\balt="([^"]*)"[^>]*>', re.IGNORECASE)
+_ATTACHMENT_TAG = re.compile(r'<attachment[^>]*\bid="([^"]+)"[^>]*>', re.IGNORECASE)
+_IMAGE = re.compile(r"<img[^>]*>", re.IGNORECASE)
+_ANY_TAG = re.compile(r"<[^>]*>")
+_BLANK_LINES = re.compile(r"\n{3,}")
+
+# An adaptive card whose JSON Teams put in the body rather than in `attachments`. Dumping it would
+# spend a model's context on layout; `services/teams-mcp` found this the hard way.
+_CARD = "[card]"
+
+
+def _text(
+    message: ChatMessage,
+    *,
+    mentions: list[ChatMessageMention],
+    attachments: list[ChatMessageAttachment],
+) -> str | None:
+    """The message as plain text, or None when it has none.
+
+    A deleted message has no content to normalise whatever `body` says, and returning what Graph
+    happens to leave in a tombstone would present a deleted message as live text.
+    """
+    if message.deleted_date_time is not None:
+        return None
+    body = message.body
+    if body is None or body.content is None:
+        return None
+    if body.content_type != BodyType.Html:
+        return body.content.strip() or None
+    return _from_html(body.content, mentions=mentions, attachments=attachments) or None
+
+
+def _from_html(
+    content: str,
+    *,
+    mentions: list[ChatMessageMention],
+    attachments: list[ChatMessageAttachment],
+) -> str:
+    mention_texts = {
+        mention.id: mention.mention_text for mention in mentions if mention.id is not None
+    }
+    names = {
+        attachment.id: attachment.name for attachment in attachments if attachment.id is not None
+    }
+
+    text = _PARAGRAPH_END.sub("\n", content)
+    text = _LINE_BREAK.sub("\n", text)
+    text = _LIST_ITEM_END.sub("\n", text)
+    text = _LIST_ITEM.sub("- ", text)
+    text = _MENTION_TAG.sub(lambda tag: _mention_text(tag, mention_texts), text)
+    text = _EMOJI.sub(lambda tag: tag.group(1), text)
+    text = _ATTACHMENT_TAG.sub(lambda tag: _attachment_text(tag, names), text)
+    text = _IMAGE.sub("[image]", text)
+    text = _ANY_TAG.sub("", text)
+    # A non-breaking space is what Teams puts between pasted words; a model reads it as a word
+    # joiner rather than as the space it is meant to be.
+    text = html.unescape(text).replace("\xa0", " ")
+    text = _BLANK_LINES.sub("\n\n", text).strip()
+    if text.startswith("{") and '"type"' in text:
+        return _CARD
+    return text
+
+
+def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> str:
+    """`<at id="0">Ada Lovelace</at>` → `@Ada Lovelace`.
+
+    The tag's `id` indexes `mentions[]` — Microsoft documents the correspondence — and that is the
+    authority, because the element's own text is sometimes empty. Its text is the fallback, and if
+    neither names anybody the mention is still marked: an `<at>` that vanished would read as the
+    author addressing nobody, and a bare `<at id="0">` left in the text would be a key to nothing.
+    """
+    index = _MENTION_INDEX.search(tag.group(1))
+    resolved = mention_texts.get(int(index.group(1))) if index is not None else None
+    name = (resolved or _ANY_TAG.sub("", tag.group(2))).strip()
+    return f"@{name}" if name else "[mention]"
+
+
+def _attachment_text(tag: re.Match[str], names: dict[str, str | None]) -> str:
+    name = names.get(tag.group(1))
+    return f"[attachment: {name}]" if name else "[attachment]"

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -405,7 +405,7 @@ def _message(hit: SearchHit) -> MessageHit | None:
     resource = hit.resource
     if not isinstance(resource, ChatMessage) or resource.id is None:
         return None
-    sender = _sender(resource.from_)
+    sender = sender_of(resource.from_)
     if sender is None:
         # A system event message — "Ada joined the chat", a call ending, a channel being renamed.
         # Graph sends `from: null` and a body of the literal `<systemEventMessage/>` for these,
@@ -461,8 +461,17 @@ def _segment(value: str) -> str:
     return quote(value, safe="")
 
 
-def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
-    """The sender, or None when the identity set names nobody at all."""
+def sender_of(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
+    """The sender, or None when the identity set names nobody at all.
+
+    Public because a search hit and a read of the same message must report the same sender, and the
+    two arrive in different shapes: search's mailbox `emailAddress` and the Teams
+    `teamworkUserIdentity` every read API answers with. One function over both shapes is what makes
+    that consistency a property of the code rather than of two implementations agreeing.
+
+    A null `from` — and an identity set that named nobody — is how Graph sends a system event
+    message, so None is also the signal `message_search` filters those hits out by.
+    """
     if identity is None:
         return None
     mailbox_name, mailbox_address = _mailbox_identity(identity)
@@ -472,8 +481,11 @@ def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None
     if display_name is None and application is not None:
         display_name = application.display_name
     sender = MessageSender(
-        display_name=display_name or mailbox_name,
-        email=mailbox_address,
+        # Empty strings are collapsed to null: `displayName` is documented Optional and Graph does
+        # send it blank, and a name that is present-but-empty reads as an unnamed sender rather
+        # than as the "Graph did not say" that `user_id` is there to work around.
+        display_name=_present(display_name) or _present(mailbox_name),
+        email=_present(mailbox_address),
         user_id=user.id if user is not None else None,
     )
     if (sender.display_name, sender.email, sender.user_id) == (None, None, None):
@@ -499,3 +511,8 @@ def _mailbox_identity(identity: ChatMessageFromIdentitySet) -> tuple[str | None,
 
 def _string(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _present(value: str | None) -> str | None:
+    """`value` if it says anything, else None."""
+    return value if value is not None and value.strip() else None

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -1,0 +1,501 @@
+"""Full-text search across the Microsoft Teams messages the signed-in user can see.
+
+`POST /search/query` with `entityTypes: ["chatMessage"]` is the only full-text path Microsoft
+Graph offers over Teams messages, and it runs in delegated context only
+(https://learn.microsoft.com/en-us/graph/search-concept-chat-messages). Four of its documented
+properties shape everything below.
+
+* **The hit is a projection, not a message.** The retrievable set is `channelIdentity`, `chatId`,
+  `createdDateTime`, `etag`, `from`, `id`, `importance`, `lastModifiedDateTime`, `subject` and
+  `webUrl` — no `body`. Graph says so outright: "The search Teams API doesn't return all
+  properties defined in chatMessage." The only text a hit carries is the `summary` snippet. A
+  result is therefore metadata plus a handle by necessity, and the handle is what a reader tool
+  resolves into the message itself.
+* **`total` is not a match count.** "For Teams messages, the total property of the
+  searchHitsContainer type contains the number of results on the page, not the total number of
+  matching results." It is not read here and no total is reported: `moreResultsAvailable` is the
+  only honest "keep going" signal Graph gives.
+* **Sorting is unsupported.** "The search API doesn't support custom sort for … chatMessage …", so
+  there is no ordering knob to expose, and none is invented.
+* **Paging is stateless.** `from`/`size` integers rather than an opaque `@odata.nextLink`, which is
+  why `graph_client.collect_pages` has nothing to do here and why a caller can resume a search on
+  a later, unrelated call.
+
+Deliberately absent: the per-chat scan that the connector this one replaces falls back to when it
+lacks a permission or is given a date filter. Graph caps reads at "one request per second per app
+per tenant … on a given channel or chat" (https://learn.microsoft.com/en-us/graph/throttling), and
+that budget is *per app*, so one user's sweep of fifty chats degrades every other user in the
+tenant. Date bounds go into the query string instead, where the index applies them for the price
+of the one request that was being made anyway.
+"""
+
+import re
+from dataclasses import dataclass, fields
+from datetime import date, datetime
+from typing import cast
+from urllib.parse import quote
+from uuid import UUID
+
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.models.chat_message_from_identity_set import ChatMessageFromIdentitySet
+from msgraph.generated.models.entity_type import EntityType
+from msgraph.generated.models.search_hit import SearchHit
+from msgraph.generated.models.search_hits_container import SearchHitsContainer
+from msgraph.generated.models.search_query import SearchQuery
+from msgraph.generated.models.search_request import SearchRequest
+from msgraph.generated.search.query.query_post_request_body import QueryPostRequestBody
+from msgraph.generated.search.query.query_post_response import QueryPostResponse
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_errors
+
+# `Chat.Read` is what `/search/query` accepts for the `chatMessage` entity; Graph's own search
+# overview promises a search never returns more than the equivalent GET would, and every
+# channel-message GET in v1.0 requires `ChannelMessage.Read.All` — so without it a search silently
+# covers chats only. Both are requested rather than one, so a tenant that withholds the broad one
+# is refused at consent time instead of being served half an answer at query time. The broad one is
+# named separately because the tool's description has to tell a model what channel coverage costs.
+CHANNEL_PERMISSION = "ChannelMessage.Read.All"
+GRAPH_PERMISSIONS: tuple[str, ...] = ("Chat.Read", CHANNEL_PERMISSION)
+
+# Graph documents `size` as defaulting to 25 with a maximum of 1000, but the paragraph that caps a
+# page at 25 names only the `message` and `event` entities, and no chatMessage-specific ceiling is
+# published. 50 is the largest page this connector will claim on undocumented ground.
+MAX_RESULTS = 50
+
+
+class MessageSender(BaseModel):
+    """Who sent a matched message, from whichever identity shape Graph used.
+
+    Two shapes, because Teams messages are indexed out of the substrate mailbox: a search hit
+    carries an Exchange-style `emailAddress` (a name and an address), while every Teams read API
+    returns a `teamworkUserIdentity` (an id and an optional display name, and no email at all).
+    Which fields are populated therefore says which shape Graph answered with, and a null is not
+    evidence that the sender has no name or no address.
+    """
+
+    display_name: str | None = Field(
+        description=(
+            "The sender's name as Teams shows it. Microsoft documents this as optional and it is "
+            + "genuinely absent on some messages, including messages from external and federated "
+            + "users — a null is not an anonymous sender."
+        )
+    )
+    email: str | None = Field(
+        description=(
+            "The sender's email address. Present when Graph answered with the mailbox-shaped "
+            + "identity that search hits normally carry, and null otherwise; the Teams identity "
+            + "has no email property at all, so compare `user_id` when this is null."
+        )
+    )
+    user_id: str | None = Field(
+        description=(
+            "The sender's Microsoft Entra object id, when Graph answered with the Teams-shaped "
+            + "identity. This is the value the `mentions` search parameter takes, and the only "
+            + "sender field safe to compare against ids from other tools. Null for a message sent "
+            + "by an application (a bot or a connector), and null when Graph gave an email "
+            + "address instead."
+        )
+    )
+
+
+class MessageHit(BaseModel):
+    """One matched message: all Graph's search index will say about it, and how to read the rest."""
+
+    uri: str | None = Field(
+        description=(
+            "A handle for this exact message, e.g. "
+            + "`teams:///chats/{chatId}/messages/{messageId}` or "
+            + "`teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}`, with each id "
+            + "percent-encoded. Pass it verbatim to a tool that reads a message resource; this "
+            + "search returns no message body, so it is the only route to the full text, the "
+            + "attachments and the mentions. Null in the rare case where Graph returned a hit "
+            + "with neither a chat nor a channel identity, which cannot be addressed."
+        )
+    )
+    message_id: str = Field(
+        description=(
+            "The message's Graph `id`. Unique only within its own chat, channel or reply thread — "
+            + "Microsoft documents that the same id may recur elsewhere — so identify a message by "
+            + "`uri`, never by this alone."
+        )
+    )
+    chat_id: str | None = Field(
+        description=(
+            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. Null for a channel "
+            + "message; `team_id` and `channel_id` are set instead."
+        )
+    )
+    team_id: str | None = Field(
+        description="The team a channel message belongs to. Null for a chat message."
+    )
+    channel_id: str | None = Field(
+        description="The channel a channel message was posted in. Null for a chat message."
+    )
+    subject: str | None = Field(
+        description=(
+            "The message subject. Usually null or empty: Teams only sets one on some channel root "
+            + "posts, never on ordinary chat messages."
+        )
+    )
+    summary: str | None = Field(
+        description=(
+            "Microsoft's own snippet of the matching text, truncated with `...` where it was cut. "
+            + "This is the ONLY message content this search returns — Graph's search projection "
+            + "has no body — so do not quote it as the whole message or infer from its absence. "
+            + "Read `uri` for the real text."
+        )
+    )
+    sender: MessageSender = Field(description="Who sent the message.")
+    created_at: datetime | None = Field(
+        description=(
+            "When the message was sent. Compare this when order matters: Graph refuses to sort a "
+            + "message search, so the sequence results arrive in is not a contract."
+        )
+    )
+    last_modified_at: datetime | None = Field(
+        description=(
+            "When the message was last modified. Microsoft counts adding or removing a reaction "
+            + "as a modification, so a difference from `created_at` is not evidence of an edit."
+        )
+    )
+    importance: str | None = Field(
+        description="`normal`, `high` or `urgent`, as the sender marked the message."
+    )
+    web_url: str | None = Field(
+        description=(
+            "A link that opens the message in Microsoft Teams. Populated for channel messages and "
+            + "null for chat messages, which Graph gives no such link — use `uri` to read those."
+        )
+    )
+
+
+class MessageSearchResults(BaseModel):
+    messages: list[MessageHit] = Field(description="The matching messages on this page of results.")
+    more_results_available: bool = Field(
+        description=(
+            "Whether Microsoft's index has further matches beyond this page. This is the only "
+            + "signal Graph gives: it reports no match total for Teams messages, so neither does "
+            + "this tool."
+        )
+    )
+    next_offset: int | None = Field(
+        description=(
+            "The `offset` that reaches the next page, or null when there is none. It counts the "
+            + "hits Graph returned rather than the messages listed here, because offsets index "
+            + "Graph's own unfiltered results."
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SearchCriteria:
+    """What to match, before it becomes a query string.
+
+    Every field is optional and Microsoft ANDs them together. All of them unset would ask for
+    every message the user can see, which is not a question anyone asked — `is_empty` is what the
+    tool boundary refuses.
+    """
+
+    query: str | None = None
+    sender: str | None = None
+    recipient: str | None = None
+    mentions: UUID | None = None
+    sent_after: date | None = None
+    sent_before: date | None = None
+    has_attachment: bool | None = None
+    is_read: bool | None = None
+    mentions_me: bool | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether these criteria would match on nothing at all."""
+        return not _query_string(self)
+
+
+# The criteria a caller may set, in declaration order. The tool advertises this as a JSON Schema
+# `anyOf` of one-element `required` lists, which is how "at least one of these" becomes something
+# a client can check rather than a sentence in a description it may not read.
+CRITERIA: tuple[str, ...] = tuple(field.name for field in fields(SearchCriteria))
+
+# The characters that would let a value be read as Keyword Query Language instead of as text:
+# whitespace separates terms, `:` `<` `>` `=` introduce a property restriction or a comparison,
+# `(` and `)` group, and `"` would close the quoting applied here. A value holding any of them is
+# quoted — which is what turns `sent>2020-01-01` into something to look for rather than a filter
+# the caller was never offered. A value holding none of them cannot express a restriction, so it is
+# left alone and stays a keyword. This is the guard `services/teams-mcp` ships merged, and it is
+# for a *filter value* — one scope term's argument, e.g. the `from:` in `from:"ada lovelace"`.
+_KQL_OPERATORS = re.compile(r'[\s:"<>=()]')
+
+
+def _quoted(value: str) -> str:
+    """A filter value, safe to put after a scope term. One value, therefore at most one term."""
+    if _KQL_OPERATORS.search(value) is None:
+        return value
+    return _phrase(value)
+
+
+# A caller's free text is not a filter value, and quoting it like one costs them every match whose
+# words are not adjacent — Microsoft is explicit about both halves of this
+# (https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference):
+# a quoted phrase "returns only the items in which the words in your phrase are located next to each
+# other", while "if there are multiple free-text expressions without any operators in between them,
+# the query behavior is the same as using the AND operator". So free text is guarded one word at a
+# time and the words reach Graph as separate terms it will AND — every word must appear, anywhere in
+# the message, in any order. Adjacency is still available: a caller who wants it quotes the words
+# themselves, and this is what tells those two apart.
+_PHRASE = re.compile(r'"([^"]*)"')
+
+# Beyond the operator characters above, a *word* has two further ways to be read as KQL. `*` is the
+# wildcard, and KQL's boolean and proximity operators are themselves words — "the operators are
+# case-sensitive (uppercase)", which is why the comparison below is too. Neither can smuggle in a
+# scope term, but both change what the search *means* rather than what it looks for: a bare `OR`
+# between two of the caller's words turns the AND they were promised into an OR. `-` is KQL's
+# documented shorthand for NOT and negates the word it precedes. (`+` is the shorthand for AND,
+# which is the default anyway, so it needs no handling.) All of these are quoted into literal text,
+# so every word of the query is looked for and none of it is obeyed.
+_KQL_WILDCARD = "*"
+_KQL_KEYWORDS = frozenset({"AND", "OR", "NOT", "NEAR", "ONEAR"})
+
+
+def _free_text(query: str) -> str:
+    """A caller's own words, as terms Graph will AND. Empty when they typed nothing to look for.
+
+    Whatever the caller put in double quotes stays one phrase — the only adjacency this tool asks
+    Graph for, because it is the only one anybody asked for. Everything outside those quotes is
+    words, and an unbalanced quote is just a character in one of them.
+    """
+    terms: list[str] = []
+    words_from = 0
+    for phrase in _PHRASE.finditer(query):
+        terms.extend(_keywords(query[words_from : phrase.start()]))
+        quoted = phrase.group(1).strip()
+        if quoted:
+            terms.append(_phrase(quoted))
+        words_from = phrase.end()
+    terms.extend(_keywords(query[words_from:]))
+    return " ".join(terms)
+
+
+def _keywords(text: str) -> list[str]:
+    """The words of `text`, each one safe to hand to Graph as a term of its own."""
+    return [_keyword(word) for word in text.split()]
+
+
+def _keyword(word: str) -> str:
+    if (
+        _KQL_OPERATORS.search(word) is not None
+        or _KQL_WILDCARD in word
+        or word.startswith("-")
+        or word in _KQL_KEYWORDS
+    ):
+        return _phrase(word)
+    return word
+
+
+def _phrase(text: str) -> str:
+    """`text` as a KQL phrase: matched where those words are adjacent, and read as no operator.
+
+    The quoting is the guard as much as it is the phrase — everything inside a quoted phrase is
+    text — so the only thing left to handle is a quote in the text itself, which KQL escapes by
+    doubling it. That keeps the number of quotes in the query even, and so keeps the quoting
+    unclosable from inside.
+    """
+    return '"' + text.replace('"', '""') + '"'
+
+
+def _flag(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _query_string(criteria: SearchCriteria) -> str:
+    """The `queryString` these criteria become. Empty exactly when nothing was asked for.
+
+    The scope terms are the ones Microsoft documents for `chatMessage`: `from`, `to`,
+    `hasAttachment`, `IsRead`, `IsMentioned`, `mentions` and `sent`, in their documented spellings
+    (the casing is Microsoft's, not a mistake). `sent` is the one that is not a `term:value` pair
+    at all — it is a comparison, `sent > 2022-07-14` — and `>=`/`<=` are used so that a bound
+    lands on the day the caller named rather than the day after it, which is what `sent_after` and
+    `sent_before` promise.
+
+    `query` is the one input that is not a scope term's value, and it is the one that becomes more
+    than one term: it is free text, so it becomes the caller's words, ANDed with everything else
+    here. A query of nothing but punctuation therefore contributes nothing, which is what makes
+    this string — rather than the arguments it was built from — the honest test of `is_empty`.
+    """
+    terms: list[str] = []
+    if criteria.query:
+        free_text = _free_text(criteria.query)
+        if free_text:
+            terms.append(free_text)
+    if criteria.sender:
+        terms.append(f"from:{_quoted(criteria.sender)}")
+    if criteria.recipient:
+        terms.append(f"to:{_quoted(criteria.recipient)}")
+    if criteria.mentions is not None:
+        # Microsoft's example is a user id "without '-'", which is exactly `UUID.hex`. Typing the
+        # parameter as a UUID is also what makes this the one term needing no quoting.
+        terms.append(f"mentions:{criteria.mentions.hex}")
+    if criteria.sent_after is not None:
+        terms.append(f"sent>={criteria.sent_after.isoformat()}")
+    if criteria.sent_before is not None:
+        terms.append(f"sent<={criteria.sent_before.isoformat()}")
+    if criteria.has_attachment is not None:
+        terms.append(f"hasAttachment:{_flag(criteria.has_attachment)}")
+    if criteria.is_read is not None:
+        terms.append(f"IsRead:{_flag(criteria.is_read)}")
+    if criteria.mentions_me is not None:
+        terms.append(f"IsMentioned:{_flag(criteria.mentions_me)}")
+    return " ".join(terms)
+
+
+async def search_messages(
+    client: GraphServiceClient, *, criteria: SearchCriteria, offset: int, size: int
+) -> MessageSearchResults:
+    """One page of matches for `criteria`, starting at `offset`.
+
+    Exactly one Graph request, whatever the criteria: there is no fan-out and no second call to
+    fill in content. Callers that want the text of a match read its `uri`.
+    """
+    query = _query_string(criteria)
+    assert query, "search_messages needs at least one criterion; the tool refuses an empty set"
+    assert 1 <= size <= MAX_RESULTS, f"size must be within 1..{MAX_RESULTS}, got {size}"
+    assert offset >= 0, f"offset must not be negative, got {offset}"
+
+    body = QueryPostRequestBody(
+        requests=[
+            SearchRequest(
+                entity_types=[EntityType.ChatMessage],
+                query=SearchQuery(query_string=query),
+                from_=offset,
+                size=size,
+            )
+        ]
+    )
+    with graph_errors():
+        response = await client.search.query.post(body)
+
+    assert response is not None, "Graph answered POST /search/query with no response"
+    container = _hits_container(response)
+    hits = (container.hits or []) if container is not None else []
+    more_results_available = bool(container.more_results_available) if container else False
+
+    return MessageSearchResults(
+        messages=[message for message in (_message(hit) for hit in hits) if message is not None],
+        more_results_available=more_results_available,
+        next_offset=offset + len(hits) if more_results_available else None,
+    )
+
+
+def _hits_container(response: QueryPostResponse) -> SearchHitsContainer | None:
+    """The one container this request can produce.
+
+    Graph "currently supports only a single searchRequest at a time" and one entity type, so the
+    nesting — a response per request, a container per entity type — only ever holds one of each.
+    """
+    for search_response in response.value or []:
+        for container in search_response.hits_containers or []:
+            return container
+    return None
+
+
+def _message(hit: SearchHit) -> MessageHit | None:
+    """One hit as a result, or None for a hit that is not a message a person wrote."""
+    resource = hit.resource
+    if not isinstance(resource, ChatMessage) or resource.id is None:
+        return None
+    sender = _sender(resource.from_)
+    if sender is None:
+        # A system event message — "Ada joined the chat", a call ending, a channel being renamed.
+        # Graph sends `from: null` and a body of the literal `<systemEventMessage/>` for these,
+        # and the human-readable sentence Teams shows is rendered by the client and never sent, so
+        # such a hit has neither an author nor any text. The `messageType` and `eventDetail`
+        # properties that would name it are not in search's retrievable set, which leaves the
+        # missing author as the signal — and it is the one Microsoft's own examples show.
+        return None
+    channel = resource.channel_identity
+    team_id = channel.team_id if channel is not None else None
+    channel_id = channel.channel_id if channel is not None else None
+    return MessageHit(
+        uri=_uri(
+            message_id=resource.id,
+            chat_id=resource.chat_id,
+            team_id=team_id,
+            channel_id=channel_id,
+        ),
+        message_id=resource.id,
+        chat_id=resource.chat_id,
+        team_id=team_id,
+        channel_id=channel_id,
+        subject=resource.subject,
+        summary=hit.summary,
+        sender=sender,
+        created_at=resource.created_date_time,
+        last_modified_at=resource.last_modified_date_time,
+        # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
+        importance=resource.importance,
+        web_url=resource.web_url,
+    )
+
+
+def _uri(
+    *, message_id: str, chat_id: str | None, team_id: str | None, channel_id: str | None
+) -> str | None:
+    """The handle a reader resolves back into this message.
+
+    Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
+    (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford ambiguity.
+    """
+    if team_id is not None and channel_id is not None:
+        return (
+            f"teams:///teams/{_segment(team_id)}/channels/{_segment(channel_id)}"
+            + f"/messages/{_segment(message_id)}"
+        )
+    if chat_id is not None:
+        return f"teams:///chats/{_segment(chat_id)}/messages/{_segment(message_id)}"
+    return None
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
+    """The sender, or None when the identity set names nobody at all."""
+    if identity is None:
+        return None
+    mailbox_name, mailbox_address = _mailbox_identity(identity)
+    user = identity.user
+    application = identity.application
+    display_name = user.display_name if user is not None else None
+    if display_name is None and application is not None:
+        display_name = application.display_name
+    sender = MessageSender(
+        display_name=display_name or mailbox_name,
+        email=mailbox_address,
+        user_id=user.id if user is not None else None,
+    )
+    if (sender.display_name, sender.email, sender.user_id) == (None, None, None):
+        return None
+    return sender
+
+
+def _mailbox_identity(identity: ChatMessageFromIdentitySet) -> tuple[str | None, str | None]:
+    """The `emailAddress` a search hit carries instead of a Teams identity, as (name, address).
+
+    Search reads Teams messages out of the substrate mailbox, so `POST /search/query` answers with
+    `from: {"emailAddress": {"name": ..., "address": ...}}` where the Teams APIs answer with
+    `from: {"user": {...}}`. The SDK's identity set has no field for the mailbox shape, so it
+    arrives in `additional_data` — untyped by construction, hence the narrowing here.
+    """
+    extra = cast("dict[str, object]", identity.additional_data)
+    mailbox = extra.get("emailAddress")
+    if not isinstance(mailbox, dict):
+        return (None, None)
+    fields_ = cast("dict[str, object]", mailbox)
+    return (_string(fields_.get("name")), _string(fields_.get("address")))
+
+
+def _string(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -33,7 +33,7 @@ import re
 from dataclasses import dataclass, fields
 from datetime import date, datetime
 from typing import cast
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from uuid import UUID
 
 from msgraph.generated.models.chat_message import ChatMessage
@@ -54,15 +54,110 @@ from office_mcp.graph_client import graph_errors
 # overview promises a search never returns more than the equivalent GET would, and every
 # channel-message GET in v1.0 requires `ChannelMessage.Read.All` — so without it a search silently
 # covers chats only. Both are requested rather than one, so a tenant that withholds the broad one
-# is refused at consent time instead of being served half an answer at query time. The broad one is
-# named separately because the tool's description has to tell a model what channel coverage costs.
+# is refused at consent time instead of being served half an answer at query time. Each is named
+# separately because both a tool description and a handle's own surface have to speak about one of
+# them alone: channel coverage is what the broad one buys, and `MessageHandle.permission` below
+# picks whichever one the surface a handle addresses is read under.
+CHAT_PERMISSION = "Chat.Read"
 CHANNEL_PERMISSION = "ChannelMessage.Read.All"
-GRAPH_PERMISSIONS: tuple[str, ...] = ("Chat.Read", CHANNEL_PERMISSION)
+GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
 
 # Graph documents `size` as defaulting to 25 with a maximum of 1000, but the paragraph that caps a
 # page at 25 names only the `message` and `event` entities, and no chatMessage-specific ceiling is
 # published. 50 is the largest page this connector will claim on undocumented ground.
 MAX_RESULTS = 50
+
+
+@dataclass(frozen=True, slots=True)
+class MessageHandle:
+    """Which message, in the one form this connector passes between tools.
+
+    A handle is minted here — a search hit is the only thing that produces one — which is why the
+    shape lives in this module and `message_read` takes it from here rather than spelling it a
+    second time. Two modules that each knew how to write `teams:///chats/…` would be free to
+    disagree, and the disagreement would look like a message that cannot be read.
+
+    Exactly two shapes exist, because Graph addresses a Teams message exactly two ways
+    (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
+
+        teams:///chats/{chatId}/messages/{messageId}
+        teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+
+    Nothing else is a handle. `mail:///`, `site:///` and friends are not "not yet implemented" —
+    this connector is scoped to Teams, and advertising a scheme it cannot serve teaches a model to
+    ask for things that will always fail.
+    """
+
+    message_id: str
+    chat_id: str | None = None
+    team_id: str | None = None
+    channel_id: str | None = None
+
+    @property
+    def permission(self) -> str:
+        """The one delegated Graph permission the message this handle addresses is read under.
+
+        Graph's permissions for a message read are per surface, and the handle is the only thing
+        that knows which surface: a 403 reading a chat can only be about `Chat.Read`, and naming
+        the channel permission alongside it would send an administrator after one that was never
+        missing.
+        """
+        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
+
+    @property
+    def uri(self) -> str:
+        """The handle as a string — what a search hit carries and a read echoes back.
+
+        Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
+        (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford
+        ambiguity.
+        """
+        if self.chat_id is not None:
+            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
+        assert self.team_id is not None and self.channel_id is not None, (
+            "a handle addresses either a chat or a team channel"
+        )
+        return (
+            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+            + f"/messages/{_segment(self.message_id)}"
+        )
+
+
+# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
+# `MessageHandle.uri` percent-encodes each one — a Teams id is full of `:` and `@` and would
+# otherwise be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was
+# already readable exactly as it is, so a handle a caller copied out of a log still resolves.
+_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
+_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+
+
+def message_handle(uri: str) -> MessageHandle | None:
+    """`uri` as a handle, or None if it is not one this connector can read.
+
+    None rather than an exception with a message: what to tell the caller about a malformed handle
+    is the tool boundary's business, and a feature module is not allowed to speak MCP.
+    """
+    chat = _CHAT_HANDLE.match(uri)
+    if chat is not None:
+        chat_id, message_id = (unquote(part) for part in chat.groups())
+        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    channel = _CHANNEL_HANDLE.match(uri)
+    if channel is not None:
+        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
+        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
+    return None
+
+
+def _handle(handle: MessageHandle) -> MessageHandle | None:
+    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
+    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    if any(value is not None and not value.strip() for value in ids):
+        return None
+    return handle
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
 
 
 class MessageSender(BaseModel):
@@ -108,10 +203,10 @@ class MessageHit(BaseModel):
             "A handle for this exact message, e.g. "
             + "`teams:///chats/{chatId}/messages/{messageId}` or "
             + "`teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}`, with each id "
-            + "percent-encoded. Pass it verbatim to a tool that reads a message resource; this "
-            + "search returns no message body, so it is the only route to the full text, the "
-            + "attachments and the mentions. Null in the rare case where Graph returned a hit "
-            + "with neither a chat nor a channel identity, which cannot be addressed."
+            + "percent-encoded. Pass it verbatim to read_message; this search returns no message "
+            + "body, so it is the only route to the full text, the attachments and the mentions. "
+            + "Null in the rare case where Graph returned a hit with neither a chat nor a channel "
+            + "identity, which cannot be addressed."
         )
     )
     message_id: str = Field(
@@ -123,8 +218,10 @@ class MessageHit(BaseModel):
     )
     chat_id: str | None = Field(
         description=(
-            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. Null for a channel "
-            + "message; `team_id` and `channel_id` are set instead."
+            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. It is the same id "
+            + "list_chats reports as `chat_id`, which is how to put a topic and members to the "
+            + "chat a hit came from. Null for a channel message; `team_id` and `channel_id` are "
+            + "set instead."
         )
     )
     team_id: str | None = Field(
@@ -157,7 +254,9 @@ class MessageHit(BaseModel):
     last_modified_at: datetime | None = Field(
         description=(
             "When the message was last modified. Microsoft counts adding or removing a reaction "
-            + "as a modification, so a difference from `created_at` is not evidence of an edit."
+            + "as a modification, so a difference from `created_at` is not evidence of an edit — "
+            + "read_message reports `last_edited_at`, which is the property behind Teams' own "
+            + "'Edited' flag and is what to read when an edit is the question."
         )
     )
     importance: str | None = Field(
@@ -173,17 +272,18 @@ class MessageHit(BaseModel):
 
 class MessageSearchResults(BaseModel):
     messages: list[MessageHit] = Field(description="The matching messages on this page of results.")
-    more_results_available: bool = Field(
+    truncated: bool = Field(
         description=(
-            "Whether Microsoft's index has further matches beyond this page. This is the only "
-            + "signal Graph gives: it reports no match total for Teams messages, so neither does "
-            + "this tool."
+            "True when Microsoft's index has more matches than this page holds — the same "
+            + "'there is more' flag every list-shaped tool here reports. Page on with "
+            + "`next_offset`. It is the only completeness signal Graph gives for a message "
+            + "search: it reports no match total for Teams messages, so neither does this tool."
         )
     )
     next_offset: int | None = Field(
         description=(
-            "The `offset` that reaches the next page, or null when there is none. It counts the "
-            + "hits Graph returned rather than the messages listed here, because offsets index "
+            "The `offset` that reaches the next page, or null when `truncated` is false. It counts "
+            + "the hits Graph returned rather than the messages listed here, because offsets index "
             + "Graph's own unfiltered results."
         )
     )
@@ -379,12 +479,12 @@ async def search_messages(
     assert response is not None, "Graph answered POST /search/query with no response"
     container = _hits_container(response)
     hits = (container.hits or []) if container is not None else []
-    more_results_available = bool(container.more_results_available) if container else False
+    truncated = bool(container.more_results_available) if container else False
 
     return MessageSearchResults(
         messages=[message for message in (_message(hit) for hit in hits) if message is not None],
-        more_results_available=more_results_available,
-        next_offset=offset + len(hits) if more_results_available else None,
+        truncated=truncated,
+        next_offset=offset + len(hits) if truncated else None,
     )
 
 
@@ -418,7 +518,7 @@ def _message(hit: SearchHit) -> MessageHit | None:
     team_id = channel.team_id if channel is not None else None
     channel_id = channel.channel_id if channel is not None else None
     return MessageHit(
-        uri=_uri(
+        uri=_hit_uri(
             message_id=resource.id,
             chat_id=resource.chat_id,
             team_id=team_id,
@@ -439,26 +539,15 @@ def _message(hit: SearchHit) -> MessageHit | None:
     )
 
 
-def _uri(
+def _hit_uri(
     *, message_id: str, chat_id: str | None, team_id: str | None, channel_id: str | None
 ) -> str | None:
-    """The handle a reader resolves back into this message.
-
-    Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
-    (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford ambiguity.
-    """
+    """This hit's handle, or None for a hit Graph gave nothing addressable."""
     if team_id is not None and channel_id is not None:
-        return (
-            f"teams:///teams/{_segment(team_id)}/channels/{_segment(channel_id)}"
-            + f"/messages/{_segment(message_id)}"
-        )
+        return MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id).uri
     if chat_id is not None:
-        return f"teams:///chats/{_segment(chat_id)}/messages/{_segment(message_id)}"
+        return MessageHandle(message_id=message_id, chat_id=chat_id).uri
     return None
-
-
-def _segment(value: str) -> str:
-    return quote(value, safe="")
 
 
 def sender_of(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:

--- a/services/office-mcp/src/office_mcp/server/__init__.py
+++ b/services/office-mcp/src/office_mcp/server/__init__.py
@@ -1,16 +1,17 @@
 """MCP server concerns: how the features are exposed, not what they do.
 
-Tool declarations (`tools`), FastMCP/ASGI middleware (`middleware`), and the process-wide
-service holder (`runtime`) that exists only because FastMCP calls tool functions with a plain
-signature and so denies them constructor injection. None of those exist yet — the one thing
-this package exposes today is `readiness`, the `/ready` route body, which is an
-exposure concern in exactly the same sense: an HTTP endpoint over what the service can reach.
+Three things, all entered here. `tools` declares the MCP tools over the features and states the
+Graph permissions sign-in must ask for; `errors` turns a Graph failure into advice a language
+model can act on, which every tool shares; `readiness` is the `/ready` route body, an exposure
+concern in exactly the same sense — an HTTP endpoint over what the service can reach.
 
 This side may import freely from `features/`. The reverse is a layering violation — see
-`features/__init__.py`. This package is entered through this `__init__`, never through its
-modules; `tests/test_layering.py` enforces that too.
+`features/__init__.py`. What this side must not do is talk to Microsoft Graph itself: the Graph
+SDK belongs to `graph_client/` and the requests belong to `features/`. This package is entered
+through this `__init__`, never through its modules; `tests/test_layering.py` enforces all of that.
 """
 
 from office_mcp.server.readiness import ready_response
+from office_mcp.server.tools import GRAPH_SCOPES, register_tools
 
-__all__ = ["ready_response"]
+__all__ = ["GRAPH_SCOPES", "ready_response", "register_tools"]

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -1,0 +1,106 @@
+"""Turning a Graph failure into something the model on the other end can act on.
+
+`graph_client` classifies what Graph said; this decides what to tell the caller to do about it,
+because the caller is a language model and its only options are: retry, retry later, ask the user
+to sign in, ask an administrator for a permission, or stop. A message that does not name one of
+those is a message it will answer by calling the same tool again.
+
+Two of them are only distinguishable with information Graph does not send. `GraphForbidden`
+covers both 401 and 403 and carries `status` for exactly this reason: 401 means the token was
+rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
+administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
+the message says *which* permission, which Graph never does; the tool does, so every mapping
+here is scoped to the permission the failing call was made with.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from fastmcp.exceptions import ToolError
+
+from office_mcp.graph_client import (
+    GraphFailure,
+    GraphForbidden,
+    GraphNotFound,
+    GraphThrottled,
+    GraphUnavailable,
+)
+
+
+@contextmanager
+def graph_tool_errors(permission: str) -> Generator[None]:
+    """Map any Graph failure raised in this block onto an actionable MCP tool error.
+
+    `permission` is the delegated Graph permission the enclosed calls were made with, e.g.
+    `Chat.Read` — it is what makes a 403 fixable rather than merely reported.
+    """
+    try:
+        yield
+    except GraphFailure as failure:
+        raise ToolError(_advice(failure, permission)) from failure
+
+
+def _advice(failure: GraphFailure, permission: str) -> str:
+    return _remedy(failure, permission) + _diagnostics(failure)
+
+
+def _remedy(failure: GraphFailure, permission: str) -> str:
+    if isinstance(failure, GraphThrottled):
+        if failure.retry_after_seconds is None:
+            return (
+                "Microsoft 365 is rate-limiting this connector. Wait before retrying, and do not "
+                + "repeat the call in a loop — throttling is per tenant and retrying makes it "
+                + "last longer."
+            )
+        return (
+            "Microsoft 365 is rate-limiting this connector and asked to be left alone for "
+            + f"{failure.retry_after_seconds:g} seconds. Retry after that, not sooner."
+        )
+    if isinstance(failure, GraphForbidden):
+        if failure.status == 401:
+            return (
+                "Microsoft 365 rejected the signed-in user's credentials. Ask the user to sign "
+                + "in to this connector again; the request itself was fine, so retrying it "
+                + "unchanged will fail the same way."
+            )
+        return (
+            f"Microsoft 365 refused this request: the connector may not use {permission} on "
+            + "behalf of this user. Ask a Microsoft 365 administrator to grant the delegated "
+            + f"permission {permission} to this connector's app registration (and consent to it "
+            + "for the organisation). Retrying will not help, and no other arguments will "
+            + "succeed either."
+        )
+    if isinstance(failure, GraphNotFound):
+        return (
+            "Microsoft 365 has no such item — or the signed-in user is not allowed to know it "
+            + "exists, which Graph reports identically. Check the id came from a tool response "
+            + "verbatim rather than being constructed."
+        )
+    if isinstance(failure, GraphUnavailable):
+        return (
+            "Microsoft 365 could not be reached or failed internally. Retry once; if it fails "
+            + "again the same way, stop and report it — some Graph 500s are permanent for "
+            + "particular content rather than transient."
+        )
+    return (
+        "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
+        + "permission problem, so retrying it unchanged will fail identically."
+    )
+
+
+def _diagnostics(failure: GraphFailure) -> str:
+    """The evidence an operator needs, appended once rather than woven into every message.
+
+    `request_id` is what Microsoft support asks for first, and it is only ever in this response —
+    losing it means the failure cannot be traced afterwards.
+    """
+    parts = [
+        f"{label} {value}"
+        for label, value in (
+            ("HTTP", failure.status),
+            ("Graph error code", failure.code),
+            ("Graph request id", failure.request_id),
+        )
+        if value is not None
+    ]
+    return f" ({', '.join(parts)})" if parts else ""

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -11,8 +11,14 @@ rejected (sign in again), 403 means the token was fine and the permission is mis
 administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
 the message says *which* permission, which Graph never does; the tool does, so every mapping
 here is scoped to the permission the failing call was made with.
+
+The same missing permission also has an earlier, uglier shape: if it was never consented to,
+Entra refuses the On-Behalf-Of exchange (AADSTS65001) and Graph is never reached at all. That
+failure is `entra_token_errors`, and it says the same thing as the 403 above — because from the
+caller's side it *is* the same thing, and the remedy is identical.
 """
 
+import re
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -38,6 +44,52 @@ def graph_tool_errors(permission: str) -> Generator[None]:
         yield
     except GraphFailure as failure:
         raise ToolError(_advice(failure, permission)) from failure
+
+
+# Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
+# or administrator has not consented"). It is the one part of a multi-line azure-identity error
+# worth repeating to the caller, and what an operator searches for.
+_ENTRA_CODE = re.compile(r"AADSTS\d+")
+
+
+@contextmanager
+def entra_token_errors(permission: str) -> Generator[None]:
+    """Map a failed On-Behalf-Of exchange in this block onto an actionable MCP tool error.
+
+    Wrap the *acquisition* of a Graph token, not the Graph call: this is the failure that happens
+    before any request is made, and the one FastMCP would otherwise report as "Failed to resolve
+    dependency 'graph_token'" — a message that names neither the missing permission nor the
+    remedy, because FastMCP's dependency resolver knows neither. It re-raises `ToolError`
+    untouched (`fastmcp.server.dependencies` lets `FastMCPError` subclasses out of dependency
+    resolution unwrapped, which is what makes this interception point work at all).
+    """
+    try:
+        yield
+    except Exception as failure:
+        raise ToolError(_token_advice(failure, permission)) from failure
+
+
+def _token_advice(failure: BaseException, permission: str) -> str:
+    """What to do about an On-Behalf-Of exchange that did not produce a token.
+
+    One message for every cause, because the two the exchange can actually fail for share the
+    first remedy: the permission was never consented to (AADSTS65001, overwhelmingly the common
+    one), or this connector's own Entra credentials are wrong. Splitting them would mean
+    classifying Entra error codes this connector has never observed, and the cost of guessing
+    wrong is advice that sends the caller after the wrong fix.
+    """
+    code = _ENTRA_CODE.search(str(failure))
+    diagnostics = code.group() if code is not None else type(failure).__name__
+    return (
+        "Microsoft 365 would not issue this connector a token to act for the signed-in user with "
+        + f"the delegated permission {permission}, so this call never reached Microsoft Graph. "
+        + f"Usually that means {permission} was never consented to: ask a Microsoft 365 "
+        + f"administrator to grant the delegated permission {permission} to this connector's app "
+        + "registration (and consent to it for the organisation), then have the user sign in to "
+        + "this connector again. If it is already granted, this connector's Entra configuration "
+        + "is broken and only an operator can fix it. Either way, retrying will not help and no "
+        + f"other arguments will succeed either. (Entra {diagnostics})"
+    )
 
 
 def _advice(failure: GraphFailure, permission: str) -> str:

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -10,12 +10,14 @@ covers both 401 and 403 and carries `status` for exactly this reason: 401 means 
 rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
 administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
 the message says *which* permission, which Graph never does; the tool does, so every mapping
-here is scoped to the permission the failing call was made with.
+here is scoped to the permissions the failing call was made under.
 
 The same missing permission also has an earlier, uglier shape: if it was never consented to,
 Entra refuses the On-Behalf-Of exchange (AADSTS65001) and Graph is never reached at all. That
 failure is `entra_token_errors`, and it says the same thing as the 403 above — because from the
-caller's side it *is* the same thing, and the remedy is identical.
+caller's side it *is* the same thing, and the remedy is identical. It is scoped to permissions
+rather than to one for the same reason the 403 is: an exchange that asks for several is refused
+as a whole, and Entra names which one was missing no more reliably than Graph does.
 """
 
 import re
@@ -34,16 +36,19 @@ from office_mcp.graph_client import (
 
 
 @contextmanager
-def graph_tool_errors(permission: str) -> Generator[None]:
+def graph_tool_errors(*permissions: str) -> Generator[None]:
     """Map any Graph failure raised in this block onto an actionable MCP tool error.
 
-    `permission` is the delegated Graph permission the enclosed calls were made with, e.g.
-    `Chat.Read` — it is what makes a 403 fixable rather than merely reported.
+    `permissions` are the delegated Graph permissions the enclosed calls were made with, e.g.
+    `Chat.Read` — they are what make a 403 fixable rather than merely reported. Where a call needs
+    more than one, name them all: Graph never says which of them it refused, so an administrator
+    given only one name may grant the wrong permission and see the same failure.
     """
+    assert permissions, "a Graph call is made under at least one permission"
     try:
         yield
     except GraphFailure as failure:
-        raise ToolError(_advice(failure, permission)) from failure
+        raise ToolError(_advice(failure, permissions)) from failure
 
 
 # Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
@@ -53,7 +58,7 @@ _ENTRA_CODE = re.compile(r"AADSTS\d+")
 
 
 @contextmanager
-def entra_token_errors(permission: str) -> Generator[None]:
+def entra_token_errors(*permissions: str) -> Generator[None]:
     """Map a failed On-Behalf-Of exchange in this block onto an actionable MCP tool error.
 
     Wrap the *acquisition* of a Graph token, not the Graph call: this is the failure that happens
@@ -62,41 +67,53 @@ def entra_token_errors(permission: str) -> Generator[None]:
     remedy, because FastMCP's dependency resolver knows neither. It re-raises `ToolError`
     untouched (`fastmcp.server.dependencies` lets `FastMCPError` subclasses out of dependency
     resolution unwrapped, which is what makes this interception point work at all).
+
+    `permissions` are the delegated Graph permissions the exchange asked for, and where it asked
+    for more than one, all of them are named: an exchange is refused as a whole, so an
+    administrator given only one name may grant the wrong permission and see the same failure —
+    the same reason `graph_tool_errors` names them all for a 403.
     """
+    assert permissions, "a token exchange asks for at least one permission"
     try:
         yield
     except Exception as failure:
-        raise ToolError(_token_advice(failure, permission)) from failure
+        raise ToolError(_token_advice(failure, permissions)) from failure
 
 
-def _token_advice(failure: BaseException, permission: str) -> str:
+def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     """What to do about an On-Behalf-Of exchange that did not produce a token.
 
     One message for every cause, because the two the exchange can actually fail for share the
-    first remedy: the permission was never consented to (AADSTS65001, overwhelmingly the common
+    first remedy: a permission was never consented to (AADSTS65001, overwhelmingly the common
     one), or this connector's own Entra credentials are wrong. Splitting them would mean
     classifying Entra error codes this connector has never observed, and the cost of guessing
     wrong is advice that sends the caller after the wrong fix.
     """
     code = _ENTRA_CODE.search(str(failure))
     diagnostics = code.group() if code is not None else type(failure).__name__
+    named = _named(permissions)
+    several = len(permissions) > 1
+    noun = "permissions" if several else "permission"
+    consented = "were never consented to" if several else "was never consented to"
+    them = "them" if several else "it"
+    granted = "they are already granted" if several else "it is already granted"
     return (
         "Microsoft 365 would not issue this connector a token to act for the signed-in user with "
-        + f"the delegated permission {permission}, so this call never reached Microsoft Graph. "
-        + f"Usually that means {permission} was never consented to: ask a Microsoft 365 "
-        + f"administrator to grant the delegated permission {permission} to this connector's app "
-        + "registration (and consent to it for the organisation), then have the user sign in to "
-        + "this connector again. If it is already granted, this connector's Entra configuration "
-        + "is broken and only an operator can fix it. Either way, retrying will not help and no "
-        + f"other arguments will succeed either. (Entra {diagnostics})"
+        + f"the delegated {noun} {named}, so this call never reached Microsoft Graph. "
+        + f"Usually that means {named} {consented}: ask a Microsoft 365 administrator to grant "
+        + f"the delegated {noun} {named} to this connector's app registration (and consent to "
+        + f"{them} for the organisation), then have the user sign in to this connector again. If "
+        + f"{granted}, this connector's Entra configuration is broken and only an operator can "
+        + "fix it. Either way, retrying will not help and no other arguments will succeed "
+        + f"either. (Entra {diagnostics})"
     )
 
 
-def _advice(failure: GraphFailure, permission: str) -> str:
-    return _remedy(failure, permission) + _diagnostics(failure)
+def _advice(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
+    return _remedy(failure, permissions) + _diagnostics(failure)
 
 
-def _remedy(failure: GraphFailure, permission: str) -> str:
+def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
     if isinstance(failure, GraphThrottled):
         if failure.retry_after_seconds is None:
             return (
@@ -115,12 +132,13 @@ def _remedy(failure: GraphFailure, permission: str) -> str:
                 + "in to this connector again; the request itself was fine, so retrying it "
                 + "unchanged will fail the same way."
             )
+        named = _named(permissions)
+        noun = "permissions" if len(permissions) > 1 else "permission"
         return (
-            f"Microsoft 365 refused this request: the connector may not use {permission} on "
-            + "behalf of this user. Ask a Microsoft 365 administrator to grant the delegated "
-            + f"permission {permission} to this connector's app registration (and consent to it "
-            + "for the organisation). Retrying will not help, and no other arguments will "
-            + "succeed either."
+            f"Microsoft 365 refused this request: the connector may not use {named} on behalf of "
+            + f"this user. Ask a Microsoft 365 administrator to grant the delegated {noun} "
+            + f"{named} to this connector's app registration, and to consent for the "
+            + "organisation. Retrying will not help, and no other arguments will succeed either."
         )
     if isinstance(failure, GraphNotFound):
         return (
@@ -138,6 +156,13 @@ def _remedy(failure: GraphFailure, permission: str) -> str:
         "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
         + "permission problem, so retrying it unchanged will fail identically."
     )
+
+
+def _named(permissions: tuple[str, ...]) -> str:
+    """The permissions as a phrase, so the message reads as a sentence rather than a list."""
+    if len(permissions) == 1:
+        return permissions[0]
+    return " and ".join((", ".join(permissions[:-1]), permissions[-1]))
 
 
 def _diagnostics(failure: GraphFailure) -> str:

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -5,6 +5,14 @@ because the caller is a language model and its only options are: retry, retry la
 to sign in, ask an administrator for a permission, or stop. A message that does not name one of
 those is a message it will answer by calling the same tool again.
 
+Every message here is written to one shape, because a model reads them all as one voice. The thing
+that refused comes first and is always "Microsoft 365" — not "Microsoft Graph", which is the name of
+an API the caller is not calling. Then the remedy, and whether retrying could possibly help. Then,
+in a parenthesis at the end rather than woven through the advice, the evidence an operator needs.
+Graph is named after that opening only where it is the explanation (one 404 meaning three different
+things, a 500 that recurs) or where an operator needs its own label — `Graph request id` is what
+Microsoft support asks for, by that name.
+
 Two of them are only distinguishable with information Graph does not send. `GraphForbidden`
 covers both 401 and 403 and carries `status` for exactly this reason: 401 means the token was
 rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
@@ -161,7 +169,7 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str 
             + "particular content rather than transient."
         )
     return (
-        "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
+        "Microsoft 365 rejected this request. This is a bad request rather than an outage or a "
         + "permission problem, so retrying it unchanged will fail identically."
     )
 

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -36,19 +36,25 @@ from office_mcp.graph_client import (
 
 
 @contextmanager
-def graph_tool_errors(*permissions: str) -> Generator[None]:
+def graph_tool_errors(*permissions: str, not_found: str | None = None) -> Generator[None]:
     """Map any Graph failure raised in this block onto an actionable MCP tool error.
 
     `permissions` are the delegated Graph permissions the enclosed calls were made with, e.g.
     `Chat.Read` — they are what make a 403 fixable rather than merely reported. Where a call needs
     more than one, name them all: Graph never says which of them it refused, so an administrator
     given only one name may grant the wrong permission and see the same failure.
+
+    `not_found` replaces the advice for a 404. The default tells the caller to check that the id it
+    sent came from a tool response verbatim, which is the likeliest cause when a tool takes an id —
+    and is misleading advice for one that takes a handle another tool just produced, where the
+    remaining causes are deletion and lost access. Pass the sentence that is true of this call; the
+    diagnostics Graph sent are appended either way.
     """
     assert permissions, "a Graph call is made under at least one permission"
     try:
         yield
     except GraphFailure as failure:
-        raise ToolError(_advice(failure, permissions)) from failure
+        raise ToolError(_advice(failure, permissions, not_found)) from failure
 
 
 # Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
@@ -109,11 +115,11 @@ def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     )
 
 
-def _advice(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
-    return _remedy(failure, permissions) + _diagnostics(failure)
+def _advice(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
+    return _remedy(failure, permissions, not_found) + _diagnostics(failure)
 
 
-def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
+def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
     if isinstance(failure, GraphThrottled):
         if failure.retry_after_seconds is None:
             return (
@@ -141,6 +147,8 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
             + "organisation. Retrying will not help, and no other arguments will succeed either."
         )
     if isinstance(failure, GraphNotFound):
+        if not_found is not None:
+            return not_found
         return (
             "Microsoft 365 has no such item — or the signed-in user is not allowed to know it "
             + "exists, which Graph reports identically. Check the id came from a tool response "

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -28,7 +28,7 @@ from fastmcp.tools import Tool
 from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import chats, identity, message_search
+from office_mcp.features import chats, identity, message_read, message_search
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -58,6 +58,7 @@ GRAPH_SCOPES: tuple[str, ...] = tuple(
             identity.GRAPH_PERMISSION,
             chats.GRAPH_PERMISSION,
             *message_search.GRAPH_PERMISSIONS,
+            *message_read.GRAPH_PERMISSIONS,
         )
     )
 )
@@ -128,6 +129,7 @@ def _graph_token(*permissions: str) -> str:
 _IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
 _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
+_READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -181,7 +183,7 @@ need to know who the user is.
 A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
 view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
 truncated with `...` where it was cut — is the only text here. Every hit carries a `uri` handle \
-identifying that exact message; read that resource for the real text, the attachments and the \
+identifying that exact message; pass it to read_message for the real text, the attachments and the \
 mentions. Never present `summary` as the whole message, and never conclude from it that the \
 message does not say more.
 
@@ -216,6 +218,61 @@ _NO_CRITERIA = (
     + ", ".join(message_search.CRITERIA)
     + ". Searching with none of them would return an arbitrary sample of every message the user "
     + "can see, not an answer. Add the keywords, person or date range the question is about."
+)
+
+_READ_MESSAGE = """\
+Read one Microsoft Teams message in full, from the `uri` handle a search_messages result carries: \
+the whole message text, who sent it, who was @-mentioned, what was attached, and whether it has \
+been edited or deleted.
+
+This is the other half of search_messages, and the only route to a message's text. Microsoft's \
+search index answers with a reduced view of a message that contains no body at all, so a search \
+result carries only Microsoft's `summary` snippet. Read the message here whenever the answer \
+depends on what somebody actually said rather than on the fact that a matching message exists — \
+and never present a snippet as the message.
+
+`uri` takes a handle this connector produced, in one of exactly two shapes:
+  teams:///chats/{chat_id}/messages/{message_id}
+  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}
+Nothing else is readable. This connector serves Microsoft Teams messages, so no handle here names \
+mail, a calendar event, a file, a SharePoint page or a meeting transcript, and nothing turns a \
+person's name or a chat topic into one — pass the `uri` from a search result verbatim.
+
+`text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
+`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and an adaptive card as \
+`[card]`. `mentions` and `attachments` say who and what those refer to.
+
+Two messages have no text and must not be reported as empty ones. A deleted message returns \
+`deleted_at` and no text: say it was deleted. A system event message — somebody joining, a call \
+ending, a chat being renamed — has no author and no text anywhere in Microsoft Graph, because the \
+sentence Teams displays is written by the Teams client and never sent. For those, `event` names \
+what happened, and inventing the wording of one is a fabrication.\
+"""
+
+# What the tool says when `uri` is not a handle at all. This is the failure that is *our* fault to
+# explain — the two below are Microsoft's answers — so it is the one that shows the shapes.
+_BAD_HANDLE = (
+    "read_message takes a `uri` handle that search_messages produced, and this is not one. A "
+    + "readable handle has one of exactly two shapes:\n"
+    + "  teams:///chats/{chat_id}/messages/{message_id}\n"
+    + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}\n"
+    + "with the ids percent-encoded, e.g. "
+    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a search "
+    + "result rather than assembling one, and note that this connector reads Teams messages only — "
+    + "no mail, files, sites or meetings are addressable here. Retrying this value will fail "
+    + "identically."
+)
+
+# Graph's 404 on a well-formed handle, which is a different failure from a malformed one and must
+# not be reported as the message never having existed.
+_UNREADABLE = (
+    "Microsoft 365 would not return this message. The handle is well formed, so this is not a bad "
+    + "argument — and it is not evidence that the message does not exist: Graph answers 'deleted', "
+    + "'never existed' and 'the signed-in user may not see it' with the same 404, and does not say "
+    + "which of them it meant. Report that the message could not be read, never that it was never "
+    + "written. Retrying will not help and this connector has no other route to the text. (A reply "
+    + "inside a channel thread is also addressed under its parent post, which this handle shape "
+    + "cannot express.)"
 )
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
@@ -411,6 +468,40 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             )
 
     _require_a_criterion(mcp.add_tool(search_messages))
+
+    @mcp.tool(
+        name="read_message",
+        title="Read a Teams Message",
+        description=_READ_MESSAGE,
+        annotations=_READ_ONLY,
+    )
+    async def read_message(
+        uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The handle of the message to read, exactly as a search_messages result gave "
+                    + "it: `teams:///chats/{chat_id}/messages/{message_id}` or "
+                    + "`teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}`. No "
+                    + "other scheme or shape is readable, and nothing else identifies a Teams "
+                    + "message — a chat topic, a person's name or a Teams web link cannot be "
+                    + "turned into one."
+                ),
+            ),
+        ],
+        graph_token: str = _READ_TOKEN,
+    ) -> message_read.TeamsMessage:
+        handle = message_read.message_handle(uri)
+        if handle is None:
+            raise ToolError(_BAD_HANDLE)
+        # One permission, not both: the handle says which surface is being read, and Graph's 403
+        # there can only be about that one. The token was exchanged for both because a dependency
+        # is resolved before the tool sees its argument.
+        with graph_tool_errors(handle.permission, not_found=_UNREADABLE):
+            return await message_read.read_message(
+                graph_client_for(transport, graph_token), handle=handle
+            )
 
 
 def _require_a_criterion(tool: Tool) -> None:

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -9,19 +9,23 @@ otherwise need a process-wide service holder for.
 The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
 token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
 for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
-tool's input schema — the model cannot see it and cannot supply it.
+tool's input schema — the model cannot see it and cannot supply it. `_GraphToken` wraps it for
+one reason: a dependency is resolved *outside* the tool body, so an exchange Entra refuses cannot
+be explained by anything the body does.
 """
 
-from typing import Annotated
+from types import TracebackType
+from typing import Annotated, cast, override
 
 import httpx
 from fastmcp import FastMCP
+from fastmcp.dependencies import Dependency
 from fastmcp.server.auth.providers.azure import EntraOBOToken
 from pydantic import Field
 
 from office_mcp.features import chats, identity
 from office_mcp.graph_client import graph_client_for
-from office_mcp.server.errors import graph_tool_errors
+from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 # A Graph delegated permission, as a scope the On-Behalf-Of exchange can ask for. Graph accepts a
 # bare permission name at the authorize endpoint too, but only because it is the default resource;
@@ -43,14 +47,63 @@ GRAPH_SCOPES: tuple[str, ...] = (
     _scope(chats.GRAPH_PERMISSION),
 )
 
-# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per Graph
-# permission. Built here rather than inline because a call inside a parameter default rebuilds the
-# descriptor on every registration and is a lint error in both of this repo's checkers. Sharing one
-# instance is safe: FastMCP enters it per call and it holds nothing but its scopes. The declared
-# type is `str` because a token is what FastMCP injects in its place — the tool body never sees
-# this object.
-_IDENTITY_TOKEN: str = EntraOBOToken([_scope(identity.GRAPH_PERMISSION)])
-_CHATS_TOKEN: str = EntraOBOToken([_scope(chats.GRAPH_PERMISSION)])
+
+class _GraphToken(Dependency[str]):
+    """`EntraOBOToken` for one permission, with the refusal explained in terms of it.
+
+    The wrapping exists because of *where* the exchange happens. FastMCP resolves a dependency
+    before it calls the tool, so a failure there never enters the tool body and never reaches the
+    `graph_tool_errors` block inside it; FastMCP reports it as "Failed to resolve dependency
+    'graph_token' for list_chats", which tells a model nothing it can act on. The one thing it
+    does pass through untouched is a `FastMCPError` — so raising `ToolError` here, from the
+    permission this instance was built for, is what makes an unconsented permission as fixable
+    before the Graph call as a 403 is after it.
+
+    The exchange itself is untouched: `__aenter__` delegates to FastMCP's dependency, which owns
+    the credential cache, and `__aexit__` delegates so any cleanup it grows is not dropped.
+    """
+
+    def __init__(self, permission: str) -> None:
+        self._permission: str = permission
+        # `EntraOBOToken` is annotated `-> str` (a lie for the type checker's benefit, so a tool
+        # can annotate the token as the string it receives); the value is the dependency object.
+        # Casting back to what it is has to go through `object` — the two types do not overlap.
+        self._exchange: Dependency[str] = cast(
+            "Dependency[str]", cast("object", EntraOBOToken([_scope(permission)]))
+        )
+
+    @override
+    async def __aenter__(self) -> str:
+        with entra_token_errors(self._permission):
+            return await self._exchange.__aenter__()
+
+    @override
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self._exchange.__aexit__(exc_type, exc_value, traceback)
+
+
+def _graph_token(permission: str) -> str:
+    """A `_GraphToken` typed as the token FastMCP will inject in its place.
+
+    The same annotation `EntraOBOToken` uses, for the same reason: the tool body is handed a
+    string and should say so, and the dependency object it never sees would otherwise have to be
+    cast at every declaration site. The cast goes through `object` for the same reason it does
+    above — a dependency is not a string, which is precisely why FastMCP replaces it with one.
+    """
+    return cast("str", cast("object", _GraphToken(permission)))
+
+
+# The dependency each tool declares as its token parameter's default, one per Graph permission.
+# Built here rather than inline because a call inside a parameter default rebuilds the descriptor
+# on every registration and is a lint error in both of this repo's checkers. Sharing one instance
+# is safe: FastMCP enters it per call and it holds nothing but its permission.
+_IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
+_CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -84,8 +137,10 @@ defines it as when the chat was renamed or its membership changed, so a chat nob
 for a year can carry yesterday's timestamp. `last_message_at` is null for a chat with no messages.
 
 `members` is returned only for chats whose `topic` is null, because those chats have no other \
-name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and `members_truncated` \
-says when the cap was hit. Set `include_member_emails` when two members share a display name.
+name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and sends no member \
+total, so `members_may_be_incomplete` says when a list came back full to that cap — people may \
+be missing from it, and Graph will not say whether they are. Set `include_member_emails` when \
+two members share a display name.
 
 There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
 the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -14,16 +14,21 @@ one reason: a dependency is resolved *outside* the tool body, so an exchange Ent
 be explained by anything the body does.
 """
 
+from datetime import date
 from types import TracebackType
 from typing import Annotated, cast, override
+from uuid import UUID
 
 import httpx
 from fastmcp import FastMCP
 from fastmcp.dependencies import Dependency
+from fastmcp.exceptions import ToolError
 from fastmcp.server.auth.providers.azure import EntraOBOToken
+from fastmcp.tools import Tool
+from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import chats, identity
+from office_mcp.features import chats, identity, message_search
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -39,42 +44,59 @@ def _scope(permission: str) -> str:
 
 # What sign-in must ask Entra for, so that the On-Behalf-Of exchange has something to redeem: a
 # Graph permission the user (or an administrator) never consented to cannot be obtained later, and
-# the exchange fails with AADSTS65001 rather than with anything a tool could explain. `create_app`
+# the exchange fails with AADSTS65001 before the tool body runs. `_GraphToken` below turns that into
+# advice, but a failure avoided at consent time beats one explained per call. `create_app`
 # passes this to the auth provider — which is why it is the union of every tool's permission, and
 # why it lives beside the tools that determine it.
-GRAPH_SCOPES: tuple[str, ...] = (
-    _scope(identity.GRAPH_PERMISSION),
-    _scope(chats.GRAPH_PERMISSION),
+GRAPH_SCOPES: tuple[str, ...] = tuple(
+    # `dict.fromkeys` rather than a set: two tools sharing a permission must not make the scope
+    # list a different string on every process start, or the consent screen and every cached
+    # On-Behalf-Of token key change with it.
+    dict.fromkeys(
+        _scope(permission)
+        for permission in (
+            identity.GRAPH_PERMISSION,
+            chats.GRAPH_PERMISSION,
+            *message_search.GRAPH_PERMISSIONS,
+        )
+    )
 )
 
 
 class _GraphToken(Dependency[str]):
-    """`EntraOBOToken` for one permission, with the refusal explained in terms of it.
+    """`EntraOBOToken` for a tool's permissions, with the refusal explained in terms of them.
 
     The wrapping exists because of *where* the exchange happens. FastMCP resolves a dependency
     before it calls the tool, so a failure there never enters the tool body and never reaches the
     `graph_tool_errors` block inside it; FastMCP reports it as "Failed to resolve dependency
     'graph_token' for list_chats", which tells a model nothing it can act on. The one thing it
     does pass through untouched is a `FastMCPError` — so raising `ToolError` here, from the
-    permission this instance was built for, is what makes an unconsented permission as fixable
+    permissions this instance was built for, is what makes an unconsented permission as fixable
     before the Graph call as a 403 is after it.
+
+    One instance covers one exchange, however many permissions that exchange asks for, because
+    Entra redeems them together and refuses them together: a tool needing two gets one token or
+    none. Naming all of them is therefore the same requirement as it is for a 403 — the refusal
+    does not say which one was missing.
 
     The exchange itself is untouched: `__aenter__` delegates to FastMCP's dependency, which owns
     the credential cache, and `__aexit__` delegates so any cleanup it grows is not dropped.
     """
 
-    def __init__(self, permission: str) -> None:
-        self._permission: str = permission
+    def __init__(self, *permissions: str) -> None:
+        assert permissions, "a token is exchanged for at least one permission"
+        self._permissions: tuple[str, ...] = permissions
         # `EntraOBOToken` is annotated `-> str` (a lie for the type checker's benefit, so a tool
         # can annotate the token as the string it receives); the value is the dependency object.
         # Casting back to what it is has to go through `object` — the two types do not overlap.
         self._exchange: Dependency[str] = cast(
-            "Dependency[str]", cast("object", EntraOBOToken([_scope(permission)]))
+            "Dependency[str]",
+            cast("object", EntraOBOToken([_scope(permission) for permission in permissions])),
         )
 
     @override
     async def __aenter__(self) -> str:
-        with entra_token_errors(self._permission):
+        with entra_token_errors(*self._permissions):
             return await self._exchange.__aenter__()
 
     @override
@@ -87,7 +109,7 @@ class _GraphToken(Dependency[str]):
         await self._exchange.__aexit__(exc_type, exc_value, traceback)
 
 
-def _graph_token(permission: str) -> str:
+def _graph_token(*permissions: str) -> str:
     """A `_GraphToken` typed as the token FastMCP will inject in its place.
 
     The same annotation `EntraOBOToken` uses, for the same reason: the tool body is handed a
@@ -95,15 +117,17 @@ def _graph_token(permission: str) -> str:
     cast at every declaration site. The cast goes through `object` for the same reason it does
     above — a dependency is not a string, which is precisely why FastMCP replaces it with one.
     """
-    return cast("str", cast("object", _GraphToken(permission)))
+    return cast("str", cast("object", _GraphToken(*permissions)))
 
 
-# The dependency each tool declares as its token parameter's default, one per Graph permission.
-# Built here rather than inline because a call inside a parameter default rebuilds the descriptor
-# on every registration and is a lint error in both of this repo's checkers. Sharing one instance
-# is safe: FastMCP enters it per call and it holds nothing but its permission.
+# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per set of
+# Graph permissions a tool calls under. Built here rather than inline because a call inside a
+# parameter default rebuilds the descriptor on every registration and is a lint error in both of
+# this repo's checkers. Sharing one instance is safe: FastMCP enters it per call and it holds
+# nothing but its permissions.
 _IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
 _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
+_SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -147,6 +171,52 @@ the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Gra
 for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
 chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
 """
+
+_SEARCH_MESSAGES = f"""\
+Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
+chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
+and read state. Messages from ANY participant match, not only the user's own; call whoami if you \
+need to know who the user is.
+
+A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
+view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
+truncated with `...` where it was cut — is the only text here. Every hit carries a `uri` handle \
+identifying that exact message; read that resource for the real text, the attachments and the \
+mentions. Never present `summary` as the whole message, and never conclude from it that the \
+message does not say more.
+
+There is no result total, and this is not an omission: Microsoft Graph reports a per-page count \
+rather than a match count for Teams messages, so a total would be a fabrication. Page by passing \
+`next_offset` back as `offset` while `more_results_available` is true. A page can hold fewer than \
+`size` messages — offsets index Graph's own results, and system messages ("Ada joined the chat") \
+are dropped from ours because Graph gives them neither an author nor any text.
+
+Results cannot be sorted: Graph refuses sort options on a message search. Its documented default \
+for message results is newest first and relevance can be mixed in, so compare `created_at` \
+whenever order matters to the answer.
+
+At least one criterion is required and all criteria given are ANDed. `query` is matched as plain \
+words and every word must appear, anywhere in the message and in any order — the words do not have \
+to be next to each other. To require that they are, quote them yourself: `"release notes"` matches \
+only where those two words are adjacent. Search operators typed into `query` are searched for \
+literally, so put a sender in `sender`, a date in `sent_after`/`sent_before`, and so on. Those two \
+dates are inclusive whole days and are \
+applied by the index itself, so a date-bounded search still costs one request and still covers \
+channels. `recipient` is honoured by Microsoft only for one-to-one chats and will hide group and \
+channel matches, so prefer `sender`. Channel matches need the delegated \
+{message_search.CHANNEL_PERMISSION} permission, which this connector requires at sign-in rather \
+than degrading to chats-only search without saying so.\
+"""
+
+# What the tool says when it is called with nothing to look for. Graph would answer such a request
+# with an arbitrary slice of everything the user can read, which reads like a real result set and
+# is the one failure mode a model cannot detect from the response.
+_NO_CRITERIA = (
+    "search_messages needs at least one of "
+    + ", ".join(message_search.CRITERIA)
+    + ". Searching with none of them would return an arbitrary sample of every message the user "
+    + "can see, not an answer. Add the keywords, person or date range the question is about."
+)
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
 
@@ -196,3 +266,161 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 limit=limit,
                 include_member_emails=include_member_emails,
             )
+
+    # Declared and registered in two steps rather than with `@mcp.tool`, which does both and hands
+    # back the function: `add_tool` returns the registered tool, which is the only way to reach the
+    # schema `_require_a_criterion` has to add to. Same registration, same metadata.
+    @tool_metadata(
+        name="search_messages",
+        title="Search Teams Messages",
+        description=_SEARCH_MESSAGES,
+        annotations=_READ_ONLY,
+    )
+    async def search_messages(
+        query: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Keywords to find in the message text or in an attachment's contents. Every "
+                    + "word must appear, anywhere in the message and in any order; they are not "
+                    + "matched as a phrase unless you quote them, so `release notes` finds "
+                    + 'messages containing both words and `"release notes"` only messages where '
+                    + "they are adjacent. Never a query language — a search operator written here "
+                    + "is searched for as literal text, so use the other parameters for filters."
+                ),
+            ),
+        ] = None,
+        sender: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only messages from this person, by name, alias or email address. Prefer this "
+                    + "over naming the person in `query`, which would match messages that merely "
+                    + "mention them."
+                ),
+            ),
+        ] = None,
+        recipient: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only messages addressed to this person. Microsoft supports this only "
+                    + "partially, for one-to-one chats, so it hides group-chat and channel "
+                    + "matches: an empty result here is not evidence that no such message exists."
+                ),
+            ),
+        ] = None,
+        mentions: Annotated[
+            UUID | None,
+            Field(
+                description=(
+                    "Only messages that @-mention this user, by Microsoft Entra object id (the "
+                    + "`user_id` of a sender here, or `id` from whoami). A name will not work: "
+                    + "Microsoft matches this term on the id alone."
+                )
+            ),
+        ] = None,
+        sent_after: Annotated[
+            date | None,
+            Field(
+                description=(
+                    "Only messages sent on or after this date (YYYY-MM-DD), inclusive. Applied by "
+                    + "Microsoft's index, so it costs nothing extra and narrows chats and "
+                    + "channels alike."
+                )
+            ),
+        ] = None,
+        sent_before: Annotated[
+            date | None,
+            Field(description="Only messages sent on or before this date (YYYY-MM-DD), inclusive."),
+        ] = None,
+        has_attachment: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages carrying an attachment, false for only messages "
+                    + "without one. Omit to search both."
+                )
+            ),
+        ] = None,
+        is_read: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages the signed-in user has read, false for only unread "
+                    + "ones. Omit to search both."
+                )
+            ),
+        ] = None,
+        mentions_me: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages that @-mention the signed-in user, false for only "
+                    + "messages that do not. Omit to search both."
+                )
+            ),
+        ] = None,
+        offset: Annotated[
+            int,
+            Field(
+                ge=0,
+                description=(
+                    "How many results to skip. Start at 0 and pass the previous response's "
+                    + "`next_offset` to advance; it is an index into Microsoft's results, not "
+                    + "into the messages this tool returned."
+                ),
+            ),
+        ] = 0,
+        size: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=message_search.MAX_RESULTS,
+                description=(
+                    "How many results to ask Microsoft for. Default 25, maximum "
+                    + f"{message_search.MAX_RESULTS} — Microsoft documents no page size above "
+                    + "that for message search."
+                ),
+            ),
+        ] = 25,
+        graph_token: str = _SEARCH_TOKEN,
+    ) -> message_search.MessageSearchResults:
+        criteria = message_search.SearchCriteria(
+            query=query,
+            sender=sender,
+            recipient=recipient,
+            mentions=mentions,
+            sent_after=sent_after,
+            sent_before=sent_before,
+            has_attachment=has_attachment,
+            is_read=is_read,
+            mentions_me=mentions_me,
+        )
+        if criteria.is_empty:
+            raise ToolError(_NO_CRITERIA)
+        with graph_tool_errors(*message_search.GRAPH_PERMISSIONS):
+            return await message_search.search_messages(
+                graph_client_for(transport, graph_token),
+                criteria=criteria,
+                offset=offset,
+                size=size,
+            )
+
+    _require_a_criterion(mcp.add_tool(search_messages))
+
+
+def _require_a_criterion(tool: Tool) -> None:
+    """Put "at least one criterion" in the tool's schema, where a client can enforce it.
+
+    FastMCP derives an input schema from the function signature, and a signature has no way to say
+    that a set of optional parameters cannot all be omitted — so the rule would otherwise live only
+    in the description and in the tool's own runtime check. `anyOf` over one-element `required`
+    lists is the JSON Schema spelling of it, and the registered tool's schema is where it goes.
+    The runtime check stays: FastMCP validates arguments against the signature rather than against
+    this schema, so a client that ignores it must still be refused.
+    """
+    tool.parameters["anyOf"] = [{"required": [name]} for name in message_search.CRITERIA]

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -6,6 +6,20 @@ no registry, no base class and no decorator of our own: `register_tools` closes 
 `create_app` built, which is the whole of what FastMCP's plain-function tool signature would
 otherwise need a process-wide service holder for.
 
+Three conventions hold across every tool here, and a new one is expected to keep them, because a
+model reads this surface as one thing:
+
+* **A name is `verb_noun`** — `get_me`, `list_chats`, `search_messages`, `read_message` — naming
+  what the tool does and what it does it to. `whoami` was the one exception and is now `get_me`:
+  the shell idiom made the odd tool out of the very tool a model calls first, and renaming a tool
+  is a breaking change best spent before there are more of them. (Microsoft's own M365 connector
+  arrived at `get_me` independently, which is one less name for a model to have to learn twice.)
+* **One word for "there is more".** Every tool that answers with a list reports `truncated`, and
+  says in its own description how to get the rest — a wider `limit` where there is no cursor, the
+  `next_offset` where there is. Two words for one idea is how a model comes to guess.
+* **A description teaches the traps, and the neighbours.** Each one says what it answers, when to
+  reach for it rather than for another tool here, and what its answer does *not* mean.
+
 The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
 token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
 for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
@@ -131,21 +145,22 @@ _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 _READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 
-_WHOAMI = """\
-Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
+_GET_ME = """\
+Return the signed-in Microsoft 365 user's own profile: `user_id`, `display_name`, `email`, \
 `user_principal_name` and `job_title`.
 
-Call this before anything that turns on who "I", "me" or "my" is: filtering a mail or message \
-search to the signed-in user, deciding which participant of a chat is them, or addressing them by \
-name. It is one cheap request and its answer is stable for the session.
+Call this before anything that turns on who "I", "me" or "my" is: filtering a message search to \
+the signed-in user, deciding which participant of a chat is them, or addressing them by name. It \
+is one cheap request and its answer is stable for the session.
 
-`mail` is the canonical primary SMTP address and the right value to match a sender or recipient \
-against — but it is null for guest and unlicensed accounts, and `user_principal_name` (Microsoft's \
-`userPrincipalName`) is then the best available identifier. Do not treat the two as \
-interchangeable when both are present: a tenant can issue a user_principal_name on a different \
-domain from the mail address, so matching message addresses against it can silently return \
-nothing. Compare `id` — the immutable directory object id — against user ids from other tools; \
-compare `mail` against addresses.\
+`email` is the canonical primary SMTP address (Microsoft's `mail`) and the right value to match a \
+sender or recipient against — but it is null for guest and unlicensed accounts, and \
+`user_principal_name` (Microsoft's `userPrincipalName`) is then the best available identifier. Do \
+not treat the two as interchangeable when both are present: a tenant can issue a \
+user_principal_name on a different domain from the email address, so matching message addresses \
+against it can silently return nothing. Compare `user_id` — the immutable directory object id — \
+against the `user_id` of a message's sender or of a mention; compare `email` against an address, \
+which is all a chat's member list gives you to match on.\
 """
 
 _LIST_CHATS = f"""\
@@ -153,8 +168,13 @@ List the Microsoft Teams chats the signed-in user is a member of — one-to-one,
 chats — most recently active first, with each chat's id, type, topic, last-message time and (for \
 unnamed chats) its members.
 
-Use it to find the `chat_id` that a chat-scoped tool needs, or to see which conversations are \
-live. This returns chats only: Teams channels live inside teams and are not part of this list.
+Reach for this to see which conversations are live, who is in them, and when each was last posted \
+in — never for what was said in them: no message text is returned here, and search_messages is the \
+only route to any. The other use is naming: a `chat_id` here is the same id search_messages puts \
+on every chat message it finds, so this list is how a found message gets a topic and a set of \
+participants. It is not an argument to anything — no tool here takes a chat id, and a search \
+cannot be narrowed to one chat. This returns chats only: Teams channels live inside teams and are \
+not part of this list.
 
 Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
 the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
@@ -171,14 +191,17 @@ two members share a display name.
 There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
 the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \
 for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
-chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
+chat is usually the oneOnOne chat whose only member is them (call get_me to know who that is; a \
+member is matched by display name or, with `include_member_emails`, by email — this list carries \
+no user ids).\
 """
 
 _SEARCH_MESSAGES = f"""\
 Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
 chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
-and read state. Messages from ANY participant match, not only the user's own; call whoami if you \
-need to know who the user is.
+and read state. Messages from ANY participant match, not only the user's own; call get_me if you \
+need to know who the user is. This is the only tool here that returns messages at all, and the \
+only way to reach a message's text: it finds them, read_message reads one.
 
 A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
 view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
@@ -188,10 +211,16 @@ mentions. Never present `summary` as the whole message, and never conclude from 
 message does not say more.
 
 There is no result total, and this is not an omission: Microsoft Graph reports a per-page count \
-rather than a match count for Teams messages, so a total would be a fabrication. Page by passing \
-`next_offset` back as `offset` while `more_results_available` is true. A page can hold fewer than \
-`size` messages — offsets index Graph's own results, and system messages ("Ada joined the chat") \
-are dropped from ours because Graph gives them neither an author nor any text.
+rather than a match count for Teams messages, so a total would be a fabrication. `truncated` says \
+there is more — as it does on every list-shaped tool here — and here the way to get it is to pass \
+`next_offset` back as `offset`. A page can hold fewer than `size` messages: offsets index Graph's \
+own results, and system messages ("Ada joined the chat") are dropped from ours because Graph gives \
+them neither an author nor any text.
+
+The search covers every chat and channel the user belongs to and cannot be narrowed to one of \
+them — Microsoft's index offers no such scope, so there is no chat or channel parameter and a \
+`chat_id` from list_chats is not one. Narrow with `sender`, dates or more words instead, and read \
+`chat_id` (or `team_id`/`channel_id`) on each hit to see where it came from.
 
 Results cannot be sorted: Graph refuses sort options on a message search. Its documented default \
 for message results is newest first and relevance can be mixed in, so compare `created_at` \
@@ -287,13 +316,16 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
     below borrow it per call and never own it. `create_app` closes it on shutdown.
     """
 
-    @mcp.tool(name="whoami", title="Who Am I", description=_WHOAMI, annotations=_READ_ONLY)
-    async def whoami(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
+    @mcp.tool(name="get_me", title="Get My Profile", description=_GET_ME, annotations=_READ_ONLY)
+    async def get_me(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
         with graph_tool_errors(identity.GRAPH_PERMISSION):
             return await identity.get_signed_in_user(graph_client_for(transport, graph_token))
 
     @mcp.tool(
-        name="list_chats", title="List My Chats", description=_LIST_CHATS, annotations=_READ_ONLY
+        name="list_chats",
+        title="List My Teams Chats",
+        description=_LIST_CHATS,
+        annotations=_READ_ONLY,
     )
     async def list_chats(
         limit: Annotated[
@@ -377,7 +409,7 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 description=(
                     "Only messages that @-mention this user, by Microsoft Entra object id (the "
-                    + "`user_id` of a sender here, or `id` from whoami). A name will not work: "
+                    + "`user_id` of a sender here, or from get_me). A name will not work: "
                     + "Microsoft matches this term on the id alone."
                 )
             ),
@@ -494,7 +526,9 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
         ],
         graph_token: str = _READ_TOKEN,
     ) -> message_read.TeamsMessage:
-        handle = message_read.message_handle(uri)
+        # The parser lives with `message_search` because the handle does: search is the only thing
+        # that mints one, and one definition of the shape is what makes a search result readable.
+        handle = message_search.message_handle(uri)
         if handle is None:
             raise ToolError(_BAD_HANDLE)
         # One permission, not both: the handle says which surface is being read, and Graph's 403

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -239,8 +239,10 @@ mail, a calendar event, a file, a SharePoint page or a meeting transcript, and n
 person's name or a chat topic into one — pass the `uri` from a search result verbatim.
 
 `text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
-`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and an adaptive card as \
-`[card]`. `mentions` and `attachments` say who and what those refer to.
+`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and a card as `[card]`. \
+`mentions` and `attachments` say who and what those refer to. Nothing else is summarised or \
+abridged — a message that happens to contain JSON, a config fragment or code is somebody's own \
+words and comes back verbatim, and `[card]` appears only where `attachments` names a card.
 
 Two messages have no text and must not be reported as empty ones. A deleted message returns \
 `deleted_at` and no text: say it was deleted. A system event message — somebody joining, a call \

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -1,0 +1,143 @@
+"""The MCP tools, and the one seam every later tool inherits.
+
+A tool is a function that (1) is handed the caller's Microsoft Graph token, (2) borrows the shared
+HTTP transport to call Graph as that caller, and (3) reports a Graph failure as advice. There is
+no registry, no base class and no decorator of our own: `register_tools` closes over the transport
+`create_app` built, which is the whole of what FastMCP's plain-function tool signature would
+otherwise need a process-wide service holder for.
+
+The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
+token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
+for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
+tool's input schema — the model cannot see it and cannot supply it.
+"""
+
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.azure import EntraOBOToken
+from pydantic import Field
+
+from office_mcp.features import chats, identity
+from office_mcp.graph_client import graph_client_for
+from office_mcp.server.errors import graph_tool_errors
+
+# A Graph delegated permission, as a scope the On-Behalf-Of exchange can ask for. Graph accepts a
+# bare permission name at the authorize endpoint too, but only because it is the default resource;
+# the full form is unambiguous and is what FastMCP's own examples use.
+_GRAPH_SCOPE_PREFIX = "https://graph.microsoft.com/"
+
+
+def _scope(permission: str) -> str:
+    return f"{_GRAPH_SCOPE_PREFIX}{permission}"
+
+
+# What sign-in must ask Entra for, so that the On-Behalf-Of exchange has something to redeem: a
+# Graph permission the user (or an administrator) never consented to cannot be obtained later, and
+# the exchange fails with AADSTS65001 rather than with anything a tool could explain. `create_app`
+# passes this to the auth provider — which is why it is the union of every tool's permission, and
+# why it lives beside the tools that determine it.
+GRAPH_SCOPES: tuple[str, ...] = (
+    _scope(identity.GRAPH_PERMISSION),
+    _scope(chats.GRAPH_PERMISSION),
+)
+
+# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per Graph
+# permission. Built here rather than inline because a call inside a parameter default rebuilds the
+# descriptor on every registration and is a lint error in both of this repo's checkers. Sharing one
+# instance is safe: FastMCP enters it per call and it holds nothing but its scopes. The declared
+# type is `str` because a token is what FastMCP injects in its place — the tool body never sees
+# this object.
+_IDENTITY_TOKEN: str = EntraOBOToken([_scope(identity.GRAPH_PERMISSION)])
+_CHATS_TOKEN: str = EntraOBOToken([_scope(chats.GRAPH_PERMISSION)])
+
+_WHOAMI = """\
+Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
+`user_principal_name` and `job_title`.
+
+Call this before anything that turns on who "I", "me" or "my" is: filtering a mail or message \
+search to the signed-in user, deciding which participant of a chat is them, or addressing them by \
+name. It is one cheap request and its answer is stable for the session.
+
+`mail` is the canonical primary SMTP address and the right value to match a sender or recipient \
+against — but it is null for guest and unlicensed accounts, and `user_principal_name` (Microsoft's \
+`userPrincipalName`) is then the best available identifier. Do not treat the two as \
+interchangeable when both are present: a tenant can issue a user_principal_name on a different \
+domain from the mail address, so matching message addresses against it can silently return \
+nothing. Compare `id` — the immutable directory object id — against user ids from other tools; \
+compare `mail` against addresses.\
+"""
+
+_LIST_CHATS = f"""\
+List the Microsoft Teams chats the signed-in user is a member of — one-to-one, group and meeting \
+chats — most recently active first, with each chat's id, type, topic, last-message time and (for \
+unnamed chats) its members.
+
+Use it to find the `chat_id` that a chat-scoped tool needs, or to see which conversations are \
+live. This returns chats only: Teams channels live inside teams and are not part of this list.
+
+Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
+the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
+looks like activity — Graph's `lastUpdatedDateTime` — is not returned here on purpose: Graph \
+defines it as when the chat was renamed or its membership changed, so a chat nobody has posted in \
+for a year can carry yesterday's timestamp. `last_message_at` is null for a chat with no messages.
+
+`members` is returned only for chats whose `topic` is null, because those chats have no other \
+name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and `members_truncated` \
+says when the cap was hit. Set `include_member_emails` when two members share a display name.
+
+There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
+the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \
+for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
+chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
+"""
+
+_READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
+
+
+def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this server's tools against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tools
+    below borrow it per call and never own it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(name="whoami", title="Who Am I", description=_WHOAMI, annotations=_READ_ONLY)
+    async def whoami(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
+        with graph_tool_errors(identity.GRAPH_PERMISSION):
+            return await identity.get_signed_in_user(graph_client_for(transport, graph_token))
+
+    @mcp.tool(
+        name="list_chats", title="List My Chats", description=_LIST_CHATS, annotations=_READ_ONLY
+    )
+    async def list_chats(
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=chats.MAX_CHATS,
+                description=(
+                    "How many chats to return, most recently active first. Default 25, maximum "
+                    + f"{chats.MAX_CHATS} — Microsoft Graph refuses a larger page on this "
+                    + "collection."
+                ),
+            ),
+        ] = 25,
+        include_member_emails: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Include each listed member's email address. Off by default: it is only "
+                    + "needed to tell apart two members with the same display name."
+                )
+            ),
+        ] = False,
+        graph_token: str = _CHATS_TOKEN,
+    ) -> chats.ChatList:
+        with graph_tool_errors(chats.GRAPH_PERMISSION):
+            return await chats.list_recent_chats(
+                graph_client_for(transport, graph_token),
+                limit=limit,
+                include_member_emails=include_member_emails,
+            )

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -1,0 +1,72 @@
+"""A mocked graph.microsoft.com, and a Graph client that calls it as a synthetic user.
+
+Every payload in this directory is invented. Nothing here came from a real tenant: the ids are
+obviously fake, the domains are `.invalid`, and the names are from the public domain.
+"""
+
+from collections.abc import AsyncGenerator, Iterator, Mapping, Sequence
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphSettings, create_graph_transport, graph_client_for
+
+GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# What FastMCP's On-Behalf-Of exchange would have returned. Only its identity matters here.
+CALLER_TOKEN = "synthetic-graph-access-token"
+
+
+@pytest.fixture
+def graph() -> Iterator[respx.MockRouter]:
+    with respx.mock(base_url=GRAPH_V1, assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+async def transport() -> AsyncGenerator[httpx.AsyncClient]:
+    client = create_graph_transport(GraphSettings())
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def client(transport: httpx.AsyncClient) -> GraphServiceClient:
+    return graph_client_for(transport, CALLER_TOKEN)
+
+
+def chat_payload(
+    chat_id: str,
+    *,
+    chat_type: str = "group",
+    topic: str | None = "Release planning",
+    last_message_at: str | None = "2026-02-11T09:15:22.31Z",
+    members: Sequence[Mapping[str, object]] | None = None,
+) -> dict[str, object]:
+    """One `chat` as `GET /me/chats?$expand=members,lastMessagePreview` returns it."""
+    payload: dict[str, object] = {
+        "id": chat_id,
+        "chatType": chat_type,
+        "topic": topic,
+        "createdDateTime": "2026-01-04T12:00:00Z",
+        "lastUpdatedDateTime": "2026-02-11T09:15:22.31Z",
+        "members": list(members) if members is not None else [aad_member("Ada Lovelace")],
+    }
+    if last_message_at is not None:
+        payload["lastMessagePreview"] = {
+            "id": "1770000000000",
+            "createdDateTime": last_message_at,
+            "body": {"contentType": "text", "content": "synthetic preview"},
+        }
+    return payload
+
+
+def aad_member(display_name: str, *, email: str | None = None) -> dict[str, object]:
+    return {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        "id": f"member-{display_name.replace(' ', '-').lower()}",
+        "displayName": display_name,
+        "email": email or f"{display_name.split()[0].lower()}@example.invalid",
+    }

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -125,6 +125,62 @@ def _chat_message(*, message_id: str, sender: Mapping[str, object] | None) -> di
     }
 
 
+# The sender shape every Teams *read* API answers with: a `teamworkUserIdentity`, which has an id,
+# an optional display name and no email property at all.
+TEAMS_SENDER: dict[str, object] = {
+    "user": {
+        "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+        "id": "00000000-0000-4000-8000-000000000001",
+        "displayName": "Ada Lovelace",
+        "userIdentityType": "aadUser",
+    }
+}
+
+
+def message_payload(
+    *,
+    message_id: str = "1770000000000",
+    content: str = "<div><p>cut the release on Friday</p></div>",
+    content_type: str = "html",
+    sender: Mapping[str, object] | None = TEAMS_SENDER,
+    message_type: str = "message",
+    last_modified_at: str = "2026-02-11T09:15:22.31Z",
+    last_edited_at: str | None = None,
+    deleted_at: str | None = None,
+    reply_to_id: str | None = None,
+    web_url: str | None = None,
+    mentions: Sequence[Mapping[str, object]] = (),
+    attachments: Sequence[Mapping[str, object]] = (),
+    event_detail: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """One full `chatMessage`, as `GET /chats/{id}/messages/{id}` returns it.
+
+    Unlike a search hit this carries a `body` — which is the whole reason a reader exists — and the
+    Teams-shaped sender rather than the mailbox-shaped one.
+    """
+    return {
+        "@odata.type": "#microsoft.graph.chatMessage",
+        "id": message_id,
+        "etag": message_id,
+        "messageType": message_type,
+        "createdDateTime": "2026-02-11T09:15:22.31Z",
+        "lastModifiedDateTime": last_modified_at,
+        "lastEditedDateTime": last_edited_at,
+        "deletedDateTime": deleted_at,
+        "subject": None,
+        "importance": "normal",
+        "locale": "en-us",
+        "webUrl": web_url,
+        "replyToId": reply_to_id,
+        "from": dict(sender) if sender is not None else None,
+        "body": {"contentType": content_type, "content": content},
+        "mentions": [dict(mention) for mention in mentions],
+        "attachments": [dict(attachment) for attachment in attachments],
+        "reactions": [],
+        "eventDetail": dict(event_detail) if event_detail is not None else None,
+    }
+
+
 def search_response(
     hits: Sequence[Mapping[str, object]] | None,
     *,

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -70,3 +70,75 @@ def aad_member(display_name: str, *, email: str | None = None) -> dict[str, obje
         "displayName": display_name,
         "email": email or f"{display_name.split()[0].lower()}@example.invalid",
     }
+
+
+# The sender shape a search hit carries: Teams messages are indexed out of the substrate mailbox,
+# so `from` is an Exchange `emailAddress` rather than a Teams identity.
+MAILBOX_SENDER: dict[str, object] = {
+    "emailAddress": {"name": "Ada Lovelace", "address": "ada@example.invalid"}
+}
+
+
+def chat_hit(
+    *,
+    chat_id: str | None = "19:release@thread.v2",
+    message_id: str = "1770000000000",
+    summary: str | None = "...cut the <c0>release</c0> on Friday...",
+    sender: Mapping[str, object] | None = MAILBOX_SENDER,
+) -> dict[str, object]:
+    """One `searchHit` over a chat message, in the reduced projection Graph returns.
+
+    `sender=None` produces a system event message — Graph sends `from: null` and a body of the
+    literal `<systemEventMessage/>` for those, and the projection carries neither `messageType`
+    nor `eventDetail` to name them by.
+    """
+    resource = _chat_message(message_id=message_id, sender=sender)
+    if chat_id is not None:
+        resource["chatId"] = chat_id
+    return {"hitId": message_id, "rank": 1, "summary": summary, "resource": resource}
+
+
+def channel_hit(
+    *,
+    team_id: str = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+    channel_id: str = "19:general@thread.tacv2",
+    message_id: str = "1770000000000",
+) -> dict[str, object]:
+    """One `searchHit` over a channel message, which identifies its container differently."""
+    resource = _chat_message(message_id=message_id, sender=MAILBOX_SENDER)
+    resource["channelIdentity"] = {"teamId": team_id, "channelId": channel_id}
+    # Graph populates `webUrl` for channel messages and leaves it null for chat messages.
+    resource["webUrl"] = f"https://teams.microsoft.invalid/l/message/{channel_id}/{message_id}"
+    return {"hitId": message_id, "rank": 1, "summary": "synthetic snippet", "resource": resource}
+
+
+def _chat_message(*, message_id: str, sender: Mapping[str, object] | None) -> dict[str, object]:
+    return {
+        "@odata.type": "#microsoft.graph.chatMessage",
+        "id": message_id,
+        "createdDateTime": "2026-02-11T09:15:22.31Z",
+        "lastModifiedDateTime": "2026-02-11T09:20:00Z",
+        "etag": message_id,
+        "importance": "normal",
+        "subject": None,
+        "from": dict(sender) if sender is not None else None,
+    }
+
+
+def search_response(
+    hits: Sequence[Mapping[str, object]] | None,
+    *,
+    total: int | None = None,
+    more_results_available: bool = False,
+) -> dict[str, object]:
+    """A `POST /search/query` response around `hits`, or around no `hits` key at all.
+
+    Graph nests one response per request and one container per entity type; since it honours a
+    single request over a single entity type, there is only ever one of each.
+    """
+    container: dict[str, object] = {"moreResultsAvailable": more_results_available}
+    if hits is not None:
+        container["hits"] = list(hits)
+    if total is not None:
+        container["total"] = total
+    return {"value": [{"searchTerms": [], "hitsContainers": [container]}]}

--- a/services/office-mcp/tests/features/test_chats.py
+++ b/services/office-mcp/tests/features/test_chats.py
@@ -137,11 +137,17 @@ class TestWhatTheCallerIsTold:
             ("Room 3", None),
         ]
 
-    async def test_graphs_silent_member_cap_is_reported(
+    async def test_a_member_list_full_to_graphs_cap_is_flagged_as_possibly_incomplete(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """Graph returns at most 25 members per chat on this endpoint and says nothing about it,
-        so a model summarising "who is in this chat" from the list is wrong without a flag."""
+        so a model summarising "who is in this chat" from the list is wrong without a flag.
+
+        The chat below has *exactly* the cap's worth of members, which is the case the flag may
+        not overclaim on: nothing was dropped from it, and Graph's response is byte-for-byte what
+        a 200-person chat's would be. So the flag is raised — 25-of-25 and 25-of-200 have to be
+        treated alike — and says only that members may be missing.
+        """
         graph.get("/me/chats").mock(
             return_value=httpx.Response(
                 200,
@@ -165,22 +171,37 @@ class TestWhatTheCallerIsTold:
 
         listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
 
-        assert listed.chats[0].members_truncated is True
-        assert listed.chats[1].members_truncated is False
+        crowded = listed.chats[0].members
+        assert crowded is not None and len(crowded) == chats.MEMBERS_PER_CHAT
+        assert listed.chats[0].members_may_be_incomplete is True
+        assert listed.chats[1].members_may_be_incomplete is False
+
+    def test_the_cap_flag_claims_only_what_graph_actually_reveals(self) -> None:
+        """The flag's description is read by the model, so it is part of the contract: a list at
+        the cap may be short of members, and Graph gives nothing that would prove it is."""
+        description = chats.ChatSummary.model_fields["members_may_be_incomplete"].description
+
+        assert description is not None
+        assert "may" in description
+        assert "not proof" in description
 
     async def test_an_unknown_chat_type_does_not_fail_the_listing(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
+        """A `chatType` the SDK's generated enum has no member for deserializes to `None` rather
+        than raising, so the chat arrives typeless and the listing must still name it something.
+        Passing a *valid* type here would exercise nothing.
+        """
         graph.get("/me/chats").mock(
             return_value=httpx.Response(
                 200,
-                json={"value": [chat_payload("19:future@thread.v2", chat_type="meeting")]},
+                json={"value": [chat_payload("19:future@thread.v2", chat_type="sharedChannel")]},
             )
         )
 
         listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
 
-        assert listed.chats[0].chat_type == "meeting"
+        assert listed.chats[0].chat_type == "unknown"
 
 
 class TestTheWindowAndItsHonesty:

--- a/services/office-mcp/tests/features/test_chats.py
+++ b/services/office-mcp/tests/features/test_chats.py
@@ -1,0 +1,249 @@
+"""`list_chats`' feature half: the query Graph is sent, and the traps in what comes back."""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import chats
+from office_mcp.graph_client import GraphThrottled
+
+from .conftest import GRAPH_V1, aad_member, chat_payload
+
+_GUEST_MEMBER = "#microsoft.graph.anonymousGuestConversationMember"
+
+
+class TestTheQueryItSends:
+    async def test_it_asks_graph_for_recency_ordering_and_both_expansions(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The three query parameters this tool's contract rests on.
+
+        Dropping `$orderby` silently returns *some* chats instead of the recent ones, and dropping
+        an expansion silently empties `members` or `last_message_at` — all three failures look
+        like a working tool.
+        """
+        route = graph.get("/me/chats").mock(
+            return_value=httpx.Response(200, json={"value": [chat_payload("19:a@thread.v2")]})
+        )
+
+        _ = await chats.list_recent_chats(client, limit=7, include_member_emails=False)
+
+        params = route.calls.last.request.url.params
+        assert params["$orderby"] == "lastMessagePreview/createdDateTime desc"
+        assert params["$expand"] == "members,lastMessagePreview"
+        assert params["$top"] == "7"
+        assert "$select" not in params, "$select is rejected on this collection"
+
+    async def test_a_limit_above_graphs_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        """The tool's schema bounds `limit` at Graph's own maximum, so a larger value can only
+        arrive from code that bypassed it."""
+        with pytest.raises(AssertionError):
+            _ = await chats.list_recent_chats(
+                client, limit=chats.MAX_CHATS + 1, include_member_emails=False
+            )
+
+
+class TestWhatTheCallerIsTold:
+    async def test_the_sort_key_is_in_the_payload(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The oracle connector sorts by last-message time but returns `lastUpdatedDateTime`, so
+        its list looks unsorted. `last_message_at` is the value the order is by."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload("19:a@thread.v2", last_message_at="2026-02-11T09:15:22.31Z"),
+                        chat_payload("19:b@thread.v2", last_message_at=None),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert [chat.chat_id for chat in listed.chats] == ["19:a@thread.v2", "19:b@thread.v2"]
+        first = listed.chats[0].last_message_at
+        assert first is not None and first.year == 2026
+        assert listed.chats[1].last_message_at is None, (
+            "a chat nobody posted in has no last message"
+        )
+
+    async def test_members_identify_the_chats_that_have_no_topic(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload("19:named@thread.v2", topic="Release planning"),
+                        chat_payload(
+                            "19:unnamed@unq.gbl.spaces",
+                            chat_type="oneOnOne",
+                            topic=None,
+                            members=[aad_member("Ada Lovelace"), aad_member("Alan Turing")],
+                        ),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].members is None, "a named chat needs no roster to be identified"
+        unnamed = listed.chats[1].members
+        assert unnamed is not None
+        assert [member.display_name for member in unnamed] == ["Ada Lovelace", "Alan Turing"]
+        assert [member.email for member in unnamed] == [None, None], "emails are opt-in"
+
+    async def test_emails_are_returned_only_when_asked_for(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:unnamed@unq.gbl.spaces",
+                            topic=None,
+                            members=[
+                                aad_member("Ada Lovelace", email="ada@example.invalid"),
+                                # A meeting room joins as a different member subtype, with no
+                                # email to disambiguate it by.
+                                {
+                                    "@odata.type": _GUEST_MEMBER,
+                                    "id": "member-room",
+                                    "displayName": "Room 3",
+                                },
+                            ],
+                        )
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=True)
+
+        members = listed.chats[0].members
+        assert members is not None
+        assert [(m.display_name, m.email) for m in members] == [
+            ("Ada Lovelace", "ada@example.invalid"),
+            ("Room 3", None),
+        ]
+
+    async def test_graphs_silent_member_cap_is_reported(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph returns at most 25 members per chat on this endpoint and says nothing about it,
+        so a model summarising "who is in this chat" from the list is wrong without a flag."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:crowded@thread.v2",
+                            topic=None,
+                            members=[
+                                aad_member(f"Person {index}")
+                                for index in range(chats.MEMBERS_PER_CHAT)
+                            ],
+                        ),
+                        chat_payload(
+                            "19:quiet@thread.v2", topic=None, members=[aad_member("Ada Lovelace")]
+                        ),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].members_truncated is True
+        assert listed.chats[1].members_truncated is False
+
+    async def test_an_unknown_chat_type_does_not_fail_the_listing(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={"value": [chat_payload("19:future@thread.v2", chat_type="meeting")]},
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].chat_type == "meeting"
+
+
+class TestTheWindowAndItsHonesty:
+    async def test_a_short_first_page_is_followed_rather_than_believed(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents that `$top` "might not return all chats within a single response" — so
+        a page shorter than `limit` with a next link is a paging artefact, not the end of the
+        collection. Believing it truncates the window for no reason."""
+        # Registered before the unconstrained route below, which would otherwise also match the
+        # second request and hand back page one again.
+        graph.get("/me/chats", params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(200, json={"value": [chat_payload("19:b@thread.v2")]})
+        )
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [chat_payload("19:a@thread.v2")],
+                    "@odata.nextLink": f"{GRAPH_V1}/me/chats?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert [chat.chat_id for chat in listed.chats] == ["19:a@thread.v2", "19:b@thread.v2"]
+        assert listed.truncated is False, "the walk reached the end of the collection"
+
+    async def test_a_full_window_with_more_behind_it_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [chat_payload(f"19:{index}@thread.v2") for index in range(2)],
+                    "@odata.nextLink": f"{GRAPH_V1}/me/chats?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=2, include_member_emails=False)
+
+        assert len(listed.chats) == 2
+        assert listed.truncated is True
+
+
+class TestGraphFailures:
+    async def test_throttling_carries_graphs_own_retry_after(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`Retry-After: 900` exceeds the SDK retry handler's 180 s ceiling, so it declines to
+        wait and the failure reaches the caller — which is the only case a tool has to explain."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                429,
+                headers={"Retry-After": "900"},
+                json={"error": {"code": "activityLimitReached", "message": "slow down"}},
+            )
+        )
+
+        with pytest.raises(GraphThrottled) as raised:
+            _ = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert raised.value.retry_after_seconds == 900

--- a/services/office-mcp/tests/features/test_identity.py
+++ b/services/office-mcp/tests/features/test_identity.py
@@ -1,0 +1,101 @@
+"""`whoami`'s feature half: what `GET /me` is asked for, and what the caller is told."""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import identity
+from office_mcp.graph_client import GraphForbidden
+
+from .conftest import CALLER_TOKEN
+
+_ME = {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "displayName": "Ada Lovelace",
+    "mail": "ada@example.invalid",
+    "userPrincipalName": "ada@corp.example.invalid",
+    "jobTitle": "Analyst",
+}
+
+
+class TestTheProfileItReturns:
+    async def test_it_asks_graph_only_for_the_properties_it_promises(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`/me`'s default projection is ~20 properties; the tool documents five."""
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        _ = await identity.get_signed_in_user(client)
+
+        selected = route.calls.last.request.url.params["$select"]
+        assert selected.split(",") == ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
+
+    async def test_it_reports_mail_and_upn_separately(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The fixture's `mail` and `userPrincipalName` are on different domains on purpose —
+        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters."""
+        graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        user = await identity.get_signed_in_user(client)
+
+        assert user.mail == "ada@example.invalid"
+        assert user.user_principal_name == "ada@corp.example.invalid"
+        assert user.id == "00000000-0000-4000-8000-000000000001"
+        assert user.display_name == "Ada Lovelace"
+        assert user.job_title == "Analyst"
+
+    async def test_a_guest_account_without_a_mailbox_still_answers(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A guest or unlicensed account has no `mail`. The tool's contract is that
+        `user_principal_name` carries the identity then, so a null must not be an error."""
+        graph.get("/me").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "displayName": "Grace Hopper",
+                    "mail": None,
+                    "userPrincipalName": "grace_example.invalid#EXT#@corp.example.invalid",
+                    "jobTitle": None,
+                },
+            )
+        )
+
+        user = await identity.get_signed_in_user(client)
+
+        assert user.mail is None
+        assert user.user_principal_name == "grace_example.invalid#EXT#@corp.example.invalid"
+
+    async def test_it_calls_as_the_caller(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        _ = await identity.get_signed_in_user(client)
+
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {CALLER_TOKEN}"
+
+
+class TestGraphFailures:
+    async def test_a_refusal_arrives_classified(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The feature wraps its own Graph work in `graph_errors`, so the server layer has a
+        typed failure to map rather than a bare `APIError`."""
+        graph.get("/me").mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "no"}},
+            )
+        )
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await identity.get_signed_in_user(client)
+
+        assert raised.value.status == 403
+        assert raised.value.code == "Authorization_RequestDenied"
+        assert raised.value.request_id == "synthetic-request-id"

--- a/services/office-mcp/tests/features/test_identity.py
+++ b/services/office-mcp/tests/features/test_identity.py
@@ -1,4 +1,4 @@
-"""`whoami`'s feature half: what `GET /me` is asked for, and what the caller is told."""
+"""`get_me`'s feature half: what `GET /me` is asked for, and what the caller is told."""
 
 import httpx
 import pytest
@@ -31,18 +31,23 @@ class TestTheProfileItReturns:
         selected = route.calls.last.request.url.params["$select"]
         assert selected.split(",") == ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
 
-    async def test_it_reports_mail_and_upn_separately(
+    async def test_it_reports_the_email_and_the_upn_separately(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """The fixture's `mail` and `userPrincipalName` are on different domains on purpose —
-        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters."""
+        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters.
+
+        Graph's `mail` and `id` are reported as `email` and `user_id`: an address is `email` and a
+        person's Entra id is `user_id` everywhere on this server's surface, and this profile is the
+        one payload a model correlates the rest against.
+        """
         graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
 
         user = await identity.get_signed_in_user(client)
 
-        assert user.mail == "ada@example.invalid"
+        assert user.email == "ada@example.invalid"
         assert user.user_principal_name == "ada@corp.example.invalid"
-        assert user.id == "00000000-0000-4000-8000-000000000001"
+        assert user.user_id == "00000000-0000-4000-8000-000000000001"
         assert user.display_name == "Ada Lovelace"
         assert user.job_title == "Analyst"
 
@@ -66,7 +71,7 @@ class TestTheProfileItReturns:
 
         user = await identity.get_signed_in_user(client)
 
-        assert user.mail is None
+        assert user.email is None
         assert user.user_principal_name == "grace_example.invalid#EXT#@corp.example.invalid"
 
     async def test_it_calls_as_the_caller(

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -1,0 +1,657 @@
+"""`read_message`' feature half: which handle addresses what, and what a Teams body really holds.
+
+Every payload is synthesised from Microsoft's own documented shapes — the Teams-identity sender, the
+authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorations a Teams body
+carries. Nothing here came from a tenant.
+"""
+
+from typing import cast
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import message_read, message_search
+from office_mcp.features.message_read import MessageHandle
+from office_mcp.features.message_search import SearchCriteria
+from office_mcp.graph_client import GraphForbidden, GraphNotFound
+
+from .conftest import chat_hit, message_payload, search_response
+
+_CHAT_ID = "19:release@thread.v2"
+_MESSAGE_ID = "1770000000000"
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+
+_CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+)
+
+# The path the ids above address once Graph has them. The SDK re-encodes them for the URL, so this
+# is what a percent-decoded handle has to come back out as.
+_CHAT_PATH = f"/chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+
+_CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
+_CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
+
+
+def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
+    _ = graph.get(path).mock(return_value=httpx.Response(200, json=payload))
+
+
+class TestTheHandlesItAccepts:
+    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
+        """The handle is `search_messages`' contract: the ids in it are percent-encoded because a
+        Teams id is full of `:` and `@`, so parsing it means decoding them back."""
+        chat = message_read.message_handle(_CHAT_URI)
+        channel = message_read.message_handle(_CHANNEL_URI)
+
+        assert chat == _CHAT_HANDLE
+        assert channel == _CHANNEL_HANDLE
+
+    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
+        assert message_read.message_handle(_CHAT_URI) is not None
+        assert cast("MessageHandle", message_read.message_handle(_CHAT_URI)).uri == _CHAT_URI
+        assert cast("MessageHandle", message_read.message_handle(_CHANNEL_URI)).uri == _CHANNEL_URI
+
+    def test_an_unencoded_id_still_resolves(self) -> None:
+        """A caller that copied a handle out of a log rather than out of a response has ids that
+        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
+        handle = message_read.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
+
+        assert handle == _CHAT_HANDLE
+
+    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
+        """Graph's permissions for a message read are per surface, so a 403 on a chat read can
+        only be about `Chat.Read` — naming the channel permission alongside it would send an
+        administrator after one that was never missing."""
+        assert _CHAT_HANDLE.permission == "Chat.Read"
+        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # The schemes a polymorphic reader would advertise and this connector cannot serve.
+            "mail:///messages/AAMkAGI2",
+            "calendar:///events/AAMkAGI2",
+            "drive:///items/01ABC",
+            "site:///sites/contoso/pages/1",
+            # Right scheme, wrong shape.
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "teams:///messages/1770000000000",
+            "teams:///chats//messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
+            "teams:///teams/8a9c3c47/messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
+            # A Teams web link, which is what a model reaches for when it has no handle.
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+            "1770000000000",
+            "",
+        ],
+    )
+    def test_it_refuses_everything_else(self, uri: str) -> None:
+        assert message_read.message_handle(uri) is None
+
+
+class TestTheRequestItMakes:
+    async def test_a_chat_handle_reads_the_chat_message_endpoint(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_CHAT_PATH).mock(return_value=httpx.Response(200, json=message_payload()))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert route.called
+
+    async def test_a_channel_handle_reads_the_channel_message_endpoint(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_CHANNEL_PATH).mock(
+            return_value=httpx.Response(200, json=message_payload())
+        )
+
+        _ = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+        assert route.called
+
+    async def test_it_asks_for_the_message_type_graph_hides_by_default(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`messageType` is an evolvable enum: without this header Graph reports
+        `systemEventMessage` as `unknownFutureValue`, which names nothing."""
+        route = graph.get(_CHAT_PATH).mock(return_value=httpx.Response(200, json=message_payload()))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert route.calls.last.request.headers["prefer"] == "include-unknown-enum-members"
+
+    async def test_the_prefer_header_is_not_added_to_every_other_graph_request(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """kiota's `RequestConfiguration.headers` defaults to one `HeadersCollection` shared by
+        every configuration in the process, so a header added to the default leaks into unrelated
+        calls. This is the check that the reader builds its own."""
+        _reads(graph, message_payload())
+        chats = graph.get("/me/chats").mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+        from office_mcp.features import chats as chats_feature
+
+        _ = await chats_feature.list_recent_chats(client, limit=1, include_member_emails=False)
+
+        assert "prefer" not in chats.calls.last.request.headers
+
+
+class TestWhatItReportsAboutTheMessage:
+    async def test_it_answers_with_the_handle_it_was_given(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.uri == _CHAT_URI
+        assert (message.message_id, message.chat_id) == (_MESSAGE_ID, _CHAT_ID)
+        assert (message.team_id, message.channel_id) == (None, None)
+
+    async def test_the_sender_is_the_teams_identity_shape_with_no_email(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A read gives `teamworkUserIdentity`, which has no email property at all — so the field
+        search fills in is null here, and the id is what the two shapes have in common."""
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert message.sender.display_name == "Ada Lovelace"
+        assert message.sender.user_id == "00000000-0000-4000-8000-000000000001"
+        assert message.sender.email is None
+
+    async def test_a_sender_graph_gave_no_name_is_still_identified(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`displayName` is documented Optional and is genuinely absent for federated and external
+        users. A blank name must not read as an anonymous sender."""
+        _reads(
+            graph,
+            message_payload(
+                sender={
+                    "user": {
+                        "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+                        "id": "00000000-0000-4000-8000-000000000002",
+                        "displayName": "",
+                        "userIdentityType": "federatedUser",
+                    }
+                }
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert message.sender.display_name is None, "an empty name is not a name"
+        assert message.sender.user_id == "00000000-0000-4000-8000-000000000002"
+
+    async def test_a_bot_is_named_by_its_application(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                sender={
+                    "application": {
+                        "@odata.type": "#microsoft.graph.teamworkApplicationIdentity",
+                        "id": "0dbc0b2f-e0d6-4a1f-b2f4-8f2b3f3f0e8c",
+                        "displayName": "Release Bot",
+                    }
+                }
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert (message.sender.display_name, message.sender.user_id) == ("Release Bot", None)
+
+    async def test_edits_and_reactions_are_not_confused_for_each_other(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`lastModifiedDateTime` moves when somebody adds a reaction; `lastEditedDateTime` is the
+        one that means the author changed the text, so it is the one reported."""
+        _reads(
+            graph,
+            message_payload(
+                last_modified_at="2026-02-11T11:00:00Z", last_edited_at="2026-02-11T10:00:00Z"
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.last_edited_at is not None
+        assert message.last_edited_at.isoformat() == "2026-02-11T10:00:00+00:00"
+
+    async def test_an_unedited_message_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.last_edited_at is None
+        assert message.deleted_at is None
+
+    async def test_a_channel_reply_carries_the_post_it_replies_to(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                reply_to_id="1770000000001",
+                web_url="https://teams.microsoft.invalid/l/message/19%3Ageneral/1770000000000",
+            ),
+            _CHANNEL_PATH,
+        )
+
+        message = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+        assert message.reply_to_id == "1770000000001"
+        assert message.web_url is not None
+
+
+class TestTheBodyItNormalises:
+    async def test_plain_text_content_is_left_alone(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload(content="cut the release on Friday", content_type="text"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "cut the release on Friday"
+
+    async def test_teams_html_becomes_readable_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole pipeline over one body: wrapper divs, paragraphs, breaks, a list, formatting
+        tags and HTML entities. Handing any of this to a model verbatim is the quality bug."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '<div><div itemprop="copy-paste-block"><p>Ship <strong>today</strong> '
+                    + "&amp; tell&nbsp;support.</p><p>Blockers:</p><ul><li>build #7</li>"
+                    + "<li>docs</li></ul>done<br/>thanks</div></div>"
+                )
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == (
+            "Ship today & tell support.\nBlockers:\n- build #7\n- docs\ndone\nthanks"
+        )
+
+    async def test_a_mention_reads_as_the_person_it_names(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An `<at id="0">` left in the text would be a key to nothing, and dropping it would read
+        as the author addressing nobody."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="0">Ada Lovelace</at> can you review?</p>',
+                mentions=[
+                    {
+                        "id": 0,
+                        "mentionText": "Ada Lovelace",
+                        "mentioned": {
+                            "user": {
+                                "id": "00000000-0000-4000-8000-000000000001",
+                                "displayName": "Ada Lovelace",
+                                "userIdentityType": "aadUser",
+                            }
+                        },
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "@Ada Lovelace can you review?"
+        assert [(m.text, m.user_id) for m in message.mentions] == [
+            ("Ada Lovelace", "00000000-0000-4000-8000-000000000001")
+        ]
+
+    async def test_a_mention_with_no_text_of_its_own_is_resolved_from_the_mentions_list(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft documents the `<at>` element's `id` as corresponding to `mentions[].id`, which
+        is the authority — the element's own text is sometimes empty."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="3"></at> heads up</p>',
+                mentions=[{"id": 3, "mentionText": "Release planning", "mentioned": {}}],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "@Release planning heads up"
+
+    async def test_a_mention_of_everyone_is_not_reported_as_a_person(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An @everyone arrives as a conversation identity with `user: null`, so a null `user_id`
+        is not a failure to resolve somebody."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="0">Everyone</at> standup moved</p>',
+                mentions=[
+                    {
+                        "id": 0,
+                        "mentionText": "Everyone",
+                        "mentioned": {
+                            "conversation": {
+                                "id": _CHAT_ID,
+                                "displayName": "Release planning",
+                                "conversationIdentityType": "chat",
+                            }
+                        },
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert [(m.text, m.user_id) for m in message.mentions] == [("Everyone", None)]
+
+    async def test_an_attachment_placeholder_names_what_was_attached(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The body carries only `<attachment id="…">`; the name lives in `attachments[]`, so
+        without resolving one against the other the message reads as if nothing was attached."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p>see this</p><attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "reference",
+                        "contentUrl": "https://contoso.sharepoint.invalid/Shared/plan.xlsx",
+                        "name": "plan.xlsx",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "see this\n[attachment: plan.xlsx]"
+        assert [(a.name, a.content_type) for a in message.attachments] == [
+            ("plan.xlsx", "reference")
+        ]
+        assert message.attachments[0].url is not None
+
+    async def test_an_unnamed_attachment_is_still_marked(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "forwardedMessageReference",
+                        "content": '{"originalMessageId":"1770000000000"}',
+                        "name": None,
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[attachment]"
+        assert message.attachments[0].url is None, (
+            "a forwarded message's `content` is a JSON payload, not a location"
+        )
+
+    async def test_emoji_survive_the_tags_that_carry_them(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`<emoji alt="👀">` holds the character in an attribute, so stripping tags without
+        reading it deletes the emoji from the message."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p>looking <emoji id="1f440_eyes" alt="\U0001f440" title="Eyes"></emoji>'
+                + '<customemoji id="x" alt="teams_party" source="https://x.invalid"></customemoji>'
+                + "</p>"
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "looking \U0001f440teams_party"
+
+    async def test_an_inline_image_is_reported_rather_than_dropped(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '<div><img height="63" src="https://graph.microsoft.com/v1.0/chats/x/'
+                    + 'messages/y/hostedContents/z/$value" width="67"></div>'
+                )
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[image]"
+
+    async def test_an_adaptive_card_is_not_dumped_into_the_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='{"type":"AdaptiveCard","version":"1.4","body":[{"type":"TextBlock"}]}'
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_a_body_with_nothing_in_it_is_null_rather_than_empty(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload(content="<div>   </div>"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text is None
+
+
+class TestTheMessagesThatHaveNoText:
+    async def test_a_deleted_message_is_not_presented_as_content(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Whatever a tombstone's body holds, it is not what the author wrote."""
+        _reads(
+            graph,
+            message_payload(deleted_at="2026-02-12T08:00:00Z", content="<div></div>"),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text is None
+        assert message.deleted_at is not None
+        assert message.deleted_at.isoformat() == "2026-02-12T08:00:00+00:00"
+
+    async def test_a_system_event_says_what_happened_instead_of_the_literal_tag(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The one Graph is most misleading about: `from` is null and the body is the literal
+        `<systemEventMessage/>`. The sentence Teams shows is written by the Teams client and never
+        sent, so `eventDetail`'s type is the only thing that names the event."""
+        _reads(
+            graph,
+            message_payload(
+                sender=None,
+                content="<systemEventMessage/>",
+                message_type="systemEventMessage",
+                event_detail={
+                    "@odata.type": "#microsoft.graph.membersJoinedEventMessageDetail",
+                    "visibleHistoryStartDateTime": "0001-01-01T00:00:00Z",
+                    "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+                },
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event == "members joined"
+        assert message.text is None, "`<systemEventMessage/>` is not text"
+        assert message.sender is None
+
+    @pytest.mark.parametrize(
+        ("odata_type", "expected"),
+        [
+            ("#microsoft.graph.chatRenamedEventMessageDetail", "chat renamed"),
+            ("#microsoft.graph.callEndedEventMessageDetail", "call ended"),
+            ("#microsoft.graph.callTranscriptEventMessageDetail", "call transcript"),
+            ("#microsoft.graph.teamsAppInstalledEventMessageDetail", "teams app installed"),
+            (
+                "#microsoft.graph.conversationMemberRoleUpdatedEventMessageDetail",
+                "conversation member role updated",
+            ),
+            # The subtype Microsoft adds next: reading the type is what covers it, where a table of
+            # the 31 that exist today would answer "unknown".
+            ("#microsoft.graph.somethingNewEventMessageDetail", "something new"),
+        ],
+    )
+    async def test_every_event_type_names_itself(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        odata_type: str,
+        expected: str,
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                sender=None,
+                content="<systemEventMessage/>",
+                message_type="systemEventMessage",
+                event_detail={"@odata.type": odata_type},
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event == expected
+
+    async def test_an_event_graph_did_not_describe_is_still_not_reported_as_a_message(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A `chatEvent` or `typing` message carries no `eventDetail` at all, and without the
+        `Prefer` header its type would arrive as `unknownFutureValue`. Either way it is not
+        something a person wrote."""
+        _reads(
+            graph,
+            message_payload(sender=None, content="", message_type="unknownFutureValue"),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event is not None
+        assert message.text is None
+
+    async def test_an_ordinary_message_has_no_event(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event is None
+
+
+class TestTheFailuresItPassesOn:
+    async def test_a_message_graph_will_not_return_is_a_not_found(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph answers 'deleted', 'never existed' and 'you may not see it' identically; the
+        classification stops here and the tool layer is what refuses to guess between them."""
+        _ = graph.get(_CHAT_PATH).mock(
+            return_value=httpx.Response(
+                404, json={"error": {"code": "NotFound", "message": "Not Found"}}
+            )
+        )
+
+        with pytest.raises(GraphNotFound):
+            _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+    async def test_a_refused_permission_is_a_forbidden(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _ = graph.get(_CHANNEL_PATH).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        with pytest.raises(GraphForbidden):
+            _ = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+
+class TestTheRoundTripFromASearchResult:
+    async def test_a_hit_from_search_is_read_by_its_own_handle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The contract between the two tools, end to end at the feature level: whatever
+        `search_messages` puts in `uri`, `read_message` has to resolve without any part of it being
+        reassembled by hand.
+        """
+        _ = graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200, json=search_response([chat_hit(chat_id=_CHAT_ID, message_id=_MESSAGE_ID)])
+            )
+        )
+        route = graph.get(_CHAT_PATH).mock(
+            return_value=httpx.Response(
+                200, json=message_payload(content="<p>cut the release on Friday</p>")
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+        uri = found.messages[0].uri
+        assert uri is not None
+        handle = message_read.message_handle(uri)
+        assert handle is not None, f"search produced a handle read_message rejects: {uri}"
+        message = await message_read.read_message(client, handle=handle)
+
+        assert route.called
+        assert message.uri == uri
+        assert message.text == "cut the release on Friday", (
+            "the point of the round trip: search has no body, and this is where the text comes from"
+        )
+        assert message.sender is not None
+        assert message.sender.display_name == found.messages[0].sender.display_name, (
+            "the same person, whichever tool reported them"
+        )

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -1,11 +1,13 @@
-"""`read_message`' feature half: which handle addresses what, and what a Teams body really holds.
+"""`read_message`' feature half: what a read asks Graph for, and what a Teams body really holds.
 
 Every payload is synthesised from Microsoft's own documented shapes — the Teams-identity sender, the
 authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorations a Teams body
 carries. Nothing here came from a tenant.
-"""
 
-from typing import cast
+Which strings are handles at all is `message_search`'s question, since search is what mints them:
+`TestTheHandleItMints` in `test_message_search.py` covers the two shapes and everything that is not
+one of them. What is covered here is what a read does with a handle it was given.
+"""
 
 import httpx
 import pytest
@@ -13,8 +15,7 @@ import respx
 from msgraph.graph_service_client import GraphServiceClient
 
 from office_mcp.features import message_read, message_search
-from office_mcp.features.message_read import MessageHandle
-from office_mcp.features.message_search import SearchCriteria
+from office_mcp.features.message_search import MessageHandle, SearchCriteria
 from office_mcp.graph_client import GraphForbidden, GraphNotFound
 
 from .conftest import chat_hit, message_payload, search_response
@@ -25,9 +26,6 @@ _TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
 _CHANNEL_ID = "19:general@thread.tacv2"
 
 _CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
-_CHANNEL_URI = (
-    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
-)
 
 # The path the ids above address once Graph has them. The SDK re-encodes them for the URL, so this
 # is what a percent-decoded handle has to come back out as.
@@ -40,61 +38,6 @@ _CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channe
 
 def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
     _ = graph.get(path).mock(return_value=httpx.Response(200, json=payload))
-
-
-class TestTheHandlesItAccepts:
-    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
-        """The handle is `search_messages`' contract: the ids in it are percent-encoded because a
-        Teams id is full of `:` and `@`, so parsing it means decoding them back."""
-        chat = message_read.message_handle(_CHAT_URI)
-        channel = message_read.message_handle(_CHANNEL_URI)
-
-        assert chat == _CHAT_HANDLE
-        assert channel == _CHANNEL_HANDLE
-
-    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
-        assert message_read.message_handle(_CHAT_URI) is not None
-        assert cast("MessageHandle", message_read.message_handle(_CHAT_URI)).uri == _CHAT_URI
-        assert cast("MessageHandle", message_read.message_handle(_CHANNEL_URI)).uri == _CHANNEL_URI
-
-    def test_an_unencoded_id_still_resolves(self) -> None:
-        """A caller that copied a handle out of a log rather than out of a response has ids that
-        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
-        handle = message_read.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
-
-        assert handle == _CHAT_HANDLE
-
-    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
-        """Graph's permissions for a message read are per surface, so a 403 on a chat read can
-        only be about `Chat.Read` — naming the channel permission alongside it would send an
-        administrator after one that was never missing."""
-        assert _CHAT_HANDLE.permission == "Chat.Read"
-        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
-
-    @pytest.mark.parametrize(
-        "uri",
-        [
-            # The schemes a polymorphic reader would advertise and this connector cannot serve.
-            "mail:///messages/AAMkAGI2",
-            "calendar:///events/AAMkAGI2",
-            "drive:///items/01ABC",
-            "site:///sites/contoso/pages/1",
-            # Right scheme, wrong shape.
-            "teams:///chats/19%3Arelease%40thread.v2",
-            "teams:///messages/1770000000000",
-            "teams:///chats//messages/1770000000000",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
-            "teams:///teams/8a9c3c47/messages/1770000000000",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
-            # A Teams web link, which is what a model reaches for when it has no handle.
-            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
-            "1770000000000",
-            "",
-        ],
-    )
-    def test_it_refuses_everything_else(self, uri: str) -> None:
-        assert message_read.message_handle(uri) is None
 
 
 class TestTheRequestItMakes:
@@ -841,7 +784,7 @@ class TestTheRoundTripFromASearchResult:
         )
         uri = found.messages[0].uri
         assert uri is not None
-        handle = message_read.message_handle(uri)
+        handle = message_search.message_handle(uri)
         assert handle is not None, f"search produced a handle read_message rejects: {uri}"
         message = await message_read.read_message(client, handle=handle)
 

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -461,20 +461,6 @@ class TestTheBodyItNormalises:
 
         assert message.text == "[image]"
 
-    async def test_an_adaptive_card_is_not_dumped_into_the_answer(
-        self, client: GraphServiceClient, graph: respx.MockRouter
-    ) -> None:
-        _reads(
-            graph,
-            message_payload(
-                content='{"type":"AdaptiveCard","version":"1.4","body":[{"type":"TextBlock"}]}'
-            ),
-        )
-
-        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
-
-        assert message.text == "[card]"
-
     async def test_a_body_with_nothing_in_it_is_null_rather_than_empty(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
@@ -483,6 +469,219 @@ class TestTheBodyItNormalises:
         message = await message_read.read_message(client, handle=_CHAT_HANDLE)
 
         assert message.text is None
+
+
+# One adaptive card, as Microsoft's own example shapes it: the payload lives in the attachment's
+# `content` and the attachment's `contentType` is what names it a card.
+_CARD_PAYLOAD = (
+    '{"type":"AdaptiveCard","version":"1.4",'
+    + '"body":[{"type":"TextBlock","text":"Deploy build #7?"}]}'
+)
+_CARD_ATTACHMENT: dict[str, object] = {
+    "id": "74d20c7f34aa4a7fb74e2b30004247c5",
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "content": _CARD_PAYLOAD,
+    "name": None,
+}
+
+
+class TestWhatCountsAsACard:
+    """A card is attachment metadata, never the shape of the body text.
+
+    Microsoft marks a card in `attachments[].contentType` —
+    `application/vnd.microsoft.card.adaptive` and its siblings
+    (https://learn.microsoft.com/en-us/graph/api/resources/chatmessageattachment,
+    https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference)
+    — and the card's payload in `attachment.content`. Going by the body text instead means a
+    developer who pastes JSON into Teams has their message reported as a card and its content
+    thrown away, in the one tool that is the only route to a message's text.
+    """
+
+    async def test_a_pasted_json_object_is_a_message_and_comes_back_whole(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The defect this class exists for: brace-and-`"type"` text is what a developer sends all
+        day, and no part of it may be traded for `[card]`."""
+        pasted = '{"type":"service","replicas":3,"image":"office-mcp:1.4.0"}'
+        _reads(graph, message_payload(content=f"<div><p>{pasted}</p></div>"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == pasted
+        assert message.attachments == [], "nothing was attached, so nothing was a card"
+
+    async def test_json_that_is_only_part_of_a_sentence_keeps_the_sentence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<p>{"type":"TextBlock"} — is this the bit that broke prod?</p>'
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == '{"type":"TextBlock"} — is this the bit that broke prod?'
+
+    async def test_a_card_attachment_reads_as_a_card_where_its_placeholder_sat(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The ordinary shape of a card message: the body carries the `<attachment id="…">`
+        placeholder and the payload is in `attachments[]`. Teams gives a card no `name`, so without
+        reading its `contentType` the card would read as an anonymous `[attachment]`."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    "<p>ready?</p>"
+                    + '<attachment id="74d20c7f34aa4a7fb74e2b30004247c5"></attachment>'
+                ),
+                attachments=[_CARD_ATTACHMENT],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "ready?\n[card]"
+        assert [a.content_type for a in message.attachments] == [
+            "application/vnd.microsoft.card.adaptive"
+        ]
+
+    @pytest.mark.parametrize(
+        ("content_type", "expected"),
+        [
+            ("application/vnd.microsoft.card.adaptive", "[card]"),
+            ("application/vnd.microsoft.card.hero", "[card]"),
+            ("application/vnd.microsoft.card.thumbnail", "[card]"),
+            ("application/vnd.microsoft.card.receipt", "[card]"),
+            ("application/vnd.microsoft.card.signin", "[card]"),
+            ("application/vnd.microsoft.card.codesnippet", "[card]"),
+            ("application/vnd.microsoft.card.announcement", "[card]"),
+            ("application/vnd.microsoft.teams.card.list", "[card]"),
+            ("application/vnd.microsoft.teams.card.o365connector", "[card]"),
+            # The card type Microsoft publishes next: the namespace is the documented shape, so
+            # matching it covers what a table of today's nine values would answer `[attachment]` to.
+            ("application/vnd.microsoft.card.somethingNew", "[card]"),
+            # Not cards. `reference` is a file and `forwardedMessageReference` is a message.
+            ("reference", "[attachment]"),
+            ("forwardedMessageReference", "[attachment]"),
+        ],
+    )
+    async def test_every_card_namespace_teams_documents_names_itself_a_card(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        content_type: str,
+        expected: str,
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {"id": "1727881360458", "contentType": content_type, "name": None},
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == expected
+
+    async def test_a_named_card_is_named_rather_than_generically_marked(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`name` is more use to a reader than the word `card`, so a card that has one keeps it."""
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "application/vnd.microsoft.card.codesnippet",
+                        "name": "deploy.sh",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[attachment: deploy.sh]"
+
+    async def test_a_card_teams_left_in_the_body_is_not_dumped_into_the_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Teams sometimes puts the card's own JSON in `body.content` instead of the placeholder.
+        That body is the attachment's payload repeated, so `[card]` loses nothing — and the
+        attachment is the evidence, which is what makes this safe where a text heuristic was not."""
+        _reads(graph, message_payload(content=_CARD_PAYLOAD, attachments=[_CARD_ATTACHMENT]))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_the_same_payload_formatted_differently_is_still_the_same_card(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The comparison is between parsed payloads, so indentation and key order do not decide
+        whether a model gets a screenful of layout JSON."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '{\n  "version": "1.4",\n  "type": "AdaptiveCard",\n'
+                    + '  "body": [ { "text": "Deploy build #7?", "type": "TextBlock" } ]\n}'
+                ),
+                attachments=[_CARD_ATTACHMENT],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_a_card_attachment_does_not_license_discarding_unrelated_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Both at once, which is the case a conjunction of the two old signals would still lose: a
+        real card attachment *and* a body that is a person's own JSON rather than that card. The
+        text is theirs, so it is returned in full and the card is reported in `attachments`."""
+        pasted = '{"type":"Deployment","replicas":3}'
+        _reads(graph, message_payload(content=f"<p>{pasted}</p>", attachments=[_CARD_ATTACHMENT]))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == pasted
+        assert [a.content_type for a in message.attachments] == [
+            "application/vnd.microsoft.card.adaptive"
+        ]
+
+    async def test_json_text_with_no_card_attachment_survives_even_beside_a_file(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An attachment that is not a card is not evidence of one."""
+        pasted = '{"type":"service","port":9544}'
+        _reads(
+            graph,
+            message_payload(
+                content=f'<p>{pasted}</p><attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "reference",
+                        "contentUrl": "https://contoso.sharepoint.invalid/Shared/values.yaml",
+                        "name": "values.yaml",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == f"{pasted}\n[attachment: values.yaml]"
 
 
 class TestTheMessagesThatHaveNoText:

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -1,0 +1,618 @@
+"""`search_messages`' feature half: the query Graph is sent, and the traps in what comes back.
+
+Every payload is synthesised from Microsoft's own documented shapes — the reduced search
+projection, the Exchange-shaped sender a search hit carries, the authorless system event message.
+Nothing here came from a tenant.
+"""
+
+import json
+from datetime import date
+from typing import cast
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import message_search
+from office_mcp.features.message_search import SearchCriteria
+from office_mcp.graph_client import GraphForbidden
+
+from .conftest import channel_hit, chat_hit, search_response
+
+_MENTIONED = UUID("497b7a2a-9e1a-48d7-80e8-2965d2fc3a81")
+
+
+def _request(route: respx.Route) -> dict[str, object]:
+    """The `searchRequest` the last call put on the wire."""
+    body = cast("dict[str, object]", json.loads(route.calls.last.request.content))
+    requests = cast("list[dict[str, object]]", body["requests"])
+    assert len(requests) == 1, "Graph honours only one searchRequest per call"
+    return requests[0]
+
+
+def _query_string(route: respx.Route) -> str:
+    query = cast("dict[str, object]", _request(route)["query"])
+    return cast("str", query["queryString"])
+
+
+def _unquoted_words(query: str) -> list[str]:
+    """The words of `query` that a KQL parser would read outside any quoted phrase.
+
+    Splitting on `"` and keeping the even-numbered pieces is exactly that, given a query whose
+    quotes are balanced — which every test using this asserts first, because it is the property the
+    quoting exists to hold.
+    """
+    return [
+        word
+        for index, part in enumerate(query.split('"'))
+        if index % 2 == 0
+        for word in part.split()
+    ]
+
+
+class TestTheQueryItSends:
+    async def test_it_asks_only_for_chat_messages_and_pages_by_offset(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph refuses to mix entity types, and its message search pages by `from`/`size`
+        integers rather than by a cursor — which is what lets a stateless tool resume a search."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([chat_hit()]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=25, size=10
+        )
+
+        request = _request(route)
+        assert request["entityTypes"] == ["chatMessage"]
+        assert (request["from"], request["size"]) == (25, 10)
+        assert "sortProperties" not in request, "Graph rejects sorting a chatMessage search"
+
+    async def test_every_criterion_becomes_its_documented_scope_term(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The spellings are Microsoft's, including the inconsistent casing and the fact that
+        `sent` is a comparison rather than a `term:value` pair."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(
+                query="release",
+                sender="ada",
+                recipient="alan",
+                mentions=_MENTIONED,
+                sent_after=date(2026, 1, 1),
+                sent_before=date(2026, 1, 31),
+                has_attachment=True,
+                is_read=False,
+                mentions_me=True,
+            ),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == (
+            "release from:ada to:alan mentions:497b7a2a9e1a48d780e82965d2fc3a81 "
+            + "sent>=2026-01-01 sent<=2026-01-31 hasAttachment:true IsRead:false IsMentioned:true"
+        )
+
+    async def test_the_mentioned_user_id_loses_its_hyphens(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft's `mentions` example is a user id "without '-'" — the one scope term whose
+        value is not the value the caller supplied."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(mentions=_MENTIONED), offset=0, size=25
+        )
+
+        assert _query_string(route) == "mentions:497b7a2a9e1a48d780e82965d2fc3a81"
+
+    async def test_date_bounds_include_the_days_they_name(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`sent>2026-01-01` silently drops everything sent on the 1st, which is never what a
+        caller asking for "since the 1st" meant."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(sent_after=date(2026, 1, 1), sent_before=date(2026, 1, 31)),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == "sent>=2026-01-01 sent<=2026-01-31"
+
+    async def test_a_multi_word_query_reaches_graph_as_words_and_not_as_a_phrase(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The recall this tool would otherwise lose silently. Quoting the whole query — the guard
+        a *filter value* needs — makes it an exact-adjacency phrase, so "cut the release" would
+        match only messages with those three words side by side and drop "the release was cut"
+        entirely, while the parameter promises the words are matched as words. Bare terms are what
+        Graph ANDs, so bare terms are what it is sent.
+        """
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="cut the release"), offset=0, size=25
+        )
+
+        assert _query_string(route) == "cut the release"
+
+    async def test_a_phrase_the_caller_quoted_themselves_stays_a_phrase(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Adjacency is not unavailable, it is just not the default: a caller who wants it asks
+        for it, and the words outside their quotes stay words."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query='friday "release notes"'), offset=0, size=25
+        )
+
+        assert _query_string(route) == 'friday "release notes"'
+
+    @pytest.mark.parametrize(
+        "injection",
+        [
+            "sent>2020-01-01",
+            "from:ceo@example.invalid",
+            "release OR from:ceo",
+            'release" OR IsRead:false OR "',
+            "(release)",
+            "IsMentioned:true",
+            "release NOT IsRead:false",
+            "-release",
+            "rele*",
+            'release" NOT "',
+        ],
+    )
+    async def test_a_caller_cannot_smuggle_kql_through_the_free_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter, injection: str
+    ) -> None:
+        """`query` is words, and the filters a caller may set are exactly the parameters this tool
+        declares. Without this guard, free text reaches Microsoft as Keyword Query Language and can
+        widen the search past every filter the tool applied.
+
+        The guard now works a word at a time rather than over the whole query, so the assertion is
+        about the query string's *structure*: outside the quoted spans there is nothing a KQL parser
+        would read as anything but a keyword. A word with no operator character, no wildcard, no
+        leading `-` and no operator spelling is the only thing left bare, and such a word cannot
+        express a restriction, a negation or a boolean.
+        """
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query=injection), offset=0, size=25
+        )
+
+        sent = _query_string(route)
+        assert sent.count('"') % 2 == 0, f"the quoting is closable from inside: {sent}"
+        for word in _unquoted_words(sent):
+            assert not set(word) & set(':"<>=()*'), f"operator left bare in {sent}: {word}"
+            assert not word.startswith("-"), f"negation left bare in {sent}: {word}"
+            assert word not in {"AND", "OR", "NOT", "NEAR", "ONEAR"}, (
+                f"boolean left bare in {sent}: {word}"
+            )
+
+    async def test_the_words_of_an_injection_attempt_are_still_searched_for(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Neutralising is not dropping: the caller typed those characters, so they are looked for
+        as text. A guard that silently discarded them would answer a different question."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release OR from:ceo"), offset=0, size=25
+        )
+
+        assert _query_string(route) == 'release "OR" "from:ceo"'
+
+    async def test_a_sender_cannot_smuggle_one_either(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(sender="ada OR IsRead:false"),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == 'from:"ada OR IsRead:false"'
+
+    async def test_an_ordinary_value_is_left_as_a_keyword(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Quoting everything would turn every search into a phrase search and lose stemming, so
+        only values that could be read as operators are quoted."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release", sender="ada"), offset=0, size=25
+        )
+
+        assert _query_string(route) == "release from:ada"
+
+
+class TestCriteriaThatAskForNothing:
+    def test_an_empty_set_knows_it_is_empty(self) -> None:
+        assert SearchCriteria().is_empty is True
+
+    def test_free_text_with_no_word_in_it_asks_for_nothing(self) -> None:
+        """`is_empty` is measured on the query string, not on which arguments were passed, so a
+        query that leaves nothing to look for is refused by the boundary that refuses no criteria
+        at all — rather than reaching Graph as a search for everything."""
+        assert SearchCriteria(query='" "').is_empty is True
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            SearchCriteria(query="release"),
+            SearchCriteria(sender="ada"),
+            SearchCriteria(recipient="alan"),
+            SearchCriteria(mentions=_MENTIONED),
+            SearchCriteria(sent_after=date(2026, 1, 1)),
+            SearchCriteria(sent_before=date(2026, 1, 31)),
+            SearchCriteria(has_attachment=False),
+            SearchCriteria(is_read=False),
+            SearchCriteria(mentions_me=False),
+        ],
+    )
+    def test_any_single_criterion_is_enough(self, criteria: SearchCriteria) -> None:
+        """`false` is a criterion — "unread messages" and "messages without attachments" are real
+        questions, so only an unset value counts as absent."""
+        assert criteria.is_empty is False
+
+    async def test_searching_for_nothing_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        """The tool refuses it at the boundary, so reaching the feature with it means the
+        boundary was bypassed."""
+        with pytest.raises(AssertionError):
+            _ = await message_search.search_messages(
+                client, criteria=SearchCriteria(), offset=0, size=25
+            )
+
+    async def test_a_size_above_what_graph_documents_is_too(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await message_search.search_messages(
+                client,
+                criteria=SearchCriteria(query="release"),
+                offset=0,
+                size=message_search.MAX_RESULTS + 1,
+            )
+
+
+class TestWhatTheCallerIsTold:
+    async def test_a_chat_hit_carries_a_chat_handle_and_a_channel_hit_a_channel_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The handle is the whole route to the message text, since the search projection has no
+        body — and the ids in it are percent-encoded because a Teams id is full of `:` and `@`."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(chat_id="19:release@thread.v2", message_id="1770000000001"),
+                        channel_hit(
+                            team_id="8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+                            channel_id="19:general@thread.tacv2",
+                            message_id="1770000000002",
+                        ),
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert [message.uri for message in found.messages] == [
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000001",
+            "teams:///teams/8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+            + "/channels/19%3Ageneral%40thread.tacv2/messages/1770000000002",
+        ]
+        # The raw ids are returned alongside, unencoded, for tools that take an id rather than a
+        # handle — a caller must never have to unpick the handle to get one back.
+        assert found.messages[0].chat_id == "19:release@thread.v2"
+        assert (found.messages[1].team_id, found.messages[1].channel_id) == (
+            "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+            "19:general@thread.tacv2",
+        )
+
+    async def test_a_hit_with_neither_identity_is_kept_without_a_handle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph does occasionally return a hit with no chatId and no channelIdentity. Its snippet
+        is still an answer, so it is reported — with a null `uri` saying it cannot be read in
+        full, rather than being dropped or given a handle that would 404."""
+        hit = chat_hit(chat_id=None)
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([hit]))
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert len(found.messages) == 1
+        assert found.messages[0].uri is None
+        assert found.messages[0].summary is not None
+
+    async def test_the_snippet_and_the_metadata_come_through(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [chat_hit(summary="...cut the <c0>release</c0> on Friday...")]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        message = found.messages[0]
+        assert message.summary == "...cut the <c0>release</c0> on Friday..."
+        assert message.importance == "normal"
+        assert message.created_at is not None and message.created_at.year == 2026
+        assert message.last_modified_at is not None
+
+    async def test_a_search_hits_mailbox_shaped_sender_is_understood(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Teams messages are indexed out of the substrate mailbox, so a hit's `from` is an
+        Exchange `emailAddress` — a shape the Graph SDK has no field for, and one the Teams read
+        APIs never return."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "emailAddress": {
+                                    "name": "Ada Lovelace",
+                                    "address": "ada@example.invalid",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert (sender.display_name, sender.email) == ("Ada Lovelace", "ada@example.invalid")
+        assert sender.user_id is None, "the mailbox shape carries no directory id"
+
+    async def test_a_teams_shaped_sender_is_understood_too(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other branch: `teamworkUserIdentity` has an id and no email at all, and Microsoft
+        documents its display name as optional — a null there is not an anonymous sender."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "user": {
+                                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+                                    "id": "00000000-0000-4000-8000-000000000001",
+                                    "displayName": None,
+                                    "userIdentityType": "aadUser",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert sender.user_id == "00000000-0000-4000-8000-000000000001"
+        assert (sender.display_name, sender.email) == (None, None)
+
+    async def test_a_bot_is_named_by_its_application_identity(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "application": {
+                                    "id": "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+                                    "displayName": "Build Notifier",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert sender.display_name == "Build Notifier"
+        assert sender.user_id is None, "an application id is not a user id"
+
+    async def test_system_event_messages_are_dropped(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A message nobody wrote is not a search result: for "Ada joined the chat" Graph sends a
+        null `from` and a body of the literal `<systemEventMessage/>`, rendering the sentence in
+        the Teams client
+        from `eventDetail` — which the search projection does not even return. Left in, these are
+        results with no author and no text, and a model summarising a page of them reports
+        membership churn as the conversation.
+        """
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(message_id="1770000000001", sender=None),
+                        chat_hit(message_id="1770000000002"),
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert [message.message_id for message in found.messages] == ["1770000000002"]
+
+
+class TestPagingAndItsHonesty:
+    async def test_more_results_available_drives_paging_and_total_is_ignored(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft documents `total` as the count of results on the page for Teams messages, not
+        the number of matches — so a tool that reports it tells a model there were 25 matches when
+        there may be thousands. Nothing here reads it."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [chat_hit(message_id=f"177000000000{index}") for index in range(3)],
+                    total=3,
+                    more_results_available=True,
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=50, size=25
+        )
+
+        assert found.more_results_available is True
+        assert found.next_offset == 53
+        assert "total" not in message_search.MessageSearchResults.model_fields
+
+    async def test_the_next_offset_counts_graphs_hits_not_the_messages_kept(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The filtering happens on our side of the offset. Advancing by the number of messages
+        returned would re-read the hits that were filtered out, forever."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(message_id="1770000000001", sender=None),
+                        chat_hit(message_id="1770000000002", sender=None),
+                        chat_hit(message_id="1770000000003"),
+                    ],
+                    more_results_available=True,
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert len(found.messages) == 1
+        assert found.next_offset == 3
+
+    async def test_the_last_page_offers_no_next_offset(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200, json=search_response([chat_hit()], more_results_available=False)
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert found.next_offset is None
+
+    async def test_a_search_that_matched_nothing_is_an_empty_page_not_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph answers a no-match search with a container holding no `hits` key at all."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response(None))
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="nothing-matches-this"), offset=0, size=25
+        )
+
+        assert found.messages == []
+        assert (found.more_results_available, found.next_offset) == (False, None)
+
+
+class TestGraphFailures:
+    async def test_a_refused_search_surfaces_as_a_permission_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The case the per-chat scan this tool deliberately does not have would have hidden: a
+        tenant that has not granted the search permissions must be told, not worked around."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await message_search.search_messages(
+                client, criteria=SearchCriteria(query="release"), offset=0, size=25
+            )
+
+        assert raised.value.status == 403

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -16,10 +16,23 @@ import respx
 from msgraph.graph_service_client import GraphServiceClient
 
 from office_mcp.features import message_search
-from office_mcp.features.message_search import SearchCriteria
+from office_mcp.features.message_search import MessageHandle, SearchCriteria
 from office_mcp.graph_client import GraphForbidden
 
 from .conftest import channel_hit, chat_hit, search_response
+
+_CHAT_ID = "19:release@thread.v2"
+_MESSAGE_ID = "1770000000000"
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+
+_CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+)
+
+_CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
+_CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
 
 _MENTIONED = UUID("497b7a2a-9e1a-48d7-80e8-2965d2fc3a81")
 
@@ -312,6 +325,65 @@ class TestCriteriaThatAskForNothing:
             )
 
 
+class TestTheHandleItMints:
+    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
+        """A handle is this module's contract with `read_message`, which is why the shape and its
+        parser live here: the ids in it are percent-encoded because a Teams id is full of `:` and
+        `@`, so reading one back means decoding them."""
+        chat = message_search.message_handle(_CHAT_URI)
+        channel = message_search.message_handle(_CHANNEL_URI)
+
+        assert chat == _CHAT_HANDLE
+        assert channel == _CHANNEL_HANDLE
+
+    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
+        chat = message_search.message_handle(_CHAT_URI)
+        channel = message_search.message_handle(_CHANNEL_URI)
+
+        assert chat is not None and chat.uri == _CHAT_URI
+        assert channel is not None and channel.uri == _CHANNEL_URI
+
+    def test_an_unencoded_id_still_resolves(self) -> None:
+        """A caller that copied a handle out of a log rather than out of a response has ids that
+        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
+        handle = message_search.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
+
+        assert handle == _CHAT_HANDLE
+
+    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
+        """Graph's permissions for a message read are per surface and the handle is the only
+        thing that knows which surface, so a 403 on a chat read can only be about `Chat.Read` —
+        naming the channel permission alongside it would send an administrator after one that was
+        never missing."""
+        assert _CHAT_HANDLE.permission == "Chat.Read"
+        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # The schemes a polymorphic reader would advertise and this connector cannot serve.
+            "mail:///messages/AAMkAGI2",
+            "calendar:///events/AAMkAGI2",
+            "drive:///items/01ABC",
+            "site:///sites/contoso/pages/1",
+            # Right scheme, wrong shape.
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "teams:///messages/1770000000000",
+            "teams:///chats//messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
+            "teams:///teams/8a9c3c47/messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
+            # A Teams web link, which is what a model reaches for when it has no handle.
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+            "1770000000000",
+            "",
+        ],
+    )
+    def test_it_refuses_everything_else(self, uri: str) -> None:
+        assert message_search.message_handle(uri) is None
+
+
 class TestWhatTheCallerIsTold:
     async def test_a_chat_hit_carries_a_chat_handle_and_a_channel_hit_a_channel_one(
         self, client: GraphServiceClient, graph: respx.MockRouter
@@ -343,8 +415,8 @@ class TestWhatTheCallerIsTold:
             "teams:///teams/8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
             + "/channels/19%3Ageneral%40thread.tacv2/messages/1770000000002",
         ]
-        # The raw ids are returned alongside, unencoded, for tools that take an id rather than a
-        # handle — a caller must never have to unpick the handle to get one back.
+        # The raw ids are returned alongside, unencoded, so a hit can be lined up with the
+        # `chat_id` list_chats reports without anyone unpicking the handle to get one back.
         assert found.messages[0].chat_id == "19:release@thread.v2"
         assert (found.messages[1].team_id, found.messages[1].channel_id) == (
             "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
@@ -516,7 +588,7 @@ class TestWhatTheCallerIsTold:
 
 
 class TestPagingAndItsHonesty:
-    async def test_more_results_available_drives_paging_and_total_is_ignored(
+    async def test_truncated_drives_paging_and_total_is_ignored(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """Microsoft documents `total` as the count of results on the page for Teams messages, not
@@ -537,7 +609,7 @@ class TestPagingAndItsHonesty:
             client, criteria=SearchCriteria(query="release"), offset=50, size=25
         )
 
-        assert found.more_results_available is True
+        assert found.truncated is True
         assert found.next_offset == 53
         assert "total" not in message_search.MessageSearchResults.model_fields
 
@@ -595,7 +667,7 @@ class TestPagingAndItsHonesty:
         )
 
         assert found.messages == []
-        assert (found.more_results_available, found.next_offset) == (False, None)
+        assert (found.truncated, found.next_offset) == (False, None)
 
 
 class TestGraphFailures:

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -18,6 +18,7 @@ from office_mcp.graph_client import (
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 _PERMISSION = "Chat.Read"
+_CHANNELS = "ChannelMessage.Read.All"
 
 # What azure-identity's `OnBehalfOfCredential.get_token` reports when the delegated permission was
 # never consented to, trimmed of its trace ids.
@@ -172,6 +173,20 @@ class TestTheRefusalThatHappensBeforeGraph:
         assert _PERMISSION in message
         assert "AADSTS" not in message, "no code was invented"
         assert "ValueError" in message
+
+    def test_an_exchange_for_several_permissions_names_them_all(self) -> None:
+        """A tool needing two permissions gets one token or none: Entra redeems the scopes together
+        and refuses them together, saying no more about which one was unconsented than a Graph 403
+        does. Naming one of two would send an administrator to grant a permission that may already
+        be there, and the second attempt fails identically."""
+        with pytest.raises(ToolError) as raised, entra_token_errors(_PERMISSION, _CHANNELS):
+            raise RuntimeError(_UNCONSENTED)
+        message = str(raised.value)
+
+        assert _PERMISSION in message
+        assert _CHANNELS in message
+        assert "grant the delegated permissions" in message, "plural, or it reads as one of them"
+        assert "administrator" in message
 
     def test_a_token_that_arrives_passes_through_untouched(self) -> None:
         with entra_token_errors(_PERMISSION):

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -1,0 +1,117 @@
+"""What a model is told when Graph says no.
+
+These assertions are about *advice*, not wording: each one pins the fact that distinguishes one
+remedy from another, because getting those wrong is what makes a model retry a call that can never
+succeed, or give up on one that would have worked a second later.
+"""
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from office_mcp.graph_client import (
+    GraphFailure,
+    GraphForbidden,
+    GraphNotFound,
+    GraphThrottled,
+    GraphUnavailable,
+)
+from office_mcp.server.errors import graph_tool_errors
+
+_PERMISSION = "Chat.Read"
+
+
+def _message(failure: GraphFailure) -> str:
+    with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION):
+        raise failure
+    return str(raised.value)
+
+
+class TestTheTwoRemediesGraphCannotTellApart:
+    """401 and 403 are both `GraphForbidden`. One is fixed by the user, the other by an admin."""
+
+    def test_a_rejected_token_asks_the_user_to_sign_in_again(self) -> None:
+        message = _message(
+            GraphForbidden("nope", status=401, code="InvalidAuthenticationToken", request_id=None)
+        )
+
+        assert "sign in" in message
+        assert _PERMISSION not in message, "a 401 is not a missing-permission problem"
+
+    def test_a_missing_permission_names_the_permission_and_who_must_grant_it(self) -> None:
+        """The failure Graph is least helpful about: it never says which permission was missing,
+        so the tool has to. Without the name, the remedy is not actionable."""
+        message = _message(
+            GraphForbidden("nope", status=403, code="Authorization_RequestDenied", request_id=None)
+        )
+
+        assert message.count(_PERMISSION) >= 1
+        assert "administrator" in message
+        assert "Retrying will not help" in message
+
+
+class TestRetryAdvice:
+    def test_throttling_passes_graphs_own_delay_through(self) -> None:
+        """Graph's `Retry-After` is the documented fastest way out of throttling; an eager retry
+        makes it last longer, so the number has to survive into the message."""
+        message = _message(
+            GraphThrottled(
+                "slow down",
+                status=429,
+                code="activityLimitReached",
+                request_id=None,
+                retry_after_seconds=42.0,
+            )
+        )
+
+        assert "42 seconds" in message
+
+    def test_throttling_without_a_delay_still_says_not_to_spin(self) -> None:
+        message = _message(
+            GraphThrottled(
+                "slow down", status=429, code=None, request_id=None, retry_after_seconds=None
+            )
+        )
+
+        assert "loop" in message
+        assert "seconds" not in message, "no invented number when Graph gave no advice"
+
+    def test_an_outage_is_worth_exactly_one_retry(self) -> None:
+        message = _message(GraphUnavailable("boom", status=503, code=None, request_id=None))
+
+        assert "Retry once" in message
+
+    def test_a_bad_request_is_not_worth_retrying(self) -> None:
+        message = _message(GraphFailure("bad filter", status=400, code=None, request_id=None))
+
+        assert "retrying it unchanged will fail identically" in message
+
+    def test_a_missing_item_does_not_claim_the_item_does_not_exist(self) -> None:
+        """Graph returns 404 both for "no such thing" and for "none of your business", so a
+        message that asserts absence teaches the model something false."""
+        message = _message(GraphNotFound("gone", status=404, code=None, request_id=None))
+
+        assert "not allowed to know it exists" in message
+
+
+class TestDiagnostics:
+    def test_the_graph_request_id_survives(self) -> None:
+        """It exists only in that one response, and it is the first thing Microsoft support asks
+        for — losing it makes a production failure untraceable afterwards."""
+        message = _message(
+            GraphUnavailable("boom", status=500, code="internalError", request_id="req-42")
+        )
+
+        assert "HTTP 500" in message
+        assert "Graph error code internalError" in message
+        assert "Graph request id req-42" in message
+
+    def test_nothing_is_invented_when_graph_sent_no_evidence(self) -> None:
+        message = _message(GraphUnavailable("unreachable", status=None, code=None, request_id=None))
+
+        assert "None" not in message
+
+    def test_a_success_passes_through_untouched(self) -> None:
+        with graph_tool_errors(_PERMISSION):
+            outcome = "fine"
+
+        assert outcome == "fine"

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -107,6 +107,25 @@ class TestRetryAdvice:
 
         assert "not allowed to know it exists" in message
 
+    def test_a_tool_whose_id_came_from_another_tool_can_say_so_instead(self) -> None:
+        """The default advice — check the id came from a tool response verbatim — is the right
+        first guess when a caller supplied an id, and wrong for a handle another tool just
+        produced: it sends the model to re-check the one thing that cannot be the cause. Only the
+        404 advice is replaceable, because it is the only one whose remedy depends on where the
+        argument came from.
+        """
+        with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION, not_found="Gone."):
+            raise GraphNotFound("gone", status=404, code=None, request_id="req-7")
+
+        assert str(raised.value) == "Gone. (HTTP 404, Graph request id req-7)"
+
+    def test_it_does_not_replace_the_advice_for_any_other_failure(self) -> None:
+        with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION, not_found="Gone."):
+            raise GraphForbidden("nope", status=403, code=None, request_id=None)
+
+        assert "Gone." not in str(raised.value)
+        assert _PERMISSION in str(raised.value)
+
 
 class TestDiagnostics:
     def test_the_graph_request_id_survives(self) -> None:

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -15,13 +15,27 @@ from office_mcp.graph_client import (
     GraphThrottled,
     GraphUnavailable,
 )
-from office_mcp.server.errors import graph_tool_errors
+from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 _PERMISSION = "Chat.Read"
+
+# What azure-identity's `OnBehalfOfCredential.get_token` reports when the delegated permission was
+# never consented to, trimmed of its trace ids.
+_UNCONSENTED = (
+    "AADSTS65001: The user or administrator has not consented to use the application with ID "
+    + "'1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'. Send an interactive authorization request for "
+    + "this user and resource."
+)
 
 
 def _message(failure: GraphFailure) -> str:
     with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION):
+        raise failure
+    return str(raised.value)
+
+
+def _token_message(failure: Exception) -> str:
+    with pytest.raises(ToolError) as raised, entra_token_errors(_PERMISSION):
         raise failure
     return str(raised.value)
 
@@ -115,3 +129,52 @@ class TestDiagnostics:
             outcome = "fine"
 
         assert outcome == "fine"
+
+
+class TestTheRefusalThatHappensBeforeGraph:
+    """A permission nobody consented to fails in the On-Behalf-Of exchange, not in Graph.
+
+    Same remedy as the 403 above, reached a step earlier — and the step matters, because this one
+    happens while FastMCP is resolving the tool's token dependency, where the default report is
+    "Failed to resolve dependency 'graph_token'".
+    """
+
+    def test_an_unconsented_permission_names_the_permission_and_the_remedy(self) -> None:
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert message.count(_PERMISSION) >= 1
+        assert "administrator" in message
+        assert "grant the delegated permission" in message
+        assert "sign in" in message, "consent granted after sign-in needs a new token"
+        assert "retrying will not help" in message.lower()
+
+    def test_it_says_the_call_never_happened(self) -> None:
+        """Unlike every Graph failure above, nothing was asked of Microsoft 365 here — a model
+        that believes otherwise reports the read as attempted-and-refused."""
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert "never reached Microsoft Graph" in message
+
+    def test_entras_own_code_survives_for_whoever_has_to_diagnose_it(self) -> None:
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert "AADSTS65001" in message
+        assert "Send an interactive authorization request" not in message, (
+            "the model cannot act on Entra's prose, and it is not addressed to this connector"
+        )
+
+    def test_a_failure_entra_never_answered_is_still_actionable(self) -> None:
+        """No AADSTS code means the exchange never got as far as Entra — a broken connector, not
+        a refused user. The permission is still named, because it is still what was being asked
+        for, and the exception type is the only evidence there is."""
+        message = _token_message(ValueError("no access token available"))
+
+        assert _PERMISSION in message
+        assert "AADSTS" not in message, "no code was invented"
+        assert "ValueError" in message
+
+    def test_a_token_that_arrives_passes_through_untouched(self) -> None:
+        with entra_token_errors(_PERMISSION):
+            token = "synthetic-obo-graph-token"
+
+        assert token == "synthetic-obo-graph-token"

--- a/services/office-mcp/tests/test_app.py
+++ b/services/office-mcp/tests/test_app.py
@@ -1,7 +1,8 @@
 """The composition root, exercised as a real ASGI app.
 
 Checks that the app starts, its lifespan runs, the process-health routes behave, and that Entra
-auth is actually mounted and enforced. No Microsoft Graph client and no tools yet.
+auth is actually mounted and enforced. The tools it exposes are exercised over the MCP protocol in
+`test_mcp_tools.py`.
 
 Nothing here reaches Entra: constructing the provider performs no I/O, and the assertions below
 only touch metadata this service serves itself plus one unauthenticated request that is rejected
@@ -10,7 +11,7 @@ before any upstream call would happen.
 
 import importlib
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
 from typing import Protocol, cast, final, override
 from unittest.mock import MagicMock
@@ -179,10 +180,18 @@ class TestReadyProbesTheConnectionSignInDependsOn:
             return storage
 
         def _auth(
-            entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue
+            entra: EntraConfig,
+            base_url: str,
+            client_storage: AsyncKeyValue,
+            graph_scopes: Sequence[str],
         ) -> AzureProvider:
             provider_was_given.append(client_storage)
-            return build_auth(entra, base_url=base_url, client_storage=client_storage)
+            return build_auth(
+                entra,
+                base_url=base_url,
+                client_storage=client_storage,
+                graph_scopes=graph_scopes,
+            )
 
         monkeypatch.setattr(app_module, "build_oauth_storage", _storage)
         monkeypatch.setattr(app_module, "build_auth", _auth)

--- a/services/office-mcp/tests/test_auth.py
+++ b/services/office-mcp/tests/test_auth.py
@@ -15,6 +15,8 @@ from office_mcp.config import DatabaseConfig, EntraConfig
 
 _DATABASE_URL = "postgresql://user:pass@db:5432/office"
 
+_GRAPH_SCOPES = ("https://graph.microsoft.com/User.Read",)
+
 
 def _entra_config() -> EntraConfig:
     return EntraConfig.model_validate(
@@ -72,6 +74,7 @@ def _build_auth(entra: EntraConfig | None = None) -> AzureProvider:
         entra,
         base_url=_BASE_URL,
         client_storage=build_oauth_storage(entra, _database_config()),
+        graph_scopes=_GRAPH_SCOPES,
     )
 
 
@@ -85,12 +88,26 @@ class TestAuthProvider:
 
     def test_the_server_gates_access_on_its_own_scope_not_a_graph_one(self) -> None:
         """Entra omits OIDC scopes from `scp`, so the provider requires a custom API scope to
-        enforce. Graph permissions are a separate channel, requested by the tools that need
-        them — so nothing Graph-shaped should be gating access to the server itself.
+        enforce. Graph permissions are the separate channel below — a Graph scope among the
+        required ones would be validated on every token and would fail every request, because
+        this API's tokens never carry Graph permissions.
         """
         provider = _build_auth()
 
         assert provider.required_scopes == ["access_as_user"]
+
+    def test_the_graph_permissions_ride_the_authorize_request(self) -> None:
+        """Without this, sign-in never asks for Graph consent, and the On-Behalf-Of exchange each
+        tool performs fails with AADSTS65001 — a failure that happens per tool call, long after
+        the sign-in that would have fixed it, and that no tool can explain to its caller.
+
+        Containment rather than equality: the provider adds `offline_access` to this list itself,
+        which is its business and not something this service should be pinning.
+        """
+        provider = _build_auth()
+
+        assert set(_GRAPH_SCOPES) <= set(provider.additional_authorize_scopes)
+        assert not set(_GRAPH_SCOPES) & set(provider.required_scopes)
 
     def test_it_uses_the_exact_storage_it_was_given(self) -> None:
         """White-box on purpose: passing `client_storage` is the whole difference between a
@@ -103,6 +120,11 @@ class TestAuthProvider:
         """
         storage = build_oauth_storage(_entra_config(), _database_config())
 
-        provider = build_auth(_entra_config(), base_url=_BASE_URL, client_storage=storage)
+        provider = build_auth(
+            _entra_config(),
+            base_url=_BASE_URL,
+            client_storage=storage,
+            graph_scopes=_GRAPH_SCOPES,
+        )
 
         assert provider._client_storage is storage  # pyright: ignore[reportPrivateUsage]

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -29,6 +29,12 @@
    which permission — ends up spread across the layer whose job is only to expose it, and the
    tool's request then escapes every test that covers the feature.
 
+7. **`features/` must not import FastMCP.** The mirror of rule 1 for the framework rather than for
+   this package: a feature answers with its own types or raises a Graph failure, and turning either
+   into something an MCP client sees — a `ToolError`, a tool annotation, a schema — is `server/`'s
+   job. Without this, "reject a search with no criteria" would sit in the feature as a `ToolError`,
+   and the layer that owns the boundary would no longer own its refusals.
+
 Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
 subpackage; the import-direction check itself runs against every module under `features/`.
 
@@ -51,6 +57,7 @@ _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
 _GRAPH_SDK = "msgraph"
+_MCP_FRAMEWORK = "fastmcp"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -295,6 +302,18 @@ class TestTheDetectionItself:
             _GRAPH_SDK,
         )
 
+    def test_catches_the_violation_the_mcp_framework_rule_exists_for(self) -> None:
+        assert _imports_under(
+            "from fastmcp.exceptions import ToolError\nimport fastmcp\n", _MCP_FRAMEWORK
+        ) == ["fastmcp.exceptions", "fastmcp"]
+
+    def test_the_mcp_framework_rule_leaves_the_protocol_types_alone(self) -> None:
+        """`mcp` is the protocol SDK, a different distribution from the server framework, and a
+        name that merely begins with `fastmcp` is not it either."""
+        assert not _imports_under(
+            "from mcp.types import TextContent\nfrom fastmcpx import thing\n", _MCP_FRAMEWORK
+        )
+
     def test_catches_the_violation_the_config_rule_exists_for(self) -> None:
         assert _imports_under("from office_mcp.config import AppConfig", _CONFIG_MODULE) == [
             "office_mcp.config"
@@ -372,6 +391,25 @@ class TestFeaturesDoNotImportServer:
         assert not violations, (
             "features/ must not import from server/ — the server wires features together, "
             + "not the reverse. Inject the collaborator from create_app() instead:\n  "
+            + "\n  ".join(violations)
+        )
+
+
+class TestFeaturesDoNotImportTheMcpFramework:
+    def test_the_tool_layer_does_import_it(self) -> None:
+        """Guards the guard: the rule is about which layer talks to FastMCP, not about the
+        framework being unused — if `server/` stopped importing it, this rule would be vacuous."""
+        assert _imports_under(
+            (_SERVER / "tools.py").read_text(), _MCP_FRAMEWORK, _package_of(_SERVER / "tools.py")
+        )
+
+    @pytest.mark.parametrize("source", sorted(_FEATURES.rglob("*.py")), ids=_source_id)
+    def test_no_feature_module_imports_the_mcp_framework(self, source: pathlib.Path) -> None:
+        violations = _violations(source, _MCP_FRAMEWORK)
+        assert not violations, (
+            "features/ must not import FastMCP — a feature returns its own types or raises a "
+            + "Graph failure, and turning either into something an MCP client sees belongs to "
+            + "server/. Return the fact (or raise) and let the tool decide what to say:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -35,6 +35,12 @@
    job. Without this, "reject a search with no criteria" would sit in the feature as a `ToolError`,
    and the layer that owns the boundary would no longer own its refusals.
 
+8. **`server/` must not import the Graph SDK's request layer either.** Rule 6 one level down.
+   `msgraph` is the generated client, but a Graph request is *configured* through `kiota_*` — a
+   `RequestConfiguration`, its query parameters, its headers, its middleware options — and all of
+   those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
+   a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
+
 Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
 subpackage; the import-direction check itself runs against every module under `features/`.
 
@@ -57,6 +63,11 @@ _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
 _GRAPH_SDK = "msgraph"
+# The distributions underneath the generated SDK: `kiota_abstractions` is where a
+# `RequestConfiguration`, its headers and its request options live, `kiota_http` is the middleware
+# pipeline and `msgraph_core` is the request adapter. All three are ways to shape a Graph call
+# without importing `msgraph`, which is why rule 8 names them separately from rule 6.
+_GRAPH_REQUEST_LAYER: tuple[str, ...] = ("kiota_abstractions", "kiota_http", "msgraph_core")
 _MCP_FRAMEWORK = "fastmcp"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
@@ -302,6 +313,37 @@ class TestTheDetectionItself:
             _GRAPH_SDK,
         )
 
+    def test_catches_configuring_a_graph_request_without_naming_the_sdk(self) -> None:
+        """The escape hatch rule 6 leaves open: this is a Graph request being shaped, and the word
+        `msgraph` appears nowhere in it."""
+        found = [
+            module
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(
+                "from kiota_abstractions.base_request_configuration import RequestConfiguration\n"
+                + "from kiota_abstractions.headers_collection import HeadersCollection\n"
+                + "import msgraph_core\n",
+                prefix,
+            )
+        ]
+
+        assert found == [
+            "kiota_abstractions.base_request_configuration",
+            "kiota_abstractions.headers_collection",
+            "msgraph_core",
+        ]
+
+    def test_the_request_layer_rule_leaves_unrelated_names_alone(self) -> None:
+        assert not [
+            module
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(
+                "from office_mcp.graph_client import graph_client_for\n"
+                + "from kiotalike.thing import Thing\n",
+                prefix,
+            )
+        ]
+
     def test_catches_the_violation_the_mcp_framework_rule_exists_for(self) -> None:
         assert _imports_under(
             "from fastmcp.exceptions import ToolError\nimport fastmcp\n", _MCP_FRAMEWORK
@@ -464,6 +506,33 @@ class TestTheServerLayerDoesNotSpeakGraph:
             "server/ must not import the Microsoft Graph SDK — a tool declares and exposes; the "
             + "request belongs in a feature module and the transport in graph_client/. Move the "
             + "Graph call into features/ and have the tool call that:\n  "
+            + "\n  ".join(violations)
+        )
+
+    def test_the_layer_that_may_configure_a_request_actually_does(self) -> None:
+        """Guards the guard for the rule below: the request layer is used, in `features/`, which is
+        where it belongs — so forbidding it in `server/` is a boundary rather than a dead letter."""
+        used = [
+            module
+            for source in sorted(_FEATURES.rglob("*.py"))
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(source.read_text(), prefix, _package_of(source))
+        ]
+
+        assert used, f"nothing under {_FEATURES} configures a Graph request"
+
+    @pytest.mark.parametrize("source", sorted(_SERVER.rglob("*.py")), ids=_source_id)
+    def test_no_server_module_imports_the_graph_request_layer(self, source: pathlib.Path) -> None:
+        violations = [
+            violation
+            for prefix in _GRAPH_REQUEST_LAYER
+            for violation in _violations(source, prefix)
+        ]
+        assert not violations, (
+            "server/ must not import the Graph SDK's request layer — a RequestConfiguration, a "
+            + "header or a request option is part of a Graph call, and a Graph call belongs in "
+            + "features/ however it is spelled. Move it there and have the tool call the "
+            + "feature:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -41,8 +41,10 @@
    those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
    a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
 
-Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
-subpackage; the import-direction check itself runs against every module under `features/`.
+Every rule is paired with a guard that fails if the rule has become vacuous — an empty tree to walk,
+a missing file to forbid reaching for, a framework nothing imports any more. None of them is
+conditional: every package these rules are about now exists, so a rule that stops running is a
+failure and not a skip.
 
 All rules are asserted by walking the AST rather than importing anything, so a violation is
 reported as a failing test with a file and line instead of an ImportError at collection time.
@@ -87,11 +89,6 @@ _CONFIG_CLASSES = frozenset({"AppConfig", "DatabaseConfig", "EntraConfig"})
 # Files allowed to construct one, relative to `_SRC`. Both are the root of a program: `app.py` is
 # the composition root, and `main.py` is the server entrypoint that hands it its `AppConfig`.
 _COMPOSITION_ROOTS = frozenset({"app.py", "main.py"})
-
-
-def _feature_packages() -> set[str]:
-    """The subpackages under `features/`. Empty in this PR — the first ones land later."""
-    return {p.name for p in _FEATURES.iterdir() if p.is_dir() and p.name != "__pycache__"}
 
 
 def _imported_modules(tree: ast.AST, package: str | None = None) -> list[tuple[str, int]]:
@@ -419,13 +416,15 @@ class TestTheDetectionItself:
 
 
 class TestFeaturesDoNotImportServer:
-    @pytest.mark.skipif(not _feature_packages(), reason="feature packages land in later PRs")
     def test_the_feature_tree_is_actually_there(self) -> None:
-        """Guards the guard: a moved/renamed tree must not silently vacate the rule below."""
-        sources = sorted(_FEATURES.rglob("*.py"))
-        assert sources, f"no python sources found under {_FEATURES}"
-        packages = {p.relative_to(_FEATURES).parts[0] for p in sources if p.name != "__init__.py"}
-        assert packages, f"no feature packages found under {_FEATURES}"
+        """Guards the guard: a moved or renamed tree must not silently vacate the rule below.
+
+        The rule is parametrized over `features/`, so an empty tree makes it zero tests that pass
+        by not existing. What has to be there is feature *modules* — `features/` is a grouping and
+        its units are modules, not subpackages (see rule 4) — so that is what is asserted.
+        """
+        modules = [p for p in sorted(_FEATURES.rglob("*.py")) if p.name != "__init__.py"]
+        assert modules, f"no feature modules found under {_FEATURES}"
 
     @pytest.mark.parametrize("source", sorted(_FEATURES.rglob("*.py")), ids=_source_id)
     def test_no_feature_module_imports_from_server(self, source: pathlib.Path) -> None:
@@ -456,7 +455,6 @@ class TestFeaturesDoNotImportTheMcpFramework:
         )
 
 
-@pytest.mark.skipif(not _GRAPH_CLIENT.is_dir(), reason="graph_client/ lands in a later PR")
 class TestGraphClientDoesNotImportFeatures:
     def test_the_client_tree_is_actually_there(self) -> None:
         """Guards the guard, same as above."""
@@ -476,7 +474,6 @@ class TestGraphClientDoesNotImportFeatures:
         )
 
 
-@pytest.mark.skipif(not _GRAPH_CLIENT.is_dir(), reason="graph_client/ lands in a later PR")
 class TestGraphClientDoesNotImportConfig:
     def test_the_settings_module_is_actually_there(self) -> None:
         """Guards the guard: without somewhere to put them, the rule below is unsatisfiable."""

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -13,8 +13,8 @@
    configured — a transport is only allowed to be told.
 
 4. **A package is entered through its `__init__`, never through its modules.** Applies to the
-   packages listed in `_PUBLIC_SURFACE_PACKAGES`. `features/` is not among them: it is a
-   grouping whose `__init__` is documentation.
+   packages listed in `_PUBLIC_SURFACE_PACKAGES`. `features/` is not among them: it is a grouping
+   whose `__init__` is documentation, and whose modules are the units features are composed from.
 
 5. **A config class is only instantiated at the composition root.** `create_app` builds each one
    exactly once and injects it; anything downstream constructing its own re-reads the
@@ -23,10 +23,14 @@
    is unrestricted; only *calling* them is the violation. `main.py` is exempt as a process
    entrypoint: it is the root of its own program and hands `create_app` the config it built.
 
-Rules 2 and 3 apply to `graph_client/`, which lands with the Graph transport — both classes run
-against it from that PR on. Rule 1's "the tree actually has feature packages" guard still skips
-until the first feature package exists; the import-direction check itself runs against whatever
-*is* under `features/` (currently just `__init__.py`, which trivially passes).
+6. **`server/` must not import the Microsoft Graph SDK.** The mirror of rules 2 and 3, from the
+   other side: `msgraph` belongs to `graph_client/` (the transport) and `features/` (the requests).
+   A tool that reaches for the SDK itself is how Graph knowledge — which endpoint, which `$expand`,
+   which permission — ends up spread across the layer whose job is only to expose it, and the
+   tool's request then escapes every test that covers the feature.
+
+Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
+subpackage; the import-direction check itself runs against every module under `features/`.
 
 All rules are asserted by walking the AST rather than importing anything, so a violation is
 reported as a failing test with a file and line instead of an ImportError at collection time.
@@ -42,9 +46,11 @@ _SRC = pathlib.Path(__file__).parent.parent / "src" / "office_mcp"
 
 _FEATURES = _SRC / "features"
 _GRAPH_CLIENT = _SRC / "graph_client"
+_SERVER = _SRC / "server"
 _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
+_GRAPH_SDK = "msgraph"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -52,7 +58,10 @@ _CONFIG_MODULE = "office_mcp.config"
 # door. A new package belongs here as soon as its `__init__` exports anything: `server/` earned
 # its place by exporting `ready_response`, `graph_client/` by exporting its transport, and the
 # feature packages join as they land.
-_PUBLIC_SURFACE_PACKAGES: tuple[str, ...] = ("office_mcp.server", "office_mcp.graph_client")
+_PUBLIC_SURFACE_PACKAGES: tuple[str, ...] = (
+    "office_mcp.graph_client",
+    "office_mcp.server",
+)
 
 # The `BaseSettings` classes in config.py, which read the environment when constructed.
 _CONFIG_CLASSES = frozenset({"AppConfig", "DatabaseConfig", "EntraConfig"})
@@ -273,16 +282,28 @@ class TestTheDetectionItself:
             _SERVER_PREFIX,
         )
 
+    def test_catches_the_violation_the_graph_sdk_rule_exists_for(self) -> None:
+        assert _imports_under(
+            "from msgraph.generated.models.chat import Chat\nimport msgraph\n", _GRAPH_SDK
+        ) == ["msgraph.generated.models.chat", "msgraph"]
+
+    def test_the_graph_sdk_rule_leaves_this_services_own_client_alone(self) -> None:
+        """`graph_client` is how `server/` is *supposed* to reach Graph, and `msgraph_core` is a
+        different distribution — neither may be mistaken for the SDK itself."""
+        assert not _imports_under(
+            "from office_mcp.graph_client import graph_client_for\nimport msgraph_core\n",
+            _GRAPH_SDK,
+        )
+
     def test_catches_the_violation_the_config_rule_exists_for(self) -> None:
         assert _imports_under("from office_mcp.config import AppConfig", _CONFIG_MODULE) == [
             "office_mcp.config"
         ]
 
     def test_catches_the_violation_the_internals_rule_exists_for(self) -> None:
-        # `_PUBLIC_SURFACE_PACKAGES` only lists `server` for now, so that's the package under
-        # test here; once the first feature package lands and joins the list, its own modules
-        # serve this same role. The importing directory is `_SRC` — i.e. `app.py`, the
-        # composition root, which is the likeliest place to reach past a front door.
+        # `server` stands in for any listed package here; the rule is about the front door, not
+        # about which package happens to be behind it. The importing directory is `_SRC` — i.e.
+        # `app.py`, the composition root, which is the likeliest place to reach past one.
         assert _internal_imports(
             "from office_mcp.server.readiness import ready_response",
             _SRC,
@@ -388,6 +409,23 @@ class TestGraphClientDoesNotImportConfig:
             "graph_client/ must not import config — it takes its own frozen settings types "
             + "from graph_client/settings.py, which create_app translates the app config into. "
             + "Add the field to those settings and map it in create_app instead:\n  "
+            + "\n  ".join(violations)
+        )
+
+
+class TestTheServerLayerDoesNotSpeakGraph:
+    def test_the_tool_module_is_actually_there(self) -> None:
+        """Guards the guard: with no tools, nothing in `server/` would be tempted to call Graph
+        and the rule below would pass vacuously."""
+        assert (_SERVER / "tools.py").is_file()
+
+    @pytest.mark.parametrize("source", sorted(_SERVER.rglob("*.py")), ids=_source_id)
+    def test_no_server_module_imports_the_graph_sdk(self, source: pathlib.Path) -> None:
+        violations = _violations(source, _GRAPH_SDK)
+        assert not violations, (
+            "server/ must not import the Microsoft Graph SDK — a tool declares and exposes; the "
+            + "request belongs in a feature module and the transport in graph_client/. Move the "
+            + "Graph call into features/ and have the tool call that:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -1,0 +1,347 @@
+"""The whole loop, over the real MCP protocol: client → tool → OBO token → Microsoft Graph.
+
+This drives the app `create_app` actually builds — same FastMCP server, same Entra auth provider,
+same registered tools, same shared Graph transport — through fastmcp's own in-process client. Only
+the two external systems are stood in for, at exactly the boundary each one owns:
+
+* **Entra's token endpoint.** The signed-in user's token and the On-Behalf-Of exchange are
+  replaced, because the exchange is a network call to login.microsoftonline.com. What is *not*
+  replaced is `EntraOBOToken` itself: the dependency still runs, still finds the app's
+  `AzureProvider`, and the token it produces is the one the tool must put on the wire.
+* **Microsoft Graph**, via respx.
+
+Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
+"""
+
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from typing import cast
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken as GraphAccessToken
+from fastmcp import Client, FastMCP
+from fastmcp.client.client import CallToolResult
+from fastmcp.client.transports import FastMCPTransport
+from fastmcp.server.auth.providers.azure import AzureProvider
+from fastmcp.server.dependencies import AccessToken
+from mcp.types import TextContent, Tool
+from starlette.applications import Starlette
+
+from office_mcp.app import create_app
+from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
+from office_mcp.graph_client import GraphSettings, create_graph_transport
+
+GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# The token the (stubbed) On-Behalf-Of exchange hands back. Asserting on it is what proves the
+# caller's delegated token — and not the connector's own — is what called Graph.
+OBO_TOKEN = "synthetic-obo-graph-token"
+
+_CLIENT_TOKEN = "synthetic-fastmcp-session-token"
+
+_ME = {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "displayName": "Ada Lovelace",
+    "mail": "ada@example.invalid",
+    "userPrincipalName": "ada@corp.example.invalid",
+    "jobTitle": "Analyst",
+}
+
+_CHATS = {
+    "value": [
+        {
+            "id": "19:release@thread.v2",
+            "chatType": "group",
+            "topic": "Release planning",
+            "createdDateTime": "2026-01-04T12:00:00Z",
+            "lastUpdatedDateTime": "2026-02-11T09:15:22.31Z",
+            "members": [
+                {
+                    "@odata.type": "#microsoft.graph.aadUserConversationMember",
+                    "id": "member-ada",
+                    "displayName": "Ada Lovelace",
+                    "email": "ada@example.invalid",
+                }
+            ],
+            "lastMessagePreview": {
+                "id": "1770000000000",
+                "createdDateTime": "2026-02-11T09:15:22.31Z",
+                "body": {"contentType": "text", "content": "synthetic preview"},
+            },
+        }
+    ]
+}
+
+
+class _StubOboCredential:
+    """Stands in for `azure.identity.aio.OnBehalfOfCredential`, which would call Entra.
+
+    Records the scopes it was asked for: those are what the tool declared it needs, and getting
+    them wrong is invisible until a real tenant refuses the exchange.
+    """
+
+    def __init__(self) -> None:
+        self.requested_scopes: list[tuple[str, ...]] = []
+
+    async def get_token(self, *scopes: str) -> GraphAccessToken:
+        self.requested_scopes.append(scopes)
+        return GraphAccessToken(token=OBO_TOKEN, expires_on=0)
+
+
+@pytest.fixture
+def obo(monkeypatch: pytest.MonkeyPatch) -> _StubOboCredential:
+    """Authenticate the in-process caller and stub only the Entra round trip."""
+    credential = _StubOboCredential()
+
+    async def get_obo_credential(
+        _self: AzureProvider, *, user_assertion: str
+    ) -> _StubOboCredential:
+        assert user_assertion == _CLIENT_TOKEN, "the caller's own token is what gets exchanged"
+        return credential
+
+    monkeypatch.setattr(AzureProvider, "get_obo_credential", get_obo_credential)
+    # `EntraOBOToken` reads the caller's token through this function; there is no HTTP request
+    # behind an in-process client, so there is nothing for it to read it from.
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_access_token",
+        lambda: AccessToken(
+            token=_CLIENT_TOKEN,
+            client_id="1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+            scopes=["access_as_user"],
+        ),
+    )
+    return credential
+
+
+@pytest.fixture
+def graph() -> Iterator[respx.MockRouter]:
+    with respx.mock(base_url=GRAPH_V1, assert_all_called=False) as router:
+        yield router
+
+
+def _build_app() -> Starlette:
+    return create_app(
+        config=AppConfig.model_validate({"public_base_url": "https://office-mcp.example"}),
+        # Nothing in these tests reaches Postgres: the engine is lazy and the OAuth state store is
+        # only touched by the HTTP auth path, which an in-process client does not go through.
+        database_config=DatabaseConfig.model_validate(
+            {"url": "postgresql://user:pass@127.0.0.1:1/nope"}
+        ),
+        entra_config=EntraConfig.model_validate(
+            {
+                "tenant_id": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+                "client_id": "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+                "client_secret": "s3cr3t",
+            }
+        ),
+    )
+
+
+@pytest.fixture
+def app() -> Starlette:
+    return _build_app()
+
+
+def _server_of(app: Starlette) -> FastMCP[None]:
+    """The FastMCP server `create_app` mounted, which is what the MCP protocol talks to."""
+    return cast("FastMCP[None]", app.state.fastmcp_server)
+
+
+@pytest.fixture
+async def mcp_client(app: Starlette) -> AsyncIterator[Client[FastMCPTransport]]:
+    """A real MCP client speaking to that server, lifespan and all."""
+    async with Client(FastMCPTransport(_server_of(app))) as client:
+        yield client
+
+
+def _named(tools: Sequence[Tool]) -> dict[str, Tool]:
+    return {tool.name: tool for tool in tools}
+
+
+def _properties(schema: Mapping[str, object] | None) -> dict[str, object]:
+    """The `properties` of a JSON schema, narrowed off the SDK's `dict[str, Any]`."""
+    assert schema is not None, "expected a schema"
+    properties = schema.get("properties")
+    assert isinstance(properties, dict), f"expected an object schema, got {schema!r}"
+    return cast("dict[str, object]", properties)
+
+
+def _object(value: object) -> dict[str, object]:
+    assert isinstance(value, dict), f"expected an object, got {value!r}"
+    return cast("dict[str, object]", value)
+
+
+def _structured(result: CallToolResult) -> dict[str, object]:
+    data = cast("dict[str, object] | None", result.structured_content)
+    assert data is not None, "the tool returned no structured content"
+    return data
+
+
+class TestTheToolsThisServerAdvertises:
+    async def test_both_tools_are_listed_and_neither_asks_for_a_token(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The Graph token is a dependency, not a parameter: if it ever leaked into the input
+        schema, a model would try to invent one."""
+        tools = _named(await mcp_client.list_tools())
+
+        assert set(tools) == {"whoami", "list_chats"}
+        for tool in tools.values():
+            assert "graph_token" not in _properties(tool.inputSchema)
+
+    async def test_whoami_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
+        tools = _named(await mcp_client.list_tools())
+
+        assert _properties(tools["whoami"].inputSchema) == {}
+        assert tools["whoami"].inputSchema.get("required", []) == []
+
+    async def test_list_chats_bounds_its_limit_where_graph_bounds_it(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Prose ("max 50") is advice; the schema is enforcement — an out-of-range call has to
+        fail loudly rather than be silently clamped to something else."""
+        tools = _named(await mcp_client.list_tools())
+        limit = _object(_properties(tools["list_chats"].inputSchema)["limit"])
+
+        assert limit["type"] == "integer", "not `number`: a fractional page size is meaningless"
+        assert (limit["minimum"], limit["maximum"], limit["default"]) == (1, 50, 25)
+
+    async def test_both_tools_declare_their_result_shape(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The oracle connector returns an unschematised stream of objects whose last element may
+        be pagination metadata. A declared output schema is how `truncated` stops being prose."""
+        tools = _named(await mcp_client.list_tools())
+
+        assert set(_properties(tools["whoami"].outputSchema)) == {
+            "id",
+            "display_name",
+            "mail",
+            "user_principal_name",
+            "job_title",
+        }
+        assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
+
+    async def test_the_tools_are_marked_read_only(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+
+        for tool in tools.values():
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+
+
+class TestCallingThem:
+    async def test_whoami_calls_graph_with_the_exchanged_token(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        result = await mcp_client.call_tool("whoami", {})
+
+        assert _structured(result)["mail"] == "ada@example.invalid"
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [("https://graph.microsoft.com/User.Read",)]
+
+    async def test_list_chats_returns_a_structured_page(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"limit": 5})
+
+        body = _structured(result)
+        assert body["truncated"] is False
+        listed = cast("Sequence[Mapping[str, object]]", body["chats"])
+        assert [chat["chat_id"] for chat in listed] == ["19:release@thread.v2"]
+        assert listed[0]["last_message_at"] == "2026-02-11T09:15:22.310000Z"
+        assert obo.requested_scopes == [("https://graph.microsoft.com/Chat.Read",)]
+
+    async def test_an_out_of_range_limit_is_refused_before_graph_is_called(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"limit": 500}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert not obo.requested_scopes, "no token is exchanged for a call that cannot run"
+
+    async def test_an_argument_this_tool_does_not_have_is_refused(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """A misremembered parameter — `cursor`, say, which this tool deliberately does not have —
+        must fail rather than be ignored, or the model believes it paged when it re-read page one.
+        """
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"cursor": "abc"}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert not obo.requested_scopes
+
+
+class TestTheTransportTheToolsShare:
+    async def test_it_is_closed_when_the_server_shuts_down(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One connection pool serves every tool call, so nothing else in the process would ever
+        notice it being leaked — until a pod's sockets ran out."""
+        built: list[httpx.AsyncClient] = []
+
+        def record(settings: GraphSettings) -> httpx.AsyncClient:
+            transport = create_graph_transport(settings)
+            built.append(transport)
+            return transport
+
+        monkeypatch.setattr("office_mcp.app.create_graph_transport", record)
+
+        async with Client(FastMCPTransport(_server_of(_build_app()))):
+            assert built and not built[0].is_closed
+
+        assert built[0].is_closed
+
+
+class TestWhatAModelIsToldWhenGraphRefuses:
+    async def test_a_missing_permission_names_the_permission(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """End to end, the case the oracle connector handles worst: a 403 that says only that
+        something was forbidden leaves a model with nothing to do but retry."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}},
+            )
+        )
+
+        result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
+
+        assert result.is_error
+        message = "\n".join(
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        assert "Chat.Read" in message
+        assert "administrator" in message
+        assert "synthetic-request-id" in message
+        assert obo.requested_scopes, "the failure came from Graph, not from the token exchange"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -92,6 +92,68 @@ _SEARCH = {
     ]
 }
 
+# The handle the search hit above carries, which is what read_message has to resolve. Written out
+# rather than derived: that a search result's `uri` and a read's argument are the same string is the
+# contract between the two tools, and deriving it here would assert only that the test agrees with
+# itself.
+_MESSAGE_URI = "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000"
+_MESSAGE_PATH = "/chats/19%3Arelease%40thread.v2/messages/1770000000000"
+
+# The same message as `GET /chats/{id}/messages/{id}` returns it: with a body, and with the
+# Teams-shaped sender that carries no email at all.
+_MESSAGE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "etag": "1770000000000",
+    "messageType": "message",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "lastModifiedDateTime": "2026-02-11T09:15:22.31Z",
+    "importance": "normal",
+    "from": {
+        "user": {
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+            "id": "00000000-0000-4000-8000-000000000001",
+            "displayName": "Ada Lovelace",
+            "userIdentityType": "aadUser",
+        }
+    },
+    "body": {
+        "contentType": "html",
+        "content": "<div><p>Let's cut the <strong>release</strong> on Friday&nbsp;&amp; tell "
+        + '<at id="0">Grace Hopper</at>.</p></div>',
+    },
+    "mentions": [
+        {
+            "id": 0,
+            "mentionText": "Grace Hopper",
+            "mentioned": {
+                "user": {
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "displayName": "Grace Hopper",
+                    "userIdentityType": "aadUser",
+                }
+            },
+        }
+    ],
+    "attachments": [],
+}
+
+# A system event message, which Graph sends with no author and no text: the body is the literal
+# `<systemEventMessage/>` and the sentence Teams displays is written by the Teams client.
+_SYSTEM_MESSAGE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "messageType": "systemEventMessage",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "from": None,
+    "body": {"contentType": "html", "content": "<systemEventMessage/>"},
+    "eventDetail": {
+        "@odata.type": "#microsoft.graph.membersJoinedEventMessageDetail",
+        "visibleHistoryStartDateTime": "0001-01-01T00:00:00Z",
+        "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+    },
+}
+
 _CHATS = {
     "value": [
         {
@@ -265,7 +327,7 @@ class TestTheToolsThisServerAdvertises:
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats", "search_messages"}
+        assert set(tools) == {"whoami", "list_chats", "search_messages", "read_message"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
@@ -306,6 +368,50 @@ class TestTheToolsThisServerAdvertises:
             "more_results_available",
             "next_offset",
         }
+        assert set(_properties(tools["read_message"].outputSchema)) == {
+            "uri",
+            "message_id",
+            "chat_id",
+            "team_id",
+            "channel_id",
+            "sender",
+            "text",
+            "event",
+            "created_at",
+            "last_edited_at",
+            "deleted_at",
+            "reply_to_id",
+            "subject",
+            "importance",
+            "web_url",
+            "mentions",
+            "attachments",
+        }
+
+    async def test_read_message_takes_exactly_one_required_handle(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A reader with optional parameters would invite a model to try reading "the last message
+        in this chat", which no handle expresses and this connector cannot serve."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["read_message"].inputSchema
+
+        assert set(_properties(schema)) == {"uri"}
+        assert schema.get("required") == ["uri"]
+
+    async def test_read_message_names_both_handle_shapes_and_no_others(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The description is where a model learns what it may pass. Naming the two shapes is what
+        stops it inventing `mail:///` — and the oracle connector's one polymorphic `read_resource`
+        is exactly the promise this connector does not make."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["read_message"].description
+        assert description is not None
+
+        assert "teams:///chats/{chat_id}/messages/{message_id}" in description
+        assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in description
+        assert "search_messages" in description, "a handle has exactly one source"
 
     async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
         self, mcp_client: Client[FastMCPTransport]
@@ -455,6 +561,89 @@ class TestCallingThem:
                 "https://graph.microsoft.com/ChannelMessage.Read.All",
             )
         ]
+
+    async def test_a_handle_from_a_search_result_reads_the_message_behind_it(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The whole point of the pair, over the real protocol: search returns a handle and no body,
+        and the handle — passed back verbatim, exactly as a model would — resolves into the text.
+        """
+        search = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        read = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_MESSAGE))
+
+        found = _structured(await mcp_client.call_tool("search_messages", {"query": "release"}))
+        hits = cast("Sequence[Mapping[str, object]]", found["messages"])
+        uri = hits[0]["uri"]
+        result = await mcp_client.call_tool("read_message", {"uri": uri})
+
+        assert search.called
+        body = _structured(result)
+        assert body["uri"] == _MESSAGE_URI == uri
+        assert body["text"] == "Let's cut the release on Friday & tell @Grace Hopper."
+        assert body["event"] is None
+        mentions = cast("Sequence[Mapping[str, object]]", body["mentions"])
+        assert [mention["user_id"] for mention in mentions] == [
+            "00000000-0000-4000-8000-000000000002"
+        ]
+        sender = cast("Mapping[str, object]", body["sender"])
+        assert sender["display_name"] == "Ada Lovelace"
+        assert read.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes[-1] == (
+            "https://graph.microsoft.com/Chat.Read",
+            "https://graph.microsoft.com/ChannelMessage.Read.All",
+        ), "the exchange happens before the handle is parsed, so it asks for both surfaces"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_reading_a_system_event_says_what_happened_rather_than_nothing(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """A handle can resolve to a message Graph gives no author and no text for. Answering with
+        an empty message would read as "they said nothing"; the event is what actually happened."""
+        _ = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_SYSTEM_MESSAGE))
+
+        result = await mcp_client.call_tool("read_message", {"uri": _MESSAGE_URI})
+
+        body = _structured(result)
+        assert body["event"] == "members joined"
+        assert body["text"] is None
+        assert body["sender"] is None
+        assert "systemEventMessage" not in json.dumps(body), (
+            "the literal tag Graph puts in the body is not an answer"
+        )
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_message_text_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A message body is as sensitive as the query that found it, and this tool is the one that
+        actually returns message content — so the same rule search is held to holds here, over the
+        whole call and both destinations."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        payload = {**_MESSAGE, "body": {"contentType": "text", "content": secret}}
+        _ = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=payload))
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool("read_message", {"uri": _MESSAGE_URI})
+
+        assert _structured(result)["text"] == secret, "the text has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     @pytest.mark.usefixtures("obo")
     async def test_a_multi_word_query_reaches_graph_as_words_over_the_real_protocol(
@@ -639,6 +828,127 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "AADSTS65001" in message
         assert "resolve dependency" not in message
         assert not route.called, "no token means no Graph request was ever made"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "mail:///messages/AAMkAGI2",
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+        ],
+    )
+    async def test_a_handle_this_connector_cannot_read_shows_the_shapes_it_can(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        uri: str,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The first of three failures a reader has to keep apart, and the only one that is this
+        connector's own fault to explain: the argument is not a handle. Graph is never called, and
+        the remedy is the shape — not "try again"."""
+        route = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_MESSAGE))
+
+        result = await mcp_client.call_tool("read_message", {"uri": uri}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        message = _error_text(result)
+        assert "teams:///chats/{chat_id}/messages/{message_id}" in message
+        assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in message
+        assert "search_messages" in message
+        assert obo.requested_scopes, "the handle is parsed inside the tool, after the exchange"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_message_graph_will_not_return_is_not_reported_as_never_existing(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The second failure: a well-formed handle Graph answers 404 to. It means deleted, or
+        invisible to this user, or gone — Graph does not say which, so neither may the tool. The
+        default advice for a missing item ("check the id came from a tool response verbatim") is
+        wrong here, because it did.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "could not be read" in message
+        assert "not evidence that the message does not exist" in message
+        assert "synthetic-request-id" in message, "the id Microsoft support asks for first"
+        assert "verbatim" not in message, "the handle did come from a tool response"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_refused_read_names_only_the_permission_that_surface_needs(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The third failure, and the one an administrator acts on. Graph's permissions for a
+        message read are per surface, so a 403 reading a chat can only be about `Chat.Read` —
+        naming the channel permission too would send them after one that was never missing, which
+        is the same defect as naming none.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "Chat.Read" in message
+        assert "administrator" in message
+        assert "ChannelMessage.Read.All" not in message, "this read was in a chat"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_refused_channel_read_names_the_channel_permission_instead(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The other half of the same rule: the tenant that grants `Chat.Read` and withholds the
+        broad channel permission is the common case, and this is the message that gets fixed."""
+        team = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+        _ = graph.get(
+            f"/teams/{team}/channels/19%3Ageneral%40thread.tacv2/messages/1770000000000"
+        ).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message",
+            {
+                "uri": (
+                    f"teams:///teams/{team}/channels/19%3Ageneral%40thread.tacv2"
+                    + "/messages/1770000000000"
+                )
+            },
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "ChannelMessage.Read.All" in message
+        assert "Chat.Read" not in message, "this read was in a channel"
 
     async def test_an_unconsented_search_names_both_permissions_it_asked_for(
         self,

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -13,6 +13,8 @@ the two external systems are stood in for, at exactly the boundary each one owns
 Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
 """
 
+import json
+import logging
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import cast
 
@@ -27,6 +29,10 @@ from fastmcp.client.transports import FastMCPTransport
 from fastmcp.server.auth.providers.azure import AzureProvider
 from fastmcp.server.dependencies import AccessToken
 from mcp.types import TextContent, Tool
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from starlette.applications import Starlette
 
 from office_mcp.app import create_app
@@ -47,6 +53,43 @@ _ME = {
     "mail": "ada@example.invalid",
     "userPrincipalName": "ada@corp.example.invalid",
     "jobTitle": "Analyst",
+}
+
+_SEARCH_HIT_RESOURCE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "chatId": "19:release@thread.v2",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "lastModifiedDateTime": "2026-02-11T09:15:22.31Z",
+    "importance": "normal",
+    "subject": None,
+    # A search hit's sender is Exchange-shaped, because Teams messages are indexed out of the
+    # substrate mailbox.
+    "from": {"emailAddress": {"name": "Ada Lovelace", "address": "ada@example.invalid"}},
+}
+
+_SEARCH = {
+    "value": [
+        {
+            "searchTerms": [],
+            "hitsContainers": [
+                {
+                    "hits": [
+                        {
+                            "hitId": "1770000000000",
+                            "rank": 1,
+                            "summary": "...cut the <c0>release</c0> on Friday...",
+                            "resource": _SEARCH_HIT_RESOURCE,
+                        }
+                    ],
+                    # Documented as the count on this page for Teams messages, not a match total.
+                    # Present here precisely so a test can prove it is not reported as one.
+                    "total": 1,
+                    "moreResultsAvailable": False,
+                }
+            ],
+        }
+    ]
 }
 
 _CHATS = {
@@ -177,21 +220,52 @@ def _object(value: object) -> dict[str, object]:
     return cast("dict[str, object]", value)
 
 
+def _optional_type(schema: object) -> dict[str, object]:
+    """The non-null branch of an optional parameter's schema, which is where its type lives."""
+    branches = cast("Sequence[object]", _object(schema)["anyOf"])
+    typed = [_object(branch) for branch in branches if _object(branch).get("type") != "null"]
+    assert len(typed) == 1, f"expected one non-null branch, got {typed!r}"
+    return typed[0]
+
+
 def _structured(result: CallToolResult) -> dict[str, object]:
     data = cast("dict[str, object] | None", result.structured_content)
     assert data is not None, "the tool returned no structured content"
     return data
 
 
+def _search_query_string(route: respx.Route) -> str:
+    """The KQL string the last `/search/query` call put on the wire."""
+    body = cast("dict[str, object]", json.loads(route.calls.last.request.content))
+    requests = cast("Sequence[Mapping[str, object]]", body["requests"])
+    assert len(requests) == 1, "Graph honours only one searchRequest per call"
+    query = cast("Mapping[str, object]", requests[0]["query"])
+    return cast("str", query["queryString"])
+
+
+def _error_text(result: CallToolResult) -> str:
+    """Everything the model would read of a failed call."""
+    return "\n".join(block.text for block in result.content if isinstance(block, TextContent))
+
+
+def _record_text(record: logging.LogRecord) -> str:
+    """A log record's whole payload: the formatted message and every field attached to it.
+
+    Structured logging is what makes this necessary — a value passed as an extra never appears in
+    the message but does reach the log sink, so checking `getMessage()` alone would miss it.
+    """
+    return f"{record.getMessage()} {record.__dict__!r}"
+
+
 class TestTheToolsThisServerAdvertises:
-    async def test_both_tools_are_listed_and_neither_asks_for_a_token(
+    async def test_every_tool_is_listed_and_none_asks_for_a_token(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
         """The Graph token is a dependency, not a parameter: if it ever leaked into the input
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats"}
+        assert set(tools) == {"whoami", "list_chats", "search_messages"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
@@ -212,7 +286,7 @@ class TestTheToolsThisServerAdvertises:
         assert limit["type"] == "integer", "not `number`: a fractional page size is meaningless"
         assert (limit["minimum"], limit["maximum"], limit["default"]) == (1, 50, 25)
 
-    async def test_both_tools_declare_their_result_shape(
+    async def test_every_tool_declares_its_result_shape(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
         """The oracle connector returns an unschematised stream of objects whose last element may
@@ -227,6 +301,90 @@ class TestTheToolsThisServerAdvertises:
             "job_title",
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
+        assert set(_properties(tools["search_messages"].outputSchema)) == {
+            "messages",
+            "more_results_available",
+            "next_offset",
+        }
+
+    async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Not one of the oracle connector's ten schemas uses `anyOf`, so every rule about which
+        parameters may combine lives in prose a model may not read, and an illegal call validates
+        cleanly and silently behaves differently. "At least one criterion" is a real constraint
+        with a JSON Schema spelling, so it is spelled.
+        """
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["search_messages"].inputSchema
+        properties = _properties(schema)
+
+        assert schema.get("required", []) == [], "each criterion is individually optional"
+        alternatives = cast("Sequence[Mapping[str, object]]", schema["anyOf"])
+        required = [cast("Sequence[str]", option["required"]) for option in alternatives]
+        assert [name for (name,) in required] == [
+            "query",
+            "sender",
+            "recipient",
+            "mentions",
+            "sent_after",
+            "sent_before",
+            "has_attachment",
+            "is_read",
+            "mentions_me",
+        ]
+        for (name,) in required:
+            assert name in properties, f"{name} is constrained but is not a parameter"
+
+    async def test_search_messages_types_the_parameters_graph_is_fussy_about(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A mentioned user must be an id — Microsoft matches that scope term on the id alone, so a
+        display name silently matches nothing — and the dates are whole days, not timestamps."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["search_messages"].inputSchema)
+
+        assert _optional_type(properties["mentions"]) == {"type": "string", "format": "uuid"}
+        assert _optional_type(properties["sent_after"]) == {"type": "string", "format": "date"}
+        assert _optional_type(properties["sent_before"]) == {"type": "string", "format": "date"}
+
+    async def test_the_query_parameter_describes_the_matching_it_actually_does(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The description is the only place a model learns what `query` does, so it has to match
+        what the query builder does. It promised "matched as words" while the whole query was being
+        sent as one quoted phrase, which is a recall loss a caller cannot see: the tool answers with
+        fewer messages than exist and nothing says so. Both halves are pinned here — that the words
+        are ANDed, and that adjacency is available by quoting.
+        """
+        tools = _named(await mcp_client.list_tools())
+        query = _object(_properties(tools["search_messages"].inputSchema)["query"])
+        description = cast("str", query["description"])
+
+        assert "Every word must appear" in description
+        assert "any order" in description
+        assert "not matched as a phrase unless you quote them" in description
+        assert '"release notes"' in description, "the phrase syntax needs an example to be usable"
+
+    async def test_search_messages_bounds_its_page_where_microsoft_documents_it(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["search_messages"].inputSchema)
+        size = _object(properties["size"])
+        offset = _object(properties["offset"])
+
+        assert (size["type"], size["minimum"], size["maximum"], size["default"]) == (
+            "integer",
+            1,
+            50,
+            25,
+        )
+        assert (offset["type"], offset["minimum"], offset["default"]) == ("integer", 0, 0)
+        assert "maximum" not in offset, (
+            "Microsoft documents no offset ceiling for message search; inventing one would refuse "
+            + "a page Graph would have served"
+        )
 
     async def test_the_tools_are_marked_read_only(
         self, mcp_client: Client[FastMCPTransport]
@@ -269,6 +427,104 @@ class TestCallingThem:
         assert [chat["chat_id"] for chat in listed] == ["19:release@thread.v2"]
         assert listed[0]["last_message_at"] == "2026-02-11T09:15:22.310000Z"
         assert obo.requested_scopes == [("https://graph.microsoft.com/Chat.Read",)]
+
+    async def test_search_messages_returns_hits_with_handles_and_no_invented_total(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The flagship call, end to end: one POST to Microsoft's search index, hits carrying a
+        handle a reader can resolve, and both search permissions on the exchanged token."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        result = await mcp_client.call_tool("search_messages", {"query": "release"})
+
+        body = _structured(result)
+        assert body["more_results_available"] is False
+        assert body["next_offset"] is None
+        assert "total" not in body, "Graph's `total` is a page count for Teams, not a match count"
+        found = cast("Sequence[Mapping[str, object]]", body["messages"])
+        assert [message["uri"] for message in found] == [
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000"
+        ]
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            (
+                "https://graph.microsoft.com/Chat.Read",
+                "https://graph.microsoft.com/ChannelMessage.Read.All",
+            )
+        ]
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_multi_word_query_reaches_graph_as_words_over_the_real_protocol(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """End to end, the recall bug: a two-word question has to arrive at Microsoft's index as
+        two terms it will AND, not as one quoted phrase that only matches them side by side."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        _ = await mcp_client.call_tool("search_messages", {"query": "cut the release"})
+
+        assert _search_query_string(route) == "cut the release"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_search_with_no_criteria_is_refused_and_says_what_to_add(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """FastMCP validates arguments against the signature, not against the advertised schema, so
+        the `anyOf` alone would not stop this — and Graph would answer it with an arbitrary slice of
+        everything the user can read, which looks exactly like a result set."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        result = await mcp_client.call_tool("search_messages", {"size": 5}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert "query" in _error_text(result) and "sent_after" in _error_text(result)
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_search_text_reaches_graph_and_nothing_else(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """What a user searched their own messages for is as sensitive as the messages: it names
+        people, deals and diagnoses. `services/teams-mcp` had to go back and strip query terms out
+        of its spans and logs, so this connector never puts them there — and this test is what says
+        so, over the whole call, not over one function.
+
+        Both destinations are checked. The log capture covers everything this process emits during
+        the call, ours and FastMCP's own. The span exporter is attached to whatever tracer provider
+        is in play: no span is created on this path today, so that half is a ratchet — the day one
+        is added carrying the query, it fails here.
+        """
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        secret = "acquisition-of-northwind-traders"
+        caplog.set_level(logging.DEBUG)
+
+        _ = await mcp_client.call_tool(
+            "search_messages", {"query": secret, "sender": "ada@example.invalid"}
+        )
+
+        assert secret in route.calls.last.request.content.decode(), (
+            "the query has to have reached Graph, or this test proves nothing"
+        )
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     async def test_an_out_of_range_limit_is_refused_before_graph_is_called(
         self,
@@ -343,9 +599,7 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
 
         assert result.is_error
-        message = "\n".join(
-            block.text for block in result.content if isinstance(block, TextContent)
-        )
+        message = _error_text(result)
         assert "Chat.Read" in message
         assert "administrator" in message
         assert "synthetic-request-id" in message
@@ -385,3 +639,41 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "AADSTS65001" in message
         assert "resolve dependency" not in message
         assert not route.called, "no token means no Graph request was ever made"
+
+    async def test_an_unconsented_search_names_both_permissions_it_asked_for(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The tenant that grants `Chat.Read` and withholds `ChannelMessage.Read.All`.
+
+        Entra redeems a two-scope exchange as a whole and refuses it as a whole, naming no more than
+        the application: which of the two was missing is not in AADSTS65001 any more than it is in a
+        Graph 403. So the refusal has to name both, exactly as the 403 path does — an administrator
+        handed one name may grant the one that was never missing and see the identical failure.
+
+        This is also the assertion that says the wording here is *ours*: the exchange happens inside
+        FastMCP's dependency resolution, so without the wrapper the model reads "Failed to resolve
+        dependency 'graph_token' for search_messages" and can act on none of it.
+        """
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "search_messages", {"query": "release"}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "Chat.Read" in message, message
+        assert "ChannelMessage.Read.All" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no search was ever made"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 import respx
 from azure.core.credentials import AccessToken as GraphAccessToken
+from azure.core.exceptions import ClientAuthenticationError
 from fastmcp import Client, FastMCP
 from fastmcp.client.client import CallToolResult
 from fastmcp.client.transports import FastMCPTransport
@@ -78,14 +79,18 @@ class _StubOboCredential:
     """Stands in for `azure.identity.aio.OnBehalfOfCredential`, which would call Entra.
 
     Records the scopes it was asked for: those are what the tool declared it needs, and getting
-    them wrong is invisible until a real tenant refuses the exchange.
+    them wrong is invisible until a real tenant refuses the exchange. Set `refusal` to be that
+    tenant — an exchange Entra declines is the failure that happens before Graph.
     """
 
     def __init__(self) -> None:
         self.requested_scopes: list[tuple[str, ...]] = []
+        self.refusal: Exception | None = None
 
     async def get_token(self, *scopes: str) -> GraphAccessToken:
         self.requested_scopes.append(scopes)
+        if self.refusal is not None:
+            raise self.refusal
         return GraphAccessToken(token=OBO_TOKEN, expires_on=0)
 
 
@@ -345,3 +350,38 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "administrator" in message
         assert "synthetic-request-id" in message
         assert obo.requested_scopes, "the failure came from Graph, not from the token exchange"
+
+    async def test_a_permission_nobody_consented_to_names_it_too(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The same missing permission, one step earlier: Entra refuses the On-Behalf-Of exchange
+        (AADSTS65001) and Graph is never called.
+
+        This runs inside FastMCP's dependency resolution rather than inside the tool body, so it
+        bypasses the tool's own error handling entirely — the report a model gets by default is
+        "Failed to resolve dependency 'graph_token' for list_chats", which names neither the
+        permission nor anyone who could grant it. Whatever else changes, this end of the wire has
+        to stay as actionable as the 403 above.
+        """
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
+
+        assert result.is_error
+        message = "\n".join(
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        assert "Chat.Read" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no Graph request was ever made"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -15,6 +15,7 @@ Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
 
 import json
 import logging
+import re
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import cast
 
@@ -327,15 +328,15 @@ class TestTheToolsThisServerAdvertises:
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats", "search_messages", "read_message"}
+        assert set(tools) == {"get_me", "list_chats", "search_messages", "read_message"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
-    async def test_whoami_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
+    async def test_get_me_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
         tools = _named(await mcp_client.list_tools())
 
-        assert _properties(tools["whoami"].inputSchema) == {}
-        assert tools["whoami"].inputSchema.get("required", []) == []
+        assert _properties(tools["get_me"].inputSchema) == {}
+        assert tools["get_me"].inputSchema.get("required", []) == []
 
     async def test_list_chats_bounds_its_limit_where_graph_bounds_it(
         self, mcp_client: Client[FastMCPTransport]
@@ -355,17 +356,17 @@ class TestTheToolsThisServerAdvertises:
         be pagination metadata. A declared output schema is how `truncated` stops being prose."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(_properties(tools["whoami"].outputSchema)) == {
-            "id",
+        assert set(_properties(tools["get_me"].outputSchema)) == {
+            "user_id",
             "display_name",
-            "mail",
+            "email",
             "user_principal_name",
             "job_title",
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
-            "more_results_available",
+            "truncated",
             "next_offset",
         }
         assert set(_properties(tools["read_message"].outputSchema)) == {
@@ -387,6 +388,25 @@ class TestTheToolsThisServerAdvertises:
             "mentions",
             "attachments",
         }
+
+    async def test_the_whole_surface_speaks_one_language(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """These tools arrived one at a time and are read all at once, by a model choosing between
+        them. So the conventions are asserted rather than merely written down: a name is verb_noun
+        (`whoami` was the one exception and is now `get_me`), a result field is snake_case, and a
+        tool whose answer is a list says "there is more" with the one word `truncated` — two words
+        for that would be two things for a model to learn, and a reason for it to guess.
+        """
+        tools = _named(await mcp_client.list_tools())
+
+        for name in tools:
+            assert re.fullmatch(r"[a-z]+(_[a-z]+)+", name), f"{name} is not verb_noun"
+        for tool in tools.values():
+            for field in _properties(tool.outputSchema):
+                assert re.fullmatch(r"[a-z][a-z0-9]*(_[a-z0-9]+)*", field), f"{field} is not snake"
+        for name in ("list_chats", "search_messages"):
+            assert "truncated" in _properties(tools[name].outputSchema), name
 
     async def test_read_message_takes_exactly_one_required_handle(
         self, mcp_client: Client[FastMCPTransport]
@@ -503,7 +523,7 @@ class TestTheToolsThisServerAdvertises:
 
 
 class TestCallingThem:
-    async def test_whoami_calls_graph_with_the_exchanged_token(
+    async def test_get_me_calls_graph_with_the_exchanged_token(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
@@ -511,9 +531,9 @@ class TestCallingThem:
     ) -> None:
         route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
 
-        result = await mcp_client.call_tool("whoami", {})
+        result = await mcp_client.call_tool("get_me", {})
 
-        assert _structured(result)["mail"] == "ada@example.invalid"
+        assert _structured(result)["email"] == "ada@example.invalid"
         assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
         assert obo.requested_scopes == [("https://graph.microsoft.com/User.Read",)]
 
@@ -547,7 +567,7 @@ class TestCallingThem:
         result = await mcp_client.call_tool("search_messages", {"query": "release"})
 
         body = _structured(result)
-        assert body["more_results_available"] is False
+        assert body["truncated"] is False
         assert body["next_offset"] is None
         assert "total" not in body, "Graph's `total` is a page count for Teams, not a match count"
         found = cast("Sequence[Mapping[str, object]]", body["messages"])

--- a/services/office-mcp/uv.lock
+++ b/services/office-mcp/uv.lock
@@ -659,6 +659,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
 ]
 
+[package.optional-dependencies]
+azure = [
+    { name = "fastmcp-slim", extra = ["azure"] },
+]
+
 [[package]]
 name = "fastmcp-slim"
 version = "3.4.5"
@@ -677,6 +682,10 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-identity" },
+    { name = "pyjwt" },
+]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
@@ -1768,7 +1777,7 @@ source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
     { name = "cryptography" },
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["azure"] },
     { name = "httpx", extra = ["http2"] },
     { name = "msgraph-sdk" },
     { name = "opentelemetry-api" },
@@ -1801,7 +1810,7 @@ dev = [
 requires-dist = [
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "cryptography", specifier = "==49.0.0" },
-    { name = "fastmcp", specifier = "==3.4.5" },
+    { name = "fastmcp", extras = ["azure"], specifier = "==3.4.5" },
     { name = "httpx", extras = ["http2"], specifier = "==0.28.1" },
     { name = "msgraph-sdk", specifier = "==1.61.0" },
     { name = "opentelemetry-api", specifier = "==1.44.0" },


### PR DESCRIPTION
Wave 1 integration. This pull request makes the four tools `get_me`, `list_chats`, `search_messages`
and `read_message` read as one server. **It adds no capability.** It deletes, renames, unifies and
rewords.

One commit, 12 files, +420/-287. The last section lists the gaps that I found and did not build.

## Where this branch sits in the stack

The base branch is `office-mcp/feat/read-resource`, which is pull request #782. The stack starts at
pull request #775, and #775 is the only one of them that targets `main`. `main` holds no
`services/office-mcp` directory today. This diff assumes that #782 merges first. A change under #782
needs a rebase here.

## The renames, and what they break

| Old | New | What it names |
| --- | --- | --- |
| `whoami` | `get_me` | the tool name |
| `Who Am I` | `Get My Profile` | the title of that tool |
| `List My Chats` | `List My Teams Chats` | the title of `list_chats` |
| `id` | `user_id` | a field of `SignedInUser`, the output of `get_me` |
| `mail` | `email` | a field of `SignedInUser`, the output of `get_me` |
| `more_results_available` | `truncated` | a field of `MessageSearchResults`, the output of `search_messages` |

The declared output schema of `get_me` and the declared output schema of `search_messages` both
change, and `tests/test_mcp_tools.py` asserts the new ones. A client that reads `whoami`, `id`,
`mail` or `more_results_available` breaks. `git grep` finds no reference to `office_mcp` or to
`more_results_available` outside `services/office-mcp`. It finds one reference to `whoami` outside
it: `op whoami` in a deploy script of temenos-mcp, which is the 1Password CLI.

## What the committed tests cover

`tests/test_mcp_tools.py` drives the server in process, over the MCP protocol. It uses
`fastmcp.Client` against the application that `create_app` builds. respx stubs Graph, and
`_StubOboCredential` takes the place of the Entra On-Behalf-Of credential and records the scopes
each call asks for. The list below names the tests that I read, with the file of each one. No test in
`tests/test_mcp_tools.py` calls more than two of the four tools in one sequence.

- `test_a_handle_from_a_search_result_reads_the_message_behind_it`, in `tests/test_mcp_tools.py`,
  calls `search_messages`. It then passes the `uri` of the first hit to `read_message` unchanged.
  That handle is `teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000`. The read answers
  with the text, one mention and the display name of the sender.
- One model, `MessageSender`, serves both message tools. Its three fields are `display_name`,
  `email` and `user_id`. One function, `sender_of`, builds it from both identity shapes of Graph.
- The chat id `19:release@thread.v2` is asserted from two sides. `tests/test_mcp_tools.py` asserts it
  on a `list_chats` result, and `tests/features/test_message_search.py` asserts it on a search hit.
  No test compares the two values inside one sequence of calls. `chat_id` is an argument to no tool,
  and the descriptions now say so.
- The OBO exchange asks for the scopes of the called tool. `get_me` asks for
  `https://graph.microsoft.com/User.Read`. `list_chats` asks for
  `https://graph.microsoft.com/Chat.Read`. `search_messages` and `read_message` both ask for
  `Chat.Read` and `ChannelMessage.Read.All`. `read_message` asks for both because the exchange runs
  before the tool parses the handle.
- `TestWhatAModelIsToldWhenGraphRefuses`, in `tests/test_mcp_tools.py`, covers seven failures at the
  MCP boundary:
  - 403 on `GET /me/chats`, which names `Chat.Read` and an administrator.
  - An AADSTS65001 refusal before Graph on `list_chats`.
  - The same refusal on `search_messages`, which names both permissions.
  - Three arguments that are not handles, in one parametrized test.
  - 404 on a handle with a correct shape.
  - 403 on a chat read, which names `Chat.Read` alone.
  - 403 on a channel read, which names `ChannelMessage.Read.All` alone.

  Each of those tests asserts the remedy in the message, and not only the failure. The 403 on
  `GET /me/chats` and the 404 both assert the Graph request id of the stub.
- `tests/server/test_errors.py` holds unit tests over `server/errors.py`. Those cover 429 with
  `Retry-After`, 429 without it, 500, 503 and 400. No test drives those statuses through the MCP
  boundary.

## The process, run by hand

I ran the process once by hand, and this run is no part of the gates. A reviewer has to repeat it.
The command is `uv run office-mcp` in the nix dev shell. The settings are `APP_ENV=development`,
`PORT=9599` (the committed default is 9544), `PUBLIC_BASE_URL=http://localhost:9599` and the three
`ENTRA_*` values. The database is a Postgres on `localhost:9001` that holds `office_mcp`.

| Route | Result |
| --- | --- |
| `GET /health` | 200 `{"status":"healthy"}` |
| `GET /probe` | 200 `{"status":"ok"}` |
| `GET /ready` | 200 `{"status":"healthy","checks":{"database":true}}` |
| `GET /metrics` | 200, Prometheus text (`mcp_calls_total`, `python_http_requests_total`) |
| `GET /.well-known/oauth-authorization-server` | 200, `issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `scopes_supported: ["access_as_user"]`, `code_challenge_methods_supported: ["S256"]` |
| `GET /.well-known/oauth-protected-resource/mcp` | 200, `resource` and `authorization_servers` |
| `POST /mcp` with no token | **401** with `www-authenticate: Bearer resource_metadata="http://localhost:9599/.well-known/oauth-protected-resource/mcp"` |

## The differences I found, and how this pull request resolves them

1. **Tool names.** Three tools used `verb_noun`, and `whoami` is a shell idiom on the first tool a
   model calls. The new name is **`get_me`**. `server/tools.py` now records the convention, and
   records that the M365 connector of Microsoft arrived at the same name. The new test
   `test_the_whole_surface_speaks_one_language` asserts three things against the live schemas: every
   tool name matches `[a-z]+(_[a-z]+)+`, every output field is snake_case, and `truncated` is an
   output field of `list_chats` and of `search_messages`. A rename breaks the expectations of a
   model, so the rename happens before more tools arrive.

2. **The words for pagination.** `list_chats` said `truncated` and `search_messages` said
   `more_results_available`. Both now say **`truncated`**. Each description states how to get the
   rest: a wider `limit` where there is no cursor, `next_offset` where there is one. `next_offset`
   stays, because it counts the hits of Graph itself. Those hits include the system messages that
   the tool drops, so a model cannot calculate the value.

3. **Field names.** The identity tool returned `id` and `mail`, and every other payload calls these
   things `user_id` and `email`. The new names are **`user_id`** and **`email`**, and the descriptions
   still name `id` and `mail` of Graph. The docstring of `SignedInUser` already claimed this rule,
   and the rule now holds.

   Timestamps were already uniform: every timestamp field ends with `_at`. `last_modified_at` on a
   search hit and `last_edited_at` on a read are two separate fields, and the description of
   `last_edited_at` names the property `lastEditedDateTime` of Microsoft. Both fields stay, and the
   description of `last_modified_at` now points at `last_edited_at`.

4. **The handle had two implementations.** `message_search` built `teams:///…` with its own
   `_segment`. `message_read` built the same two shapes a second time in `MessageHandle.uri`. The two
   permission constants, `MessageHandle`, `message_handle` and `_handle` moved into
   **`message_search`**. That module already had a `_segment` of its own, and it is the one module
   that mints a handle. The docstring of `message_read` already named that module as the owner of the
   contract.

   `message_read` imports them, as it already imported `sender_of`. Under `src/`, the literal
   `"Chat.Read"` drops from three places to two, and `"ChannelMessage.Read.All"` from two to one.
   The search keeps one small helper, renamed from `_uri` to `_hit_uri`, which builds a
   `MessageHandle` and returns its `uri`. The test class for the handle moved from
   `test_message_read.py` to `test_message_search.py`, and its name changed from
   `TestTheHandlesItAccepts` to `TestTheHandleItMints`.

5. **The words in an error message.** `_remedy` in `server/errors.py` writes seven messages. Six of
   them already opened with "Microsoft 365". The seventh is the fallback: it opened with "Microsoft
   Graph" and now opens with "Microsoft 365". The top of the module now states the shape every
   message follows. The actor comes first, then the remedy and whether a retry can help, then the
   diagnostics in brackets at the end.

   `_diagnostics` appends `HTTP`, `Graph error code` and `Graph request id` for the values Graph
   sent, on every message built from a Graph failure. The refusal from Entra is no Graph failure:
   `_token_advice` writes it, and it ends `(Entra AADSTS65001)` with no Graph request id. The diff
   changes no other message in `server/errors.py`.

6. **A description promised a tool that does not exist.** `list_chats` said "use it to find the
   `chat_id` that a chat-scoped tool needs". No tool here takes a chat id. A model that follows that
   sentence looks for a missing tool, or it assembles a handle, which `read_message` refuses.

   The description now states what `chat_id` is for: it names the chat that a search hit came from.
   It also states that no tool takes a chat id, and that a search cannot narrow to one chat.
   `search_messages` now states the same from its own side. `list_chats` also states that it returns
   no message text, and that `search_messages` is the only route to message text.

7. **Layering rules.** All eight rules ran before this pull request, and all eight run now.
   `tests/test_layering.py` carried three `skipif` markers, and this pull request removes all three.
   Two of them sat on the `graph_client` classes and were already inert, because `graph_client/`
   holds `__init__.py`, `client.py`, `errors.py`, `pagination.py` and `settings.py`. The third
   skipped `test_the_feature_tree_is_actually_there`, the guard over rule 1, and that was the one
   skipped test on the base branch.

   The rewritten guard asserts that `features/` holds one module or more that is not `__init__.py`.
   The dead `_feature_packages()` helper is gone.

8. **The README.** The renames reach the intro, the permission table and the tool table. It gains a
   paragraph on the ownership of the handle and of the sender shape, and a bullet on the conventions
   of the four tools. The bullet on `list_chats` now states what a `chat_id` is for. The bullet on a
   refusal now states the one error voice. The paragraph on the layering rules now states that each
   rule has a guard. It also states that no guard waits on a package that has yet to land.

## Deployability

The diff touches no file under `services/office-mcp/deploy`, so this round changed no configuration
surface. Nothing in the environment configures `GraphSettings`: it is a frozen dataclass of default
values, and `create_app` calls `GraphSettings()` and injects the result. I verified two points rather
than an assumption:

- `helm dependency update && helm template . -f ci-values.yaml` renders with exit status 0. The
  `validate-helm` job of `.github/workflows/python-ci.yaml` runs those two commands. The rendered
  manifests hold `APP_ENV`, `LOG_LEVEL`, `PORT` and `PUBLIC_BASE_URL`, and the `/health` and `/ready`
  probes.
- `scripts/render-values-schema.sh --check` reports OK for office-mcp and for six other charts.

## What this pull request does not change

- **`members_may_be_incomplete`.** I did not rename it to `truncated`. It makes a different claim
  about a different thing: a cap inside one chat cut the member list short. A model that must answer
  "who is in this chat" reads the explicit name. It does not trust the list.
- **A `GRAPH_PERMISSION` constant in each module.** `chats.py` still spells `Chat.Read` itself. A
  stated rule gives each feature the permission that its own request needs, next to the call that
  requires it. The messages pair collapsed only because the *handle* forced it.
- **`matches` and `max_scanned` on `collect_pages`.** The one caller under `src/` passes neither, and
  only `tests/graph_client/test_pagination.py` exercises them. They are the lesson that the
  pagination part imported from teams-mcp on purpose: a filtered collection can read many pages and
  keep few items. A deletion drops that lesson before the first filtered collection arrives.
- **The Helm chart validates `PUBLIC_BASE_URL` and does not validate `ENTRA_*`.** A new check is new
  chart behaviour. The localhost issuer is a different case: the container restarts in a loop and
  nothing states the cause. `.env.example` records that this service does not start without all
  three `ENTRA_*` values.
- **The privacy rule.** This pull request does not touch it, and two tests still assert it. No
  message text and no query term reaches a log record or a span attribute, over the whole call. The
  test for a read is `test_the_message_text_reaches_the_caller_and_no_log_or_span`. The test for a
  search is `test_the_search_text_reaches_graph_and_nothing_else`.

## Gaps for the owner, found and not built

- **A model cannot scope `search_messages` to a chat, a channel or a team.** The tool has no such
  parameter. The descriptions now state that, in place of an implication of the opposite. "What did
  we discuss in *this* chat" is the obvious question that a model asks. The owner must make a
  decision.
- **`ChatMember` carries `display_name` and `email` only.** Without an id, a model cannot answer
  "which participant is the signed-in user" from an id. It can match on the display name, or on the
  email address when the caller sets `include_member_emails`. The descriptions of `get_me` and
  `list_chats` now admit this.
- **No tool reads the messages of a chat by id.** `list_chats` gives a `chat_id`, and a model can
  correlate it against the output of search only. A tool of the shape of `list_messages`, or a chat
  scope on search, is what this pair still needs.
- **`read_message` cannot address a reply inside a channel thread.** The advice on a 404 states that
  such a reply is addressed under its parent post, and that this handle shape cannot express it.

## Gates

All four gates pass on this branch.

- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright .`
