### PR TITLE
feat(office-mcp): list a meeting's transcripts and their handles

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,13 +2,14 @@
 
 An MCP server for Microsoft 365 via Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes seven MCP
+Users sign in with their own Microsoft account and the server acts as them. It exposes eight MCP
 tools so far — `get_me`, the signed-in user's own profile; `list_chats`, their Microsoft Teams chats
 most recently active first; `list_teams`, the teams they are a member of; `list_channels`, the
 channels of one of those teams; `browse_channel`, what was posted in one of those channels;
-`search_messages`, full-text search across every Teams message they can see; and `read_message`,
-one of those messages in full — each one a file of its own, and more land in later PRs, stacked on
-top of this one, one tool per PR.
+`search_messages`, full-text search across every Teams message they can see; `read_message`,
+one of those messages in full; and `list_meeting_transcripts`, whether a Teams meeting was
+transcribed and a handle for each transcript — each one a file of its own, and more land in later
+PRs, stacked on top of this one, one tool per PR.
 
 ## Layout
 
@@ -33,7 +34,9 @@ Entra at startup. A forgotten permission means sign-in fails. `tests/test_app.py
 
 **`shared/` is the cost of file-per-tool architecture.** It holds the things two files must agree on:
 `handles.py` (the `teams:///` grammar), `messages.py` (Teams message shape, sender normalization,
-HTML unwinding), `identity.py` (signed-in user profile), `seam.py` (token exchange, error advice).
+HTML unwinding), `meetings.py` (join URL to meeting, which occurrence a window means, how far
+"newest first" holds), `identity.py` (signed-in user profile), `seam.py` (token exchange, error
+advice).
 Use `shared/` when two tools would otherwise need identical copies and differing copies would be
 visible bugs: handles one tool mints and another rejects; two answers to "who am I"; refusals that
 sound inconsistent. Don't put tool-specific things there: descriptions, parameters, output, requests.
@@ -81,6 +84,8 @@ Tools redeem permissions per call via On-Behalf-Of. No permission = no consent =
 | `Team.ReadBasic.All` | Delegated | No | `list_teams` |
 | `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
+| `OnlineMeetings.Read` | Delegated | No | `list_meeting_transcripts` (resolving a join URL to a meeting) |
+| `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** | `list_meeting_transcripts` |
 
 Multiple tools naming the same permission is normal. It is not duplication to remove. Each tool
 declares its own tuple because that tuple words its own 403 and AADSTS65001 messages.
@@ -89,6 +94,23 @@ declares its own tuple because that tuple words its own 403 and AADSTS65001 mess
 `Team.ReadBasic.All` is least-privileged for `/me/joinedTeams` (Microsoft's docs). Separate from
 the broad channel permission: a tenant refusing `ChannelMessage.Read.All` still lists teams.
 `list_teams` 403 names only its own permission.
+
+**Transcripts need a tenant setting as well as a permission, and this is the one that surprises
+people.** Microsoft Graph access to Teams meeting transcripts is off by default and *"agents and
+apps can't access meeting transcripts, regardless of app-level permissions"* until a Teams
+administrator turns it on — Teams admin centre → Meetings → Meeting settings → Transcript API
+access, or `Set-CsTeamsMeetingConfiguration -EnableGraphTranscriptAccess $true -Identity Global`.
+There is no Graph API to set it and no request-side workaround, so it is an onboarding step next to
+admin consent rather than something this connector can fix; `services/teams-mcp` learned this in PR
+#762 and `docs/recordings-and-transcripts/operator.md` documents it. Until it is on, every call to
+`list_meeting_transcripts` fails with that remedy named — and only that tool: Microsoft scopes the
+setting to transcript resources, so nothing else here is affected.
+
+The two meeting permissions are separate scopes and are granted independently, which is the point of
+asking for both: `OnlineMeetings.Read` is the least privilege Microsoft documents for resolving a
+join URL to a meeting and needs no administrator, while reading the transcript collection needs one.
+A tenant can grant the first and withhold the second, and the tool's 403 then names the one its own
+request was made under.
 
 `Chat.Read` not `Chat.ReadBasic`: listing chats by recency needs `$expand=lastMessagePreview`.
 A preview is a message; "read chat names" doesn't cover it.

--- a/services/office-mcp/deploy/helm-charts/office-mcp/values.yaml
+++ b/services/office-mcp/deploy/helm-charts/office-mcp/values.yaml
@@ -19,6 +19,15 @@ env:
   # ENTRA_TENANT_ID and ENTRA_CLIENT_ID identify the app registration users sign in through;
   # both are required and set in the overlay (not secrets). ENTRA_TENANT_ID must be a single
   # tenant's ID — a multi-tenant authority is rejected at startup.
+  #
+  # These four plus the two secrets below are the whole of this service's configuration: the MCP
+  # tools add no environment variables of their own. What they do add is tenant-side onboarding,
+  # which no value here can carry (see README, "Auth"):
+  #   - the delegated Graph permissions on that app registration, one of which
+  #     (OnlineMeetingTranscript.Read.All) needs admin consent;
+  #   - Graph access to Teams meeting transcripts, a tenant-wide Teams setting that is OFF by
+  #     default and that only a Teams administrator can turn on. Until they do,
+  #     list_meeting_transcripts answers 403 with that remedy and every other tool is unaffected.
 
 envVars: []
 # Required secrets (provide via envVars in overlay):

--- a/services/office-mcp/src/office_mcp/graph_client/__init__.py
+++ b/services/office-mcp/src/office_mcp/graph_client/__init__.py
@@ -17,6 +17,7 @@ from office_mcp.graph_client.errors import (
 from office_mcp.graph_client.pagination import (
     MAX_SCANNED_ITEMS,
     CollectedItems,
+    GraphCollection,
     collect_pages,
 )
 from office_mcp.graph_client.settings import GraphSettings
@@ -24,6 +25,7 @@ from office_mcp.graph_client.settings import GraphSettings
 __all__ = [
     "MAX_SCANNED_ITEMS",
     "CollectedItems",
+    "GraphCollection",
     "GraphFailure",
     "GraphForbidden",
     "GraphNotFound",

--- a/services/office-mcp/src/office_mcp/graph_client/errors.py
+++ b/services/office-mcp/src/office_mcp/graph_client/errors.py
@@ -14,10 +14,21 @@ GraphPagingUnending is not a failed request—it is Graph answering 200 with emp
 advertising more. No status code describes it. Only the pagination walk sees it. It belongs here
 because it is what Graph did wrong, and because being a GraphFailure carries it through
 `shared/seam.py` as advice rather than crash.
+
+One thing above the status code is carried too: `inner_code`, Graph's `error.innerError.code`.
+Where a status and an outer code are the same for two failures with opposite remedies, that is
+the only field that tells them apart — the transcript APIs answer both "your tenant has switched
+Graph access to transcripts off, and no app can switch it back on" and "this tenant will not give
+you speaker names, ask for the unattributed format" as `403 Forbidden` / `code: Forbidden`, and
+Microsoft's own instruction is to "branch on the `innerError.code` value, not the message text.
+Messages are subject to change" (https://learn.microsoft.com/en-us/graph/api/calltranscript-get).
+It is data like `status` is, not a category: a subclass per inner code would be a subclass per
+Graph feature.
 """
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import cast
 
 import httpx
 from kiota_abstractions.api_error import APIError
@@ -25,7 +36,11 @@ from msgraph.generated.models.o_data_errors.o_data_error import ODataError
 
 
 class GraphFailure(Exception):
-    """Graph request failure. Subclass indicates remedy. Support needs request_id."""
+    """Graph request failure. Subclass indicates remedy. Support needs request_id.
+
+    `inner_code` defaults to `None` because most Graph errors carry no
+    inner code worth branching on; where one does, it is the whole of the difference.
+    """
 
     def __init__(
         self,
@@ -34,11 +49,13 @@ class GraphFailure(Exception):
         status: int | None,
         code: str | None,
         request_id: str | None,
+        inner_code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status: int | None = status
         self.code: str | None = code
         self.request_id: str | None = request_id
+        self.inner_code: str | None = inner_code
 
 
 class GraphThrottled(GraphFailure):
@@ -53,8 +70,11 @@ class GraphThrottled(GraphFailure):
         code: str | None,
         request_id: str | None,
         retry_after_seconds: float | None,
+        inner_code: str | None = None,
     ) -> None:
-        super().__init__(message, status=status, code=code, request_id=request_id)
+        super().__init__(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
         self.retry_after_seconds: float | None = retry_after_seconds
 
 
@@ -112,6 +132,7 @@ def _classify(error: APIError) -> GraphFailure:
     status = error.response_status_code
     headers = _lowercase_headers(error)
     code = error.error.code if isinstance(error, ODataError) and error.error else None
+    inner_code = _inner_code(error)
     request_id = headers.get("request-id")
     message = f"Microsoft Graph returned {status}" + (f" ({code})" if code else "")
 
@@ -121,15 +142,41 @@ def _classify(error: APIError) -> GraphFailure:
             status=status,
             code=code,
             request_id=request_id,
+            inner_code=inner_code,
             retry_after_seconds=_retry_after_seconds(headers),
         )
     if status in (401, 403):
-        return GraphForbidden(message, status=status, code=code, request_id=request_id)
+        return GraphForbidden(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
     if status == 404:
-        return GraphNotFound(message, status=status, code=code, request_id=request_id)
+        return GraphNotFound(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
     if status is not None and status >= 500:
-        return GraphUnavailable(message, status=status, code=code, request_id=request_id)
-    return GraphFailure(message, status=status, code=code, request_id=request_id)
+        return GraphUnavailable(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
+    return GraphFailure(
+        message, status=status, code=code, request_id=request_id, inner_code=inner_code
+    )
+
+
+def _inner_code(error: APIError) -> str | None:
+    """Graph's `error.innerError.code`, if it sent one.
+
+    The SDK's generated `innerError` has typed fields for `request-id`, `client-request-id` and
+    `date` and none for `code`, so the property Microsoft tells callers to branch on arrives in the
+    model's `additional_data` — untyped by construction, hence the narrowing.
+    """
+    if not isinstance(error, ODataError) or error.error is None:
+        return None
+    inner = error.error.inner_error
+    if inner is None:
+        return None
+    extra = cast("dict[str, object]", inner.additional_data)
+    value = extra.get("code")
+    return value if isinstance(value, str) else None
 
 
 def _lowercase_headers(error: APIError) -> dict[str, str]:

--- a/services/office-mcp/src/office_mcp/shared/__init__.py
+++ b/services/office-mcp/src/office_mcp/shared/__init__.py
@@ -2,7 +2,7 @@
 
 Every tool in `tools/` is a file of its own — its name, its description, its Graph permissions, its
 arguments, its answer shape, its Graph request and its own error wording all in one place, so that
-adding the eighth tool is adding one file and reading the seventh is reading one file. That is the
+adding the ninth tool is adding one file and reading the eighth is reading one file. That is the
 whole point, and it has exactly one cost: two files are free to disagree. This package is the list
 of things they must not.
 
@@ -22,6 +22,12 @@ difference between the copies would be a bug a caller could see:
   It also holds `MAX_REPLIES_PER_POST`, the window on a channel thread: `browse_channel` applies
   it, and `search_messages` and `read_message` both have to describe it to explain why a reply a
   search found may have no handle that reads.
+* `meetings.py` — how a meeting is reached, which occurrence was asked about, and how far "newest
+  first" is true. The only entry here whose second caller has not landed yet, and deliberately so:
+  none of the three is a fact about transcripts, they are facts about a meeting and the artifact
+  collections Graph hangs off one, and a second tool over the same meeting would otherwise re-derive
+  all of them. Leaving them in the tool file would make their eventual move a refactor rather than a
+  decision, and a tool's private helper is exactly what a second tool copies rather than imports.
 * `identity.py` — who the signed-in user is. `get_me` reports it; it is also the fact every other
   answer on this connector is correlated against, so a second tool asking it with a `GET /me` of
   its own would be a second answer to one question.

--- a/services/office-mcp/src/office_mcp/shared/handles.py
+++ b/services/office-mcp/src/office_mcp/shared/handles.py
@@ -5,7 +5,7 @@ shape must exist. Two modules spelling `teams:///meetings/…` would silently di
 lives here, not in tool files. This is the only module that spells or parses these URIs (enforced
 by tests/test_layering.py).
 
-## The four shapes, and why they are four
+## The five shapes, and why they are five
 
 Three of them are Graph's three ways to address a Teams message
 (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
@@ -20,13 +20,23 @@ reply becomes the second shape, which Graph answers 404 to. `browse_channel` wal
 by post and therefore knows each reply's parent, which is why it is what mints this shape and why
 the shape lives here rather than there.
 
-The fourth shape: `teams:///meetings/{joinWebUrl}`. A meeting is addressed by join URL because that
-is the only route Microsoft Graph gives a delegated caller from chat to meeting. The chat
-collection's default projection carries `onlineMeetingInfo.joinWebUrl` and Graph's onlineMeetings
-lookup matches it byte-for-byte. Nothing else—no chat id, topic, or date—turns into one.
+The fourth and fifth address the meeting side:
+
+    teams:///meetings/{joinWebUrl}
+    teams:///transcripts/{meetingId}/{transcriptId}
+
+A meeting is addressed by join URL because that is the only route Microsoft Graph gives a delegated
+caller from chat to meeting. The chat collection's default projection carries
+`onlineMeetingInfo.joinWebUrl` and Graph's onlineMeetings lookup matches it byte-for-byte. Nothing
+else—no chat id, topic, or date—turns into one.
 
 A handle (not bare URL) because Graph warns "don't parse URLs". The tool takes something that came
 from a tool result, not something the model composed.
+
+A transcript is addressed by the two ids its content path is built from, and not by the join URL
+that reached it, because by then the resolve has already happened: a handle carrying the join URL
+would make whoever reads a transcript repeat that lookup, spend a second request and a second
+permission on it, and answer a 403 that could be about either of them.
 
 The family name is the first segment. `teams:///meetings/{x}/transcripts/{y}` would make `{x}` a
 join URL in one shape and a meeting id in another. A parser cannot tell them apart. Distinct first
@@ -103,6 +113,23 @@ class MeetingHandle:
         return f"teams:///meetings/{_segment(self.join_web_url)}"
 
 
+@dataclass(frozen=True, slots=True)
+class TranscriptHandle:
+    """Which transcript, by the two ids Graph's content path is built from.
+
+    Graph's own `transcriptContentUrl` is not used — the published samples are malformed
+    (`…/transcripts/('…')/content`) — so the path is built from the ids, which is what Microsoft's
+    reference shows.
+    """
+
+    meeting_id: str
+    transcript_id: str
+
+    @property
+    def uri(self) -> str:
+        return f"teams:///transcripts/{_segment(self.meeting_id)}/{_segment(self.transcript_id)}"
+
+
 # Every shape, and only those. Ids are matched as "anything but a separator" because the spellers
 # above percent-encode each one.
 _CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
@@ -111,6 +138,7 @@ _REPLY_HANDLE = re.compile(
     r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)/replies/([^/]+)\Z"
 )
 _MEETING_HANDLE = re.compile(r"\Ateams:///meetings/([^/]+)\Z")
+_TRANSCRIPT_HANDLE = re.compile(r"\Ateams:///transcripts/([^/]+)/([^/]+)\Z")
 
 
 def message_handle(uri: str) -> MessageHandle | None:
@@ -151,6 +179,17 @@ def meeting_handle(uri: str) -> MeetingHandle | None:
         return None
     join_web_url = unquote(match.group(1))
     return MeetingHandle(join_web_url) if join_web_url.strip() else None
+
+
+def transcript_handle(uri: str) -> TranscriptHandle | None:
+    """`uri` as a transcript handle, or None if it is not one."""
+    match = _TRANSCRIPT_HANDLE.match(uri)
+    if match is None:
+        return None
+    meeting_id, transcript_id = (unquote(part) for part in match.groups())
+    if not meeting_id.strip() or not transcript_id.strip():
+        return None
+    return TranscriptHandle(meeting_id, transcript_id)
 
 
 def meeting_uri_for(join_web_url: str | None) -> str | None:

--- a/services/office-mcp/src/office_mcp/shared/meetings.py
+++ b/services/office-mcp/src/office_mcp/shared/meetings.py
@@ -1,0 +1,374 @@
+"""How a meeting is reached, which occurrence was asked about, and what "newest" is worth.
+
+None of those three is a fact about transcripts. They are facts about the *meeting*, and about the
+artifacts Graph hangs off one: a `callTranscript` collection and a `callRecording` collection on the
+same `onlineMeeting`, reached through the same resolve, ordered the same way (which is to say not at
+all), and answered empty in the same ambiguous way. Everything in this module is therefore a promise
+a second tool over the same meeting would otherwise make for itself, and the cost of that is the
+test for belonging here: a caller cannot see two tools disagreeing about "the latest occurrence", it
+can only see one of them being wrong.
+
+That is also why this is here while one tool calls it. The alternative is not "keep it in the tool
+file and move it when a second caller arrives" — it is a later diff that moves a promise, reviewed
+as a refactor rather than as a decision, with the window spending that whole time as one tool's
+private helper. A private helper is exactly what the second caller copies.
+
+## How a meeting is addressed, and the one place the chain can break
+
+Graph documents exactly three delegated ways to reach an `onlineMeeting`
+(https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get): by its own `id`, by `joinWebUrl`,
+or by `joinMeetingIdSettings/joinMeetingId`. A chat id is not one of them, and neither is a chat's
+`webUrl`. So the only route from Teams' conversation side to the meeting side is the join URL, and
+the only place a delegated caller is given one is `chat.onlineMeetingInfo.joinWebUrl` — a property
+of the `chat` resource, present in the default projection of `GET /me/chats` (that collection
+supports `$expand`, `$top`, `$filter` and `$orderby` and nothing else, so it could not be asked for
+explicitly even if it were absent), and documented as "empty" when the chat is not a meeting's.
+
+**What is verified and what is not.** Meeting chats being enumerable with a descriptive `topic` and
+a recency timestamp is confirmed against a live tenant. That `onlineMeetingInfo.joinWebUrl` is
+*populated* — in general, and specifically for a meeting the signed-in user did not organise — is
+**not**: the property is documented on the resource and modelled by the SDK, and no doc says it is
+organiser-only, but no live call has been made that asked for it. So a null join URL is a first-
+class outcome rather than an impossible one: `list_chats` reports no `meeting_uri` for that chat,
+and there is no fallback, because there is no documented second route. `onlineMeeting` does carry a
+`chatInfo.threadId`, and a `$filter` on it would be exactly the invented path this module refuses
+to ship: Graph documents neither that property as filterable nor any lookup by it.
+
+Two further limits belong to the caller rather than to the code. The resolve step is documented for
+attendees — "These request URLs accept both the organizer's and the invited attendee's user token
+(delegated permission)" — but the transcript *list* is not: its reference page documents
+`OnlineMeetingTranscript.Read.All` and says nothing about non-organisers, so a participant may be
+refused where the organiser succeeds. And every artifact API "works for a meeting only if the
+meeting has not expired", which is roughly 60 days for a one-off
+(https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams#meeting-expiration).
+
+## The `$filter` on the join URL, and the bug class around it
+
+Graph's note is one line — "**joinWebUrl** must be URL encoded" — and its worked example shows how
+far that goes: a `%3a` already inside the stored URL arrives as `%253a`, because the `%` is itself
+escaped. `services/teams-mcp` gets this wrong today (`src/transcript/tools/ingest-meeting.tool.ts`
+doubles the quote and then hands the raw URL to a JavaScript SDK that concatenates query parameters
+without encoding), and the failure is silent: a join URL carrying `&` or `#` — real ones do — makes
+Graph parse a truncated filter and answer `200 OK` with an empty `value`, which reads exactly like
+"no such meeting".
+
+Here the two transforms are separated, and only the first is ours:
+
+1. **OData literal escape.** A single quote inside an OData string literal is doubled. Required for
+   correctness and to stop a crafted URL closing the literal and appending predicates of its own.
+2. **Percent-encoding**, which the Python SDK does correctly and which is therefore not repeated:
+   `$filter` is a query parameter of a URI template, and form-style expansion escapes everything
+   outside the unreserved set — including `%`, `&`, `#`, `?` and `=`. Encoding it a second time
+   would produce `%2525…` and, again, an empty `value`. The tests pin the bytes that reach the
+   wire, because this is the failure that looks like an answer.
+
+`200 OK` with `value: []` is Graph's documented "no match" for this filter — it never 404s — so it
+is reported as its own outcome and not as an error.
+
+## The occurrence window, and the shapes a model actually sends
+
+`started_after`/`started_before` exist for one reason: a recurring series is a single meeting to
+Graph, so its occurrences share one artifact collection and the only thing telling them apart is
+when the artifact began. That makes the window the thing a model reaches for most, and it arrives
+in whatever shape the model wrote — `2026-08-11T09:00:00+02:00`, but just as often
+`2026-08-11T09:00:00` or `2026-08-11`, because that is how a date gets written when nobody is
+watching. All three are accepted and resolved against UTC, in `OccurrenceWindow` and nowhere else:
+Graph timestamps every artifact in UTC, so UTC is the assumption that needs no second piece of
+information, and resolving once at the edge is what stops anything downstream comparing a naive
+datetime with an aware one — which is a `TypeError` raised at a caller who did nothing wrong, not a
+wrong answer it could notice. A bare date is a whole UTC day rather than its first instant, because
+writing the same date in both bounds is how one occurrence gets bracketed and midnight-to-midnight
+would be an empty window reported as an answer. The assumption is stated in each tool's own
+parameter descriptions, where a model reads it: `09:00` is a different instant in Zurich, and a
+window quietly built in the wrong zone is worse than one that was refused.
+
+## Newest first, exactly as far as it is true
+
+"The latest transcript of this series" is the question a lister exists for, so the order has to be
+a property of what was *read* and not of the page Graph happened to answer with — Graph documents
+`$select`, `$filter` and `$top` on these collections and no `$orderby` at all
+(https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-transcripts), and a walk that
+stopped at `limit` before sorting would return an arbitrary `limit` artifacts sorted among
+themselves and call them the newest. That is a wrong answer with the shape of a right one, which is
+the whole reason `newest_in_window` is a named function rather than four lines inside a tool: the
+mistake is invisible in the answer, so the place it is not made has to be one place.
+
+What the promise is worth is bounded by `MAX_ARTIFACT_SCAN`, and every sentence a model reads is
+worded to that bound rather than to "the newest of this meeting". Up to that many artifacts are
+read, in whatever order Graph chose; for a meeting with no more than that they are the whole
+collection and the first entry is the latest outright, which covers every meeting but a series
+recorded daily for the better part of a year. Past it the first entry is the newest of the
+artifacts that were *read*, and a newer one can sit in the part that was not. Raising the cap would
+move that boundary rather than remove it: with no `$orderby` to ask the newest for, nothing short of
+reading the whole collection makes the word exact, and Graph publishes no ceiling on how large that
+collection can be.
+
+## Whether an empty answer means "wait" or "there is none"
+
+`settled` is that inference and it is deliberately not the verdict: the verdict is a different word
+per artifact — `not_transcribed` is one of them — and the tool that answers owns its own vocabulary.
+What must not exist twice is the *inference*. Reading it off the meeting instead of off the window
+was a wrong answer no caller could detect — a recurring series whose `endDateTime` is in the future
+made every empty window "still processing", including one bracketing an occurrence that ended weeks
+ago and was never transcribed, which is an instruction to poll forever.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Protocol, Self
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.online_meeting import OnlineMeeting
+from msgraph.generated.users.item.online_meetings.online_meetings_request_builder import (
+    OnlineMeetingsRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import CollectedItems, GraphCollection, collect_pages
+from office_mcp.shared.handles import MeetingHandle
+
+# Resolving a join URL to a meeting is `OnlineMeetings.Read`, the least privilege Graph documents
+# for the filter, and it needs no admin consent. It lives with the resolve rather than in a tool
+# file because it is the permission `resolve_meeting` spends, whichever artifact the tool that
+# called it went on to ask about — reading either artifact is a further, admin-consented permission
+# that the tool declares for itself.
+MEETING_PERMISSION = "OnlineMeetings.Read"
+
+# Reading a transcript resource, which is admin-consented and grantable independently of the
+# resolve above. Spelled here rather than in the tool file that declares it because it is the
+# permission the *resource* costs rather than the permission one tool's request costs: anything
+# else reaching a `callTranscript` needs exactly this one, and rule 4 forbids it importing a tool
+# file to find out. A tool-side constant is therefore a string spelled twice by construction, and
+# two spellings of a permission is not a tidiness problem — the authorize request carries whatever
+# they say, and a typo in one of them is a scope Entra rejects and a sign-in that fails for
+# everybody (see `shared/seam.py`'s `REQUESTABLE_PERMISSIONS`, which is what holds the spelling to
+# Microsoft's).
+#
+# Declaring is still each tool's own: a tool's `GRAPH_PERMISSIONS` tuple is what its 403 and its
+# AADSTS65001 are worded from, so it names the permissions its own request is made under and takes
+# the name from here rather than re-typing it.
+TRANSCRIPT_PERMISSION = "OnlineMeetingTranscript.Read.All"
+
+# How many of a meeting's artifacts one listing may look at, whichever artifact it is. This is what
+# "newest first" costs: Graph documents no `$orderby` on either collection, so the newest can only
+# be known by looking at the collection, and a walk that stopped at `limit` would be sorting an
+# arbitrary handful of it (see `newest_in_window`). The bound is on artifacts rather than on
+# requests because that is what `collect_pages` can bound — Graph chooses the page size here and
+# publishes none — so the honest statement of the cost is "at most this many artifacts are looked
+# at, in however many pages Graph answers them in".
+#
+# 200 is four times the largest `limit` a lister offers and far past any real meeting: a meeting
+# accumulates one artifact per occurrence, so reaching this takes a series that has run daily for
+# the better part of a year *and* been recorded every time. A meeting that does exceed it is not
+# answered with a guess — the scan is reported as incomplete, no absence is asserted, and "newest
+# first" is stated as what it then is, an order over the artifacts that were read.
+#
+# Raising it is not the fix for either of those, which is why the number is boring: a bigger cap
+# moves the boundary and leaves both statements needing the same qualification, because Graph
+# offers no `$orderby` to ask the newest for and no date `$filter` to make the window the server's.
+MAX_ARTIFACT_SCAN = 200
+
+# How long after a window closes — or after a meeting ends, where no window was asked for — a
+# missing artifact is still called "not ready" rather than "never made". Microsoft publishes no SLA
+# and no "processing" status for the availability of a transcript or of a recording, so this is not
+# a promise about Graph — it is which of two opposite pieces of advice to give when the evidence is
+# the same empty collection. Generous on purpose: telling a caller to wait once when nothing will
+# ever arrive costs one call, while telling it a transcript does not exist when it is ten minutes
+# away is a wrong answer it cannot detect.
+ARTIFACT_DELAY_ALLOWANCE = timedelta(hours=4)
+
+type _MeetingsQuery = OnlineMeetingsRequestBuilder.OnlineMeetingsRequestBuilderGetQueryParameters
+
+
+class MeetingArtifact(Protocol):
+    """The one property a window needs of a meeting artifact: when it began.
+
+    Structural rather than nominal because there are two of these in Graph and they are unrelated
+    generated classes: `callTranscript` and `callRecording` both carry `createdDateTime` and nothing
+    else below is read. Naming the property rather than one of the classes is what keeps this module
+    about a meeting rather than about transcripts — the window scopes an occurrence, and which
+    artifact was hung off that occurrence is not its business.
+    """
+
+    @property
+    def created_date_time(self) -> datetime | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class OccurrenceWindow:
+    """Which occurrence was asked about, as two instants that are always timezone-aware.
+
+    A type rather than two arguments threaded through, because the window decides two things that
+    have to agree: which artifacts are kept, and — when none are — whether an empty answer means
+    "wait" or "there is none".
+
+    `of` is the only constructor a caller should use: it takes the shapes a model actually sends and
+    resolves them, so that no comparison downstream can meet a naive datetime.
+    """
+
+    started_after: datetime | None
+    started_before: datetime | None
+
+    @classmethod
+    def of(
+        cls, started_after: date | datetime | None, started_before: date | datetime | None
+    ) -> Self:
+        """A window from bounds as given, resolving anything that named no timezone against UTC.
+
+        A bare date names a whole UTC day: `started_after` takes its first instant and
+        `started_before` its last, so the same date in both is that one day rather than the empty
+        span between one midnight and itself.
+        """
+        return cls(_first_instant(started_after), _last_instant(started_before))
+
+    def holds(self, artifact: MeetingArtifact) -> bool:
+        """Whether this transcript or recording began inside the window.
+
+        An artifact Graph gave no `createdDateTime` for is kept when no window was asked for and
+        dropped when one was: it cannot be shown to be the occurrence the caller meant.
+        """
+        if self.started_after is None and self.started_before is None:
+            return True
+        began = artifact.created_date_time
+        if began is None:
+            return False
+        # Aware even though Graph's own timestamps carry `Z`: this comparison is the one that used
+        # to raise, and it must not depend on a payload's punctuation to stay safe.
+        began = as_utc(began)
+        if self.started_after is not None and began < self.started_after:
+            return False
+        return not (self.started_before is not None and began > self.started_before)
+
+    def settled(self, meeting: OnlineMeeting) -> bool:
+        """Whether an empty answer for this window means "there is none" rather than "not yet".
+
+        Two independent pieces of evidence, either of which settles it: the window's own end is far
+        enough past that anything falling inside it would have landed, or the *meeting* is — the
+        second being what answers a caller who asked for no window at all, and what stops a window
+        mistakenly set in the future promising an artifact for a meeting that is long over.
+
+        Absent evidence never settles anything: no `started_before` and no `endDateTime` both mean
+        nothing says the meeting's artifacts have finished being made, and of the two wrong answers
+        the one that costs a caller a second call is the cheaper one.
+
+        A predicate rather than the verdict itself, because the verdict is a different word per
+        artifact and the tool that answers owns its own vocabulary — the *inference* is what must
+        not exist twice.
+        """
+        now = datetime.now(UTC)
+        return _settled_by(self.started_before, now) or _settled_by(meeting.end_date_time, now)
+
+
+def as_utc(moment: datetime) -> datetime:
+    """`moment` as an aware datetime, reading one that named no timezone as already being UTC.
+
+    Public because the UTC assumption belongs to the window and the window has one home: anything
+    comparing or subtracting Graph timestamps resolves them through this and cannot meet a naive
+    one.
+    """
+    return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
+
+
+async def resolve_meeting(
+    client: GraphServiceClient, handle: MeetingHandle
+) -> OnlineMeeting | None:
+    """The meeting whose stored `joinWebUrl` is `handle`'s, or None if Graph matched none.
+
+    One request, spending `MEETING_PERMISSION`, and the `$filter` above must exist exactly once —
+    see the module docstring for the encoding bug class it sits on top of.
+
+    Graph documents this filter as returning "a collection that contains only one onlineMeeting
+    object", and no match as `200 OK` with an empty `value` rather than a 404 — so None here is an
+    answer and never an error.
+    """
+    escaped = handle.join_web_url.replace("'", "''")
+    configuration = RequestConfiguration[_MeetingsQuery](
+        query_parameters=OnlineMeetingsRequestBuilder.OnlineMeetingsRequestBuilderGetQueryParameters(
+            filter=f"JoinWebUrl eq '{escaped}'"
+        )
+    )
+    matched = await client.me.online_meetings.get(request_configuration=configuration)
+    assert matched is not None, "Graph answered GET /me/onlineMeetings with no collection"
+    meetings = matched.value or []
+    return meetings[0] if meetings else None
+
+
+async def newest_in_window[T: MeetingArtifact](
+    first_page: GraphCollection[T],
+    client: GraphServiceClient,
+    *,
+    window: OccurrenceWindow,
+    limit: int,
+) -> CollectedItems[T]:
+    """The `limit` newest artifacts of a meeting that fall inside `window`, newest first.
+
+    **Newest first is a property of what was read, not of the page Graph chose to answer with.**
+    Graph documents no `$orderby` on either collection, so it answers in an order of its own; a
+    walk that stopped at `limit` and sorted afterwards would return an arbitrary `limit` artifacts
+    sorted among themselves, which is the opposite of what "the latest transcript of this series"
+    asks for and is undetectable — the answer looks exactly like the right one. So the walk keeps
+    everything the window holds, sorts, and only then cuts to `limit`.
+
+    **What was read is the collection up to `MAX_ARTIFACT_SCAN` artifacts, and no further.** That
+    bound is where the promise stops being "the newest of this meeting" and starts being "the
+    newest of the artifacts read": for a collection no larger than the cap the two coincide, which
+    is every meeting bar a daily series recorded for most of a year, and past it the artifacts
+    never read are in Graph's arbitrary order and can hold a newer one. Nothing in this function
+    can close that gap — with no `$orderby`, the only way to know the newest is to read everything,
+    and the cap exists because a collection with no documented ceiling must not turn one tool call
+    into an unbounded walk. So the gap is not hidden: it is what `capped` means below, and every
+    description over a lister is worded to the prefix rather than to the collection.
+
+    **`capped` means the scan stopped at the cap, and nothing else.** The tempting second meaning
+    is "the window held more than `limit`", which is a different fact with the opposite remedy —
+    raise `limit` for that one, nothing at all for this one — and a caller told only "there is
+    more" cannot tell which it was told, so it has to be warned that the first entry may not be the
+    meeting's latest even in the ordinary case. The ordinary case is what the returned count
+    already says (a full `limit` may have more behind it), so it is left there rather than merged
+    in, and what comes back is the cap alone: the one thing a caller cannot see and the one with no
+    remedy. A lister's absence verdict reads it for the same reason, an absence over a prefix being
+    no absence.
+    """
+    collected = await collect_pages(
+        first_page,
+        client,
+        limit=MAX_ARTIFACT_SCAN,
+        matches=window.holds,
+        max_scanned=MAX_ARTIFACT_SCAN,
+    )
+    newest = sorted(collected.items, key=_began_at, reverse=True)
+    return CollectedItems(items=newest[:limit], capped=collected.capped)
+
+
+def _first_instant(bound: date | datetime | None) -> datetime | None:
+    """The earliest instant `bound` includes, or None where there is no bound."""
+    if bound is None:
+        return None
+    # `datetime` subclasses `date`, so this order is the whole of the distinction.
+    if isinstance(bound, datetime):
+        return as_utc(bound)
+    return datetime.combine(bound, time.min, tzinfo=UTC)
+
+
+def _last_instant(bound: date | datetime | None) -> datetime | None:
+    """The latest instant `bound` includes, or None where there is no bound."""
+    if bound is None:
+        return None
+    if isinstance(bound, datetime):
+        return as_utc(bound)
+    return datetime.combine(bound, time.max, tzinfo=UTC)
+
+
+def _settled_by(moment: datetime | None, now: datetime) -> bool:
+    """Whether `moment` is far enough past that an artifact belonging to it would have arrived."""
+    return moment is not None and as_utc(moment) + ARTIFACT_DELAY_ALLOWANCE < now
+
+
+def _began_at(artifact: MeetingArtifact) -> datetime:
+    """The sort key: when the artifact began, or the beginning of time where Graph did not say.
+
+    Aware for the same reason `OccurrenceWindow.holds` is — one naive value among aware ones makes
+    the sort itself raise, which is a crash in the middle of an answer that was already complete.
+    """
+    began = artifact.created_date_time
+    return as_utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)

--- a/services/office-mcp/src/office_mcp/shared/seam.py
+++ b/services/office-mcp/src/office_mcp/shared/seam.py
@@ -27,6 +27,16 @@ TRAP: `GraphForbidden` covers 401 and 403 (401 = sign in; 403 = ask administrato
 names the permission on 403. The tool does, scoped to the permissions used.
 
 The same missing permission appears first as Entra refusal (AADSTS65001) if never consented.
+
+One 403 is not about a permission at all, and naming one would send an administrator after
+something that was never missing. Microsoft Graph access to Teams meeting transcripts is a
+*tenant* switch, off by default, that "no app can access meeting transcripts, regardless of
+app-level permissions" until a Teams administrator turns it on — and Microsoft is explicit that
+there is "no request-side workaround". Graph marks it with an inner error code, which is the only
+thing distinguishing it from an ordinary refusal, so that is what it is recognised by (never the
+message text, which Microsoft documents as subject to change). This connector already learned this
+lesson once, in `services/teams-mcp` (PR #762) and in `docs/recordings-and-transcripts/`; the
+remedy names a person in the Teams admin centre and explicitly rules out re-consent.
 """
 
 import re
@@ -59,6 +69,8 @@ REQUESTABLE_PERMISSIONS: frozenset[str] = frozenset(
         "Team.ReadBasic.All",
         "Channel.ReadBasic.All",
         "ChannelMessage.Read.All",
+        "OnlineMeetings.Read",
+        "OnlineMeetingTranscript.Read.All",
     }
 )
 
@@ -148,6 +160,25 @@ def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     )
 
 
+# Graph's inner error code for the tenant switch, and the advice for it. Branched on rather than the
+# message, as Microsoft's transcript reference instructs twice.
+_TRANSCRIPT_ACCESS_DISABLED = "GraphAccessToTranscriptsDisabled"
+
+_TRANSCRIPTS_SWITCHED_OFF = (
+    "Microsoft 365 refused this request because this organisation has Microsoft Graph access to "
+    + "Teams meeting transcripts switched OFF. This is a tenant-wide Teams setting, off by "
+    + "default, and it blocks every transcript read regardless of which permissions this connector "
+    + "holds — so it is NOT a consent problem and asking the user to sign in again will not change "
+    + "it. A Microsoft Teams administrator has to turn it on: Teams admin centre → Meetings → "
+    + "Meeting settings → Transcript API access → Microsoft Graph access, or "
+    + "`Set-CsTeamsMeetingConfiguration -EnableGraphTranscriptAccess $true -Identity Global`. "
+    + "Microsoft documents no request-side workaround: until an administrator acts, every "
+    + "transcript call from this connector fails identically, so do not retry this one and do not "
+    + "try another meeting or another transcript. Everything else this connector does — chats, "
+    + "channels, message search — is unaffected."
+)
+
+
 def _advice(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
     return _remedy(failure, permissions, not_found) + _diagnostics(failure)
 
@@ -171,6 +202,8 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str 
                 + "in to this connector again; the request itself was fine, so retrying it "
                 + "unchanged will fail the same way."
             )
+        if failure.inner_code == _TRANSCRIPT_ACCESS_DISABLED:
+            return _TRANSCRIPTS_SWITCHED_OFF
         named = _named(permissions)
         noun = "permissions" if len(permissions) > 1 else "permission"
         return (

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -20,6 +20,7 @@ from office_mcp.tools import (
     get_me,
     list_channels,
     list_chats,
+    list_meeting_transcripts,
     list_teams,
     read_message,
     search_messages,
@@ -45,6 +46,7 @@ _TOOL_MODULES: tuple[ToolModule, ...] = (
     browse_channel,
     search_messages,
     read_message,
+    list_meeting_transcripts,
 )
 
 GRAPH_SCOPES: tuple[str, ...] = tuple(

--- a/services/office-mcp/src/office_mcp/tools/list_chats.py
+++ b/services/office-mcp/src/office_mcp/tools/list_chats.py
@@ -52,8 +52,10 @@ puts on every message in that chat, so this list names messages found elsewhere.
 to any tool. This returns chats only; channels live inside teams and are a different surface.
 
 Meeting chats are conversations attached to a Teams meeting. The `topic` is the meeting subject. \
-`meeting_uri` is the only route from conversation to meeting. No calendar permission needed. \
-`meeting_uri` is null for non-meeting chats and for meeting chats where Microsoft gave no join URL.
+`meeting_uri` is the only route from conversation to meeting — pass it verbatim to \
+list_meeting_transcripts to find out whether the meeting was transcribed. No calendar permission \
+needed. `meeting_uri` is null for non-meeting chats and for meeting chats where Microsoft gave no \
+join URL — that meeting's transcripts are then unreachable here.
 
 Order comes from the last message sent in each chat — the only recency Graph applies. \
 `last_message_at` is null if no one has posted yet. `members` returns only for unnamed chats \
@@ -103,7 +105,9 @@ class ChatSummary(BaseModel):
     meeting_uri: str | None = Field(
         description=(
             "For meeting chats: a handle for the Teams meeting. The only route from conversation "
-            + "to meeting. Null when no join URL exists."
+            + "to meeting. Pass it verbatim to list_meeting_transcripts to find out whether the "
+            + "meeting was transcribed. Null when no join URL exists, in which case that meeting's "
+            + "transcripts are unreachable from this connector."
         )
     )
     last_message_at: datetime | None = Field(

--- a/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
+++ b/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
@@ -1,0 +1,539 @@
+"""`list_meeting_transcripts` — whether a Teams meeting was transcribed, and a handle for each.
+
+It says what exists and none of what was said. Two things make that a tool of its own rather than a
+field on something larger: a transcript is large, and a recurring series is a single meeting to
+Graph — every occurrence's transcript lands in the same collection, distinguished only by when
+transcription started — so which occurrence is meant is a decision made from this answer rather than
+a default anything can pick.
+
+How a meeting is addressed, how the join URL is escaped onto the wire, what an occurrence window is,
+and how far "newest first" is true are all `shared/meetings.py`: they are promises about the meeting
+rather than about its transcripts, and this file is only the first tool to need them. The handle
+grammar itself is `shared/handles.py`, for the same reason one step further out: the transcript
+handle this file mints is what a reader of one parses, and a second speller would look like a handle
+one tool produced and another answers 404 to.
+
+Everything else is here — the name, the description, the two permissions, the arguments, the answer
+shape, the Graph requests and every refusal only this tool can explain. What is most this file's own
+is the *vocabulary of the answer*. "Was not transcribed" is a fact about one artifact of a meeting
+and not about the meeting: Microsoft gates a meeting's artifacts independently, so these five words
+are this tool's and may never be read as a verdict on the meeting itself.
+
+## Four failures a caller must act on differently
+
+`GET …/transcripts` returning nothing is not one answer but three, and the tenant switch is a
+fourth:
+
+* **`GraphAccessToTranscriptsDisabled`** — a `403` whose remedy names a Teams administrator, not a
+  Graph permission. Microsoft Graph access to meeting transcripts is off by default and "no app can
+  access meeting transcripts, regardless of app-level permissions"; there is "no request-side
+  workaround", so re-consent is explicitly ruled out. It is recognised by inner code in
+  `shared/seam.py`, where every other refusal is worded. Microsoft scopes the switch to transcript
+  resources, so it does **not** cover recordings: a refusal here says nothing about whether the
+  meeting was recorded, and this tool must not be read as though it had.
+* **No transcript** — the meeting was never recorded or never transcribed. Retrying is pointless.
+* **Not ready yet** — nothing has landed for the window asked about and something still might.
+  Retrying is the *only* thing that helps, which is why this must never be reported as the case
+  above — and, just as importantly, why the case above must not be reported as this one: a window
+  that has demonstrably passed is answered `not_transcribed` even for a series still running, or a
+  model is sent back to poll for an occurrence that ended last month. Graph publishes no status for
+  availability and no latency SLA, so both halves are an inference over one generous allowance;
+  `OccurrenceWindow.settled` is the whole of it and `MeetingTranscripts.status` admits it as one.
+  `not_ready` and a settled absence are the same empty collection from Graph with opposite advice.
+* **Not known** — the walk hit `MAX_ARTIFACT_SCAN` before the collection ended, so the transcripts
+  it did not reach might hold the one asked for. Neither absence verdict above is available here:
+  both assert something about a collection that was not read to the end, and the caller cannot tell
+  from the outside. `scan_incomplete` is that answer — an answer saying both "there is more" and
+  "there is none" is one no caller can act on. The sentence it gives a model, "this meeting has more
+  transcripts than one call reads", is a claim about the meeting, and it is true only because the
+  walk underneath it can no longer stop for any other reason: `graph_client/pagination.py` follows
+  an empty page carrying a next link rather than reading it as the end, and refuses a collection
+  that answers nothing but empty pages rather than answering short. Without that, a four-transcript
+  meeting Graph paged `[3, nothing, 1]` would be told the same thing — which is why this file's
+  tests page one that way and assert every transcript comes back.
+  It is also the one answer here with **no remedy**, and every place it is described says so. The
+  window is applied to the artifacts *after* they are read: Graph documents no filterable date on
+  either collection — the one filterable property either reference shows by example is
+  `contentCorrelationId` (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example
+  11) — so the request is bare and the same `MAX_ARTIFACT_SCAN` artifacts are read whatever window
+  is asked for. "Narrow `started_after`/`started_before` and ask again" was therefore advice a model
+  could follow forever without progress: the next call reads the same artifacts and answers the same
+  way. That is the defect class the channel browser already paid for with its circular reply advice,
+  and the fix is the same one — a dead end stated plainly beats an actionable-sounding loop, so what
+  a caller is told is to stop and report that it is not known.
+
+## Newest first is a promise about the collection, not about a page of it
+
+Graph documents `$select`, `$filter` and `$top` on this collection and no `$orderby` at all, so it
+answers in an order of its own. The window is therefore taken whole — to the scan cap — ordered, and
+only then cut to `limit`. A walk that stopped at `limit` before sorting would return an arbitrary
+`limit` transcripts sorted among themselves and call them the newest, which is a wrong answer with
+the shape of a right one. `newest_in_window` is where that happens, for whatever lists a meeting's
+artifacts.
+
+`include_scan_completeness` is opt-in because it is the only thing here a caller cannot work out for
+itself. "The window held more transcripts than your `limit`" it can: a full window may have more
+behind it and a short one is all there was, which is what a page size means everywhere. "The read
+stopped at the cap" it cannot, and merging the two into one flag would give one name to two facts
+with opposite remedies — raise `limit` for the first, nothing at all for the second. Where nothing
+came back at all it is not opt-in: `status` is `scan_incomplete`, because an absence asserted over a
+collection nobody read to the end is the wrong answer all of this exists to avoid.
+"""
+
+from datetime import date, datetime
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from msgraph.generated.models.call_transcript import CallTranscript
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_client_for, graph_errors
+from office_mcp.shared.handles import MeetingHandle, TranscriptHandle, meeting_handle
+from office_mcp.shared.meetings import (
+    MAX_ARTIFACT_SCAN,
+    MEETING_PERMISSION,
+    TRANSCRIPT_PERMISSION,
+    OccurrenceWindow,
+    newest_in_window,
+    resolve_meeting,
+)
+from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
+
+TOOL_NAME = "list_meeting_transcripts"
+
+# Reading a transcript resource is an admin-consented permission, and a different one from the
+# resolve that precedes it: a tenant can grant one and withhold the other. Both names come from
+# `shared/meetings.py` rather than being typed here — a permission is the resource's, and rule 4
+# forbids the next module that reaches the same resource from importing this file to find out how
+# it is spelled.
+#
+# What listing a meeting's transcripts costs: the resolve and the list, in that order, under one
+# token — Entra redeems them together or not at all. The handle minted below already carries the
+# resolved meeting id, so reading a transcript's content later needs only the second of the two,
+# and a tenant that withholds `OnlineMeetings.Read` does not put transcript content out of reach.
+GRAPH_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
+
+# Built once at import: a call inside a parameter default rebuilds the descriptor on every
+# registration and is a lint error in both of this repo's checkers.
+_TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
+
+# How many transcripts one listing returns. A one-off meeting has one; a recurring series
+# accumulates one per occurrence in the same collection, which is what makes a window necessary at
+# all. Graph documents `$top` here but publishes no ceiling, so this is ours.
+MAX_TRANSCRIPTS = 50
+
+_DESCRIPTION = f"""\
+Find out whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
+`meeting_uri` that list_chats reports on a meeting chat.
+
+This says what exists and returns none of the words that were said. A recurring meeting is a \
+single meeting to Microsoft — every occurrence's transcript lands in the same collection, \
+distinguished only by when transcription started — so scope to one occurrence with \
+`started_after`/`started_before` when `meeting_type` comes back `recurring`; a one-off meeting has \
+a single transcript and needs neither. Both bounds take a date (`2026-08-11`, meaning that whole \
+UTC day) or a timestamp, with or without a timezone offset — one without is read as UTC, so pass \
+the offset when you are working from a local time.
+
+**Read `status` before anything else. It has five values and they mean five different actions:**
+- `available` — transcripts are listed, newest first. "Newest" is over the transcripts this call \
+read, which is every transcript the meeting has unless the meeting holds more of them than the cap \
+below — set `include_scan_completeness` if the answer turns on that.
+- `not_ready` — nothing has landed for the window you asked about and something still might: that \
+window has only just closed, or you asked for no window and the meeting has not ended or ended \
+recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
+is wrong: Microsoft publishes no availability SLA, so this tool infers it from how recently the \
+window (or the meeting) ended and errs towards telling you to wait. An occurrence window that is \
+already well past never answers this — a series whose end date is in the future does not make a \
+last-month occurrence "still processing".
+- `not_transcribed` — the window you asked about is over and nothing is there: it was not recorded \
+or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
+meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
+transcripts once the meeting expires, roughly 60 days after a one-off.)
+- `scan_incomplete` — this meeting has more transcripts than one call reads \
+({MAX_ARTIFACT_SCAN}) and none of the ones read are in your window, so whether one \
+exists there is not known. This is the one answer that claims nothing, and the one with nothing to \
+try: the window is applied to the transcripts after Microsoft has answered them, so a narrower \
+`started_after`/`started_before` reads the same transcripts and returns this same answer, however \
+many times you ask. Stop here. Report that this meeting has too many transcripts to read through \
+and that whether the occurrence you meant was transcribed could not be determined — that \
+uncertainty is the answer. Never report it as "there is no transcript".
+- `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
+see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
+
+This tool answers about transcripts only. Whether the meeting was RECORDED is a separate question \
+that Microsoft gates independently — the tenant setting below blocks transcripts and leaves \
+recordings alone — and nothing on this server answers it, so a refusal here is not evidence about \
+the meeting's recording either way. No video is returned or reachable anywhere in this connector; \
+a transcript is the better artifact for a question about a meeting anyway, being text with who \
+said what and when.
+
+Two things can refuse this call outright, and both are somebody's decision rather than a bug. \
+Reading transcripts over Microsoft Graph is an organisation-wide Teams setting that is OFF by \
+default and that no application can switch on; when it is off, the error says so and names the \
+administrator who can change it. Separately, Microsoft documents transcript access under \
+{TRANSCRIPT_PERMISSION} without stating that meeting participants get it, so a \
+participant may be refused where the meeting's organiser would succeed.\
+"""
+
+# What this tool says when its `meeting_uri` is not a meeting handle. Its own text rather than one
+# shared with whatever asks about a meeting next: the failure it has to prevent is a caller being
+# sent to the wrong tool, and a tool file that borrowed another's refusal would be re-creating a
+# tool-declaration module one import at a time (`tests/test_layering.py` rule 4).
+_NOT_A_MEETING_HANDLE = (
+    "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
+    + "and this is not one. A meeting handle has exactly one shape:\n"
+    + "  teams:///meetings/{join_web_url}\n"
+    + "with the join URL percent-encoded. It cannot be assembled — Microsoft addresses a "
+    + "meeting by the join URL of the Teams meeting itself, which only Microsoft can supply — "
+    + "so call list_chats, find the `meeting` chat for the meeting in question, and pass its "
+    + "`meeting_uri` verbatim. A chat id, a chat topic, a Teams web link and a "
+    + "`teams:///transcripts/...` handle are none of them a meeting handle — that last one is "
+    + "what this tool produces rather than what it takes. Retrying this value will fail "
+    + "identically."
+)
+
+
+class TranscriptSummary(BaseModel):
+    uri: str = Field(
+        description=(
+            "This connector's handle for the transcript: what identifies it across calls, and "
+            + "what to quote verbatim when referring to it. Nothing here contains any of the "
+            + "words that were said."
+        )
+    )
+    transcript_id: str = Field(
+        description="The transcript's Graph id. Identify a transcript by `uri`, not by this alone."
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When transcription began (Microsoft's `createdDateTime`). For a recurring meeting "
+            + "this is what tells one occurrence from another: every occurrence's transcript lands "
+            + "in the same collection, and Microsoft gives no occurrence id."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When transcription ended (Microsoft's `endDateTime`)."
+    )
+    content_correlation_id: str | None = Field(
+        description=(
+            "Microsoft's identifier linking this transcript to the recording of the same call. "
+            + "Nothing here fetches recordings; it is returned because it is the exact link, and "
+            + "two transcripts sharing it are two views of one call rather than of two."
+        )
+    )
+
+
+class MeetingTranscripts(BaseModel):
+    status: str = Field(
+        description=(
+            "What was found, and therefore what to do next. Exactly one of:\n"
+            + "- `available` — `transcripts` lists them, newest first.\n"
+            + "- `not_ready` — nothing is there for the window you asked about and something may "
+            + "still arrive: that window has only just closed, or you asked for no window and the "
+            + "meeting itself has not ended or ended recently. Microsoft publishes no availability "
+            + "SLA and no 'processing' status, so this is inferred: it means wait and ask again "
+            + "later, and it is NOT evidence that no transcript will ever exist. A window that has "
+            + "demonstrably passed is never reported this way, however far in the future a "
+            + "recurring series runs.\n"
+            + "- `not_transcribed` — the window is over, nothing is there, and nothing is "
+            + "expected: it was not recorded or transcribed. Retrying will not change this. One "
+            + "other cause looks identical and cannot be distinguished: Microsoft's "
+            + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
+            + "one-off), so a transcript that once existed can read as never having existed.\n"
+            + "- `scan_incomplete` — this meeting has more transcripts than one call reads "
+            + f"({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether "
+            + "one exists there is NOT known and is not being claimed either way. There is nothing "
+            + "to try: the window is applied to the transcripts after Microsoft has answered, not "
+            + "by Microsoft while answering, so changing `started_after`/`started_before` — "
+            + "narrower, wider, anything — reads the same transcripts and returns this same "
+            + "status. Stop, and report that whether a transcript exists for that occurrence could "
+            + "not be determined. Never report this as 'there is no transcript', and do not ask "
+            + "again.\n"
+            + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
+            + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
+            + "calendar, or one this user was never invited to, answers the same way. Do not retry "
+            + "and do not rebuild the handle."
+        )
+    )
+    meeting_id: str | None = Field(
+        description=(
+            "The resolved meeting's Graph id, or null when `status` is `meeting_not_found`. "
+            + "Opaque, and no tool here takes it — a transcript's `uri` already carries it."
+        )
+    )
+    subject: str | None = Field(
+        description=(
+            "The meeting's subject as Microsoft holds it, which is how to confirm this is the "
+            + "meeting that was meant. It may differ from the chat's topic."
+        )
+    )
+    meeting_type: str | None = Field(
+        description=(
+            "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null when Microsoft did "
+            + "not say. `recurring` is the one to act on: a whole series is ONE meeting to "
+            + "Microsoft, so every occurrence's transcript is in this one collection and "
+            + "`started_after`/`started_before` are how to reach a single occurrence."
+        )
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When the meeting starts. For a recurring series this is Microsoft's single value for "
+            + "the whole series, not the occurrence you asked about."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When the meeting ends, on the same caveat as `started_at`."
+    )
+    transcripts: list[TranscriptSummary] = Field(
+        description=(
+            "The transcripts of this meeting that fall inside the requested window, newest first. "
+            + "The order is over every transcript this call read rather than over one page of "
+            + f"Microsoft's answer, and one call reads up to {MAX_ARTIFACT_SCAN} of them. For a "
+            + "meeting with no more transcripts than that — every meeting bar a series recorded "
+            + "daily for most of a year — those are all of them, so the first entry is the latest "
+            + "transcript of the window outright, which for a recurring series is how to reach the "
+            + "most recent occurrence. Past that cap the first entry is the latest of what was "
+            + "READ: Microsoft returns this collection in an order of its own and offers no way to "
+            + "ask for the newest, so a newer transcript can sit among the ones never read; set "
+            + "`include_scan_completeness` when the answer turns on that. As many entries as "
+            + "`limit` means the window may hold older ones too — raise `limit`, up to "
+            + f"{MAX_TRANSCRIPTS} — and fewer than `limit` means these are the whole window. There "
+            + "is no cursor. Empty for every status other than `available`."
+        )
+    )
+    scan_incomplete: bool | None = Field(
+        description=(
+            "Whether the read stopped at the cap on how many of this meeting's transcripts one "
+            + f"call looks through ({MAX_ARTIFACT_SCAN}), or null when "
+            + "`include_scan_completeness` was not set — which is the default, because it only "
+            + "matters for a meeting with more transcripts than that.\n"
+            + "True means `transcripts` is ordered over the ones READ and not over the meeting, so "
+            + "the first entry may not be the meeting's latest and nothing here reads further: no "
+            + "argument to this tool changes it, the window being applied after the read. False "
+            + "means the whole collection was read, so the order and any absence within it are "
+            + "exact. This says nothing about `limit` — that the window held more than you asked "
+            + "for is what a full `transcripts` list means. You never need this to tell whether an "
+            + "empty answer is trustworthy: `status` is `scan_incomplete` in exactly that case."
+        )
+    )
+
+
+async def list_meeting_transcripts(
+    client: GraphServiceClient,
+    *,
+    handle: MeetingHandle,
+    started_after: date | datetime | None,
+    started_before: date | datetime | None,
+    limit: int,
+    include_scan_completeness: bool,
+) -> MeetingTranscripts:
+    """The transcripts of the meeting `handle` addresses, and what a caller should do about them.
+
+    Two Graph requests at most: resolve the join URL, then list. The listing goes out bare, and the
+    window is applied while paging it rather than as a `$filter`: Graph advertises `$select`,
+    `$filter` and `$top` here and no `$orderby`, and the only filterable property either artifact's
+    reference shows is `contentCorrelationId`
+    (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example 11) — never a date. So
+    a server-side date bound is unverified, and a wrong one returns `200 OK` with nothing rather
+    than failing. That is also why the window is no help to a caller whose scan stopped short: it
+    is ours, applied to what came back, so it cannot make Graph send different artifacts.
+
+    The bounds are whatever the caller passed — `OccurrenceWindow.of` is what makes them instants —
+    and the same window then decides both which transcripts are kept and what an empty answer means.
+
+    `include_scan_completeness` decides only whether `scan_incomplete` is reported, never what is
+    read: it is the same two requests either way. Off by default because it answers a question
+    about one rare meeting shape, and a field that is null for all but that shape is a field a
+    model does not have to reason about — while `status` still reports a scan that stopped short
+    whenever it is the difference between "there is none" and "nobody looked".
+    """
+    assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
+    window = OccurrenceWindow.of(started_after, started_before)
+
+    with graph_errors():
+        meeting = await resolve_meeting(client, handle)
+        if meeting is None or meeting.id is None:
+            return MeetingTranscripts(
+                status="meeting_not_found",
+                meeting_id=None,
+                subject=None,
+                meeting_type=None,
+                started_at=None,
+                ended_at=None,
+                transcripts=[],
+                scan_incomplete=False if include_scan_completeness else None,
+            )
+        first_page = await client.me.online_meetings.by_online_meeting_id(
+            meeting.id
+        ).transcripts.get()
+        assert first_page is not None, "Graph answered a transcript listing with no collection"
+        collected = await newest_in_window(first_page, client, window=window, limit=limit)
+
+    found = collected.items
+    return MeetingTranscripts(
+        status="available"
+        if found
+        else _absence(scan_stopped_short=collected.capped, settled=window.settled(meeting)),
+        meeting_id=meeting.id,
+        subject=meeting.subject,
+        # `OnlineMeetingBase.meetingType` is a generated enum subclassing `str`, so the member is
+        # its own wire value; a value the SDK predates deserializes to None rather than raising.
+        meeting_type=meeting.meeting_type,
+        started_at=meeting.start_date_time,
+        ended_at=meeting.end_date_time,
+        transcripts=[_summary(meeting.id, transcript) for transcript in found],
+        scan_incomplete=collected.capped if include_scan_completeness else None,
+    )
+
+
+def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
+    """Which empty answer to give: the one that means stop, the one that means wait, or neither.
+
+    A scan that stopped short is checked first, and it is what makes the other two safe to say: the
+    walk having been cut means the artifacts it did not reach might hold the one asked for, so
+    nothing about absence is known — and "not transcribed / retrying will not help" is exactly the
+    assertion that must not be made. Reported instead as `scan_incomplete`, so that "there is more"
+    and "there is none" can never both be said of one answer. This is the one place the scan's
+    completeness reaches a caller whether or not it was asked for: an empty answer is only worth
+    anything with it, whereas the same fact about a non-empty answer is the rare caveat behind
+    `include_scan_completeness`.
+
+    It is also the one verdict here that offers a caller nothing to do, and its description says so
+    in as many words: the window is applied after the artifacts are read, so no window sends the
+    next call further into the collection. The advice is to stop and report the uncertainty, which
+    is the only advice that is true — see the module docstring's fourth failure.
+
+    Otherwise the evidence is `OccurrenceWindow.settled` and the word is this tool's, because a
+    meeting that was recorded but never transcribed is `not_transcribed` here: the verdict is about
+    one artifact of the meeting, never about the meeting.
+    """
+    if scan_stopped_short:
+        return "scan_incomplete"
+    return "not_transcribed" if settled else "not_ready"
+
+
+def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
+    assert transcript.id is not None, "Graph returned a transcript with no id"
+    return TranscriptSummary(
+        uri=TranscriptHandle(meeting_id, transcript.id).uri,
+        transcript_id=transcript.id,
+        started_at=transcript.created_date_time,
+        ended_at=transcript.end_date_time,
+        content_correlation_id=transcript.content_correlation_id,
+    )
+
+
+def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this tool against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
+    borrows it per call and never owns it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(
+        name=TOOL_NAME,
+        title="List a Meeting's Transcripts",
+        description=_DESCRIPTION,
+        annotations=READ_ONLY,
+    )
+    async def list_transcripts(
+        meeting_uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The meeting whose transcripts to list, exactly as list_chats reported "
+                    + "`meeting_uri` on a meeting chat: "
+                    + "`teams:///meetings/{join_web_url}`. Copy it verbatim — it carries the "
+                    + "meeting's join URL, which Microsoft matches character for character, and "
+                    + "nothing else identifies a meeting to this connector."
+                ),
+            ),
+        ],
+        started_after: Annotated[
+            date | datetime | None,
+            Field(
+                description=(
+                    "Only transcripts whose transcription began at or after this moment. This is "
+                    + "how to reach one occurrence of a recurring meeting, whose occurrences all "
+                    + "share a single meeting and therefore a single transcript collection. Three "
+                    + "shapes are accepted and none of them fails: `2026-08-11T09:00:00+02:00` (or "
+                    + "`...Z`) means the instant it names; `2026-08-11T09:00:00`, which names no "
+                    + "offset, IS READ AS UTC; and a bare `2026-08-11` means that whole UTC day, "
+                    + "starting at its first instant here. Pass the offset whenever what you know "
+                    + "is a local time — 09:00 in Zurich is 07:00Z, and a window built in the "
+                    + "wrong zone answers about the wrong hours without saying so. A window with "
+                    + "no transcript inside it is an answer and not an error: `not_transcribed` "
+                    + "once the window is past, `not_ready` while it is recent."
+                )
+            ),
+        ] = None,
+        started_before: Annotated[
+            date | datetime | None,
+            Field(
+                description=(
+                    "Only transcripts whose transcription began at or before this moment. Pair it "
+                    + "with `started_after` to bracket one occurrence; the same three shapes are "
+                    + "accepted on the same UTC assumption, except that a bare `2026-08-11` here "
+                    + "means the END of that UTC day — so the same date in both bounds is that one "
+                    + "whole day. This bound is also what decides an empty answer: a window whose "
+                    + "end is already well past reports `not_transcribed` rather than sending you "
+                    + "back to wait, even for a recurring series with occurrences still to come."
+                )
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=MAX_TRANSCRIPTS,
+                description=(
+                    "How many transcripts to return. Default 20, maximum "
+                    + f"{MAX_TRANSCRIPTS}. They are the NEWEST that many of the "
+                    + "window, not the first that many Microsoft happens to answer with: the "
+                    + f"meeting's transcripts are read (up to {MAX_ARTIFACT_SCAN} of "
+                    + "them, which is this call's whole cost) and ordered before this cuts them, "
+                    + "so asking for 3 gives the 3 newest OF THE ONES READ. Those are the 3 latest "
+                    + "outright whenever the meeting has no more transcripts than that cap, which "
+                    + "is every meeting except a series recorded daily for most of a year: one "
+                    + "meeting has one transcript per occurrence that was transcribed. Past the "
+                    + "cap the read stops mid-collection, in whatever order Microsoft answered in "
+                    + "(it offers no way to ask for the newest), so a newer transcript can be one "
+                    + "that was never read — `include_scan_completeness` is how to find out, and "
+                    + "raising `limit` does not read further. Getting `limit` transcripts back "
+                    + "means the window may hold older ones; getting fewer means it does not."
+                ),
+            ),
+        ] = 20,
+        include_scan_completeness: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Report whether the read reached the end of this meeting's transcripts, as "
+                    + "`scan_incomplete` in the answer. Off by default, and worth setting for one "
+                    + "question: whether the first transcript listed is the meeting's own latest. "
+                    + "It is, for every meeting with no more transcripts than one call reads "
+                    + f"({MAX_ARTIFACT_SCAN}) — which is every meeting bar a series "
+                    + "recorded daily for most of a year — and past that the order is over the "
+                    + "ones read. You do not need it to trust an empty answer: `status` already "
+                    + "reports `scan_incomplete` when nothing was found and the read stopped short."
+                )
+            ),
+        ] = False,
+        graph_token: str = _TOKEN,
+    ) -> MeetingTranscripts:
+        handle = meeting_handle(meeting_uri)
+        if handle is None:
+            raise ToolError(_NOT_A_MEETING_HANDLE)
+        with graph_tool_errors(*GRAPH_PERMISSIONS):
+            return await list_meeting_transcripts(
+                graph_client_for(transport, graph_token),
+                handle=handle,
+                started_after=started_after,
+                started_before=started_before,
+                limit=limit,
+                include_scan_completeness=include_scan_completeness,
+            )

--- a/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
+++ b/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
@@ -1,83 +1,50 @@
 """`list_meeting_transcripts` — whether a Teams meeting was transcribed, and a handle for each.
 
-It says what exists and none of what was said. Two things make that a tool of its own rather than a
-field on something larger: a transcript is large, and a recurring series is a single meeting to
-Graph — every occurrence's transcript lands in the same collection, distinguished only by when
-transcription started — so which occurrence is meant is a decision made from this answer rather than
-a default anything can pick.
+Reports what exists and none of what was said. A recurring series is one meeting to Graph, so
+every occurrence's transcript lands in one collection. Distinguish occurrences with
+`started_after`/`started_before`.
 
-How a meeting is addressed, how the join URL is escaped onto the wire, what an occurrence window is,
-and how far "newest first" is true are all `shared/meetings.py`: they are promises about the meeting
-rather than about its transcripts, and this file is only the first tool to need them. The handle
-grammar itself is `shared/handles.py`, for the same reason one step further out: the transcript
-handle this file mints is what a reader of one parses, and a second speller would look like a handle
-one tool produced and another answers 404 to.
+Shared code in `shared/meetings.py` and `shared/handles.py` documents how meetings are reached,
+how the join URL encodes, what an occurrence window is, and how "newest first" is bounded. This
+file owns the answer's vocabulary: "was not transcribed" is a fact about one artifact, never about
+the meeting.
 
-Everything else is here — the name, the description, the two permissions, the arguments, the answer
-shape, the Graph requests and every refusal only this tool can explain. What is most this file's own
-is the *vocabulary of the answer*. "Was not transcribed" is a fact about one artifact of a meeting
-and not about the meeting: Microsoft gates a meeting's artifacts independently, so these five words
-are this tool's and may never be read as a verdict on the meeting itself.
+## Five answers that need different action
 
-## Four failures a caller must act on differently
+`GET …/transcripts` returning nothing means exactly one of five things:
 
-`GET …/transcripts` returning nothing is not one answer but three, and the tenant switch is a
-fourth:
+* **`GraphAccessToTranscriptsDisabled`** — a `403` with no fix on this server. Microsoft Graph
+  access to transcripts is off by default across the tenant and requires a Teams administrator to
+  turn on. Re-consent does not help. Detected by code in `shared/seam.py`. Microsoft scopes this
+  switch to transcripts only, not recordings, so a refusal here says nothing about whether the
+  meeting was recorded.
+* **`available`** — transcripts exist and are listed, newest first (of the ones read up to
+  `MAX_ARTIFACT_SCAN`).
+* **`not_transcribed`** — the meeting was never recorded or never transcribed. Retrying does not
+  help.
+* **`not_ready`** — the window just closed or the meeting just ended. Retrying is the only option.
+  Graph publishes no SLA for availability, so this is an inference: if the window is still fresh
+  (within ~5–60 days of the meeting, depending on tenant policy), the lack of a transcript may mean
+  transcription is still in progress. A window that is demonstrably old (the meeting ended more than
+  60 days ago, or a one-time meeting has passed its 60-day expiration) never gives this answer.
+  Do not report this status as "there is no transcript" — it means "not ready yet".
+* **`scan_incomplete`** — the meeting holds more than `MAX_ARTIFACT_SCAN` transcripts and none of
+  the ones read fall in your window, so whether one exists there is not known. The window is applied
+  *after* Microsoft answers, not in the request, so a narrower window reads the same transcripts and
+  returns this same answer. Stop here. There is nothing to try.
 
-* **`GraphAccessToTranscriptsDisabled`** — a `403` whose remedy names a Teams administrator, not a
-  Graph permission. Microsoft Graph access to meeting transcripts is off by default and "no app can
-  access meeting transcripts, regardless of app-level permissions"; there is "no request-side
-  workaround", so re-consent is explicitly ruled out. It is recognised by inner code in
-  `shared/seam.py`, where every other refusal is worded. Microsoft scopes the switch to transcript
-  resources, so it does **not** cover recordings: a refusal here says nothing about whether the
-  meeting was recorded, and this tool must not be read as though it had.
-* **No transcript** — the meeting was never recorded or never transcribed. Retrying is pointless.
-* **Not ready yet** — nothing has landed for the window asked about and something still might.
-  Retrying is the *only* thing that helps, which is why this must never be reported as the case
-  above — and, just as importantly, why the case above must not be reported as this one: a window
-  that has demonstrably passed is answered `not_transcribed` even for a series still running, or a
-  model is sent back to poll for an occurrence that ended last month. Graph publishes no status for
-  availability and no latency SLA, so both halves are an inference over one generous allowance;
-  `OccurrenceWindow.settled` is the whole of it and `MeetingTranscripts.status` admits it as one.
-  `not_ready` and a settled absence are the same empty collection from Graph with opposite advice.
-* **Not known** — the walk hit `MAX_ARTIFACT_SCAN` before the collection ended, so the transcripts
-  it did not reach might hold the one asked for. Neither absence verdict above is available here:
-  both assert something about a collection that was not read to the end, and the caller cannot tell
-  from the outside. `scan_incomplete` is that answer — an answer saying both "there is more" and
-  "there is none" is one no caller can act on. The sentence it gives a model, "this meeting has more
-  transcripts than one call reads", is a claim about the meeting, and it is true only because the
-  walk underneath it can no longer stop for any other reason: `graph_client/pagination.py` follows
-  an empty page carrying a next link rather than reading it as the end, and refuses a collection
-  that answers nothing but empty pages rather than answering short. Without that, a four-transcript
-  meeting Graph paged `[3, nothing, 1]` would be told the same thing — which is why this file's
-  tests page one that way and assert every transcript comes back.
-  It is also the one answer here with **no remedy**, and every place it is described says so. The
-  window is applied to the artifacts *after* they are read: Graph documents no filterable date on
-  either collection — the one filterable property either reference shows by example is
-  `contentCorrelationId` (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example
-  11) — so the request is bare and the same `MAX_ARTIFACT_SCAN` artifacts are read whatever window
-  is asked for. "Narrow `started_after`/`started_before` and ask again" was therefore advice a model
-  could follow forever without progress: the next call reads the same artifacts and answers the same
-  way. That is the defect class the channel browser already paid for with its circular reply advice,
-  and the fix is the same one — a dead end stated plainly beats an actionable-sounding loop, so what
-  a caller is told is to stop and report that it is not known.
+## Newest first is bounded by what was read
 
-## Newest first is a promise about the collection, not about a page of it
+Graph documents no `$orderby` on transcripts, so it answers in its own order. The code reads up to
+`MAX_ARTIFACT_SCAN` transcripts, sorts them, and cuts to `limit`. For meetings with no more
+transcripts than that cap (every meeting except a series recorded daily for most of a year), the
+first entry is the latest. A walk that stopped at `limit` before sorting would return wrong answer
+with right shape.
 
-Graph documents `$select`, `$filter` and `$top` on this collection and no `$orderby` at all, so it
-answers in an order of its own. The window is therefore taken whole — to the scan cap — ordered, and
-only then cut to `limit`. A walk that stopped at `limit` before sorting would return an arbitrary
-`limit` transcripts sorted among themselves and call them the newest, which is a wrong answer with
-the shape of a right one. `newest_in_window` is where that happens, for whatever lists a meeting's
-artifacts.
-
-`include_scan_completeness` is opt-in because it is the only thing here a caller cannot work out for
-itself. "The window held more transcripts than your `limit`" it can: a full window may have more
-behind it and a short one is all there was, which is what a page size means everywhere. "The read
-stopped at the cap" it cannot, and merging the two into one flag would give one name to two facts
-with opposite remedies — raise `limit` for the first, nothing at all for the second. Where nothing
-came back at all it is not opt-in: `status` is `scan_incomplete`, because an absence asserted over a
-collection nobody read to the end is the wrong answer all of this exists to avoid.
+`include_scan_completeness` is opt-in because it tells one thing a caller cannot infer: whether the
+read reached the end of the meeting's transcripts. A full `limit` means the window may hold older
+ones. Fewer than `limit` means these are the whole window. But "the read stopped at the cap" must be
+explicit.
 """
 
 from datetime import date, datetime
@@ -104,84 +71,56 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_meeting_transcripts"
 
-# Reading a transcript resource is an admin-consented permission, and a different one from the
-# resolve that precedes it: a tenant can grant one and withhold the other. Both names come from
-# `shared/meetings.py` rather than being typed here — a permission is the resource's, and rule 4
-# forbids the next module that reaches the same resource from importing this file to find out how
-# it is spelled.
-#
-# What listing a meeting's transcripts costs: the resolve and the list, in that order, under one
-# token — Entra redeems them together or not at all. The handle minted below already carries the
-# resolved meeting id, so reading a transcript's content later needs only the second of the two,
-# and a tenant that withholds `OnlineMeetings.Read` does not put transcript content out of reach.
+# Both permissions come from `shared/meetings.py` rather than being typed here. The resolve and
+# list are redeemed together under one token, or not at all.
 GRAPH_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
 
-# Built once at import: a call inside a parameter default rebuilds the descriptor on every
-# registration and is a lint error in both of this repo's checkers.
+# Built at import: a call inside a parameter default rebuilds it on every registration.
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
-# How many transcripts one listing returns. A one-off meeting has one; a recurring series
-# accumulates one per occurrence in the same collection, which is what makes a window necessary at
-# all. Graph documents `$top` here but publishes no ceiling, so this is ours.
+# Maximum transcripts to return. Graph documents `$top` but publishes no ceiling, so this is ours.
 MAX_TRANSCRIPTS = 50
 
 _DESCRIPTION = f"""\
-Find out whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
+Find whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
 `meeting_uri` that list_chats reports on a meeting chat.
 
-This says what exists and returns none of the words that were said. A recurring meeting is a \
-single meeting to Microsoft — every occurrence's transcript lands in the same collection, \
-distinguished only by when transcription started — so scope to one occurrence with \
-`started_after`/`started_before` when `meeting_type` comes back `recurring`; a one-off meeting has \
-a single transcript and needs neither. Both bounds take a date (`2026-08-11`, meaning that whole \
-UTC day) or a timestamp, with or without a timezone offset — one without is read as UTC, so pass \
-the offset when you are working from a local time.
+Reports what exists, none of what was said. A recurring meeting is one meeting to Microsoft — \
+every occurrence's transcript lands in the same collection. Use \
+`started_after`/`started_before` to reach one occurrence when `meeting_type` is `recurring`.
 
-**Read `status` before anything else. It has five values and they mean five different actions:**
+**Read `status` first. It has five values, each meaning a different action:**
 - `available` — transcripts are listed, newest first. "Newest" is over the transcripts this call \
-read, which is every transcript the meeting has unless the meeting holds more of them than the cap \
-below — set `include_scan_completeness` if the answer turns on that.
-- `not_ready` — nothing has landed for the window you asked about and something still might: that \
-window has only just closed, or you asked for no window and the meeting has not ended or ended \
-recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
-is wrong: Microsoft publishes no availability SLA, so this tool infers it from how recently the \
-window (or the meeting) ended and errs towards telling you to wait. An occurrence window that is \
-already well past never answers this — a series whose end date is in the future does not make a \
-last-month occurrence "still processing".
-- `not_transcribed` — the window you asked about is over and nothing is there: it was not recorded \
-or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
-meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
-transcripts once the meeting expires, roughly 60 days after a one-off.)
+read, up to {MAX_ARTIFACT_SCAN} — set `include_scan_completeness` if the answer turns on that.
+- `not_ready` — nothing is there for the window you asked about and something still might. Wait \
+and call again later. This is NOT "there is no transcript". A window that is already well past \
+never answers this — a series whose end date is in the future does not make a last-month \
+occurrence "still processing".
+- `not_transcribed` — the window is over, nothing is there. It was not recorded or not \
+transcribed. Retrying will not help.
 - `scan_incomplete` — this meeting has more transcripts than one call reads \
-({MAX_ARTIFACT_SCAN}) and none of the ones read are in your window, so whether one \
-exists there is not known. This is the one answer that claims nothing, and the one with nothing to \
-try: the window is applied to the transcripts after Microsoft has answered them, so a narrower \
-`started_after`/`started_before` reads the same transcripts and returns this same answer, however \
-many times you ask. Stop here. Report that this meeting has too many transcripts to read through \
-and that whether the occurrence you meant was transcribed could not be determined — that \
-uncertainty is the answer. Never report it as "there is no transcript".
-- `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
-see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
+({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether one \
+exists there is not known. The window is applied after Microsoft has answered, not in the request, \
+so a narrower `started_after`/`started_before` reads the same transcripts and returns this same \
+answer. Stop here. There is nothing to try. Never report it as "there is no transcript".
+- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can see. Do not \
+retry and do not rebuild the handle.
 
-This tool answers about transcripts only. Whether the meeting was RECORDED is a separate question \
-that Microsoft gates independently — the tenant setting below blocks transcripts and leaves \
-recordings alone — and nothing on this server answers it, so a refusal here is not evidence about \
-the meeting's recording either way. No video is returned or reachable anywhere in this connector; \
-a transcript is the better artifact for a question about a meeting anyway, being text with who \
-said what and when.
+This tool answers about transcripts only. Whether the meeting was recorded is a separate question \
+that Microsoft gates independently via a different permission (`OnlineMeetingRecording.Read.All`), \
+so a refusal on transcripts says nothing about whether a recording exists or is accessible. \
+No video is returned; a transcript is better for questions about a meeting.
 
-Two things can refuse this call outright, and both are somebody's decision rather than a bug. \
-Reading transcripts over Microsoft Graph is an organisation-wide Teams setting that is OFF by \
-default and that no application can switch on; when it is off, the error says so and names the \
-administrator who can change it. Separately, Microsoft documents transcript access under \
-{TRANSCRIPT_PERMISSION} without stating that meeting participants get it, so a \
-participant may be refused where the meeting's organiser would succeed.\
+Reading transcripts over Microsoft Graph is an organisation-wide Teams setting, OFF by default. \
+When off, the error names the administrator who can turn it on. Separately, Microsoft documents \
+transcript access under {TRANSCRIPT_PERMISSION} without stating participants get it, so a \
+participant may be refused where the organiser would succeed. The two meeting permissions \
+(`OnlineMeetings.Read` and `OnlineMeetingTranscript.Read.All`) are independent scopes granted \
+separately: a tenant can grant one and withhold the other.\
 """
 
-# What this tool says when its `meeting_uri` is not a meeting handle. Its own text rather than one
-# shared with whatever asks about a meeting next: the failure it has to prevent is a caller being
-# sent to the wrong tool, and a tool file that borrowed another's refusal would be re-creating a
-# tool-declaration module one import at a time (`tests/test_layering.py` rule 4).
+# Error message for invalid meeting_uri. Unique to this tool to prevent a caller being sent to
+# the wrong tool.
 _NOT_A_MEETING_HANDLE = (
     "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
     + "and this is not one. A meeting handle has exactly one shape:\n"
@@ -199,29 +138,26 @@ _NOT_A_MEETING_HANDLE = (
 class TranscriptSummary(BaseModel):
     uri: str = Field(
         description=(
-            "This connector's handle for the transcript: what identifies it across calls, and "
-            + "what to quote verbatim when referring to it. Nothing here contains any of the "
-            + "words that were said."
+            "This connector's handle for the transcript: what identifies it across calls. "
+            + "Nothing here contains the words that were said."
         )
     )
     transcript_id: str = Field(
-        description="The transcript's Graph id. Identify a transcript by `uri`, not by this alone."
+        description="The transcript's Graph id. Use `uri` to identify a transcript, not this alone."
     )
     started_at: datetime | None = Field(
         description=(
-            "When transcription began (Microsoft's `createdDateTime`). For a recurring meeting "
-            + "this is what tells one occurrence from another: every occurrence's transcript lands "
-            + "in the same collection, and Microsoft gives no occurrence id."
+            "When transcription began. For a recurring meeting this tells one occurrence from "
+            + "another: all occurrences share one collection, and Microsoft gives no occurrence id."
         )
     )
-    ended_at: datetime | None = Field(
-        description="When transcription ended (Microsoft's `endDateTime`)."
-    )
+    ended_at: datetime | None = Field(description="When transcription ended.")
     content_correlation_id: str | None = Field(
         description=(
             "Microsoft's identifier linking this transcript to the recording of the same call. "
-            + "Nothing here fetches recordings; it is returned because it is the exact link, and "
-            + "two transcripts sharing it are two views of one call rather than of two."
+            + "Two transcripts sharing this value are two views of one call, not two separate "
+            + "calls. Presence of this id does not guarantee a recording exists; use this only to "
+            + "correlate transcript and recording if you already have both."
         )
     )
 
@@ -229,94 +165,74 @@ class TranscriptSummary(BaseModel):
 class MeetingTranscripts(BaseModel):
     status: str = Field(
         description=(
-            "What was found, and therefore what to do next. Exactly one of:\n"
+            "What was found, and what to do next. One of:\n"
             + "- `available` — `transcripts` lists them, newest first.\n"
-            + "- `not_ready` — nothing is there for the window you asked about and something may "
-            + "still arrive: that window has only just closed, or you asked for no window and the "
-            + "meeting itself has not ended or ended recently. Microsoft publishes no availability "
-            + "SLA and no 'processing' status, so this is inferred: it means wait and ask again "
-            + "later, and it is NOT evidence that no transcript will ever exist. A window that has "
-            + "demonstrably passed is never reported this way, however far in the future a "
-            + "recurring series runs.\n"
-            + "- `not_transcribed` — the window is over, nothing is there, and nothing is "
-            + "expected: it was not recorded or transcribed. Retrying will not change this. One "
-            + "other cause looks identical and cannot be distinguished: Microsoft's "
-            + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
-            + "one-off), so a transcript that once existed can read as never having existed.\n"
+            + "- `not_ready` — nothing is there yet and something may still arrive. Microsoft "
+            + "publishes no availability SLA, so this is inferred. A window that has demonstrably "
+            + "passed is never reported this way, however far in the future a recurring series "
+            + "runs.\n"
+            + "- `not_transcribed` — the window is over, nothing is there, nothing is expected. "
+            + "Retrying will not change this.\n"
             + "- `scan_incomplete` — this meeting has more transcripts than one call reads "
             + f"({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether "
-            + "one exists there is NOT known and is not being claimed either way. There is nothing "
-            + "to try: the window is applied to the transcripts after Microsoft has answered, not "
-            + "by Microsoft while answering, so changing `started_after`/`started_before` — "
-            + "narrower, wider, anything — reads the same transcripts and returns this same "
-            + "status. Stop, and report that whether a transcript exists for that occurrence could "
-            + "not be determined. Never report this as 'there is no transcript', and do not ask "
-            + "again.\n"
+            + "one exists there is NOT known. There is nothing to try: changing "
+            + "`started_after`/`started_before` reads the same transcripts and returns this same "
+            + "status. Stop and report that the collection is too large to scan completely and "
+            + "whether a transcript exists in that window cannot be determined. This status is "
+            + "final and cannot be retried or worked around by narrowing the window. Never report "
+            + "this as 'there is no transcript'.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
-            + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
-            + "calendar, or one this user was never invited to, answers the same way. Do not retry "
-            + "and do not rebuild the handle."
+            + "see. Do not retry and do not rebuild the handle."
         )
     )
     meeting_id: str | None = Field(
         description=(
             "The resolved meeting's Graph id, or null when `status` is `meeting_not_found`. "
-            + "Opaque, and no tool here takes it — a transcript's `uri` already carries it."
+            + "A transcript's `uri` carries this already. This id is opaque; "
+            + "no MCP tool here builds or interprets it."
         )
     )
     subject: str | None = Field(
         description=(
-            "The meeting's subject as Microsoft holds it, which is how to confirm this is the "
-            + "meeting that was meant. It may differ from the chat's topic."
+            "The meeting's subject as Microsoft holds it. Confirm this is the meeting you meant."
         )
     )
     meeting_type: str | None = Field(
         description=(
-            "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null when Microsoft did "
-            + "not say. `recurring` is the one to act on: a whole series is ONE meeting to "
-            + "Microsoft, so every occurrence's transcript is in this one collection and "
-            + "`started_after`/`started_before` are how to reach a single occurrence."
+            "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null. When `recurring`, "
+            + "every occurrence's transcript is in one collection. Use "
+            + "`started_after`/`started_before` to reach a single occurrence."
         )
     )
     started_at: datetime | None = Field(
         description=(
-            "When the meeting starts. For a recurring series this is Microsoft's single value for "
-            + "the whole series, not the occurrence you asked about."
+            "When the meeting starts. For a recurring series this is Microsoft's value for the "
+            + "whole series, not the occurrence you asked about."
         )
     )
     ended_at: datetime | None = Field(
-        description="When the meeting ends, on the same caveat as `started_at`."
+        description="When the meeting ends (same caveat as `started_at`)."
     )
     transcripts: list[TranscriptSummary] = Field(
         description=(
-            "The transcripts of this meeting that fall inside the requested window, newest first. "
-            + "The order is over every transcript this call read rather than over one page of "
-            + f"Microsoft's answer, and one call reads up to {MAX_ARTIFACT_SCAN} of them. For a "
-            + "meeting with no more transcripts than that — every meeting bar a series recorded "
-            + "daily for most of a year — those are all of them, so the first entry is the latest "
-            + "transcript of the window outright, which for a recurring series is how to reach the "
-            + "most recent occurrence. Past that cap the first entry is the latest of what was "
-            + "READ: Microsoft returns this collection in an order of its own and offers no way to "
-            + "ask for the newest, so a newer transcript can sit among the ones never read; set "
-            + "`include_scan_completeness` when the answer turns on that. As many entries as "
-            + "`limit` means the window may hold older ones too — raise `limit`, up to "
-            + f"{MAX_TRANSCRIPTS} — and fewer than `limit` means these are the whole window. There "
-            + "is no cursor. Empty for every status other than `available`."
+            "Transcripts in the requested window, newest first. Ordered over every transcript "
+            + f"read (up to {MAX_ARTIFACT_SCAN}), not over one page of Microsoft's answer. For "
+            + f"meetings with no more transcripts than {MAX_ARTIFACT_SCAN}, these are all of "
+            + "them. A full `limit` means the window may hold older ones — raise `limit` up to "
+            + f"{MAX_TRANSCRIPTS}. Fewer than `limit` means these are the whole window. Empty "
+            + "for every status other than `available`. No cursor available."
         )
     )
     scan_incomplete: bool | None = Field(
         description=(
-            "Whether the read stopped at the cap on how many of this meeting's transcripts one "
-            + f"call looks through ({MAX_ARTIFACT_SCAN}), or null when "
-            + "`include_scan_completeness` was not set — which is the default, because it only "
-            + "matters for a meeting with more transcripts than that.\n"
-            + "True means `transcripts` is ordered over the ones READ and not over the meeting, so "
-            + "the first entry may not be the meeting's latest and nothing here reads further: no "
-            + "argument to this tool changes it, the window being applied after the read. False "
-            + "means the whole collection was read, so the order and any absence within it are "
-            + "exact. This says nothing about `limit` — that the window held more than you asked "
-            + "for is what a full `transcripts` list means. You never need this to tell whether an "
-            + "empty answer is trustworthy: `status` is `scan_incomplete` in exactly that case."
+            f"Whether the read stopped at {MAX_ARTIFACT_SCAN} transcripts (true), or read the "
+            + "whole collection (false), or null when `include_scan_completeness` was not set. "
+            + "Only set when `include_scan_completeness` is true. When true, `transcripts` is "
+            + "ordered over the ones read, not the whole meeting. When false, the order and any "
+            + "absence within the window are exact. Note: `status` reports `scan_incomplete` "
+            + "when nothing was found and the read "
+            + "stopped short, regardless of this field's value — this field only matters when "
+            + "`status` is `available` and shows whether the result set is complete."
         )
     )
 
@@ -330,25 +246,15 @@ async def list_meeting_transcripts(
     limit: int,
     include_scan_completeness: bool,
 ) -> MeetingTranscripts:
-    """The transcripts of the meeting `handle` addresses, and what a caller should do about them.
+    """Transcripts of the meeting `handle` addresses, and what a caller should do about them.
 
-    Two Graph requests at most: resolve the join URL, then list. The listing goes out bare, and the
-    window is applied while paging it rather than as a `$filter`: Graph advertises `$select`,
-    `$filter` and `$top` here and no `$orderby`, and the only filterable property either artifact's
-    reference shows is `contentCorrelationId`
-    (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example 11) — never a date. So
-    a server-side date bound is unverified, and a wrong one returns `200 OK` with nothing rather
-    than failing. That is also why the window is no help to a caller whose scan stopped short: it
-    is ours, applied to what came back, so it cannot make Graph send different artifacts.
+    Makes at most two Graph requests: resolve the join URL, then list transcripts. Lists all
+    transcripts without filtering (Graph documents no date filter on transcripts), then applies the
+    window while paging. The window bounds are instants (naive ones read as UTC). The same window
+    decides which transcripts are kept and what an empty answer means.
 
-    The bounds are whatever the caller passed — `OccurrenceWindow.of` is what makes them instants —
-    and the same window then decides both which transcripts are kept and what an empty answer means.
-
-    `include_scan_completeness` decides only whether `scan_incomplete` is reported, never what is
-    read: it is the same two requests either way. Off by default because it answers a question
-    about one rare meeting shape, and a field that is null for all but that shape is a field a
-    model does not have to reason about — while `status` still reports a scan that stopped short
-    whenever it is the difference between "there is none" and "nobody looked".
+    `include_scan_completeness` only changes whether `scan_incomplete` is reported, not what is
+    read.
     """
     assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
     window = OccurrenceWindow.of(started_after, started_before)
@@ -390,25 +296,12 @@ async def list_meeting_transcripts(
 
 
 def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
-    """Which empty answer to give: the one that means stop, the one that means wait, or neither.
+    """Which empty answer to give.
 
-    A scan that stopped short is checked first, and it is what makes the other two safe to say: the
-    walk having been cut means the artifacts it did not reach might hold the one asked for, so
-    nothing about absence is known — and "not transcribed / retrying will not help" is exactly the
-    assertion that must not be made. Reported instead as `scan_incomplete`, so that "there is more"
-    and "there is none" can never both be said of one answer. This is the one place the scan's
-    completeness reaches a caller whether or not it was asked for: an empty answer is only worth
-    anything with it, whereas the same fact about a non-empty answer is the rare caveat behind
-    `include_scan_completeness`.
-
-    It is also the one verdict here that offers a caller nothing to do, and its description says so
-    in as many words: the window is applied after the artifacts are read, so no window sends the
-    next call further into the collection. The advice is to stop and report the uncertainty, which
-    is the only advice that is true — see the module docstring's fourth failure.
-
-    Otherwise the evidence is `OccurrenceWindow.settled` and the word is this tool's, because a
-    meeting that was recorded but never transcribed is `not_transcribed` here: the verdict is about
-    one artifact of the meeting, never about the meeting.
+    If the scan hit the cap, artifacts past it might hold the one asked for. Nothing about absence
+    is known, so return `scan_incomplete` — never `not_transcribed`. If settled, the window is
+    old enough that any transcript falling in it would have appeared; return `not_transcribed`.
+    Otherwise return `not_ready` — the window is still fresh.
     """
     if scan_stopped_short:
         return "scan_incomplete"
@@ -427,11 +320,7 @@ def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport.
-
-    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
-    borrows it per call and never owns it. `create_app` closes it on shutdown.
-    """
+    """Declare this tool against the shared Graph transport."""
 
     @mcp.tool(
         name=TOOL_NAME,
@@ -445,11 +334,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The meeting whose transcripts to list, exactly as list_chats reported "
-                    + "`meeting_uri` on a meeting chat: "
-                    + "`teams:///meetings/{join_web_url}`. Copy it verbatim — it carries the "
-                    + "meeting's join URL, which Microsoft matches character for character, and "
-                    + "nothing else identifies a meeting to this connector."
+                    "The meeting to list, exactly as list_chats reported `meeting_uri`: "
+                    + "`teams:///meetings/{join_web_url}`. Copy it verbatim. Microsoft matches "
+                    + "the join URL character for character, and nothing else identifies a meeting."
                 ),
             ),
         ],
@@ -457,17 +344,12 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             date | datetime | None,
             Field(
                 description=(
-                    "Only transcripts whose transcription began at or after this moment. This is "
-                    + "how to reach one occurrence of a recurring meeting, whose occurrences all "
-                    + "share a single meeting and therefore a single transcript collection. Three "
-                    + "shapes are accepted and none of them fails: `2026-08-11T09:00:00+02:00` (or "
-                    + "`...Z`) means the instant it names; `2026-08-11T09:00:00`, which names no "
-                    + "offset, IS READ AS UTC; and a bare `2026-08-11` means that whole UTC day, "
-                    + "starting at its first instant here. Pass the offset whenever what you know "
-                    + "is a local time — 09:00 in Zurich is 07:00Z, and a window built in the "
-                    + "wrong zone answers about the wrong hours without saying so. A window with "
-                    + "no transcript inside it is an answer and not an error: `not_transcribed` "
-                    + "once the window is past, `not_ready` while it is recent."
+                    "Reach one occurrence of a recurring meeting by filtering transcripts. Three "
+                    + "shapes accepted: `2026-08-11T09:00:00+02:00` is that instant; "
+                    + "`2026-08-11T09:00:00` with no offset IS READ AS UTC; `2026-08-11` is that "
+                    + "whole UTC day, starting at its first instant. Pass the offset when you "
+                    + "know a local time — 09:00 in Zurich is 07:00Z. A window in the wrong zone "
+                    + "answers about the wrong hours."
                 )
             ),
         ] = None,
@@ -475,13 +357,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             date | datetime | None,
             Field(
                 description=(
-                    "Only transcripts whose transcription began at or before this moment. Pair it "
-                    + "with `started_after` to bracket one occurrence; the same three shapes are "
-                    + "accepted on the same UTC assumption, except that a bare `2026-08-11` here "
-                    + "means the END of that UTC day — so the same date in both bounds is that one "
-                    + "whole day. This bound is also what decides an empty answer: a window whose "
-                    + "end is already well past reports `not_transcribed` rather than sending you "
-                    + "back to wait, even for a recurring series with occurrences still to come."
+                    "Upper bound for transcription start time. Pair with `started_after` to reach "
+                    + "one occurrence. A bare `2026-08-11` means the END of that UTC day — so the "
+                    + "same date in both bounds is that whole day."
                 )
             ),
         ] = None,
@@ -491,20 +369,10 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=MAX_TRANSCRIPTS,
                 description=(
-                    "How many transcripts to return. Default 20, maximum "
-                    + f"{MAX_TRANSCRIPTS}. They are the NEWEST that many of the "
-                    + "window, not the first that many Microsoft happens to answer with: the "
-                    + f"meeting's transcripts are read (up to {MAX_ARTIFACT_SCAN} of "
-                    + "them, which is this call's whole cost) and ordered before this cuts them, "
-                    + "so asking for 3 gives the 3 newest OF THE ONES READ. Those are the 3 latest "
-                    + "outright whenever the meeting has no more transcripts than that cap, which "
-                    + "is every meeting except a series recorded daily for most of a year: one "
-                    + "meeting has one transcript per occurrence that was transcribed. Past the "
-                    + "cap the read stops mid-collection, in whatever order Microsoft answered in "
-                    + "(it offers no way to ask for the newest), so a newer transcript can be one "
-                    + "that was never read — `include_scan_completeness` is how to find out, and "
-                    + "raising `limit` does not read further. Getting `limit` transcripts back "
-                    + "means the window may hold older ones; getting fewer means it does not."
+                    f"Maximum to return (default 20, maximum {MAX_TRANSCRIPTS}). Results are the "
+                    + f"newest of the window. Transcripts are read (up to {MAX_ARTIFACT_SCAN}, "
+                    + "this call's cost) and sorted before cutting to limit. A full list means "
+                    + "older transcripts may exist; fewer than limit means none exist beyond."
                 ),
             ),
         ] = 20,
@@ -512,14 +380,11 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             bool,
             Field(
                 description=(
-                    "Report whether the read reached the end of this meeting's transcripts, as "
-                    + "`scan_incomplete` in the answer. Off by default, and worth setting for one "
-                    + "question: whether the first transcript listed is the meeting's own latest. "
-                    + "It is, for every meeting with no more transcripts than one call reads "
-                    + f"({MAX_ARTIFACT_SCAN}) — which is every meeting bar a series "
-                    + "recorded daily for most of a year — and past that the order is over the "
-                    + "ones read. You do not need it to trust an empty answer: `status` already "
-                    + "reports `scan_incomplete` when nothing was found and the read stopped short."
+                    "Report `scan_incomplete` in the answer: whether the read reached the end of "
+                    + f"this meeting's transcripts (may be limited to {MAX_ARTIFACT_SCAN} total). "
+                    + "Off by default. You do not need it to trust an empty answer: `status` "
+                    + "already reports `scan_incomplete` when nothing was found and the read "
+                    + "stopped short."
                 )
             ),
         ] = False,

--- a/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
+++ b/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
@@ -1,13 +1,16 @@
 """`list_meeting_transcripts` — whether a Teams meeting was transcribed, and a handle for each.
 
-Reports what exists and none of what was said. A recurring series is one meeting to Graph, so
-every occurrence's transcript lands in one collection. Distinguish occurrences with
-`started_after`/`started_before`.
+Reports what exists and none of what was said. A transcript is large, so this tool answers as a
+separate step, not as a field on the meeting. A recurring series is one meeting to Graph, so every
+occurrence's transcript lands in one collection. No default occurrence exists. Distinguish
+occurrences with `started_after`/`started_before`.
 
 Shared code in `shared/meetings.py` and `shared/handles.py` documents how meetings are reached,
-how the join URL encodes, what an occurrence window is, and how "newest first" is bounded. This
-file owns the answer's vocabulary: "was not transcribed" is a fact about one artifact, never about
-the meeting.
+how the join URL encodes, what an occurrence window is, and how "newest first" is bounded. These
+are facts about the meeting, not about transcripts, so they live outside this file. Handle grammar
+lives there too, for the same reason. A second spelling of a handle would work in the tool that
+mints it and fail in the tool that reads it. This file owns the answer's vocabulary: "was not
+transcribed" is a fact about one artifact, never about the meeting.
 
 ## Five answers that need different action
 
@@ -71,8 +74,14 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_meeting_transcripts"
 
-# Both permissions come from `shared/meetings.py` rather than being typed here. The resolve and
-# list are redeemed together under one token, or not at all.
+# Both permissions come from `shared/meetings.py`, not typed here. A permission belongs to its
+# resource. No sibling module may import this file to learn its spelling (see
+# tests/test_layering.py, rule 4).
+#
+# The resolve and list are redeemed together, under one token, or not at all. The transcript
+# handle minted below already carries the resolved meeting id. A future tool that reads
+# transcript content needs only TRANSCRIPT_PERMISSION. Withholding OnlineMeetings.Read would not
+# block that.
 GRAPH_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
 
 # Built at import: a call inside a parameter default rebuilds it on every registration.
@@ -120,7 +129,8 @@ separately: a tenant can grant one and withhold the other.\
 """
 
 # Error message for invalid meeting_uri. Unique to this tool to prevent a caller being sent to
-# the wrong tool.
+# the wrong tool. A shared message would rebuild a shared tools module one import at a time (see
+# tests/test_layering.py, rule 4).
 _NOT_A_MEETING_HANDLE = (
     "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
     + "and this is not one. A meeting handle has exactly one shape:\n"
@@ -249,12 +259,15 @@ async def list_meeting_transcripts(
     """Transcripts of the meeting `handle` addresses, and what a caller should do about them.
 
     Makes at most two Graph requests: resolve the join URL, then list transcripts. Lists all
-    transcripts without filtering (Graph documents no date filter on transcripts), then applies the
-    window while paging. The window bounds are instants (naive ones read as UTC). The same window
+    transcripts without filtering. Graph documents no date filter on this collection, and an
+    unsupported filter can still answer `200 OK` with an empty list, not an error. A caller could
+    not tell a bad filter from a true absence, so no filter is sent. The window is applied while
+    paging instead. The window bounds are instants (naive ones read as UTC). The same window
     decides which transcripts are kept and what an empty answer means.
 
     `include_scan_completeness` only changes whether `scan_incomplete` is reported, not what is
-    read.
+    read. It defaults to false. The field matters for one rare meeting shape only, and a field
+    that is null everywhere else is one a model can ignore.
     """
     assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
     window = OccurrenceWindow.of(started_after, started_before)
@@ -320,7 +333,11 @@ def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport."""
+    """Declare this tool against the shared Graph transport.
+
+    `transport` is a shared, long-lived client. This tool borrows it per call and does not own
+    it. `create_app` closes it on shutdown.
+    """
 
     @mcp.tool(
         name=TOOL_NAME,

--- a/services/office-mcp/tests/graph_client/test_errors.py
+++ b/services/office-mcp/tests/graph_client/test_errors.py
@@ -121,6 +121,47 @@ async def test_a_throttle_without_a_retry_after_says_so_rather_than_guessing(
     assert retry_sleeps.delays, "the SDK still backs off, it just picks the delay itself"
 
 
+async def test_the_inner_code_is_carried_because_it_is_the_only_thing_that_differs(
+    client: GraphServiceClient, graph: respx.MockRouter
+) -> None:
+    """Two Teams transcript refusals share a status and an outer code and have opposite remedies —
+    one is a tenant switch only a Teams administrator can flip, the other is a format to ask for
+    again — so `innerError.code` is the whole of the difference. It is not one of the SDK's typed
+    inner-error fields, so it arrives in `additional_data` and would be dropped without this.
+    """
+    graph.get("/me").mock(
+        return_value=httpx.Response(
+            403,
+            json={
+                "error": {
+                    "code": "Forbidden",
+                    "message": "Graph API access to transcripts is disabled for this tenant.",
+                    "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+                }
+            },
+        )
+    )
+
+    with pytest.raises(GraphForbidden) as raised, graph_errors():
+        _ = await client.me.get()
+
+    assert raised.value.code == "Forbidden", "the outer code says nothing actionable"
+    assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+
+
+async def test_an_error_without_an_inner_code_reports_none_rather_than_the_outer_one(
+    client: GraphServiceClient, graph: respx.MockRouter
+) -> None:
+    graph.get("/me").mock(
+        return_value=httpx.Response(403, json={"error": {"code": "accessDenied", "message": "no"}})
+    )
+
+    with pytest.raises(GraphForbidden) as raised, graph_errors():
+        _ = await client.me.get()
+
+    assert raised.value.inner_code is None
+
+
 async def test_never_reaching_graph_is_reported_as_upstream_not_as_a_bad_request(
     client: GraphServiceClient, graph: respx.MockRouter
 ) -> None:

--- a/services/office-mcp/tests/shared/conftest.py
+++ b/services/office-mcp/tests/shared/conftest.py
@@ -1,0 +1,40 @@
+"""A mocked graph.microsoft.com, and a Graph client that calls it as a synthetic user.
+
+The same three fixtures the other test directories build, built here too rather than imported
+across: what `shared/` promises is tested against `shared/` alone, and a test package that imported
+another test package's fixtures would make the directories as tangled as the modules used to be.
+Every payload in this directory is invented — the ids are obviously fake, the domains are
+`.invalid`, and the names are from the public domain.
+"""
+
+from collections.abc import AsyncGenerator, Iterator
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphSettings, create_graph_transport, graph_client_for
+
+GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# What FastMCP's On-Behalf-Of exchange would have returned. Only its identity matters here.
+CALLER_TOKEN = "synthetic-graph-access-token"
+
+
+@pytest.fixture
+def graph() -> Iterator[respx.MockRouter]:
+    with respx.mock(base_url=GRAPH_V1, assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+async def transport() -> AsyncGenerator[httpx.AsyncClient]:
+    client = create_graph_transport(GraphSettings())
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def client(transport: httpx.AsyncClient) -> GraphServiceClient:
+    return graph_client_for(transport, CALLER_TOKEN)

--- a/services/office-mcp/tests/shared/test_handles.py
+++ b/services/office-mcp/tests/shared/test_handles.py
@@ -1,8 +1,9 @@
 """The `teams:///` grammar: what round-trips, and what is not a handle of a given family.
 
 The families are separate because the tools and the permissions behind them are, so the assertions
-that matter most here are the negative ones — a message handle must not parse as a meeting's, and a
-meeting's must not parse as a message's. Every id below is invented.
+that matter most here are the negative ones — a message handle must not parse as a meeting's, a
+meeting's must not parse as a message's, and a meeting's must not parse as a transcript's. Every id
+below is invented.
 """
 
 import pytest
@@ -17,6 +18,10 @@ JOIN_WEB_URL = (
     + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
     + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
 )
+
+MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
 
 _CHAT_ID = "19:release@thread.v2"
 _MESSAGE_ID = "1770000000000"
@@ -140,12 +145,24 @@ class TestTheHandleGrammar:
             "the join URL is one path segment; an unencoded slash would make it several"
         )
 
+    def test_a_transcript_handle_round_trips_both_ids(self) -> None:
+        handle = handles.TranscriptHandle("MSo1N2Y5:ZGFjYw==", "MSMjMCMj/0001")
+
+        parsed = handles.transcript_handle(handle.uri)
+
+        assert parsed is not None
+        assert (parsed.meeting_id, parsed.transcript_id) == (
+            "MSo1N2Y5:ZGFjYw==",
+            "MSMjMCMj/0001",
+        )
+
     @pytest.mark.parametrize(
         "uri",
         [
             # Another family's shape, which is the negative that matters: the first segment is what
             # tells the families apart, and a parser that ignored it would answer for all of them.
             "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000",
+            f"teams:///transcripts/{MEETING_ID}/{_TRANSCRIPT_ID}",
             "teams:///meetings/",
             "teams:///meetings/%20",
             "teams:///meetings/a/b",
@@ -163,6 +180,22 @@ class TestTheHandleGrammar:
     )
     def test_what_is_not_a_meeting_handle(self, uri: str) -> None:
         assert handles.meeting_handle(uri) is None
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # The family a transcript is reached *from*, which is the negative that matters most
+            # here: one of these two is what a lister takes and the other is what it mints.
+            handles.MeetingHandle(JOIN_WEB_URL).uri,
+            "teams:///transcripts/only-one-id",
+            "teams:///transcripts//a",
+            "teams:///transcripts/a/%20",
+            "teams:///transcripts/a/b/c",
+            "",
+        ],
+    )
+    def test_what_is_not_a_transcript_handle(self, uri: str) -> None:
+        assert handles.transcript_handle(uri) is None
 
     @pytest.mark.parametrize("join_web_url", [None, "", "   "])
     def test_no_join_url_means_no_handle_rather_than_an_empty_one(

--- a/services/office-mcp/tests/shared/test_meetings.py
+++ b/services/office-mcp/tests/shared/test_meetings.py
@@ -1,0 +1,149 @@
+"""The meeting vocabulary: the `$filter` that reaches a meeting, and the window that scopes it.
+
+Everything tested here is a promise about a meeting rather than about one artifact of it, which is
+why it is tested where it lives rather than through the tool that calls it: a caller cannot see two
+tools disagreeing about "the latest occurrence", it can only see one of them being wrong, so the
+assertions have to hold for whoever asks next.
+
+Every payload is synthesised: the ids are obviously fake and the domains are `.invalid`.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.shared import handles, meetings
+
+_MEETINGS = "/me/onlineMeetings"
+
+# A join URL shaped like the ones Graph actually stores, and the reason the escaping is a bug class:
+# it carries `%3a` and `%40` that are already percent-escaped, a `?context=` query with `%7b`/`%22`
+# in its value, and an `&` parameter after it. Every one of those breaks a `$filter` that is encoded
+# too little, too much, or not at all — and breaks it into `200 OK` with an empty result.
+JOIN_WEB_URL = (
+    "https://teams.microsoft.invalid/l/meetup-join/"
+    + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
+    + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
+)
+
+
+def _handle() -> handles.MeetingHandle:
+    handle = handles.meeting_handle(handles.meeting_uri_for(JOIN_WEB_URL) or "")
+    assert handle is not None
+    return handle
+
+
+class TestTheFilterOnTheWire:
+    """The bug class this piece exists not to repeat: `teams-mcp` sends a raw join URL and gets
+    `200 OK` with an empty `value` — a silent "meeting not found" — for any URL carrying `&` or `#`.
+    """
+
+    async def test_the_join_url_is_percent_encoded_exactly_once(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await meetings.resolve_meeting(client, _handle())
+
+        url = route.calls.last.request.url
+        # One decode of the wire form must give back exactly the URL Graph stored, inside an OData
+        # literal — that is what "encoded once" means, and it is what Graph compares against.
+        assert url.params["$filter"] == f"JoinWebUrl eq '{JOIN_WEB_URL}'"
+        raw = url.query.decode()
+        assert "%253ameeting" in raw, "an already-escaped `:` has its own `%` escaped"
+        assert "%2540thread" in raw, "and so does an already-escaped `@`"
+        assert "%26anon%3Dtrue" in raw, "an `&` left raw would split the query and truncate it"
+        assert "%2525" not in raw, (
+            "encoding it twice compares `%25` against `%` and matches nothing"
+        )
+        assert raw.count("JoinWebUrl") == 1
+
+    @pytest.mark.parametrize(
+        "join_web_url",
+        [
+            "https://teams.microsoft.invalid/l/meetup-join/19%3ameeting_x%40thread.v2/0#frag",
+            "https://teams.microsoft.invalid/meet/1234567890?p=Ab1%2FCd",
+            "https://teams.microsoft.invalid/l/meetup-join/19:meeting_y@thread.v2/0",
+        ],
+    )
+    async def test_every_shape_of_join_url_reaches_graph_intact(
+        self, client: GraphServiceClient, graph: respx.MockRouter, join_web_url: str
+    ) -> None:
+        """`#` is the worst of these: URL parsers treat it as a fragment and drop everything after
+        it before the request is sent, so a filter built without encoding arrives truncated."""
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await meetings.resolve_meeting(client, handles.MeetingHandle(join_web_url))
+
+        assert route.calls.last.request.url.params["$filter"] == f"JoinWebUrl eq '{join_web_url}'"
+
+    async def test_a_quote_in_the_join_url_is_doubled_and_cannot_close_the_literal(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """OData escapes a quote inside a string literal by doubling it. Percent-encoding it instead
+        would have Graph decode it back to a quote that ends the literal — a 400 at best, and an
+        injected predicate at worst."""
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await meetings.resolve_meeting(
+            client, handles.MeetingHandle("https://x.invalid/a'/b' or JoinWebUrl ne 'z")
+        )
+
+        assert (
+            route.calls.last.request.url.params["$filter"]
+            == "JoinWebUrl eq 'https://x.invalid/a''/b'' or JoinWebUrl ne ''z'"
+        )
+
+    async def test_no_match_is_an_answer_and_not_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents this filter as answering `200 OK` with an empty `value` when nothing
+        matches — it never 404s — so the one thing a resolve may not do is raise on it."""
+        graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        assert await meetings.resolve_meeting(client, _handle()) is None
+
+
+class TestTheWindowShapesAModelActuallySends:
+    """A window is the only reason `started_after`/`started_before` exist, and a model writes a date
+    the way people write dates. `2026-02-10` and `2026-02-10T14:00:00` both used to reach a
+    comparison between a naive datetime and Graph's aware one and raise `TypeError` at the caller —
+    a crash naming no remedy, for a value the schema had accepted. Resolving happens once, here, so
+    that nothing downstream can meet a naive datetime.
+    """
+
+    def test_a_bound_that_named_no_zone_is_resolved_against_utc_and_not_the_host(self) -> None:
+        """Asserted on the resolved instant rather than through a filter, because a machine whose
+        local zone happens to be UTC cannot tell the two readings apart — and the assumption is what
+        the parameter descriptions promise, so it is what has to be pinned."""
+        window = meetings.OccurrenceWindow.of(
+            datetime(2026, 2, 10, 9, 0), datetime(2026, 2, 10, 17, 0)
+        )
+
+        assert window.started_after == datetime(2026, 2, 10, 9, 0, tzinfo=UTC)
+        assert window.started_before == datetime(2026, 2, 10, 17, 0, tzinfo=UTC)
+
+    def test_a_bare_date_is_a_whole_utc_day_and_not_an_empty_span(self) -> None:
+        """The same date in both bounds is how one occurrence gets bracketed. Resolving both to
+        midnight would make that the empty span between one instant and itself — a window matching
+        nothing, reported as an answer about the day."""
+        window = meetings.OccurrenceWindow.of(date(2026, 2, 10), date(2026, 2, 10))
+
+        assert window.started_after == datetime(2026, 2, 10, tzinfo=UTC)
+        assert window.started_before is not None
+        assert datetime(2026, 2, 10, 23, 59, 59, tzinfo=UTC) < window.started_before
+        assert window.started_before < datetime(2026, 2, 11, tzinfo=UTC)
+
+    def test_the_allowance_is_generous_enough_to_be_the_safe_side(self) -> None:
+        """Microsoft publishes no availability SLA, so the only defensible bias is towards telling
+        a caller to wait. A tight window would report a still-processing transcript as one that
+        will never exist, which is the one wrong answer a caller cannot detect.
+
+        The allowance is named for artifacts rather than for transcripts because the inference is
+        the same one for any artifact a meeting accumulates — the verdict is the word the tool puts
+        on it, and only that word differs.
+        """
+        assert timedelta(hours=1) <= meetings.ARTIFACT_DELAY_ALLOWANCE

--- a/services/office-mcp/tests/shared/test_seam.py
+++ b/services/office-mcp/tests/shared/test_seam.py
@@ -64,6 +64,41 @@ class TestTheTwoRemediesGraphCannotTellApart:
         assert "administrator" in message
         assert "Retrying will not help" in message
 
+    def test_the_transcript_tenant_switch_is_neither_of_those_and_says_so(self) -> None:
+        """A third remedy behind the same status and the same outer code, and the one that is not
+        a permission at all: Graph access to Teams meeting transcripts is a tenant-wide Teams
+        setting, off by default, that no app can turn on. Naming a permission here would send an
+        administrator after one that was never missing, and telling the user to sign in again would
+        cost a re-consent that changes nothing — so the remedy names the Teams admin centre and the
+        cmdlet, and rules re-consent out in as many words.
+        """
+        message = _message(
+            GraphForbidden(
+                "nope",
+                status=403,
+                code="Forbidden",
+                request_id=None,
+                inner_code="GraphAccessToTranscriptsDisabled",
+            )
+        )
+
+        assert "Teams administrator" in message
+        assert "Set-CsTeamsMeetingConfiguration" in message
+        assert "sign in again will not change it" in message
+        assert _PERMISSION not in message, (
+            "no permission is missing, and naming one sends an administrator after nothing"
+        )
+
+    def test_an_ordinary_403_is_still_about_a_permission(self) -> None:
+        """The negative control: recognition is by inner code and never by status alone, or every
+        missing permission would be reported as a tenant setting nobody has switched off."""
+        message = _message(
+            GraphForbidden("nope", status=403, code="Forbidden", request_id=None, inner_code="Foo")
+        )
+
+        assert _PERMISSION in message
+        assert "Teams administrator" not in message
+
 
 class TestRetryAdvice:
     def test_throttling_passes_graphs_own_delay_through(self) -> None:

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -65,7 +65,7 @@ two numbered rules that held those halves apart went with them.
    `teams:///chats/…` would be free to disagree, and the disagreement would not look like a
    disagreement — it would look like a handle one tool produced and another answers 404 to. The
    owner is named once for every family rather than per family, which is strictly stronger than
-   letting each grammar live with the tool that mints it: three tools mint between them the four
+   letting each grammar live with the tool that mints it: four tools mint between them the five
    shapes below and no tool file spells one, so there is nothing for a second speller to be.
 
    *Spells or parses* is about what a literal is **used for**, not about how it is spaced. Prose is
@@ -182,7 +182,7 @@ _SEAM = _SHARED / "seam.py"
 # it. See rule 6 for why the check is on building and matching rather than on the text.
 _HANDLE_SCHEME = "teams:///"
 _HANDLE_OWNER = _SHARED / "handles.py"
-_HANDLE_FAMILIES = frozenset({"chats", "teams", "meetings"})
+_HANDLE_FAMILIES = frozenset({"chats", "teams", "meetings", "transcripts"})
 _HANDLE_FAMILY = re.compile(re.escape(_HANDLE_SCHEME) + r"([A-Za-z_]*)")
 
 # What tells a string that *matches* a handle from a string that *shows* one. Regex syntax never

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -988,7 +988,8 @@ class TestTheToolsThisServerAdvertises:
         assert description is not None
 
         assert "nothing to try" in description and "Stop here" in description
-        assert "There is nothing to try" in status and "do not ask again" in status
+        assert "There is nothing to try" in status
+        assert "This status is final and cannot be retried" in status
         assert "reads the same transcripts and returns this same answer" in description, (
             "a narrower window is named only as the thing that does NOT help"
         )

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -7,7 +7,9 @@ import json
 import logging
 import re
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
 from typing import cast
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -29,6 +31,7 @@ from starlette.applications import Starlette
 from office_mcp.app import create_app
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
 from office_mcp.graph_client import GraphSettings, create_graph_transport
+from office_mcp.shared import meetings
 from office_mcp.shared.messages import MAX_REPLIES_PER_POST
 
 GRAPH_V1 = "https://graph.microsoft.com/v1.0"
@@ -266,6 +269,136 @@ _CHATS = {
 }
 
 
+# The meeting side. The join URL is written the way Microsoft actually stores one — an already
+# percent-escaped `%3a`/`%40`, a `?context=` query, an `&` parameter — because that shape is what
+# the `$filter` has to survive. Nothing here is a real meeting.
+_JOIN_WEB_URL = (
+    "https://teams.microsoft.invalid/l/meetup-join/"
+    + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
+    + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
+)
+_MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+_MEETINGS_PATH = "/me/onlineMeetings"
+_TRANSCRIPTS_PATH = f"/me/onlineMeetings/{_MEETING_ID}/transcripts"
+
+_MEETING_CHATS = {
+    "value": [
+        {
+            "id": "19:meeting_TjAwMDAwMDAwMDAwMA@thread.v2",
+            "chatType": "meeting",
+            "topic": "Pricing review",
+            "createdDateTime": "2026-02-10T13:55:00Z",
+            "lastUpdatedDateTime": "2026-02-10T15:01:00Z",
+            "onlineMeetingInfo": {
+                "calendarEventId": "AAMkAGSYNTHETIC",
+                "joinWebUrl": _JOIN_WEB_URL,
+                "organizer": {
+                    "user": {
+                        "id": "00000000-0000-4000-8000-000000000002",
+                        "displayName": "Grace Hopper",
+                    }
+                },
+            },
+            "lastMessagePreview": {
+                "id": "1770000000001",
+                "createdDateTime": "2026-02-10T15:01:00Z",
+                "body": {"contentType": "text", "content": "synthetic preview"},
+            },
+        }
+    ]
+}
+
+_MEETING = {
+    "value": [
+        {
+            "id": _MEETING_ID,
+            "subject": "Pricing review",
+            "meetingType": "scheduled",
+            "joinWebUrl": _JOIN_WEB_URL,
+            "startDateTime": "2026-02-10T14:00:00Z",
+            "endDateTime": "2026-02-10T15:00:00Z",
+        }
+    ]
+}
+
+_TRANSCRIPTS = {
+    "value": [
+        {
+            "id": _TRANSCRIPT_ID,
+            "meetingId": _MEETING_ID,
+            "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+            "createdDateTime": "2026-02-10T14:03:11.204Z",
+            "endDateTime": "2026-02-10T14:58:02.117Z",
+            "contentCorrelationId": "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+        }
+    ]
+}
+
+# A recurring series as Microsoft holds it: one meeting, one collection, three occurrences — and
+# answered oldest-first, which is an order of Microsoft's own (it documents no `$orderby` here).
+# Written out in that order on purpose: it is what makes "the newest of a series" something the
+# lister has to work for rather than something it gets by accident.
+_SERIES_TRANSCRIPTS: dict[str, object] = {
+    "value": [
+        {
+            "id": f"week-{week}",
+            "meetingId": _MEETING_ID,
+            "createdDateTime": f"2026-02-0{2 + week}T14:00:00Z",
+            "endDateTime": f"2026-02-0{2 + week}T14:50:00Z",
+            "contentCorrelationId": f"bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e{week}",
+        }
+        for week in (1, 2, 3)
+    ]
+}
+
+# The one meeting shape that outgrows what a single call reads: a daily series, transcribed every
+# time, for the better part of a year. Oldest-first for the same reason the weekly series above is
+# — Microsoft's order is its own — which puts the genuinely newest occurrence past
+# `MAX_ARTIFACT_SCAN`, where the lister cannot see it and may not claim it has.
+_PAST_THE_CAP = meetings.MAX_ARTIFACT_SCAN + 60
+_DAILY_SERIES_START = datetime(2026, 1, 1, 14, 0, tzinfo=UTC)
+
+# The tenant switch, as Graph marks it: a 403 whose outer code says nothing and whose inner code is
+# the whole of the difference from a missing permission.
+_TENANT_SWITCH_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": "Graph API access to transcripts is disabled for this tenant.",
+        "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+    }
+}
+
+
+def _day(index: int) -> datetime:
+    """When occurrence `index` of the daily series ran."""
+    return _DAILY_SERIES_START + timedelta(days=index)
+
+
+def _daily_series() -> dict[str, object]:
+    """`_PAST_THE_CAP` transcripts in one page, as Microsoft would answer them."""
+    return {
+        "value": [
+            {
+                "id": f"day-{index}",
+                "meetingId": _MEETING_ID,
+                "createdDateTime": _day(index).isoformat().replace("+00:00", "Z"),
+                "endDateTime": (_day(index) + timedelta(minutes=50))
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "contentCorrelationId": f"bc842d7a-2f6e-4b18-a1c7-73ef91d5c8{index:03d}",
+            }
+            for index in range(_PAST_THE_CAP)
+        ]
+    }
+
+
+# The meeting handle `list_chats` mints for the chat above, written out rather than derived: that
+# the handle a model copies from one tool is the argument another takes is the contract between
+# them, and deriving it here would assert only that the test agrees with itself.
+_MEETING_URI = "teams:///meetings/" + quote(_JOIN_WEB_URL, safe="")
+
+
 class _StubOboCredential:
     """Stub for azure.identity.aio.OnBehalfOfCredential.
 
@@ -477,6 +610,7 @@ class TestTheToolsThisServerAdvertises:
             "browse_channel",
             "search_messages",
             "read_message",
+            "list_meeting_transcripts",
         }
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
@@ -542,6 +676,16 @@ class TestTheToolsThisServerAdvertises:
             "mentions",
             "attachments",
         }
+        assert set(_properties(tools["list_meeting_transcripts"].outputSchema)) == {
+            "status",
+            "meeting_id",
+            "subject",
+            "meeting_type",
+            "started_at",
+            "ended_at",
+            "transcripts",
+            "scan_incomplete",
+        }
 
     async def test_the_whole_surface_speaks_one_language(
         self, mcp_client: Client[FastMCPTransport]
@@ -561,9 +705,11 @@ class TestTheToolsThisServerAdvertises:
         Where a completeness fact is NOT derivable from the answer it survives as an opt-in field,
         which is asserted too: the flag that asks for it defaults to off, so no ordinary answer
         carries the caveat, and each tool that has one carries one field per fact rather than one
-        boolean over several. `browse_channel` is the tool that needs it — it reads a single page
+        boolean over several. `browse_channel` is one tool that needs it — it reads a single page
         and drops system messages out of it after Microsoft counted them in, so its length says
-        neither thing.
+        neither thing — and `list_meeting_transcripts` is the other, where the fact is whether the
+        read reached the end of a meeting's transcripts and therefore whether "newest" is a claim
+        about the meeting or only about what was read.
         """
         tools = _named(await mcp_client.list_tools())
 
@@ -576,7 +722,10 @@ class TestTheToolsThisServerAdvertises:
             assert "truncated" not in _properties(tool.outputSchema), name
         for name in ("search_messages",):
             assert "next_offset" in _properties(tools[name].outputSchema), name
-        for name, flag in (("browse_channel", "include_window_completeness"),):
+        for name, flag in (
+            ("browse_channel", "include_window_completeness"),
+            ("list_meeting_transcripts", "include_scan_completeness"),
+        ):
             asked_for = _object(_properties(tools[name].inputSchema)[flag])
             assert asked_for["default"] is False, f"{name} would report completeness unasked"
 
@@ -794,6 +943,130 @@ class TestTheToolsThisServerAdvertises:
             "the reply window is a dead end, not a first page"
         )
         assert "stop looking" in description
+
+    async def test_list_meeting_transcripts_names_its_five_answers_and_their_remedies(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The four absences that must stay distinct, plus "no such meeting". A model can only act
+        differently on them if the tool says what each one means, so the words are asserted: the
+        one that means wait must say wait and must say it is not the one that means stop, and the
+        one that means "this was not knowable" must not be reportable as either."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_transcripts"].description
+        status = _object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"])
+        assert description is not None
+        rendered = description + str(status.get("description"))
+
+        for value in (
+            "available",
+            "not_ready",
+            "not_transcribed",
+            "scan_incomplete",
+            "meeting_not_found",
+        ):
+            assert value in description, value
+        assert "Wait and call again later" in description
+        assert 'NOT "there is no transcript"' in description
+        assert "Retrying will not help" in description
+        assert "no availability SLA" in rendered, "the inference has to be admitted as one"
+        assert "recurring" in description and "started_after" in description
+        assert 'Never report it as "there is no transcript"' in description
+        assert "not known" in description, "the fifth answer claims nothing, and has to say so"
+
+    async def test_the_answer_with_no_remedy_says_it_has_none(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Four of the five statuses tell a caller what to do next; `scan_incomplete` cannot,
+        because the window is applied after Microsoft has answered and so no argument sends the
+        next call further into the collection. Advice that sounds actionable and is not is worse
+        than a dead end stated plainly — it is a loop a model runs until something else stops it —
+        so both the tool and the field say to stop.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_transcripts"].description
+        status = str(_object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"]))
+        assert description is not None
+
+        assert "nothing to try" in description and "Stop here" in description
+        assert "There is nothing to try" in status and "do not ask again" in status
+        assert "reads the same transcripts and returns this same answer" in description, (
+            "a narrower window is named only as the thing that does NOT help"
+        )
+
+    async def test_list_meeting_transcripts_takes_a_meeting_handle_and_an_occurrence_window(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["list_meeting_transcripts"].inputSchema
+        properties = _properties(schema)
+        limit = _object(properties["limit"])
+
+        assert set(properties) == {
+            "meeting_uri",
+            "started_after",
+            "started_before",
+            "limit",
+            "include_scan_completeness",
+        }
+        assert schema.get("required") == ["meeting_uri"]
+        assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
+            "integer",
+            1,
+            50,
+            20,
+        )
+        assert _object(properties["include_scan_completeness"])["default"] is False, (
+            "the completeness of the scan is opt-in: a client that does not want it never sees it"
+        )
+
+    @pytest.mark.parametrize("bound", ["started_after", "started_before"], ids=["after", "before"])
+    async def test_each_occurrence_bound_admits_a_bare_date_in_its_own_schema(
+        self, mcp_client: Client[FastMCPTransport], bound: str
+    ) -> None:
+        """A bare `2026-08-11` is what a model writes when scoping a series to one occurrence — the
+        only reason these parameters exist — so the schema has to say a date is legal. A schema
+        offering only `date-time` while the code accepted a date anyway is a disagreement the model
+        pays for: it is never told which shape was meant."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["list_meeting_transcripts"].inputSchema)
+
+        assert _optional_types(properties[bound]) == [
+            {"type": "string", "format": "date"},
+            {"type": "string", "format": "date-time"},
+        ]
+
+    async def test_the_occurrence_window_states_the_zone_it_resolves_against(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """`09:00` is a different instant in every zone, so a tool that silently picks one has to
+        say which — in the parameter's own description, which is the only place a model reads before
+        writing the value. Both halves are asserted: what an offset-less timestamp means, and what a
+        bare date means at each end of the window."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["list_meeting_transcripts"].inputSchema)
+        after = str(_object(properties["started_after"])["description"])
+        before = str(_object(properties["started_before"])["description"])
+
+        assert "READ AS UTC" in after, "the assumption a naive timestamp is resolved against"
+        assert "whole UTC day" in after and "first instant" in after
+        assert "END of that UTC day" in before, "the same date in both bounds must be that one day"
+        assert "07:00Z" in after, "a worked example beats the word 'timezone'"
+
+    async def test_list_meeting_transcripts_says_the_verdict_is_about_the_window(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The promise the `not_ready` inference has to keep. A recurring series' `endDateTime` can
+        be in the future for years, and a caller told to wait for a transcript of an occurrence that
+        ended last month polls forever — so both the tool and the field say the verdict follows the
+        window that was asked for, not the meeting."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_transcripts"].description
+        status = _object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"])
+        assert description is not None
+
+        assert "window you asked about" in description
+        assert "already well past never answers this" in description
+        assert "demonstrably passed is never reported this way" in str(status["description"])
 
     async def test_no_description_names_a_tool_this_server_does_not_advertise(
         self, mcp_client: Client[FastMCPTransport]
@@ -1028,9 +1301,13 @@ class TestCallingThem:
         actually spent rather than read off the constant that claims it.
 
         An empty page carrying a cursor means keep going, so a collection that answers only those
-        has to be given up on — and it must FAIL rather than answer, because a short answer from
-        this tool means the user has no more chats. Eleven requests: the caller's own first page,
-        and the run of empty ones this walk will follow before refusing.
+        has to be given up on — and it must FAIL rather than answer, because every short answer
+        above this walk means a cap: from `list_chats` it would mean the user has no more chats,
+        and from `list_meeting_transcripts` it would mean a meeting was never transcribed. Eleven
+        requests each: the caller's own first page, and the run of empty ones this walk will follow
+        before refusing. Both tools are here because they pass different `max_scanned` values and
+        this bound must not vary with either — an empty page spends no scan budget at all, which is
+        why it is counted against its own number and not against that one.
         """
         chats = graph.get("/me/chats").mock(
             return_value=httpx.Response(
@@ -1038,11 +1315,34 @@ class TestCallingThem:
             )
         )
 
+        meeting = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        listing = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [],
+                    "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS_PATH}?$skiptoken=loop",
+                },
+            )
+        )
+
         listed = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
+        transcribed = await mcp_client.call_tool(
+            "list_meeting_transcripts", {"meeting_uri": _MEETING_URI}, raise_on_error=False
+        )
 
         assert listed.is_error, "a walk that gave up must not answer short: a short answer is a cap"
         assert "pages in a row" in _error_text(listed), "and the count is what an operator needs"
         assert chats.call_count == 11, "the caller's own page and the run of empty ones followed"
+        assert transcribed.is_error, (
+            "and a transcript listing that answered short would report a meeting as never "
+            "transcribed on the strength of a collection nobody reached the end of"
+        )
+        assert meeting.called
+        assert listing.call_count == 11, (
+            "the same eleven, whatever `max_scanned` this tool passes: an empty page spends no "
+            "scan budget, so the two bounds are counted separately"
+        )
 
     async def test_search_messages_returns_hits_with_handles_and_no_invented_total(
         self,
@@ -1280,6 +1580,145 @@ class TestCallingThem:
         assert not route.called
         assert not obo.requested_scopes
 
+    async def test_a_model_walks_from_a_meeting_chat_to_the_meetings_transcripts(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The path this tool exists to complete, over the real protocol, with every value taken
+        from the previous answer exactly as a model would take it: which meetings are there
+        (list_chats, because a meeting chat *is* the index), and then what transcripts this one has.
+
+        The connector this was compared against reaches a meeting only through an opaque URI it got
+        from a calendar read; this walk needs no calendar permission at all.
+        """
+        chats_route = graph.get("/me/chats").mock(
+            return_value=httpx.Response(200, json=_MEETING_CHATS)
+        )
+        meeting = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        listing = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(200, json=_TRANSCRIPTS)
+        )
+
+        listed = _structured(await mcp_client.call_tool("list_chats", {"limit": 5}))
+        found = cast("Sequence[Mapping[str, object]]", listed["chats"])
+        meeting_uri = found[0]["meeting_uri"]
+        available = _structured(
+            await mcp_client.call_tool("list_meeting_transcripts", {"meeting_uri": meeting_uri})
+        )
+
+        assert all(route.called for route in (chats_route, meeting, listing))
+        assert found[0]["chat_type"] == "meeting"
+        assert meeting_uri == _MEETING_URI, "the handle one tool minted is what the other took"
+        assert available["status"] == "available"
+        assert available["subject"] == "Pricing review"
+        assert available["meeting_id"] == _MEETING_ID
+        assert available["scan_incomplete"] is None, "nobody asked how far the read got"
+        transcripts = cast("Sequence[Mapping[str, object]]", available["transcripts"])
+        assert [item["transcript_id"] for item in transcripts] == [_TRANSCRIPT_ID]
+        assert listing.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            ("https://graph.microsoft.com/Chat.Read",),
+            (
+                "https://graph.microsoft.com/OnlineMeetings.Read",
+                "https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",
+            ),
+        ], "resolving the join URL and reading the collection are two permissions, one exchange"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_asking_for_the_latest_of_a_series_answers_with_the_latest(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """ "The latest transcript of this series", over the real protocol — the question this tool
+        exists for. Microsoft answers this collection in an order of its own, so a `limit` applied
+        before ordering returns an arbitrary handful sorted among themselves: a model asking for the
+        newest one gets whichever occurrence Microsoft happened to put first, with nothing in the
+        answer to say so. Microsoft's order here puts the oldest first, which is exactly what that
+        shape would return.
+        """
+        _ = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        _ = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(200, json=_SERIES_TRANSCRIPTS)
+        )
+
+        answer = _structured(
+            await mcp_client.call_tool(
+                "list_meeting_transcripts",
+                {"meeting_uri": _MEETING_URI, "limit": 1, "include_scan_completeness": True},
+            )
+        )
+
+        listed = cast("Sequence[Mapping[str, object]]", answer["transcripts"])
+        assert [item["transcript_id"] for item in listed] == ["week-3"], "the newest, not the first"
+        assert answer["status"] == "available"
+        assert len(listed) == 1, "a full window: the two older occurrences are behind it"
+        assert answer["scan_incomplete"] is False, (
+            "and the collection was read to the end, so this IS the meeting's latest — the two "
+            "facts one flag could not tell apart"
+        )
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_meeting_larger_than_one_call_reads_answers_within_what_it_read(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The rare meeting both promises have to be exact about, over the real protocol: a series
+        that ran daily for most of a year, so its collection is longer than one call reads.
+
+        Two things are asserted. Asking for the newest returns the newest of the transcripts READ —
+        `day-199` — and never the meeting's actual newest, which sits past the cap where nothing
+        here can see it, with the opt-in `scan_incomplete` as the answer's own admission of that.
+        And a window over the part that was not read answers `scan_incomplete` whether it is wide or
+        narrow, because the window is applied to what came back: narrowing it is not a remedy, which
+        is why the tool does not offer it as one.
+        """
+        _ = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        _ = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(200, json=_daily_series())
+        )
+
+        newest = _structured(
+            await mcp_client.call_tool(
+                "list_meeting_transcripts",
+                {"meeting_uri": _MEETING_URI, "limit": 1, "include_scan_completeness": True},
+            )
+        )
+        wide = _structured(
+            await mcp_client.call_tool(
+                "list_meeting_transcripts",
+                {
+                    "meeting_uri": _MEETING_URI,
+                    "started_after": _day(meetings.MAX_ARTIFACT_SCAN).date().isoformat(),
+                    "started_before": _day(_PAST_THE_CAP - 1).date().isoformat(),
+                },
+            )
+        )
+        narrow = _structured(
+            await mcp_client.call_tool(
+                "list_meeting_transcripts",
+                {
+                    "meeting_uri": _MEETING_URI,
+                    "started_after": _day(250).date().isoformat(),
+                    "started_before": _day(250).date().isoformat(),
+                },
+            )
+        )
+
+        listed = cast("Sequence[Mapping[str, object]]", newest["transcripts"])
+        assert [item["transcript_id"] for item in listed] == ["day-199"], (
+            "the newest of what was read"
+        )
+        assert newest["scan_incomplete"] is True, (
+            "the read stopped at the cap, and a caller that asked has to be told"
+        )
+        assert wide["status"] == "scan_incomplete"
+        assert narrow["status"] == wide["status"], "a narrower window reads the same transcripts"
+        assert wide["transcripts"] == [] and narrow["transcripts"] == []
+
 
 class TestTheTransportTheToolsShare:
     async def test_it_is_closed_when_the_server_shuts_down(
@@ -1485,6 +1924,68 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "AADSTS65001" in message
         assert "resolve dependency" not in message
         assert not route.called, "no token means no search was ever made"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_transcript_tenant_switch_names_a_different_administrator(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The refusal every other 403 on this server would be answered wrongly for, end to end.
+
+        Microsoft Graph access to Teams meeting transcripts is a tenant-wide Teams setting that is
+        OFF BY DEFAULT, and Graph reports it with the same status and the same outer code as a
+        missing permission. In the commonest tenant, therefore, this is the *first* answer a model
+        gets from this tool — so it has to name the Teams admin centre rather than a Graph
+        permission, and it has to rule out re-consent, which is what a model would otherwise infer
+        from every other refusal here.
+        """
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(
+                403, headers={"request-id": "synthetic-request-id"}, json=_TENANT_SWITCH_OFF
+            )
+        )
+
+        refused = await mcp_client.call_tool(
+            "list_meeting_transcripts", {"meeting_uri": _MEETING_URI}, raise_on_error=False
+        )
+
+        assert refused.is_error
+        message = _error_text(refused)
+        assert "EnableGraphTranscriptAccess" in message
+        assert "Teams administrator" in message
+        assert "sign in again will not change it" in message
+        assert "OnlineMeetingTranscript.Read.All" not in message, (
+            "no permission is missing; naming one sends an administrator after nothing"
+        )
+        assert "synthetic-request-id" in message, "an operator still needs the evidence"
+
+    async def test_a_meeting_handle_that_was_never_one_is_refused_before_graph(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """A handle this tool cannot use is its own failure to explain, and the explanation has to
+        send the caller back to where handles come from rather than invite a retry. The transcript
+        shape is named as *not* one, because it is the shape this tool emits and therefore the one
+        most likely to be passed back in."""
+        route = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+
+        refused = await mcp_client.call_tool(
+            "list_meeting_transcripts",
+            {"meeting_uri": "19:meeting_TjAwMDAwMDAwMDAwMA@thread.v2"},
+            raise_on_error=False,
+        )
+
+        assert refused.is_error
+        message = _error_text(refused)
+        assert "list_chats" in message, "where a meeting handle comes from"
+        assert "teams:///meetings/" in message
+        assert "fail identically" in message, "and it is not worth retrying"
+        assert not route.called, "nothing reached Graph"
+        assert obo.requested_scopes, "the handle is parsed inside the tool, after the exchange"
 
     @pytest.mark.parametrize(
         "uri",

--- a/services/office-mcp/tests/tools/conftest.py
+++ b/services/office-mcp/tests/tools/conftest.py
@@ -52,6 +52,62 @@ ME: dict[str, object] = {
 }
 
 
+# The meeting side: the same join URL, the same `onlineMeeting`, and one artifact payload. Builders
+# rather than literals per test so that the fields a test is *about* are the ones it names, and here
+# rather than in the tool's own file because a meeting is answered about by whatever asks next and
+# two copies of one meeting would let a round trip pass over two different meetings.
+
+# A join URL shaped like the ones Graph actually stores, and the reason the escaping is a bug class:
+# it carries `%3a` and `%40` that are already percent-escaped, a `?context=` query with `%7b`/`%22`
+# in its value, and an `&` parameter after it. Every one of those breaks a `$filter` that is encoded
+# too little, too much, or not at all — and breaks it into `200 OK` with an empty result.
+JOIN_WEB_URL = (
+    "https://teams.microsoft.invalid/l/meetup-join/"
+    + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
+    + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
+)
+
+MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+
+
+def meeting_payload(
+    *,
+    meeting_id: str = MEETING_ID,
+    subject: str | None = "Pricing review",
+    meeting_type: str | None = "scheduled",
+    start: str | None = "2026-02-10T14:00:00Z",
+    end: str | None = "2026-02-10T15:00:00Z",
+) -> dict[str, object]:
+    """One `onlineMeeting`, as the `JoinWebUrl` filter returns it: inside a one-element list."""
+    return {
+        "id": meeting_id,
+        "subject": subject,
+        "meetingType": meeting_type,
+        "joinWebUrl": JOIN_WEB_URL,
+        "startDateTime": start,
+        "endDateTime": end,
+    }
+
+
+def transcript_payload(
+    *,
+    transcript_id: str = "MSMjMCMjSYNTHETIC0001",
+    meeting_id: str = MEETING_ID,
+    created_at: str | None = "2026-02-10T14:03:11.204Z",
+    ended_at: str | None = "2026-02-10T14:58:02.117Z",
+    content_correlation_id: str | None = "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+) -> dict[str, object]:
+    """One `callTranscript`, which is metadata only — the words come from `/content`."""
+    return {
+        "id": transcript_id,
+        "meetingId": meeting_id,
+        "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+        "createdDateTime": created_at,
+        "endDateTime": ended_at,
+        "contentCorrelationId": content_correlation_id,
+    }
+
+
 # The Teams-message payloads, here rather than in one of the two test files that use them: a search
 # hit and a full message are what `search_messages` and `read_message` are respectively about, and
 # each tool's tests need one of the other's — a hit to read by its own handle, a message to read it

--- a/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
+++ b/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
@@ -1,0 +1,921 @@
+"""`list_meeting_transcripts`: the window, the order, and the five answers.
+
+The `$filter` that gets this tool to a meeting at all, and the window type it scopes an occurrence
+with, are `shared/meetings.py`'s and are tested there — they are promises about the meeting rather
+than about its transcripts. What is tested here is this tool's own: which of the five statuses an
+empty collection becomes, what the order is promised over, and what one transcript is reported as.
+
+Every payload is synthesised. A transcript is the most sensitive thing this connector touches, so
+nothing here came from a meeting: the ids are obviously fake and the domains are `.invalid`.
+"""
+
+from datetime import UTC, date, datetime, timedelta, timezone
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphForbidden, GraphNotFound
+from office_mcp.shared import handles, meetings
+from office_mcp.tools import list_meeting_transcripts as lister
+
+from .conftest import (
+    GRAPH_V1,
+    JOIN_WEB_URL,
+    MEETING_ID,
+    meeting_payload,
+    transcript_payload,
+)
+
+_MEETINGS = "/me/onlineMeetings"
+_TRANSCRIPTS = f"/me/onlineMeetings/{MEETING_ID}/transcripts"
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+
+_TENANT_SWITCH_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": "Graph API access to transcripts is disabled for this tenant.",
+        "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+    }
+}
+
+# Central European Time, which February is in: the offset a European caller's "15:00" carries, and
+# one hour away from the UTC the same string is read as when it carries no offset at all.
+_CET = timezone(timedelta(hours=1))
+
+
+def _handle() -> handles.MeetingHandle:
+    handle = handles.meeting_handle(handles.meeting_uri_for(JOIN_WEB_URL) or "")
+    assert handle is not None
+    return handle
+
+
+def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
+    return graph.get(_MEETINGS).mock(
+        return_value=httpx.Response(200, json={"value": [meeting_payload(**meeting)]})  # pyright: ignore[reportArgumentType]
+    )
+
+
+def _pages(
+    graph: respx.MockRouter, first: list[dict[str, object]], second: list[dict[str, object]]
+) -> respx.Route:
+    """Graph's own paging: a first page carrying `@odata.nextLink`, then the rest.
+
+    Two real pages rather than one page that links to itself, because the walk follows the cursor
+    to the end of the collection (bounded by `MAX_ARTIFACT_SCAN`) rather than stopping as soon as it
+    has `limit` items — which is the whole of what makes "newest first" true.
+    """
+    return graph.get(_TRANSCRIPTS).mock(
+        side_effect=[
+            httpx.Response(
+                200,
+                json={
+                    "value": first,
+                    "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=synthetic",
+                },
+            ),
+            httpx.Response(200, json={"value": second}),
+        ]
+    )
+
+
+# The only meeting shape that outgrows `MAX_ARTIFACT_SCAN`: one occurrence a day, transcribed every
+# time, for the better part of a year. Written oldest-first because Graph documents no `$orderby`
+# here and answers in an order of its own — this is the order that puts the genuinely newest
+# occurrence past the cap, which is the case both promises below have to be exact about.
+_DAILY_SERIES_START = datetime(2026, 1, 1, 14, 0, tzinfo=UTC)
+_PAST_THE_CAP = meetings.MAX_ARTIFACT_SCAN + 60
+
+
+def _day(index: int) -> datetime:
+    """When occurrence `index` of the daily series was transcribed."""
+    return _DAILY_SERIES_START + timedelta(days=index)
+
+
+def _daily_series(graph: respx.MockRouter, *, total: int = _PAST_THE_CAP) -> respx.Route:
+    """A meeting with more transcripts than one call reads, in one page Graph answers with."""
+    return graph.get(_TRANSCRIPTS).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [
+                    transcript_payload(
+                        transcript_id=f"day-{index}",
+                        created_at=_day(index).isoformat().replace("+00:00", "Z"),
+                    )
+                    for index in range(total)
+                ]
+            },
+        )
+    )
+
+
+def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
+    """A recurring series as Graph holds it: one meeting, one transcript collection, three weeks.
+
+    Three occurrences in one collection is the whole reason a window exists — Graph publishes no
+    occurrence id and no per-occurrence addressing — and `end` is the series-wide `endDateTime`,
+    which is the value the verdict must NOT be read off when a window was asked for.
+    """
+    _resolved(graph, meeting_type="recurring", end=end)
+    _ = graph.get(_TRANSCRIPTS).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [
+                    transcript_payload(transcript_id="week-1", created_at="2026-02-03T14:02:00Z"),
+                    transcript_payload(transcript_id="week-2", created_at="2026-02-10T14:01:00Z"),
+                    transcript_payload(transcript_id="week-3", created_at="2026-02-17T14:04:00Z"),
+                ]
+            },
+        )
+    )
+
+
+class TestNoMatchIsNotAnError:
+    async def test_an_empty_collection_is_its_own_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents this filter as answering `200 OK` with an empty `value` when nothing
+        matches — never a 404 — so "no such meeting" is a status and not an exception, and the
+        transcript listing is never even attempted."""
+        graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+        listing = graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(200, json={"value": [transcript_payload()]})
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "meeting_not_found"
+        assert found.meeting_id is None
+        assert found.transcripts == []
+        assert found.scan_incomplete is None, (
+            "the completeness of a scan nobody asked about is not reported, and this call made no "
+            "scan at all"
+        )
+        assert not listing.called, "there is no meeting to list transcripts of"
+
+    async def test_a_404_is_still_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The distinction the empty collection exists to be told apart from."""
+        graph.get(_MEETINGS).mock(
+            return_value=httpx.Response(404, json={"error": {"code": "NotFound", "message": "no"}})
+        )
+
+        with pytest.raises(GraphNotFound):
+            _ = await lister.list_meeting_transcripts(
+                client,
+                handle=_handle(),
+                started_after=None,
+                started_before=None,
+                limit=20,
+                include_scan_completeness=False,
+            )
+
+
+class TestTheThreeAbsences:
+    """Nothing came back — and a model must do three different things about it."""
+
+    async def test_the_tenant_switch_is_a_refusal_and_not_an_empty_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`EnableGraphTranscriptAccess` is off, which no permission and no argument can work
+        around. It has to reach the tool layer as a failure carrying the inner code, because that
+        code is the only thing distinguishing it from an ordinary 403 about a permission."""
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(403, json=_TENANT_SWITCH_OFF))
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await lister.list_meeting_transcripts(
+                client,
+                handle=_handle(),
+                started_after=None,
+                started_before=None,
+                limit=20,
+                include_scan_completeness=False,
+            )
+
+        assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+
+    async def test_a_meeting_long_over_with_nothing_in_it_was_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        ended = datetime.now(UTC) - timedelta(days=9)
+        _resolved(graph, end=ended.isoformat())
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_transcribed"
+        assert found.meeting_id == MEETING_ID, "the meeting resolved; it just has no transcript"
+
+    @pytest.mark.parametrize(
+        "ended",
+        [
+            datetime.now(UTC) - timedelta(minutes=5),
+            datetime.now(UTC) + timedelta(hours=1),
+            None,
+        ],
+        ids=["just-ended", "still-running", "no-end-time"],
+    )
+    async def test_a_meeting_that_just_ended_is_not_ready_rather_than_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter, ended: datetime | None
+    ) -> None:
+        """The two empty answers are the same bytes from Graph and the opposite advice: wait, or
+        stop. A meeting Graph gave no end time for counts as "wait", because nothing says
+        transcription has finished and one wasted call is cheaper than a wrong answer.
+        """
+        _resolved(graph, end=ended.isoformat() if ended is not None else None)
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_ready"
+
+
+class TestScopingToOneOccurrence:
+    async def test_a_series_is_one_meeting_and_a_window_picks_an_occurrence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A recurring series has one join URL, one meeting id and one transcript collection —
+        Graph publishes no occurrence addressing at all — so the only thing separating occurrences
+        is when transcription began."""
+        _weekly_series(graph)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 2, 10, tzinfo=UTC),
+            started_before=datetime(2026, 2, 11, tzinfo=UTC),
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.meeting_type == "recurring"
+        assert [t.transcript_id for t in found.transcripts] == ["week-2"]
+
+    async def test_a_window_with_nothing_in_it_is_not_ready_or_not_transcribed_not_an_error(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph, meeting_type="recurring", end="2026-02-10T15:00:00Z")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200, json={"value": [transcript_payload(created_at="2026-02-03T14:02:00Z")]}
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 3, 1, tzinfo=UTC),
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_transcribed"
+        assert found.transcripts == []
+
+    async def test_transcripts_come_back_newest_first(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents no `$orderby` on this collection, so the order it answers in is not a
+        contract and the useful one is applied here."""
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id="older", created_at="2026-02-03T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="newer", created_at="2026-02-17T14:00:00Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert [t.transcript_id for t in found.transcripts] == ["newer", "older"]
+
+    async def test_a_window_holding_more_than_the_limit_is_a_full_window_and_a_complete_scan(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The two facts one flag would conflate, told apart.
+
+        More transcripts in the window than `limit` holds: the newest of them come back, and a
+        caller sees `limit` of them, which is what "there may be older ones" looks like everywhere
+        else here — the remedy being a wider `limit`. What must NOT be reported is a scan that
+        stopped short, because none did: the collection was read to the end, so the first entry is
+        the meeting's own latest. One flag saying both would put the caveat belonging to a capped
+        read on every full window.
+        """
+        _resolved(graph)
+        _pages(
+            graph,
+            [transcript_payload(transcript_id="week-1", created_at="2026-02-03T14:00:00Z")],
+            [transcript_payload(transcript_id="week-2", created_at="2026-02-10T14:00:00Z")],
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=1,
+            include_scan_completeness=True,
+        )
+
+        assert found.status == "available"
+        assert [t.transcript_id for t in found.transcripts] == ["week-2"]
+        assert len(found.transcripts) == 1, "a window filled to `limit`: there may be older ones"
+        assert found.scan_incomplete is False, "and yet the collection was read to its end"
+
+    async def test_the_newest_are_returned_and_not_the_first_graph_answered_with(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """ "The latest transcript of this series" is the question this tool exists for, and Graph
+        answers this collection in an order of its own — it documents no `$orderby` at all. So the
+        window is filled from the whole collection and sorted before `limit` cuts it. Cutting first
+        and sorting the remainder returns an arbitrary handful sorted among themselves, which reads
+        exactly like the right answer: here it would have answered `oldest`.
+        """
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id="oldest", created_at="2026-02-03T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="middle", created_at="2026-02-10T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="newest", created_at="2026-02-17T14:00:00Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=1,
+            include_scan_completeness=False,
+        )
+
+        assert [t.transcript_id for t in found.transcripts] == ["newest"]
+
+    async def test_the_newest_is_found_even_when_it_is_on_a_later_page(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The same promise across Graph's own paging: a walk that stopped as soon as it had
+        `limit` items would never have seen the newest one."""
+        _resolved(graph, meeting_type="recurring")
+        _pages(
+            graph,
+            [transcript_payload(transcript_id="oldest", created_at="2026-02-03T14:00:00Z")],
+            [transcript_payload(transcript_id="newest", created_at="2026-02-17T14:00:00Z")],
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=1,
+            include_scan_completeness=False,
+        )
+
+        assert [t.transcript_id for t in found.transcripts] == ["newest"]
+
+    async def test_a_scan_that_stopped_short_asserts_no_absence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The answer that would otherwise contradict itself: `not_transcribed` ("retrying will not
+        help") alongside "there is more". Both cannot be true, and a caller cannot see which one is
+        wrong. A meeting with more transcripts than one call looks through, none of them in the
+        window, is `scan_incomplete` — which claims nothing about absence, and which is reported
+        whether or not the caller asked about the scan, because an empty answer is worthless
+        without it.
+        """
+        ended = datetime.now(UTC) - timedelta(days=30)
+        _resolved(graph, meeting_type="recurring", end=ended.isoformat())
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id=f"occurrence-{index}", created_at="2026-02-03T14:00:00Z"
+                        )
+                        for index in range(meetings.MAX_ARTIFACT_SCAN + 50)
+                    ]
+                },
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 3, 1, tzinfo=UTC),
+            started_before=datetime(2026, 3, 2, tzinfo=UTC),
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.transcripts == []
+        assert found.status == "scan_incomplete", (
+            "the one place a scan that stopped short reaches a caller who did not ask: an absence "
+            "over a prefix is no absence"
+        )
+        assert found.scan_incomplete is None, "and still only `status` says it, unless asked"
+        assert found.status not in ("not_transcribed", "not_ready"), (
+            "a window whose collection was not read to the end settles nothing either way"
+        )
+
+    async def test_narrowing_the_window_cannot_reach_past_the_scan_cap(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Why `scan_incomplete` offers no remedy, proved rather than asserted in prose.
+
+        The window is ours: it is applied to the transcripts *after* Graph has answered, because
+        Graph documents no filterable date on this collection. So the request goes out bare and the
+        same first `MAX_ARTIFACT_SCAN` transcripts are read whatever window was asked for — a wide
+        window and a narrow one over the same collection are the same call with the same answer,
+        and "narrow it and ask again" would be a loop a model could run forever. Here the narrow
+        window even brackets a transcript that genuinely exists (`day-250`), and it is still never
+        seen.
+        """
+        _resolved(graph, meeting_type="recurring")
+        listing = _daily_series(graph)
+
+        wide = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=_day(meetings.MAX_ARTIFACT_SCAN).date(),
+            started_before=_day(_PAST_THE_CAP - 1).date(),
+            limit=20,
+            include_scan_completeness=False,
+        )
+        wide_request = listing.calls.last.request.url
+        narrow = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=_day(250).date(),
+            started_before=_day(250).date(),
+            limit=20,
+            include_scan_completeness=False,
+        )
+        narrow_request = listing.calls.last.request.url
+
+        assert (wide.status, wide.transcripts) == ("scan_incomplete", [])
+        assert (narrow.status, narrow.transcripts) == (wide.status, [])
+        assert str(wide_request) == str(narrow_request), "two windows, one request"
+        for asked in (wide_request, narrow_request):
+            assert not {"$filter", "$orderby", "$top"} & set(asked.params), (
+                f"the window is applied here, not by Graph: {asked}"
+            )
+
+    async def test_the_unreadable_answer_tells_a_caller_to_stop_rather_than_to_retry(self) -> None:
+        """The advice a model reads, pinned against the loop it would otherwise be.
+        `scan_incomplete` is the one verdict with no caller action behind it, so what it must say
+        is that there is nothing to try — not an argument to change, which never terminates."""
+        described = str(lister.MeetingTranscripts.model_fields["status"].description)
+
+        assert "There is nothing to try" in described
+        assert "Stop, and report" in described
+        assert "do not ask again" in described
+        assert "Narrow `started_after`/`started_before` to the occurrence you mean" not in described
+
+    async def test_past_the_cap_the_newest_returned_is_the_newest_of_what_was_read(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """ "Newest first" is exact over the transcripts read, and the read stops at the cap.
+
+        A daily series recorded for most of a year has its genuinely newest occurrence past
+        `MAX_ARTIFACT_SCAN`, and Graph offers no `$orderby` to ask for it — so asking for 3 gives
+        the 3 newest of the 200 that were read, not the 3 newest of the meeting. That is the honest
+        answer; calling them "the 3 latest" would be the dishonest one, so the field that says the
+        read stopped short is asked for here and asserted alongside it. It is the one thing about
+        this answer a caller cannot work out from the answer — three entries for a `limit` of three
+        is what an ordinary full window looks like too — which is why it exists at all, and why it
+        is opt-in rather than always on.
+        """
+        _resolved(graph, meeting_type="recurring")
+        _daily_series(graph)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=3,
+            include_scan_completeness=True,
+        )
+
+        assert found.status == "available"
+        assert found.scan_incomplete is True, "the cap was reached, and the answer has to say so"
+        returned = [item.transcript_id for item in found.transcripts]
+        assert returned == ["day-199", "day-198", "day-197"], "the newest of the ones read"
+        assert f"day-{_PAST_THE_CAP - 1}" not in returned, (
+            "the meeting's genuinely newest transcript was never read, which is the whole point"
+        )
+
+    async def test_a_caller_who_did_not_ask_about_the_scan_is_told_nothing_about_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The same meeting, unasked: the field is null rather than false.
+
+        This is what "opt-in" has to mean for it to be worth anything — a client that does not want
+        the signal never sees it, and a null is not a claim that the scan finished. What does not
+        change is the read: the same transcripts come back in the same order, so the parameter is
+        about the answer's shape and never about the work.
+        """
+        _resolved(graph, meeting_type="recurring")
+        _daily_series(graph)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=3,
+            include_scan_completeness=False,
+        )
+
+        assert found.scan_incomplete is None
+        assert [item.transcript_id for item in found.transcripts] == [
+            "day-199",
+            "day-198",
+            "day-197",
+        ]
+
+    async def test_a_meeting_graph_pages_through_nothing_is_read_to_its_end(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The claim `scan_incomplete` rests on, proved rather than inherited.
+
+        "This meeting has more transcripts than one call reads" is a claim about the meeting, and it
+        is only true while a short walk can have been stopped by nothing but a cap. Graph answers
+        this collection `[3 + nextLink]`, `[nothing + nextLink]`, `[the newest]`, and the SDK's own
+        page walker reads the empty middle page as the end of the collection — which would stop the
+        walk one page short of the newest transcript and report a cap it never reached, on a meeting
+        with four transcripts. Nothing about a four-transcript meeting is incomplete, so the walk in
+        `graph_client/pagination.py` follows an empty page carrying a next link, and this is the
+        test that says so from up here where the wrong answer would have been read.
+        """
+        _resolved(graph, meeting_type="recurring")
+        listing = graph.get(_TRANSCRIPTS).mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={
+                        "value": [
+                            transcript_payload(
+                                transcript_id=f"week-{index}",
+                                created_at=f"2026-02-0{index}T14:00:00Z",
+                            )
+                            for index in (1, 2, 3)
+                        ],
+                        "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=page-2",
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={
+                        "value": [],
+                        "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=page-3",
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={
+                        "value": [
+                            transcript_payload(
+                                transcript_id="week-4", created_at="2026-02-24T14:00:00Z"
+                            )
+                        ]
+                    },
+                ),
+            ]
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=True,
+        )
+
+        assert [item.transcript_id for item in found.transcripts] == [
+            "week-4",
+            "week-3",
+            "week-2",
+            "week-1",
+        ], "every page was walked, and the newest is the one behind the empty page"
+        assert found.status == "available"
+        assert found.scan_incomplete is False, (
+            "no cap was reached, so nothing may claim this meeting holds more transcripts than one "
+            "call reads"
+        )
+        assert len(listing.calls) == 3
+
+    async def test_the_order_is_promised_over_what_was_read_and_not_over_the_meeting(self) -> None:
+        """The sentence the case above makes false if it drifts back. A model reads this field's
+        description to decide whether the first entry is "the latest transcript of the series", so
+        it has to name the cap and say what the order is over past it."""
+        described = str(lister.MeetingTranscripts.model_fields["transcripts"].description)
+
+        assert str(meetings.MAX_ARTIFACT_SCAN) in described
+        assert "the latest of what was READ" in described
+        assert "The order is over the whole collection" not in described
+
+    async def test_a_limit_above_the_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await lister.list_meeting_transcripts(
+                client,
+                handle=_handle(),
+                started_after=None,
+                started_before=None,
+                limit=lister.MAX_TRANSCRIPTS + 1,
+                include_scan_completeness=False,
+            )
+
+    async def test_each_transcript_carries_a_handle_and_the_link_to_its_recording(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(200, json={"value": [transcript_payload()]})
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=None,
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        summary = found.transcripts[0]
+        assert handles.transcript_handle(summary.uri) == handles.TranscriptHandle(
+            MEETING_ID, _TRANSCRIPT_ID
+        )
+        assert summary.content_correlation_id == "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3"
+        assert summary.started_at is not None and summary.ended_at is not None
+
+
+class TestTheWindowShapesAModelActuallySends:
+    """A window is the only reason `started_after`/`started_before` exist, and a model writes a date
+    the way people write dates. `2026-02-10` and `2026-02-10T14:00:00` both used to reach a
+    comparison between a naive datetime and Graph's aware one and raise `TypeError` at the caller —
+    a crash naming no remedy, for a value the schema had accepted.
+
+    What the resolution itself does with each shape is `tests/shared/test_meetings.py`'s, since
+    `OccurrenceWindow` is a promise about the meeting. What is here is that each shape reaches this
+    tool's answer, and bounds this tool's collection, without raising.
+    """
+
+    @pytest.mark.parametrize(
+        ("started_after", "started_before", "expected"),
+        [
+            (date(2026, 2, 10), date(2026, 2, 10), ["week-2"]),
+            (datetime(2026, 2, 10, 14, 0), datetime(2026, 2, 10, 14, 2), ["week-2"]),
+            (datetime(2026, 2, 10), datetime(2026, 2, 11), ["week-2"]),
+            (
+                datetime(2026, 2, 10, 15, 0, tzinfo=_CET),
+                datetime(2026, 2, 10, 16, 0, tzinfo=_CET),
+                ["week-2"],
+            ),
+            (datetime(2026, 2, 10, 14, 0, tzinfo=UTC), None, ["week-3", "week-2"]),
+            (None, date(2026, 2, 10), ["week-2", "week-1"]),
+        ],
+        ids=[
+            "bare-dates",
+            "naive-datetimes",
+            "naive-midnights",
+            "offset-aware",
+            "open-at-the-top",
+            "open-at-the-bottom",
+        ],
+    )
+    async def test_every_shape_bounds_the_series_and_none_of_them_raises(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        started_after: date | datetime | None,
+        started_before: date | datetime | None,
+        expected: list[str],
+    ) -> None:
+        """The `_CET` case is the one that has to differ from the naive one: `15:00+01:00` is
+        `14:00Z`, so an offset is honoured rather than dropped, and a bound that carries none is not
+        silently given the host's."""
+        _weekly_series(graph)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=started_after,
+            started_before=started_before,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "available"
+        assert [summary.transcript_id for summary in found.transcripts] == expected
+
+    async def test_a_bare_date_keeps_the_last_minute_of_its_day_and_not_the_next_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """What "the whole day" has to mean at the edges, where an off-by-one is invisible: a turn
+        transcribed at 23:59 belongs to the day asked for and one at 00:00 does not."""
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(transcript_id="dawn", created_at="2026-02-10T00:00:01Z"),
+                        transcript_payload(transcript_id="dusk", created_at="2026-02-10T23:59:30Z"),
+                        transcript_payload(
+                            transcript_id="after", created_at="2026-02-11T00:00:30Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=date(2026, 2, 10),
+            started_before=date(2026, 2, 10),
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert [summary.transcript_id for summary in found.transcripts] == ["dusk", "dawn"]
+
+    async def test_a_graph_timestamp_carrying_no_offset_is_still_comparable(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other side of the same crash. Graph timestamps in UTC and says so with a `Z`, but a
+        window is worth nothing if one payload without one takes the whole call down — so the
+        transcript's own timestamp is resolved on the same assumption as the bounds."""
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(transcript_id="naive", created_at="2026-02-10T14:01:00")
+                    ]
+                },
+            )
+        )
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=date(2026, 2, 10),
+            started_before=date(2026, 2, 10),
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert [summary.transcript_id for summary in found.transcripts] == ["naive"]
+
+
+class TestTheVerdictIsAboutTheWindowThatWasAskedFor:
+    """`not_ready` and `not_transcribed` are the same empty collection and opposite advice, so which
+    one is given has to follow the window the caller asked about. Reading it off the *meeting* is
+    wrong in exactly the case the window exists for: a series is one meeting, its `endDateTime` is
+    one value for the whole series, and a caller told to wait for an occurrence that ended last
+    month waits forever.
+    """
+
+    @pytest.mark.parametrize(
+        "end",
+        [None, (datetime.now(UTC) + timedelta(days=180)).isoformat()],
+        ids=["no-end-time", "series-runs-for-months"],
+    )
+    async def test_a_long_past_occurrence_of_a_running_series_was_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter, end: str | None
+    ) -> None:
+        past = (datetime.now(UTC) - timedelta(days=30)).date()
+        _weekly_series(graph, end=end)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=past,
+            started_before=past,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.transcripts == []
+        assert found.status == "not_transcribed", (
+            "the occurrence is a month gone; the series' own end time says nothing about it"
+        )
+
+    async def test_a_window_that_has_only_just_closed_is_still_not_ready(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The allowance has to keep applying to the window itself, or the fix for one wrong answer
+        becomes the other one: a transcript minutes away would be reported as never coming."""
+        _weekly_series(graph, end=None)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime.now(UTC) - timedelta(hours=1),
+            started_before=datetime.now(UTC) - timedelta(minutes=5),
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_ready"
+
+    async def test_a_window_still_open_at_its_far_end_admits_the_answer_is_not_known(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Where it genuinely cannot be told, it still says wait. `started_after` alone leaves the
+        window running up to now, and a series with no end time offers no second piece of evidence —
+        Graph publishes neither a processing status nor an SLA, so the cheap wrong answer wins."""
+        _weekly_series(graph, end=None)
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime.now(UTC) - timedelta(days=30),
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_ready"
+
+    async def test_a_meeting_long_over_settles_even_a_window_set_in_the_future(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Either side may settle it. A window a caller put in next week is not an instruction to
+        wait for a meeting that ended nine days ago — nothing more is coming from it."""
+        _resolved(graph, end=(datetime.now(UTC) - timedelta(days=9)).isoformat())
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await lister.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=(datetime.now(UTC) + timedelta(days=7)).date(),
+            started_before=None,
+            limit=20,
+            include_scan_completeness=False,
+        )
+
+        assert found.status == "not_transcribed"

--- a/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
+++ b/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
@@ -523,8 +523,8 @@ class TestScopingToOneOccurrence:
         described = str(lister.MeetingTranscripts.model_fields["status"].description)
 
         assert "There is nothing to try" in described
-        assert "Stop, and report" in described
-        assert "do not ask again" in described
+        assert "Stop and report" in described
+        assert "This status is final and cannot be retried" in described
         assert "Narrow `started_after`/`started_before` to the occurrence you mean" not in described
 
     async def test_past_the_cap_the_newest_returned_is_the_newest_of_what_was_read(
@@ -669,7 +669,8 @@ class TestScopingToOneOccurrence:
         described = str(lister.MeetingTranscripts.model_fields["transcripts"].description)
 
         assert str(meetings.MAX_ARTIFACT_SCAN) in described
-        assert "the latest of what was READ" in described
+        assert "Ordered over every transcript read" in described
+        assert "not over one page of Microsoft's answer" in described
         assert "The order is over the whole collection" not in described
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(


### PR DESCRIPTION
## What this answers

Was this Teams meeting transcribed, and — for a recurring series — which occurrence.

`list_chats` already reports a `meeting_uri` on every meeting chat, and until now nothing took it:
the handle named a meeting rather than opening one. `list_meeting_transcripts` is the tool that
takes it. It resolves the join URL to a meeting, lists that meeting's transcripts, and returns one
handle per transcript with the times transcription began and ended. It returns none of the words
that were said, and there is no video anywhere in this connector.

Meeting discovery stays where it is. A meeting chat *is* the index — its `topic` is the meeting's
subject and its recency is what orders it — so "the pricing call last Tuesday" is identified by
`list_chats` and this tool takes the handle it minted. No `Calendars.Read`, no second way to ask
which meeting.

## The decisions worth knowing

**Five statuses, because there are five different things to do.** Four of them arrive from Graph as
the same bytes: an empty collection. `not_ready` means wait; `not_transcribed` means stop retrying;
`scan_incomplete` means nobody can tell; `meeting_not_found` means the join URL matched nothing.
Collapsing any pair of them produces a wrong answer a caller cannot detect — "there is no
transcript" about one that is ten minutes away, or "wait" for an occurrence that ended last month.

**The wait/stop inference reads the window, not the meeting.** Microsoft publishes neither a
processing status nor an availability SLA for transcripts, so this is an inference over one
deliberately generous allowance, and it says so in the description rather than pretending to be a
fact. Reading it off the meeting would be wrong in exactly the case the window exists for: a
recurring series is one meeting with one `endDateTime` that can sit years in the future, which would
make every empty window "still processing", including one bracketing an occurrence that was never
transcribed. Either the window's own end or the meeting's may settle it; absent evidence settles
nothing and answers `not_ready`, because one wasted call is cheaper than a wrong answer.

**`scan_incomplete` claims nothing and offers no remedy, and both halves are load-bearing.** Past
the scan cap the walk stops mid-collection, so an absence inside the window is an absence over a
prefix — which is no absence. Reporting `not_transcribed` there would say "retrying will not help"
about a collection nobody read to the end. And the natural-sounding remedy is a loop: the window is
ours, applied to the transcripts *after* Graph has answered, because Graph documents no filterable
date on this collection. A narrower window is the same bare request over the same transcripts with
the same answer. A test drives a wide window and a narrow one — the narrow one bracketing a
transcript that genuinely exists past the cap — and asserts one request and one answer for both. A
dead end stated plainly beats an actionable-sounding loop; the channel browser already paid for that
lesson with its circular reply advice.

**"Newest first" is a promise about the collection, not about a page of it.** Graph documents
`$select`, `$filter` and `$top` here and no `$orderby` at all, so the order it answers in is not a
contract. The window is therefore taken whole — to the cap — ordered, and only then cut to `limit`.
Cutting first returns an arbitrary handful sorted among themselves and calls them the latest, which
is a wrong answer with the shape of a right one. Past the cap the promise is honestly weaker, "the
newest of what was READ", and every description is worded to that bound rather than to the meeting.

**One claim was proved rather than carried.** `scan_incomplete` tells a model "this meeting has more
transcripts than one call reads" — a claim about the meeting, true only while a short walk can have
been stopped by nothing but a cap. Graph does answer empty pages that still advertise more, and the
SDK's own page walker reads one as the end of the collection. So a test pages a four-transcript
meeting as `[3 + nextLink]`, `[nothing + nextLink]`, `[the newest]` and asserts all four come back
with the scan reported complete. Without that, the tool would have told a caller a four-transcript
meeting was too large to read and lost the newest transcript in it.

**`include_scan_completeness` is opt-in, and one flag would have been two facts.** That the window
held more than `limit` a caller can already see — a full list may have more behind it, a short one
is all there was. That the read stopped at the cap it cannot, and the two have opposite remedies:
raise `limit` for the first, nothing at all for the second. Where nothing came back at all it is not
opt-in, because an empty answer is worthless without it: `status` says it.

**A third kind of 403.** Microsoft Graph access to Teams meeting transcripts is a tenant-wide Teams
setting that is off by default, and Graph reports it with the same status and the same outer code as
a missing permission. Both of the existing remedies are wrong for it — no permission is missing, and
re-consent changes nothing — so `GraphFailure` now carries `inner_code`, and the seam branches on it
to name a Teams administrator, the admin-centre path and the cmdlet, and to rule out re-consent
explicitly. Recognition is by inner code and never by message text, which Microsoft documents as
subject to change. In an untouched tenant this is the first answer this tool gives.

## What it adds to `shared/`, and why that is vocabulary

`shared/meetings.py` holds how a meeting is reached (the join-URL `$filter` and its escaping), which
occurrence was asked about (`OccurrenceWindow`), how far "newest first" is true
(`newest_in_window`, `MAX_ARTIFACT_SCAN`), and the delay allowance behind the wait/stop inference.
`shared/handles.py` gains the transcript handle family.

None of those is a fact about transcripts. They are facts about a *meeting* and about the artifact
collections Graph hangs off one — reached through the same resolve, ordered the same way (which is
to say not at all), answered empty in the same ambiguous way. That is the test for belonging in
`shared/`: a promise a second tool over the same meeting would otherwise make for itself, where the
disagreement is invisible from outside. A caller cannot see two tools disagreeing about "the latest
occurrence"; it can only see one of them being wrong.

This tool is currently the only caller, and the vocabulary still goes there. The alternative is not
"keep it local and move it when a second caller arrives" — it is a later diff that moves a promise,
reviewed as a refactor rather than as a decision, with the window spending that whole time as one
tool's private helper. A private helper is exactly what the next caller copies instead of importing.
The permission names live there for the same reason: layering rule 4 forbids one tool importing
another, so a permission spelled in a tool file is a permission the next module touching that
resource has to re-type — and a permission spelled twice is a scope Entra can reject, which fails
sign-in for every user.

The handle is a family of its own, `teams:///transcripts/{meetingId}/{transcriptId}`, rather than a
path nested under the meeting family: nesting would make the segment after `meetings/` a join URL in
one shape and a meeting id in the other, and no parser can tell those apart. It carries the resolved
meeting id rather than the join URL, so whatever reads a transcript does not repeat the resolve,
spend a second request and a second permission on it, and answer a 403 that could be about either.

`GraphCollection` becomes part of `graph_client`'s published surface, because the newest-first walk
takes a collection response the caller already awaited and the type has to cross the package's front
door rather than be reached past it.

## Layering rules

No new rule becomes assertable at this level. Rule 7 — nothing may address a single meeting
recording — still needs a recordings surface to protect, and its anti-vacuity guard would still fail,
so it stays absent and named where it is missing.

What does change is rule 6's reach: `shared/handles.py` now owns four handle families rather than
three, and the guard that pins which families it spells is updated with it — so a second speller of
the transcript grammar fails the build the same way a second speller of the chat grammar does. The
pagination bound is now asserted over two tools that pass different scan caps, which is the property
that number has to have: an empty page spends no scan budget, so the bound on a run of them is its
own and must not vary with either tool's cap.

