### PR TITLE
fix(office-mcp): make "newest first" true of the collection, and never assert an absence the scan did not see

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -16,7 +16,8 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats, channels, messages)
+  features/              what the connector does — one module per slice (identity, chats, channels,
+                         message search/read, meeting transcripts, meeting recordings)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -171,9 +172,14 @@ gets that string onto the wire.
   Wrap Graph work in `with graph_errors():`. Anything else stays the base `GraphFailure`.
 - **Paging follows `@odata.nextLink`** via `collect_pages`, replaying the URL verbatim, with both an
   item cap and a *scan* cap — the teams-mcp lesson that a filtered collection can walk a long way
-  for very few kept items — and a `truncated` flag so a partial answer never looks complete. Search
-  is not paged this way: `POST /search/query` takes stateless `from`/`size` offsets, so a search
-  tool resumes by re-issuing rather than by carrying a cursor.
+  for very few kept items — and a `truncated` flag so a partial answer never looks complete. There
+  are three ways a read is bounded here and `graph_client/pagination.py` sets all three out
+  together: an inventory walks until it has `limit` items, a meeting's artifacts are walked to a
+  tighter *scan* cap (they are filtered and ordered here, so the walk cannot stop at `limit`), and
+  a channel's messages are not walked at all — Graph allows about one request a second on a given
+  channel for the whole app, so `browse_channel` makes exactly one and `$top` is its window. Search
+  is not paged this way either: `POST /search/query` takes stateless `from`/`size` offsets, so a
+  search tool resumes by re-issuing rather than by carrying a cursor.
 - **The caller's token goes to `graph.microsoft.com` and nowhere else.** The SDK's bearer provider
   does not check its own allowed-hosts validator, so a redirect or an off-Graph `nextLink` would
   otherwise be handed a user's delegated credential.
@@ -330,13 +336,28 @@ Decisions worth knowing:
   over the protocol.
 - **`200 OK` with an empty `value` is an answer, not an error.** The `JoinWebUrl` filter never 404s,
   so "no match" is `status: meeting_not_found` — reported as not proof the meeting is gone.
-- **Four statuses, because there are four different things to do.** `available`, `not_ready`,
-  `not_transcribed`, `meeting_not_found`. `not_ready` and `not_transcribed` are the *same* empty
-  collection from Graph and the opposite advice — wait, or stop — and Graph publishes no
-  "processing" status and no availability SLA, so the split is inferred from the meeting's end time
-  with a deliberately generous allowance and the field says so. A meeting Graph gave no end time for
-  counts as `not_ready`: one wasted call is cheaper than telling a caller a transcript will never
-  exist ten minutes before it arrives.
+- **Five statuses, because there are five different things to do.** `available`, `not_ready`,
+  `not_transcribed` (`not_recorded` for the other artifact), `scan_incomplete`,
+  `meeting_not_found`. `not_ready` and the settled absence are the *same* empty collection from
+  Graph and the opposite advice — wait, or stop — and Graph publishes no "processing" status and no
+  availability SLA, so the split is inferred from the end of the *window that was asked about*,
+  falling back to the meeting's own end time where no window was, with a deliberately generous
+  allowance; the field says so. A meeting Graph gave no end time for counts as `not_ready`: one
+  wasted call is cheaper than telling a caller a transcript will never exist ten minutes before it
+  arrives. `scan_incomplete` is the fifth because an absence is only knowable from a collection
+  that was read to the end: a meeting with more artifacts than one call looks through, none of them
+  in the window, used to answer "there is none" *and* `truncated: true` in the same breath, which
+  cannot both be true and which a caller cannot see through. Now the scan that stopped short is the
+  answer, and it claims nothing.
+- **"Newest first" is a promise about the collection, not about a page of it.** Both meeting
+  listers take the whole window (up to a 200-artifact scan cap, which is this call's whole cost),
+  order it, and only then cut it to `limit` — because Graph documents no `$orderby` on either
+  collection, so a `limit` applied to the order Graph chose returns an arbitrary handful sorted
+  among themselves and calls them the latest. "The latest transcript of this series" is the
+  question the tools exist for, and that shape answered it wrongly with the shape of a right
+  answer. The order, the cut, the scan cap and the `truncated` flag are one function
+  (`features/transcripts.newest_in_window`) shared by both, which is why the recordings lister
+  inherited the bug and why both were fixed at once.
 - **The tenant switch gets its own remedy, keyed on the inner error code.** `403` +
   `GraphAccessToTranscriptsDisabled` is not a permission problem and not a consent problem, so the
   message names a Teams administrator and the cmdlet, and explicitly rules out re-consent and
@@ -380,9 +401,10 @@ Decisions worth knowing:
   fails the whole call or carries a verdict per artifact instead of the single `status` that makes
   either answer actionable. It would also blunt a 403, which is only useful here because each tool
   names the permissions its own request was made under. So the artifacts are siblings that share
-  everything shareable — the handle, the window, the resolve, the four-outcome vocabulary — and
-  differ in one word of it: `not_transcribed` against `not_recorded`. `tests/test_mcp_tools.py`
-  asserts the two answers stay the same shape, and that the tenant switch stops at transcripts.
+  everything shareable — the handle, the window, the resolve, the newest-first walk and the
+  five-outcome vocabulary — and differ in one word of it: `not_transcribed` against `not_recorded`.
+  `tests/test_mcp_tools.py` asserts the two answers stay the same shape, that they teach the same
+  status words, and that the tenant switch stops at transcripts.
 - **A search query is never logged. Neither is a transcript.** Not in a message, not as a structured
   field, not as a span attribute — what someone searched their own messages for names people and
   deals, and a transcript is a verbatim record of a room. `teams-mcp` had to remove query terms from

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,10 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes seven tools
-so far — `get_me`, `list_chats`, `list_teams`, `list_channels`, `browse_channel`, `search_messages`
-and `read_message` — and more land in later PRs, stacked on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes nine tools
+so far — `get_me`, `list_chats`, `list_teams`, `list_channels`, `browse_channel`, `search_messages`,
+`read_message`, `list_meeting_transcripts` and `read_transcript` — and more land in later PRs,
+stacked on top of this one.
 
 ## Layout
 
@@ -33,8 +34,10 @@ Search is where a handle and a search-shaped sender are minted, and two modules 
 to spell a handle would be free to disagree; the disagreement would surface as a search result that
 cannot be read. The same rule runs one step further out: `channels` takes the message shape and the
 "did a person write this" test from `message_read`, so a post browsed in a channel and a message read
-by handle are the same type, normalised by the same function. A layering rule enforces the first
-half — only `message_search` may spell a handle.
+by handle are the same type, normalised by the same function. The meeting-side handles
+(`teams:///meetings/…`, `teams:///transcripts/…`) belong to `transcripts` for the same reason and by
+the same rule, and `chats` asks it for one rather than assembling a URI: a layering rule says each
+handle *family* has exactly one speller, and names which module owns which.
 
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
@@ -92,6 +95,20 @@ consented to, which is why sign-in has to ask for it:
 | `Team.ReadBasic.All` | Delegated | No | `list_teams` |
 | `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
+| `OnlineMeetings.Read` | Delegated | No | `list_meeting_transcripts` (resolving a join URL to a meeting) |
+| `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** | `list_meeting_transcripts`, `read_transcript` |
+
+**Transcripts need a tenant setting as well as a permission, and this is the one that surprises
+people.** Microsoft Graph access to Teams meeting transcripts is off by default and *"agents and apps
+can't access meeting transcripts, regardless of app-level permissions"* until a Teams administrator
+turns it on — Teams admin centre → Meetings → Meeting settings → Transcript API access, or
+`Set-CsTeamsMeetingConfiguration -EnableGraphTranscriptAccess $true -Identity Global`. There is no
+Graph API to set it and no request-side workaround, so it is an onboarding step next to admin
+consent rather than something this connector can fix; `services/teams-mcp` learned this in PR #762
+and `docs/recordings-and-transcripts/operator.md` documents it. The neighbouring
+`-EnableAttributedTranscripts` setting is *not* a prerequisite: when it is off, `read_transcript`
+degrades to Microsoft's unattributed format and reports `speaker_attribution: false` rather than
+failing.
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
@@ -159,6 +176,8 @@ gets that string onto the wire.
 | `browse_channel` | One channel's posts, each with its newest replies, in Graph's reply-chain order | `GET /teams/{id}/channels/{id}/messages?$expand=replies` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
 | `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}[/replies/{id}]` |
+| `list_meeting_transcripts` | Whether a meeting was transcribed, and a handle per transcript | `GET /me/onlineMeetings?$filter=JoinWebUrl eq '…'`, `GET /me/onlineMeetings/{id}/transcripts` |
+| `read_transcript` | What was said in a meeting: speaker-attributed, timestamped turns | `GET /me/onlineMeetings/{id}/transcripts/{id}/content` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
 all are described to the model in prose that names the traps rather than only the fields — `email` is
@@ -249,8 +268,9 @@ Decisions worth knowing:
   surface (`Chat.Read` in a chat, `ChannelMessage.Read.All` in a channel) and a token is exchanged
   per tool, so one reader over every entity type would have to redeem the union of every read
   permission on every call: a tenant unwilling to grant meeting-transcript access would break
-  reading a chat message. Transcripts (which Microsoft addresses by a join-URL-derived handle) and
-  recordings therefore arrive as their own handle-taking readers rather than as new schemes here.
+  reading a chat message. That is no longer hypothetical — `read_transcript` is the second reader,
+  it takes its own handle shape, and it redeems `OnlineMeetingTranscript.Read.All` and nothing else,
+  so a tenant that withholds transcript access still reads messages.
 - **A message body is normalised, never passed through as Teams HTML.** Wrapper divs, `<at>`
   mentions, `<emoji alt="👀">`, hostedContents `<img>`, `<attachment>` placeholders and adaptive-card
   JSON all become readable text (`@Name`, the emoji itself, `[image]`, `[attachment: name]`,
@@ -268,10 +288,66 @@ Decisions worth knowing:
   answers deleted, invisible and absent identically); a 403 names the one permission that surface
   needs. The generic "check the id came from a tool response verbatim" advice is suppressed for the
   404 here, because the handle did come from one — that is `graph_tool_errors(..., not_found=...)`.
-- **A search query is never logged.** Not in a message, not as a structured field, not as a span
-  attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
-  to remove query terms from its spans and logs after the fact; a test here asserts they never
-  arrive.
+- **Meeting discovery is `list_chats`, not a tool of its own.** A meeting chat is already listed
+  there, with the meeting's subject as its `topic` and its recency to order by, and Graph puts
+  `onlineMeetingInfo` in that collection's default projection — so the chat carries `meeting_uri`,
+  the handle `list_meeting_transcripts` takes, for no extra request and no extra permission. A
+  `find_meetings` beside `list_chats` would have been a second way to ask which meeting. It also
+  means no `Calendars.Read`: the connector stays Teams-only, where the M365 connector we compared
+  against reaches a transcript only through a URI it got from a calendar read.
+- **The join URL is the only route from a chat to a meeting, and it is not guaranteed.** Graph
+  documents exactly three delegated ways to reach an `onlineMeeting` — its id, its `joinWebUrl`, its
+  `joinMeetingId` — and a chat id is none of them. `chat.onlineMeetingInfo.joinWebUrl` is the one
+  value a delegated caller is handed. That the property is *populated*, and populated for meetings
+  the user did not organise, is **not verified against a live tenant**: it is documented on the
+  resource and modelled by the SDK, nothing says it is organiser-only, and no call has been made
+  that asked for it. So a null is a first-class outcome — `meeting_uri` is null, the description says
+  that meeting's transcripts are unreachable here, and nothing is invented from the chat id to stand
+  in. (`onlineMeeting` carries a `chatInfo.threadId`; filtering on it is undocumented and is not
+  shipped.)
+- **The `$filter` escaping is one line of doc and a live bug class.** *"joinWebUrl must be URL
+  encoded"*, and Microsoft's own example shows how far that goes: a `%3a` already in the stored URL
+  goes on the wire as `%253a`. `services/teams-mcp` doubles the OData quote and then hands the raw
+  URL to a JavaScript SDK that concatenates query parameters without encoding, so a join URL with an
+  `&` or a `#` — real ones have both — silently resolves to "meeting not found". Here the two
+  transforms are separate: the quote doubling is ours, the percent-encoding is the Python SDK's
+  (form-style URI-template expansion escapes `%`, `&`, `#`, `?` and `=`), and doing it twice would be
+  as wrong as not at all. Tests pin the bytes that reach the wire, at the feature level and again
+  over the protocol.
+- **`200 OK` with an empty `value` is an answer, not an error.** The `JoinWebUrl` filter never 404s,
+  so "no match" is `status: meeting_not_found` — reported as not proof the meeting is gone.
+- **Four statuses, because there are four different things to do.** `available`, `not_ready`,
+  `not_transcribed`, `meeting_not_found`. `not_ready` and `not_transcribed` are the *same* empty
+  collection from Graph and the opposite advice — wait, or stop — and Graph publishes no
+  "processing" status and no availability SLA, so the split is inferred from the meeting's end time
+  with a deliberately generous allowance and the field says so. A meeting Graph gave no end time for
+  counts as `not_ready`: one wasted call is cheaper than telling a caller a transcript will never
+  exist ten minutes before it arrives.
+- **The tenant switch gets its own remedy, keyed on the inner error code.** `403` +
+  `GraphAccessToTranscriptsDisabled` is not a permission problem and not a consent problem, so the
+  message names a Teams administrator and the cmdlet, and explicitly rules out re-consent and
+  signing in again. Microsoft says to branch on `innerError.code` and never on the message text, so
+  `GraphFailure` now carries `inner_code` — the SDK has no typed field for it, and it arrives in the
+  model's `additional_data`.
+- **Speaker attribution degrades instead of failing.** A tenant can permit transcripts and forbid
+  speaker names; Graph's documented remedy is to ask again for
+  `application/vnd.microsoft.graph.transcript+text`, which `read_transcript` does exactly once and
+  only for that inner code — the tenant switch answers with the same status and has no workaround.
+  `speaker_attribution: false` then says the words and the timings are all there and the names are
+  not. That is the gap `teams-mcp` still has (it hardcodes `Accept: text/vtt`).
+- **A recurring series is one meeting.** One join URL, one meeting id, one transcript collection, and
+  no occurrence addressing anywhere in Graph — so `started_after`/`started_before` scope to an
+  occurrence by when transcription began, filtered while paging rather than as a `$filter` (the
+  collection advertises `$filter` without documenting a single filterable property).
+- **`read_transcript` returns text, and only transcripts.** Recordings are deliberately absent:
+  Graph streams an MP4 inline with no ranged contract, an hour of 1080p is hundreds of megabytes, a
+  model cannot watch video, and delegated recording *content* is organiser-only by default. The
+  transcript is the artifact worth having anyway.
+- **A search query is never logged. Neither is a transcript.** Not in a message, not as a structured
+  field, not as a span attribute — what someone searched their own messages for names people and
+  deals, and a transcript is a verbatim record of a room. `teams-mcp` had to remove query terms from
+  its spans and logs after the fact; tests here assert both never arrive, and every transcript
+  fixture in the suite is synthetic.
 - **A refusal names its remedy, in one voice.** `server/errors.py` maps each Graph failure onto the
   one thing a model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator
   for *this named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. Every one of

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,9 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes four tools
-so far — `get_me`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
-stacked on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes seven tools
+so far — `get_me`, `list_chats`, `list_teams`, `list_channels`, `browse_channel`, `search_messages`
+and `read_message` — and more land in later PRs, stacked on top of this one.
 
 ## Layout
 
@@ -15,7 +15,7 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats, messages)
+  features/              what the connector does — one module per slice (identity, chats, channels, messages)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -27,11 +27,14 @@ answers with, and the delegated Graph permissions that request needs. `server/to
 MCP tools over them and is the only place that knows about MCP.
 
 Where two features answer about the same thing, the shared vocabulary lives in one of them rather
-than in both: `message_search` owns the `teams:///` message handle — its two shapes, its parser and
+than in both: `message_search` owns the `teams:///` message handle — its three shapes, its parser and
 which permission each surface is read under — and the sender shape, and `message_read` imports both.
 Search is where a handle and a search-shaped sender are minted, and two modules that each knew how
 to spell a handle would be free to disagree; the disagreement would surface as a search result that
-cannot be read.
+cannot be read. The same rule runs one step further out: `channels` takes the message shape and the
+"did a person write this" test from `message_read`, so a post browsed in a channel and a message read
+by handle are the same type, normalised by the same function. A layering rule enforces the first
+half — only `message_search` may spell a handle.
 
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
@@ -86,7 +89,9 @@ consented to, which is why sign-in has to ask for it:
 | --- | --- | --- | --- |
 | `User.Read` | Delegated | No | `get_me` |
 | `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` (chats) |
-| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages`, `read_message` (channels) |
+| `Team.ReadBasic.All` | Delegated | No | `list_teams` |
+| `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
@@ -96,9 +101,15 @@ enough for Graph to *accept* a `chatMessage` search, but Microsoft documents tha
 returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
 `ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
 missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
-than serve half an answer per query. It is also what `read_message` needs for a channel message —
-Graph's permissions for a message read are per surface, so that tool's own 403 names whichever one
-the handle it was given required.
+than serve half an answer per query. It is also what `browse_channel` and `read_message` need for a
+channel message — Graph's permissions for a message read are per surface, so the reader's own 403
+names whichever one the handle it was given required.
+
+The two channel-inventory permissions are the least-privileged ones Microsoft documents for their
+collections, and they are separate scopes on purpose: a tenant that refuses
+`ChannelMessage.Read.All` can still list its teams and channels, and each tool's 403 names only the
+permission its own request needed rather than sending an administrator after one that was never
+missing.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -143,8 +154,11 @@ gets that string onto the wire.
 | --- | --- | --- |
 | `get_me` | Who the signed-in user is: `user_id`, `display_name`, `email`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
+| `list_teams` | The teams the user is a member of | `GET /me/joinedTeams` |
+| `list_channels` | The channels of one team the user can see | `GET /teams/{id}/channels` |
+| `browse_channel` | One channel's posts, each with its newest replies, in Graph's reply-chain order | `GET /teams/{id}/channels/{id}/messages?$expand=replies` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
-| `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}` |
+| `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}[/replies/{id}]` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
 all are described to the model in prose that names the traps rather than only the fields — `email` is
@@ -154,7 +168,7 @@ hit's `summary` is a snippet rather than the message.
 
 Decisions worth knowing:
 
-- **The four tools are one surface, and the conventions are asserted, not just intended.** A name is
+- **The tools are one surface, and the conventions are asserted, not just intended.** A name is
   `verb_noun` — which is why the identity tool is `get_me` and not `whoami`, the shell idiom having
   made the odd one out of the tool a model calls first (Microsoft's own M365 connector landed on
   `get_me` too). A result field is snake_case, and one thing has one name across every tool: a
@@ -162,7 +176,7 @@ Decisions worth knowing:
   tool whose answer is a list says "there is more" with the same word, `truncated`, and says in its
   own description how to get the rest — a wider `limit` where there is no cursor, `next_offset` where
   there is. `tests/test_mcp_tools.py` checks all of that against the live schemas, because a
-  convention nothing enforces is how the fifth tool comes out different from the first four.
+  convention nothing enforces is how a new tool comes out different from the ones before it.
 - **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
   typed fields rather than prose or, worse, an extra object appended to the results array that a
   model can mistake for a result.
@@ -175,6 +189,31 @@ Decisions worth knowing:
   tool here takes a chat id as an argument, a search cannot be narrowed to one chat, and a handle
   cannot be assembled out of one — so the description says all three rather than promising a
   chat-scoped tool that does not exist.
+- **`browse_channel` is the only channel-message tool, because browsing is the only thing missing.**
+  `search_messages` already searches channel content and cannot be scoped to one channel; a
+  `get_channel_messages` beside it would have been a second way to ask a question one of them already
+  answers. What neither could do is walk a single channel in order, so that is the tool: one channel
+  per call, `$expand=replies` so a thread is one request rather than one per post, and no sweep —
+  Graph allows this whole connector about one request a second on a given channel *per tenant*, so a
+  loop over a team's channels would degrade every other user of the app registration.
+- **`browse_channel` says what Graph's order actually is.** Microsoft sorts a channel's messages by
+  the last modified date of the *entire reply chain*, so a two-year-old post returns to the front the
+  moment somebody replies to it. The list is therefore not reordered here (that would invent an order
+  Graph never gave) and the description tells the model to read `created_at` rather than the position
+  — a tool that let "newest first" be assumed would have it reporting an old post as today's news.
+  The same fact is why paging is bounded by a count and never by a date: "stop when a page is older
+  than X" is unsound on this collection, and Graph accepts no `$filter` or `$orderby` here at all, so
+  a date-bounded question goes to `search_messages` instead. Neither `$top` on `/me/joinedTeams` nor
+  on `/teams/{id}/channels` is sent, either: both are documented as unsupported and `teams-mcp` had
+  to remove them.
+- **A channel reply got the handle grammar's third shape.** Graph addresses a reply *under* the post
+  it answers (`…/messages/{root}/replies/{reply}`), which the two shapes minted by search could not
+  express — and since the search projection carries no `replyToId`, a hit on a reply produced a
+  root-post handle that Graph answers 404 to. `browse_channel` walks a channel post by post and so
+  knows each reply's parent, which makes it the one tool that can mint the shape; the grammar itself
+  stayed in `message_search` where the other two live, and `read_message` grew one request branch.
+  The 404 advice now names this as the one well-formed handle that always fails, and says to browse
+  the channel instead.
 - **`search_messages` is one Graph request, always.** No fan-out, and specifically no per-chat scan
   when a date filter is set or a permission is missing — which is what the connector this replaces
   falls back to, up to 50 chats × 50 messages. Graph's read budget is "one request per second per

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,9 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes three tools
-so far — `whoami`, `list_chats` and `search_messages` — and more land in later PRs, stacked on top
-of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes four tools
+so far — `whoami`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
+stacked on top of this one.
 
 ## Layout
 
@@ -15,7 +15,7 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats, search)
+  features/              what the connector does — one module per slice (identity, chats, messages)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -30,8 +30,9 @@ The layering rules are that **nothing under `features/` may import from `server/
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
 is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
 imports neither `features/` nor `config`**, taking its own frozen `GraphSettings` instead, that
-**`server/` does not import the Graph SDK**, since a tool declares and exposes while the request
-belongs to a feature, and that
+**`server/` does not import the Graph SDK** — nor the `kiota_*`/`msgraph_core` request layer
+underneath it, which is how a Graph call gets shaped without ever spelling `msgraph` — since a tool
+declares and exposes while the request belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
 environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
 and grows as each package arrives.
@@ -75,8 +76,8 @@ consented to, which is why sign-in has to ask for it:
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
 | `User.Read` | Delegated | No | `whoami` |
-| `Chat.Read` | Delegated | No | `list_chats`, `search_messages` |
-| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages` |
+| `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` (chats) |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages`, `read_message` (channels) |
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
@@ -86,7 +87,9 @@ enough for Graph to *accept* a `chatMessage` search, but Microsoft documents tha
 returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
 `ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
 missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
-than serve half an answer per query. It is also what the message reader in the next PR needs.
+than serve half an answer per query. It is also what `read_message` needs for a channel message —
+Graph's permissions for a message read are per surface, so that tool's own 403 names whichever one
+the handle it was given required.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -132,6 +135,7 @@ gets that string onto the wire.
 | `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
+| `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
 all are described to the model in prose that names the traps rather than only the fields — `mail` is
@@ -174,6 +178,34 @@ Decisions worth knowing:
   than the advertised schema. It is the only constraint of that kind here: nothing else about
   Microsoft's KQL scope terms makes two of these parameters genuinely incompatible, so nothing else
   is invented.
+- **The reader is `read_message`, not a polymorphic `read_resource`.** It takes a URI handle, which
+  pairs with a search that returns one, but its name says only what it reads. Two reasons, and the
+  second is the load-bearing one. A tool called `read_resource` that serves Teams messages alone
+  invites `mail:///`, `site:///` and `drive:///` — the connector we compared against exposes exactly
+  that one polymorphic reader over every M365 entity — and every one of those is a failure a model
+  could not have predicted from the name. More importantly, a message read's permission is per
+  surface (`Chat.Read` in a chat, `ChannelMessage.Read.All` in a channel) and a token is exchanged
+  per tool, so one reader over every entity type would have to redeem the union of every read
+  permission on every call: a tenant unwilling to grant meeting-transcript access would break
+  reading a chat message. Transcripts (which Microsoft addresses by a join-URL-derived handle) and
+  recordings therefore arrive as their own handle-taking readers rather than as new schemes here.
+- **A message body is normalised, never passed through as Teams HTML.** Wrapper divs, `<at>`
+  mentions, `<emoji alt="👀">`, hostedContents `<img>`, `<attachment>` placeholders and adaptive-card
+  JSON all become readable text (`@Name`, the emoji itself, `[image]`, `[attachment: name]`,
+  `[card]`), and `mentions` / `attachments` come back resolved so the placeholders have a key. This
+  is `services/teams-mcp`'s normaliser ported, not a second attempt at it.
+- **A message with no text says why.** Microsoft Graph has no rendered text for a system event
+  message — `from` is null and the body is the literal `<systemEventMessage/>`, because Teams writes
+  "Ada joined the chat" in the client — so a read that lands on one reports the event named from
+  `eventDetail` (`members joined`, `chat renamed`) and a null `text`. A deleted message reports
+  `deleted_at` and a null `text` rather than a tombstone's leftovers. Both are the difference
+  between "no content" and "they said nothing".
+- **`read_message` keeps three failures distinct.** A malformed handle is ours to explain, so its
+  error shows both readable shapes and says where a handle comes from; Graph's 404 on a well-formed
+  handle says the message could not be read and explicitly *not* that it never existed (Graph
+  answers deleted, invisible and absent identically); a 403 names the one permission that surface
+  needs. The generic "check the id came from a tool response verbatim" advice is suppressed for the
+  404 here, because the handle did come from one — that is `graph_tool_errors(..., not_found=...)`.
 - **A search query is never logged.** Not in a message, not as a structured field, not as a span
   attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
   to remove query terms from its spans and logs after the fact; a test here asserts they never

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,9 +2,8 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes no MCP
-tools yet: the feature packages and the tools that use the Graph client land in later PRs, stacked
-on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes two tools so
+far — `whoami` and `list_chats` — and more land in later PRs, stacked on top of this one.
 
 ## Layout
 
@@ -15,19 +14,24 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — empty until the first feature lands
-  server/                how it's exposed over MCP — the /ready probe today, tools when they land
+  features/              what the connector does — one module per slice (identity, chats)
+  server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
 This service owns no database schema and has no ORM, no engine and no migrations. Its only table
 (`oauth_kv`) belongs to the OAuth state store, which creates it itself — see **State** below.
 
+A feature module owns three things that belong together: the Graph request it makes, the shape it
+answers with, and the delegated Graph permission that request needs. `server/tools.py` declares the
+MCP tools over them and is the only place that knows about MCP.
+
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — that **`graph_client/` imports neither `features/`
-nor `config`**, taking its own frozen `GraphSettings` instead, and that **only `create_app`
-constructs a config**, so nothing downstream can quietly re-read the environment and disagree with
-the app it runs in. `tests/test_layering.py` enforces all of them, and grows as each package
-arrives.
+nor `config`**, taking its own frozen `GraphSettings` instead, that **`server/` does not import the
+Graph SDK**, since a tool declares and exposes while the request belongs to a feature, and that
+**only `create_app` constructs a config**, so nothing downstream can quietly re-read the
+environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
+and grows as each package arrives.
 
 ## Auth
 
@@ -59,7 +63,19 @@ all of these hold:
   the provider validates every token against one issuer derived from that value, so a
   multi-tenant authority would reject all of them rather than accept all tenants.
 
-Graph permissions are deliberately not requested yet — they belong to the tools that need them.
+**Graph permissions** belong to the tools that need them, and `create_app` passes their union to
+the provider as `additional_authorize_scopes`. They ride the authorize request only — Entra issues
+one token per resource, so the code exchange asks for this API's own scope and each tool redeems a
+Graph one per call via On-Behalf-Of. That redemption can only succeed for a permission already
+consented to, which is why sign-in has to ask for it:
+
+| Permission | Type | Admin consent | Used by |
+| --- | --- | --- | --- |
+| `User.Read` | Delegated | No | `whoami` |
+| `Chat.Read` | Delegated | No | `list_chats` |
+
+`Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
+`$expand=lastMessagePreview`, and a message preview is a message.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -97,6 +113,32 @@ gets that string onto the wire.
 - **The caller's token goes to `graph.microsoft.com` and nowhere else.** The SDK's bearer provider
   does not check its own allowed-hosts validator, so a redirect or an off-Graph `nextLink` would
   otherwise be handed a user's delegated credential.
+
+## Tools
+
+| Tool | What it answers | Graph |
+| --- | --- | --- |
+| `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
+| `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
+
+Both are read-only, both take their caller's identity from the token rather than from a parameter,
+and both are described to the model in prose that names the traps rather than only the fields —
+`mail` is null for guests (use `user_principal_name`, which may be on a different domain), and a
+chat's recency is its last message, not the `lastUpdatedDateTime` that Graph moves on a rename.
+
+Three decisions worth knowing:
+
+- **Every result has a declared output schema.** So `truncated` and `members_truncated` are typed
+  fields rather than prose or, worse, an extra object appended to the results array that a model can
+  mistake for a result.
+- **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
+  collection) is a window on the most recent chats, and `truncated` says when there are more. A
+  cursor over a collection that reorders itself on every message returns duplicates and gaps, and
+  the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+- **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
+  model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
+  named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
+  rides along, because that is what Microsoft support asks for.
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,10 +2,10 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes nine tools
+Users sign in with their own Microsoft account and the server acts as them. It exposes ten tools
 so far — `get_me`, `list_chats`, `list_teams`, `list_channels`, `browse_channel`, `search_messages`,
-`read_message`, `list_meeting_transcripts` and `read_transcript` — and more land in later PRs,
-stacked on top of this one.
+`read_message`, `list_meeting_transcripts`, `read_transcript` and `list_meeting_recordings` — and
+more land in later PRs, stacked on top of this one.
 
 ## Layout
 
@@ -37,7 +37,10 @@ cannot be read. The same rule runs one step further out: `channels` takes the me
 by handle are the same type, normalised by the same function. The meeting-side handles
 (`teams:///meetings/…`, `teams:///transcripts/…`) belong to `transcripts` for the same reason and by
 the same rule, and `chats` asks it for one rather than assembling a URI: a layering rule says each
-handle *family* has exactly one speller, and names which module owns which.
+handle *family* has exactly one speller, and names which module owns which. `recordings` borrows the
+most of any module — the meeting handle, the join-URL resolve, the occurrence window and the "is an
+empty answer settled" inference — and mints no handle of its own, because there is nothing to read:
+a recording is answered as metadata, never as video.
 
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
@@ -95,8 +98,9 @@ consented to, which is why sign-in has to ask for it:
 | `Team.ReadBasic.All` | Delegated | No | `list_teams` |
 | `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
-| `OnlineMeetings.Read` | Delegated | No | `list_meeting_transcripts` (resolving a join URL to a meeting) |
+| `OnlineMeetings.Read` | Delegated | No | `list_meeting_transcripts`, `list_meeting_recordings` (resolving a join URL to a meeting) |
 | `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** | `list_meeting_transcripts`, `read_transcript` |
+| `OnlineMeetingRecording.Read.All` | Delegated | **Yes** | `list_meeting_recordings` |
 
 **Transcripts need a tenant setting as well as a permission, and this is the one that surprises
 people.** Microsoft Graph access to Teams meeting transcripts is off by default and *"agents and apps
@@ -109,6 +113,15 @@ and `docs/recordings-and-transcripts/operator.md` documents it. The neighbouring
 `-EnableAttributedTranscripts` setting is *not* a prerequisite: when it is off, `read_transcript`
 degrades to Microsoft's unattributed format and reports `speaker_attribution: false` rather than
 failing.
+
+**That setting does not cover recordings, and the asymmetry is why they are a separate tool.**
+Microsoft scopes it to transcript resources only — the change-notification reference says so in as
+many words — and neither recordings reference page publishes a tenant control or an inner error code
+of its own. So in a default tenant (the switch off, admin consent granted) `list_meeting_transcripts`
+answers `403` while `list_meeting_recordings` answers normally, which one combined artifact tool
+could not do without either failing the whole call or growing a status per artifact.
+`OnlineMeetingRecording.Read.All` does need admin consent in its own right, separately from the
+transcript permission, so a tenant can grant either without the other.
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
@@ -178,6 +191,7 @@ gets that string onto the wire.
 | `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}[/replies/{id}]` |
 | `list_meeting_transcripts` | Whether a meeting was transcribed, and a handle per transcript | `GET /me/onlineMeetings?$filter=JoinWebUrl eq '…'`, `GET /me/onlineMeetings/{id}/transcripts` |
 | `read_transcript` | What was said in a meeting: speaker-attributed, timestamped turns | `GET /me/onlineMeetings/{id}/transcripts/{id}/content` |
+| `list_meeting_recordings` | Whether a meeting was recorded, how long each recording runs, and whether this user may download it | `GET /me/onlineMeetings?$filter=JoinWebUrl eq '…'`, `GET /me/onlineMeetings/{id}/recordings`, `GET /me` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
 all are described to the model in prose that names the traps rather than only the fields — `email` is
@@ -339,10 +353,36 @@ Decisions worth knowing:
   no occurrence addressing anywhere in Graph — so `started_after`/`started_before` scope to an
   occurrence by when transcription began, filtered while paging rather than as a `$filter` (the
   collection advertises `$filter` without documenting a single filterable property).
-- **`read_transcript` returns text, and only transcripts.** Recordings are deliberately absent:
-  Graph streams an MP4 inline with no ranged contract, an hour of 1080p is hundreds of megabytes, a
-  model cannot watch video, and delegated recording *content* is organiser-only by default. The
-  transcript is the artifact worth having anyway.
+- **A recording is answered as metadata and availability. The bytes are never returned, by anything
+  here.** Graph streams an MP4 inline with no ranged contract on that path, a Teams meeting can run
+  thirty hours, and a model cannot watch video — so a tool that returned one would be a defect
+  wearing a feature's clothes. `recordingContentUrl` is no better: it opens only with this
+  connector's own bearer token, so passing it on is either useless or a token leak. What
+  `list_meeting_recordings` answers is "there is a 47-minute recording from Tuesday, only the
+  organiser can download it, and here is the transcript instead" — existence, start and end,
+  a derived `duration_seconds` (Microsoft publishes no duration property at all), and
+  `content_correlation_id`, which is Microsoft's own link to the transcript of the same call.
+  Layering rule 10 forbids any module from addressing a single recording, because that is the only
+  door to its bytes and the change that opens it looks like a convenience.
+- **The organiser-only rule is a reported state, not a footnote.** Microsoft: *"In delegated
+  permission scenarios, getting callRecording content is supported only for the meeting organizer.
+  Meeting participants don't have permission to download meeting recordings"* — unless an
+  administrator unblocked participants. The *metadata* is not so restricted, so for most meetings a
+  participant asks about the recording is visible and its video is out of reach, and answering "there
+  is no recording" would be a wrong answer nobody could detect. `content_access` says which side of
+  the rule the signed-in user is on (`you_are_the_organizer` / `organizer_only` / `unknown`), which
+  is why the listing spends one `GET /me`: Graph returns the organiser's `displayName` as null in
+  every documented sample, so the comparison has to be made here rather than handed to the model as
+  a bare object id.
+- **Two artifacts, two tools — argued rather than assumed.** One tool listing a meeting's
+  transcripts *and* its recordings is the tidier surface and it loses answers: Microsoft gates the
+  two independently, the transcript gate is off by default, and a combined tool in that tenant either
+  fails the whole call or carries a verdict per artifact instead of the single `status` that makes
+  either answer actionable. It would also blunt a 403, which is only useful here because each tool
+  names the permissions its own request was made under. So the artifacts are siblings that share
+  everything shareable — the handle, the window, the resolve, the four-outcome vocabulary — and
+  differ in one word of it: `not_transcribed` against `not_recorded`. `tests/test_mcp_tools.py`
+  asserts the two answers stay the same shape, and that the tenant switch stops at transcripts.
 - **A search query is never logged. Neither is a transcript.** Not in a message, not as a structured
   field, not as a span attribute — what someone searched their own messages for names people and
   deals, and a transcript is a verbatim record of a room. `teams-mcp` had to remove query terms from

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -128,9 +128,9 @@ chat's recency is its last message, not the `lastUpdatedDateTime` that Graph mov
 
 Three decisions worth knowing:
 
-- **Every result has a declared output schema.** So `truncated` and `members_truncated` are typed
-  fields rather than prose or, worse, an extra object appended to the results array that a model can
-  mistake for a result.
+- **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
+  typed fields rather than prose or, worse, an extra object appended to the results array that a
+  model can mistake for a result.
 - **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
@@ -138,7 +138,10 @@ Three decisions worth knowing:
 - **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
   model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
   named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
-  rides along, because that is what Microsoft support asks for.
+  rides along, because that is what Microsoft support asks for. A permission that was never
+  consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
+  FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
+  exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,8 +2,9 @@
 
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes two tools so
-far — `whoami` and `list_chats` — and more land in later PRs, stacked on top of this one.
+Users sign in with their own Microsoft account and the server acts as them. It exposes three tools
+so far — `whoami`, `list_chats` and `search_messages` — and more land in later PRs, stacked on top
+of this one.
 
 ## Layout
 
@@ -14,7 +15,7 @@ src/office_mcp/
   auth.py                Entra auth: which app registration, and where its state lives
   logging.py metrics.py  cross-cutting, used by both sides below
   graph_client/          the Microsoft Graph transport — the official SDK, one caller's token
-  features/              what the connector does — one module per slice (identity, chats)
+  features/              what the connector does — one module per slice (identity, chats, search)
   server/                how it's exposed over MCP — the tools, the errors they report, /ready
 ```
 
@@ -22,13 +23,15 @@ This service owns no database schema and has no ORM, no engine and no migrations
 (`oauth_kv`) belongs to the OAuth state store, which creates it itself — see **State** below.
 
 A feature module owns three things that belong together: the Graph request it makes, the shape it
-answers with, and the delegated Graph permission that request needs. `server/tools.py` declares the
+answers with, and the delegated Graph permissions that request needs. `server/tools.py` declares the
 MCP tools over them and is the only place that knows about MCP.
 
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
-wires features together, never the reverse — that **`graph_client/` imports neither `features/`
-nor `config`**, taking its own frozen `GraphSettings` instead, that **`server/` does not import the
-Graph SDK**, since a tool declares and exposes while the request belongs to a feature, and that
+wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
+is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
+imports neither `features/` nor `config`**, taking its own frozen `GraphSettings` instead, that
+**`server/` does not import the Graph SDK**, since a tool declares and exposes while the request
+belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
 environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
 and grows as each package arrives.
@@ -72,10 +75,18 @@ consented to, which is why sign-in has to ask for it:
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
 | `User.Read` | Delegated | No | `whoami` |
-| `Chat.Read` | Delegated | No | `list_chats` |
+| `Chat.Read` | Delegated | No | `list_chats`, `search_messages` |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages` |
 
 `Chat.Read` rather than the least-privileged `Chat.ReadBasic` because listing chats by recency needs
 `$expand=lastMessagePreview`, and a message preview is a message.
+
+`ChannelMessage.Read.All` is the broad one, and it is requested deliberately. `Chat.Read` alone is
+enough for Graph to *accept* a `chatMessage` search, but Microsoft documents that a search never
+returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
+`ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
+missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
+than serve half an answer per query. It is also what the message reader in the next PR needs.
 
 **State.** Every token the server issues is a reference token re-validated on each request, so
 where that state lives decides whether the deployment survives a restart or a second replica.
@@ -120,13 +131,15 @@ gets that string onto the wire.
 | --- | --- | --- |
 | `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
+| `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
 
-Both are read-only, both take their caller's identity from the token rather than from a parameter,
-and both are described to the model in prose that names the traps rather than only the fields —
-`mail` is null for guests (use `user_principal_name`, which may be on a different domain), and a
-chat's recency is its last message, not the `lastUpdatedDateTime` that Graph moves on a rename.
+All are read-only, all take their caller's identity from the token rather than from a parameter, and
+all are described to the model in prose that names the traps rather than only the fields — `mail` is
+null for guests (use `user_principal_name`, which may be on a different domain), a chat's recency is
+its last message rather than the `lastUpdatedDateTime` that Graph moves on a rename, and a search
+hit's `summary` is a snippet rather than the message.
 
-Three decisions worth knowing:
+Decisions worth knowing:
 
 - **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
   typed fields rather than prose or, worse, an extra object appended to the results array that a
@@ -135,6 +148,36 @@ Three decisions worth knowing:
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
   the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+- **`search_messages` is one Graph request, always.** No fan-out, and specifically no per-chat scan
+  when a date filter is set or a permission is missing — which is what the connector this replaces
+  falls back to, up to 50 chats × 50 messages. Graph's read budget is "one request per second per
+  app per tenant … on a given channel or chat", and *per app* means one user's sweep degrades every
+  other user in the tenant; the connector we compared against returned zero results and a rate-limit
+  note from that path in a live tenant. Date bounds go into the query string as `sent>=` / `sent<=`
+  instead, where Microsoft's index applies them — inclusive, and covering channels as well as chats.
+- **`search_messages` reports no result total,** because Graph does not give one: for Teams messages
+  the `total` it returns is the count on the page. `more_results_available` plus `next_offset` are
+  the whole of the paging contract, and a page can be shorter than `size` because system messages
+  (`from: null`, a body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
+- **`query` is words, not a phrase.** Multi-word free text reaches Microsoft's index as separate
+  terms, which KQL ANDs: every word must appear, anywhere in the message and in any order. Wrapping
+  the whole query in the quotes that guard a *filter value* would make it an exact-adjacency phrase
+  and silently drop every match whose words are not side by side — the recall loss a caller cannot
+  see, since the tool answers with fewer messages than exist and says nothing. A caller who wants
+  adjacency quotes the words themselves, and that phrase is passed through as one. The injection
+  guard is unweakened, only moved: it now runs a word at a time, so `from:ceo`, `sent>2026-01-01`,
+  `(`, `*`, a leading `-` and a bare `OR` are each quoted into literal text rather than obeyed —
+  `services/teams-mcp`'s guard, applied where a scope term's *value* is built and per word where
+  the caller's own text is.
+- **"At least one search criterion" is in the schema,** as an `anyOf` of one-element `required`
+  lists, and re-checked at the tool boundary because FastMCP validates against the signature rather
+  than the advertised schema. It is the only constraint of that kind here: nothing else about
+  Microsoft's KQL scope terms makes two of these parameters genuinely incompatible, so nothing else
+  is invented.
+- **A search query is never logged.** Not in a message, not as a structured field, not as a span
+  attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
+  to remove query terms from its spans and logs after the fact; a test here asserts they never
+  arrive.
 - **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
   model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
   named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
@@ -142,6 +185,12 @@ Three decisions worth knowing:
   consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
   FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
   exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".
+  Both paths name *every* permission the call was made under, which for `search_messages` is
+  `Chat.Read` and `ChannelMessage.Read.All` both: neither Graph's 403 nor Entra's AADSTS65001 says
+  which of the two was missing, and an administrator handed one name may grant the one that was
+  already there. So the tenant that grants `Chat.Read` and withholds `ChannelMessage.Read.All` gets
+  a refusal of this connector's own wording, naming both permissions and the remedy — not
+  azure-identity's stack trace.
 
 ## Run locally
 

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -3,7 +3,7 @@
 An MCP server over Microsoft 365, via the Microsoft Graph API.
 
 Users sign in with their own Microsoft account and the server acts as them. It exposes four tools
-so far — `whoami`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
+so far — `get_me`, `list_chats`, `search_messages` and `read_message` — and more land in later PRs,
 stacked on top of this one.
 
 ## Layout
@@ -26,6 +26,13 @@ A feature module owns three things that belong together: the Graph request it ma
 answers with, and the delegated Graph permissions that request needs. `server/tools.py` declares the
 MCP tools over them and is the only place that knows about MCP.
 
+Where two features answer about the same thing, the shared vocabulary lives in one of them rather
+than in both: `message_search` owns the `teams:///` message handle — its two shapes, its parser and
+which permission each surface is read under — and the sender shape, and `message_read` imports both.
+Search is where a handle and a search-shaped sender are minted, and two modules that each knew how
+to spell a handle would be free to disagree; the disagreement would surface as a search result that
+cannot be read.
+
 The layering rules are that **nothing under `features/` may import from `server/`** — the server
 wires features together, never the reverse — nor **from FastMCP**, since deciding what an MCP client
 is told (a `ToolError`, a schema, an annotation) is the tool layer's job; that **`graph_client/`
@@ -34,8 +41,10 @@ imports neither `features/` nor `config`**, taking its own frozen `GraphSettings
 underneath it, which is how a Graph call gets shaped without ever spelling `msgraph` — since a tool
 declares and exposes while the request belongs to a feature, and that
 **only `create_app` constructs a config**, so nothing downstream can quietly re-read the
-environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them,
-and grows as each package arrives.
+environment and disagree with the app it runs in. `tests/test_layering.py` enforces all of them, and
+each rule is paired with a guard that fails if the rule has gone vacuous — an empty tree to walk, a
+missing file to forbid reaching past. None of them is conditional on a package that has yet to land,
+because they all have now: a rule that stops running is a failure there and not a skip.
 
 ## Auth
 
@@ -75,7 +84,7 @@ consented to, which is why sign-in has to ask for it:
 
 | Permission | Type | Admin consent | Used by |
 | --- | --- | --- | --- |
-| `User.Read` | Delegated | No | `whoami` |
+| `User.Read` | Delegated | No | `get_me` |
 | `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` (chats) |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `search_messages`, `read_message` (channels) |
 
@@ -132,26 +141,40 @@ gets that string onto the wire.
 
 | Tool | What it answers | Graph |
 | --- | --- | --- |
-| `whoami` | Who the signed-in user is: `id`, `display_name`, `mail`, `user_principal_name`, `job_title` | `GET /me` |
+| `get_me` | Who the signed-in user is: `user_id`, `display_name`, `email`, `user_principal_name`, `job_title` | `GET /me` |
 | `list_chats` | The user's Teams chats, most recently active first | `GET /me/chats` |
 | `search_messages` | Teams messages matching keywords, a sender, mentions, a date range, attachment or read state | `POST /search/query` |
 | `read_message` | One Teams message in full — text, sender, mentions, attachments, edits, deletion | `GET /chats/{id}/messages/{id}`, `GET /teams/{id}/channels/{id}/messages/{id}` |
 
 All are read-only, all take their caller's identity from the token rather than from a parameter, and
-all are described to the model in prose that names the traps rather than only the fields — `mail` is
+all are described to the model in prose that names the traps rather than only the fields — `email` is
 null for guests (use `user_principal_name`, which may be on a different domain), a chat's recency is
 its last message rather than the `lastUpdatedDateTime` that Graph moves on a rename, and a search
 hit's `summary` is a snippet rather than the message.
 
 Decisions worth knowing:
 
+- **The four tools are one surface, and the conventions are asserted, not just intended.** A name is
+  `verb_noun` — which is why the identity tool is `get_me` and not `whoami`, the shell idiom having
+  made the odd one out of the tool a model calls first (Microsoft's own M365 connector landed on
+  `get_me` too). A result field is snake_case, and one thing has one name across every tool: a
+  person's Entra id is `user_id` wherever it appears, an address is `email`, a time is `…_at`. Every
+  tool whose answer is a list says "there is more" with the same word, `truncated`, and says in its
+  own description how to get the rest — a wider `limit` where there is no cursor, `next_offset` where
+  there is. `tests/test_mcp_tools.py` checks all of that against the live schemas, because a
+  convention nothing enforces is how the fifth tool comes out different from the first four.
 - **Every result has a declared output schema.** So `truncated` and `members_may_be_incomplete` are
   typed fields rather than prose or, worse, an extra object appended to the results array that a
   model can mistake for a result.
 - **`list_chats` does not paginate.** `limit` (max 50, which is Graph's own `$top` ceiling on that
   collection) is a window on the most recent chats, and `truncated` says when there are more. A
   cursor over a collection that reorders itself on every message returns duplicates and gaps, and
-  the window is what "recent chats" means; `services/teams-mcp` ships the same shape.
+  the window is what "recent chats" means; `services/teams-mcp` ships the same shape. What the
+  `chat_id` it returns is *for* is naming: it is the same id `search_messages` puts on every chat
+  message it finds, so the list is how a found message gets a topic and a set of participants. No
+  tool here takes a chat id as an argument, a search cannot be narrowed to one chat, and a handle
+  cannot be assembled out of one — so the description says all three rather than promising a
+  chat-scoped tool that does not exist.
 - **`search_messages` is one Graph request, always.** No fan-out, and specifically no per-chat scan
   when a date filter is set or a permission is missing — which is what the connector this replaces
   falls back to, up to 50 chats × 50 messages. Graph's read budget is "one request per second per
@@ -160,9 +183,9 @@ Decisions worth knowing:
   note from that path in a live tenant. Date bounds go into the query string as `sent>=` / `sent<=`
   instead, where Microsoft's index applies them — inclusive, and covering channels as well as chats.
 - **`search_messages` reports no result total,** because Graph does not give one: for Teams messages
-  the `total` it returns is the count on the page. `more_results_available` plus `next_offset` are
-  the whole of the paging contract, and a page can be shorter than `size` because system messages
-  (`from: null`, a body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
+  the `total` it returns is the count on the page. `truncated` plus `next_offset` are the whole of the
+  paging contract, and a page can be shorter than `size` because system messages (`from: null`, a
+  body of `<systemEventMessage/>`) are dropped and offsets index Graph's own hits.
 - **`query` is words, not a phrase.** Multi-word free text reaches Microsoft's index as separate
   terms, which KQL ANDs: every word must appear, anywhere in the message and in any order. Wrapping
   the whole query in the quotes that guard a *filter value* would make it an exact-adjacency phrase
@@ -210,10 +233,14 @@ Decisions worth knowing:
   attribute — what someone searched their own messages for names people and deals. `teams-mcp` had
   to remove query terms from its spans and logs after the fact; a test here asserts they never
   arrive.
-- **A refusal names its remedy.** `server/errors.py` maps each Graph failure onto the one thing a
-  model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator for *this
-  named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. The Graph request id
-  rides along, because that is what Microsoft support asks for. A permission that was never
+- **A refusal names its remedy, in one voice.** `server/errors.py` maps each Graph failure onto the
+  one thing a model can do about it: 401 → ask the user to sign in again, 403 → ask an administrator
+  for *this named permission*, 429 → wait Graph's own `Retry-After`, 5xx → retry once. Every one of
+  them is written to the same shape, because a model reads them all as one server: "Microsoft 365"
+  is what refused and is named first (not "Microsoft Graph", which is an API the caller is not
+  calling), then the remedy and whether retrying could possibly help, then the diagnostics in a
+  parenthesis at the end. The Graph request id rides along there, because that is what Microsoft
+  support asks for, by that name. A permission that was never
   consented to fails earlier still — Entra refuses the On-Behalf-Of exchange (AADSTS65001) while
   FastMCP is resolving the tool's token, before the tool body runs — so `server/tools.py` wraps that
   exchange to give it the same named-permission remedy instead of "Failed to resolve dependency".

--- a/services/office-mcp/deploy/helm-charts/office-mcp/values.yaml
+++ b/services/office-mcp/deploy/helm-charts/office-mcp/values.yaml
@@ -19,6 +19,17 @@ env:
   # ENTRA_TENANT_ID and ENTRA_CLIENT_ID identify the app registration users sign in through;
   # both are required and set in the overlay (not secrets). ENTRA_TENANT_ID must be a single
   # tenant's ID — a multi-tenant authority is rejected at startup.
+  #
+  # These four plus the two secrets below are the whole of this service's configuration: the ten
+  # MCP tools add no environment variables of their own. What they do add is tenant-side
+  # onboarding, which no value here can carry (see README, "Auth"):
+  #   - eight delegated Graph permissions on that app registration, two of which
+  #     (OnlineMeetingTranscript.Read.All, OnlineMeetingRecording.Read.All) need admin consent
+  #     and are granted independently of each other;
+  #   - Graph access to Teams meeting transcripts, a tenant-wide Teams setting that is OFF by
+  #     default and that only a Teams administrator can turn on. Until they do,
+  #     list_meeting_transcripts answers 403 with that remedy and every other tool — recordings
+  #     included — is unaffected.
 
 envVars: []
 # Required secrets (provide via envVars in overlay):

--- a/services/office-mcp/pyproject.toml
+++ b/services/office-mcp/pyproject.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 description = "Microsoft 365 (Office) FastMCP server"
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp==3.4.5",
+    # The `azure` extra (azure-identity, pyjwt) is what FastMCP's On-Behalf-Of exchange needs —
+    # `EntraOBOToken` raises ImportError without it, and every tool goes through it. Both packages
+    # also arrive transitively via `msgraph-sdk`, which is precisely why this is declared: the day
+    # the Graph SDK stops depending on them, OBO must not break silently.
+    "fastmcp[azure]==3.4.5",
     # fastmcp already depends on py-key-value-aio[filetree,keyring,memory]; declared here for
     # the postgresql extra and because auth.py imports it directly (OAuth state store).
     "py-key-value-aio[postgresql]==0.4.5",

--- a/services/office-mcp/src/office_mcp/app.py
+++ b/services/office-mcp/src/office_mcp/app.py
@@ -11,9 +11,10 @@ from unique_mcp.monitoring import setup_ops
 
 from office_mcp.auth import build_auth, build_oauth_storage
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
+from office_mcp.graph_client import GraphSettings, create_graph_transport
 from office_mcp.logging import configure_logging
 from office_mcp.metrics import configure_metrics
-from office_mcp.server import ready_response
+from office_mcp.server import GRAPH_SCOPES, ready_response, register_tools
 
 
 def create_app(
@@ -24,9 +25,9 @@ def create_app(
     """The composition root.
 
     Every config object and every long-lived collaborator is built exactly once here and then
-    injected. Nothing downstream re-reads the environment. The Microsoft Graph client and the
-    tools that use it land in later PRs, wired in here the same way — so the MCP endpoint below
-    authenticates callers but exposes no tools yet.
+    injected. Nothing downstream re-reads the environment: `graph_client` in particular is handed
+    its own frozen `GraphSettings` rather than being allowed to read config, and the tools are
+    handed the one HTTP transport built from it.
     """
     config = config or AppConfig()
     database_config = database_config or DatabaseConfig()
@@ -42,19 +43,31 @@ def create_app(
     # rather than inside `build_auth` so that one object serves both consumers: the auth
     # provider that depends on it, and the readiness probe that has to prove it works.
     oauth_storage = build_oauth_storage(entra_config, database_config)
-    auth = build_auth(entra_config, base_url=config.issuer, client_storage=oauth_storage)
+    auth = build_auth(
+        entra_config,
+        base_url=config.issuer,
+        client_storage=oauth_storage,
+        graph_scopes=GRAPH_SCOPES,
+    )
+    # `GraphSettings`' defaults are what this service wants (see its docstring: interactive-call
+    # timeouts, the SDK's own retry count). It is still built here rather than inside
+    # `graph_client`, because the composition root is where a knob would have to be mapped from
+    # `AppConfig` the day an operator needs a different value.
+    graph_transport = create_graph_transport(GraphSettings())
 
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncGenerator[None, None]:
         try:
             yield
         finally:
-            # One On-Behalf-Of credential is cached per signed-in user, each holding an open
-            # HTTP transport of its own. The OAuth state store is deliberately not closed here:
-            # its asyncpg pool dies with the process, and the wrapper chain `oauth_storage`
-            # names publishes get/put/delete only — no close — so shutting the pool down would
-            # mean reaching through the encryption wrapper for a store the process is about to
-            # drop anyway.
+            # The Graph transport is a connection pool shared by every tool call, and one
+            # On-Behalf-Of credential is cached per signed-in user, each holding an open HTTP
+            # transport of its own. The OAuth state store is deliberately not closed here: its
+            # asyncpg pool dies with the process, and the wrapper chain `oauth_storage` names
+            # publishes get/put/delete only — no close — so shutting the pool down would mean
+            # reaching through the encryption wrapper for a store the process is about to drop
+            # anyway.
+            await graph_transport.aclose()
             await auth.close_obo_credentials()
 
     mcp = FastMCP(
@@ -64,6 +77,7 @@ def create_app(
         middleware=[],
         lifespan=lifespan,
     )
+    register_tools(mcp, graph_transport)
 
     # Mounts /probe, /health, /metrics and returns HTTP request-metrics middleware.
     ops_middleware = setup_ops(mcp)

--- a/services/office-mcp/src/office_mcp/auth.py
+++ b/services/office-mcp/src/office_mcp/auth.py
@@ -5,15 +5,17 @@ OAuth 2.1 proxy — it presents a DCR-capable authorization server to MCP client
 onto the Entra app registration, so the authorize endpoint, PKCE (enforced on both hops), the
 redirect callback, the consent screen, refresh-token rotation and the On-Behalf-Of exchange that
 turns a user's token into a Microsoft Graph one are all its own. What is left for this service to
-decide is the two things the library cannot know: which app registration to use, and where the
-resulting state is kept.
+decide is the three things the library cannot know: which app registration to use, which Graph
+permissions its tools will need, and where the resulting state is kept.
 
-The second one is not a preference. Every token FastMCP issues is a reference token that is
+The last one is not a preference. Every token FastMCP issues is a reference token that is
 re-validated against this store on every single request, and the default store is an encrypted
 file tree under the *process's own* home directory — so on Kubernetes it would log every user out
 on each pod restart and fail outright as soon as a second replica served a request. Postgres,
 which this service already runs, is what makes the deployment horizontally scalable.
 """
+
+from collections.abc import Sequence
 
 from fastmcp.server.auth.providers.azure import AzureProvider
 from key_value.aio.protocols import AsyncKeyValue
@@ -30,8 +32,7 @@ _OAUTH_TABLE_NAME = "oauth_kv"
 # The custom scope the app registration exposes under its Application ID URI, which is what
 # gates access to *this* server. `AzureProvider` refuses to start without at least one non-OIDC
 # scope here, because Entra omits OIDC scopes from the `scp` claim and they therefore cannot be
-# enforced. Graph permissions are a separate channel and are not listed here: they are requested
-# by the tools that need them, via the On-Behalf-Of exchange, and none exist yet.
+# enforced. Graph permissions are the separate channel below.
 _REQUIRED_SCOPES = ("access_as_user",)
 
 _ENCRYPTION_SALT = "office-mcp-oauth-storage"
@@ -63,7 +64,12 @@ def build_oauth_storage(entra: EntraConfig, database: DatabaseConfig) -> AsyncKe
     )
 
 
-def build_auth(entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue) -> AzureProvider:
+def build_auth(
+    entra: EntraConfig,
+    base_url: str,
+    client_storage: AsyncKeyValue,
+    graph_scopes: Sequence[str],
+) -> AzureProvider:
     """The auth provider — `create_app` is its only caller.
 
     `base_url` must be the externally-reachable URL of this service: the OAuth metadata clients
@@ -75,12 +81,21 @@ def build_auth(entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue)
     built here: the readiness probe answers by reading through the very same object, so that a
     200 means *this* provider's store can reach Postgres and not merely that some second
     connection resembling it could.
+
+    `graph_scopes` are the Microsoft Graph permissions the tools need, which is why they arrive
+    from outside rather than being listed here — the tools decide them. They ride the authorize
+    request only: Entra issues one token per resource (AADSTS28000), so the code exchange asks
+    only for this API's own scope, and the Graph ones are redeemed later, per tool call, by the
+    On-Behalf-Of exchange. Sending them at authorize time is what makes that possible at all —
+    OBO can only redeem a permission the user or an administrator has already consented to, and
+    a permission that is never requested is never consented to.
     """
     return AzureProvider(
         client_id=entra.client_id,
         client_secret=entra.client_secret.get_secret_value(),
         tenant_id=entra.tenant_id,
         required_scopes=list(_REQUIRED_SCOPES),
+        additional_authorize_scopes=list(graph_scopes),
         base_url=base_url,
         client_storage=client_storage,
     )

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,9 +1,9 @@
 """Feature implementations: what this connector actually does.
 
 One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
-chats) and `message_search` (finding a Teams message) so far. Each owns three things that belong
-together: the Graph request it makes, the shape it answers with, and the delegated Graph
-permissions that request needs.
+chats), `message_search` (finding a Teams message) and `message_read` (reading one) so far. Each
+owns three things that belong together: the Graph request it makes, the shape it answers with, and
+the delegated Graph permissions that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -12,9 +12,11 @@ message handles are minted, `channels` takes both the message shape and the "did
 this" test from `message_read`, so that a message means the same thing whichever tool produced it,
 and `chats` takes the meeting handle from `transcripts`, which owns that family for the same reason
 — a chat is where a meeting's join URL comes from, and one grammar with two spellers is two
-grammars. `recordings` borrows the most: the handle, the join-URL resolve, the occurrence window
-and the "is an empty answer settled" inference all come from `transcripts`, because both artifacts
-are asked for by the same handle over the same window. What it does not borrow is why the two are
+grammars. `recordings` borrows the most: the handle, the join-URL resolve, the occurrence window,
+the newest-first walk over a meeting's artifacts and the "is an empty answer settled" inference all
+come from `transcripts`, because both artifacts are asked for by the same handle over the same
+window — and a promise about order or about absence that the two made separately is a promise they
+would keep differently. What it does not borrow is why the two are
 separate tools rather than one — Microsoft gates transcripts behind a tenant switch that is off by
 default and gates recordings behind nothing of the kind, so a single tool would answer nothing
 about a reachable recording in the commonest tenant. `recordings` argues that where the decision

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,9 +1,14 @@
 """Feature implementations: what this connector actually does.
 
 One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
-chats), `message_search` (finding a Teams message) and `message_read` (reading one) so far. Each
-owns three things that belong together: the Graph request it makes, the shape it answers with, and
-the delegated Graph permissions that request needs.
+chats), `channels` (their teams, a team's channels and one channel's posts), `message_search`
+(finding a Teams message) and `message_read` (reading one) so far. Each owns three things that
+belong together: the Graph request it makes, the shape it answers with, and the delegated Graph
+permissions that request needs.
+
+A module may import another: `message_read` takes the handle grammar from `message_search`, where
+handles are minted, and `channels` takes both the message shape and the "did a person write this"
+test from `message_read`, so that a message means the same thing whichever tool produced it.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,8 +1,9 @@
 """Feature implementations: what this connector actually does.
 
-One module per slice of Microsoft 365 — `identity` (who the caller is) and `chats` (their Teams
-chats) so far. Each owns three things that belong together: the Graph request it makes, the shape
-it answers with, and the delegated Graph permission that request needs.
+One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
+chats) and `message_search` (finding a Teams message) so far. Each owns three things that belong
+together: the Graph request it makes, the shape it answers with, and the delegated Graph
+permissions that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -1,7 +1,8 @@
 """Feature implementations: what this connector actually does.
 
-Empty for now — the Microsoft Graph client, Entra auth, and the Microsoft 365 domain logic land
-in later PRs, stacked on top of this scaffolding.
+One module per slice of Microsoft 365 — `identity` (who the caller is) and `chats` (their Teams
+chats) so far. Each owns three things that belong together: the Graph request it makes, the shape
+it answers with, and the delegated Graph permission that request needs.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -2,13 +2,16 @@
 
 One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
 chats), `channels` (their teams, a team's channels and one channel's posts), `message_search`
-(finding a Teams message) and `message_read` (reading one) so far. Each owns three things that
-belong together: the Graph request it makes, the shape it answers with, and the delegated Graph
-permissions that request needs.
+(finding a Teams message), `message_read` (reading one) and `transcripts` (a meeting's transcripts,
+and the words in one) so far. Each owns three things that belong together: the Graph request it
+makes, the shape it answers with, and the delegated Graph permissions that request needs.
 
 A module may import another: `message_read` takes the handle grammar from `message_search`, where
-handles are minted, and `channels` takes both the message shape and the "did a person write this"
-test from `message_read`, so that a message means the same thing whichever tool produced it.
+message handles are minted, `channels` takes both the message shape and the "did a person write
+this" test from `message_read`, so that a message means the same thing whichever tool produced it,
+and `chats` takes the meeting handle from `transcripts`, which owns that family for the same reason
+— a chat is where a meeting's join URL comes from, and one grammar with two spellers is two
+grammars.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/__init__.py
+++ b/services/office-mcp/src/office_mcp/features/__init__.py
@@ -2,16 +2,23 @@
 
 One module per slice of Microsoft 365 — `identity` (who the caller is), `chats` (their Teams
 chats), `channels` (their teams, a team's channels and one channel's posts), `message_search`
-(finding a Teams message), `message_read` (reading one) and `transcripts` (a meeting's transcripts,
-and the words in one) so far. Each owns three things that belong together: the Graph request it
-makes, the shape it answers with, and the delegated Graph permissions that request needs.
+(finding a Teams message), `message_read` (reading one), `transcripts` (a meeting's transcripts, and
+the words in one) and `recordings` (whether a meeting was recorded, and who may fetch the video) so
+far. Each owns three things that belong together: the Graph request it makes, the shape it answers
+with, and the delegated Graph permissions that request needs.
 
 A module may import another: `message_read` takes the handle grammar from `message_search`, where
 message handles are minted, `channels` takes both the message shape and the "did a person write
 this" test from `message_read`, so that a message means the same thing whichever tool produced it,
 and `chats` takes the meeting handle from `transcripts`, which owns that family for the same reason
 — a chat is where a meeting's join URL comes from, and one grammar with two spellers is two
-grammars.
+grammars. `recordings` borrows the most: the handle, the join-URL resolve, the occurrence window
+and the "is an empty answer settled" inference all come from `transcripts`, because both artifacts
+are asked for by the same handle over the same window. What it does not borrow is why the two are
+separate tools rather than one — Microsoft gates transcripts behind a tenant switch that is off by
+default and gates recordings behind nothing of the kind, so a single tool would answer nothing
+about a reachable recording in the commonest tenant. `recordings` argues that where the decision
+was taken.
 
 This side must not import from `server/`: the server wires features together, never the reverse.
 `tests/test_layering.py` enforces it.

--- a/services/office-mcp/src/office_mcp/features/channels.py
+++ b/services/office-mcp/src/office_mcp/features/channels.py
@@ -1,0 +1,341 @@
+"""The channel side of Microsoft Teams: a user's teams, a team's channels, one channel's posts.
+
+`chats` and `message_search` reach the conversations a user is *in*; nothing so far reaches the
+channels they can *browse*. Three Graph collections cover it, and each one is documented as
+refusing something a caller would expect it to accept:
+
+* `GET /me/joinedTeams` — "This method doesn't currently support the OData query parameters"
+  (https://learn.microsoft.com/en-us/graph/api/user-list-joinedteams). No `$top`, no `$select`, no
+  `$filter`, and no documented order. `services/teams-mcp` shipped a `$top` here and had to take it
+  back out ("drop unsupported $top on joinedTeams and channels lists"), so it is not sent. Only
+  `id`, `displayName`, `description`, `isArchived` and `tenantId` come back populated; every other
+  property of a team is null on this endpoint whether or not it is asked for.
+* `GET /teams/{id}/channels` — `$select` and `$filter` only, again no `$top`
+  (https://learn.microsoft.com/en-us/graph/api/channel-list). `$select` is not an optimisation here
+  but a requirement: Graph documents populating a channel's `email` as "an expensive operation that
+  results in slow performance", and the only way not to pay for it is to select around it. The
+  collection is already access-trimmed — "Teams members can't see private or shared channels that
+  they aren't members of in the response for this API".
+* `GET /teams/{id}/channels/{id}/messages` — `$top` (default 20, max 50) and `$expand=replies`, and
+  nothing else: "The other OData query parameters aren't currently supported"
+  (https://learn.microsoft.com/en-us/graph/api/channel-list-messages). **No `$filter` and no
+  `$orderby`**, so this collection cannot be date-bounded at all and no date parameter is offered —
+  `message_search` puts a date into the search index instead, for the price of the one request it
+  was making anyway.
+
+The last of those also has the ordering nobody expects. Graph sorts it "by the last modified date
+of the entire reply chain, including both the root channel message and its replies", so a two-year-
+old post returns to the first page the moment somebody replies to it. That is thread activity, not
+post recency: it makes "the newest posts" the wrong reading of a page, and it makes "stop paging
+once a page is older than X" an unsound stop condition, which is why paging here is bounded by a
+count and never by a date.
+
+Neither is there a sweep. Graph caps reads at "one request per second per app per tenant … on a
+given channel" (https://learn.microsoft.com/en-us/graph/throttling-limits) and that budget is per
+*app*, so walking every channel of a team degrades every other user in the tenant. One call reads
+one channel; searching across channels is `message_search`'s job.
+"""
+
+from datetime import UTC, datetime
+from typing import cast
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.channel import Channel
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.models.team import Team
+from msgraph.generated.teams.item.channels.channels_request_builder import ChannelsRequestBuilder
+from msgraph.generated.teams.item.channels.item.messages.messages_request_builder import (
+    MessagesRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.features.message_read import TeamsMessage, event_of, message_of
+from office_mcp.features.message_search import CHANNEL_PERMISSION, MessageHandle
+from office_mcp.graph_client import collect_pages, graph_errors
+
+# One permission per request, as Graph documents them: listing teams and listing channels are the
+# two cheap "basic" scopes, and reading what was posted in a channel is the broad one that also
+# buys channel coverage in `message_search`. That last one is imported rather than repeated —
+# `message_search` is where the permission constants live because that is where handles do, and a
+# second spelling of `ChannelMessage.Read.All` is a second thing to keep true.
+TEAMS_PERMISSION = "Team.ReadBasic.All"
+CHANNELS_PERMISSION = "Channel.ReadBasic.All"
+POSTS_PERMISSION = CHANNEL_PERMISSION
+
+# Neither inventory collection takes a `$top`, so a window over them is this connector's own and so
+# is its bound. It exists to cap the number of Graph requests one call can make, not because Graph
+# would refuse a larger one.
+MAX_LISTED = 200
+
+# Graph's documented ceiling on `$top` for a channel's messages.
+MAX_POSTS = 50
+
+# How many of a post's replies are returned. `$expand=replies` brings back up to 200 replies per
+# post, and 50 posts of 200 replies is a response no caller has a budget for — so the newest of
+# each thread are kept and `truncated` says when a thread had more. There is no "rest of this
+# thread" tool: a reply further back is reachable through `message_search`.
+MAX_REPLIES_PER_POST = 10
+
+# What a channel listing asks for, which is everything Graph populates that identifies a channel.
+# `email` is excluded deliberately (see the module docstring), and so is `isArchived`: Graph
+# documents `layoutType` as coming back null on this collection and archived channels are a Teams
+# preview concept, so neither is claimed here.
+_CHANNEL_FIELDS = ("id", "displayName", "description", "createdDateTime", "membershipType")
+
+# The cursor Graph puts on a post whose expanded replies are themselves only a page. The SDK has no
+# field for it, so it arrives in `additional_data`.
+_REPLIES_NEXT_LINK = "replies@odata.nextLink"
+
+type _ChannelsQuery = ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters
+type _MessagesQuery = MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters
+
+
+class TeamSummary(BaseModel):
+    team_id: str = Field(
+        description=(
+            "The team's Graph id. It is what list_channels and browse_channel take, and the same "
+            + "id search_messages reports as `team_id` on a channel message. Opaque — copy it, "
+            + "never build one from a team's name."
+        )
+    )
+    display_name: str | None = Field(
+        description="The team's name as Teams shows it. Two teams may share one."
+    )
+    description: str | None = Field(
+        description=(
+            "What the team is for, as its owners wrote it. Null when nobody wrote one, which is "
+            + "common."
+        )
+    )
+    is_archived: bool | None = Field(
+        description=(
+            "True for a team that has been archived, which in Teams means read-only and usually "
+            + "means finished. Null when Microsoft Graph did not say. Together with `description` "
+            + "this is what tells two teams with the same name apart."
+        )
+    )
+
+
+class TeamList(BaseModel):
+    teams: list[TeamSummary] = Field(description="The teams the signed-in user is a member of.")
+    truncated: bool = Field(
+        description=(
+            "True when the user is in more teams than this `limit` holds — the same 'there is "
+            + "more' flag every list-shaped tool here reports. There is no cursor: raise `limit` "
+            + f"(up to {MAX_LISTED}) to widen the window. Microsoft Graph applies no order to this "
+            + "collection, so the teams beyond the window are an arbitrary rest rather than the "
+            + "least important ones."
+        )
+    )
+
+
+class ChannelSummary(BaseModel):
+    channel_id: str = Field(
+        description=(
+            "The channel's Graph id, e.g. `19:...@thread.tacv2`. Pass it with its `team_id` to "
+            + "browse_channel; it is also the id search_messages reports as `channel_id` on a "
+            + "channel message. Opaque — copy it rather than constructing one from a name."
+        )
+    )
+    display_name: str | None = Field(
+        description=(
+            "The channel's name as Teams shows it, e.g. `General`. Every team has a `General` "
+            + "channel, so a name is only unique within its own team."
+        )
+    )
+    description: str | None = Field(
+        description="What the channel is for, as its owners wrote it. Often null."
+    )
+    membership_type: str | None = Field(
+        description=(
+            "`standard` for a channel every team member is in, `private` for one with its own "
+            + "member list, or `shared` for one shared with other teams. Null when Microsoft Graph "
+            + "reported a type this connector predates. Private and shared channels the signed-in "
+            + "user is not a member of are not in this list at all."
+        )
+    )
+    created_at: datetime | None = Field(
+        description="When the channel was created — useful to tell apart similarly named channels."
+    )
+
+
+class ChannelList(BaseModel):
+    channels: list[ChannelSummary] = Field(
+        description="The channels of this team that the signed-in user can see."
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the team has more channels than this `limit` holds — the same 'there is "
+            + "more' flag every list-shaped tool here reports. There is no cursor: raise `limit` "
+            + f"(up to {MAX_LISTED}). Microsoft Graph applies no order to this collection either."
+        )
+    )
+
+
+class ChannelPosts(BaseModel):
+    messages: list[TeamsMessage] = Field(
+        description=(
+            "The channel's posts and their replies, in thread order: each root post is followed by "
+            + "the replies to it, oldest first, and a reply carries the post it answers in "
+            + "`reply_to_id`. Every message is complete — the same shape and the same normalised "
+            + "text read_message answers with — so nothing here needs a second read."
+        )
+    )
+    truncated: bool = Field(
+        description=(
+            "True when this page is not everything — the same 'there is more' flag every "
+            + "list-shaped tool here reports. It covers both ways this answer can be short: the "
+            + f"channel has more posts than `limit` (raise it, up to {MAX_POSTS}), or a thread had "
+            + f"more than {MAX_REPLIES_PER_POST} replies and only its newest are here. There is no "
+            + "cursor, and paging deeper is not a way to reach older posts: Microsoft orders this "
+            + "collection by reply-chain activity rather than by date, so use search_messages with "
+            + "`sent_before` to reach back in time."
+        )
+    )
+
+
+async def list_teams(client: GraphServiceClient, *, limit: int) -> TeamList:
+    """The teams the signed-in user is a member of, up to `limit`.
+
+    No request configuration at all: `/me/joinedTeams` accepts no OData query parameters, so a
+    `$top` or a `$select` here is a 400 rather than a narrower answer. The window is therefore
+    applied while walking the pages Graph chose.
+    """
+    assert 1 <= limit <= MAX_LISTED, f"limit must be within 1..{MAX_LISTED}, got {limit}"
+
+    with graph_errors():
+        first_page = await client.me.joined_teams.get()
+        assert first_page is not None, "Graph answered GET /me/joinedTeams with no collection"
+        collected = await collect_pages(first_page, client, limit=limit)
+
+    return TeamList(teams=[_team(team) for team in collected.items], truncated=collected.truncated)
+
+
+def _team(team: Team) -> TeamSummary:
+    assert team.id is not None, "Graph returned a joined team with no id"
+    return TeamSummary(
+        team_id=team.id,
+        display_name=team.display_name,
+        description=team.description,
+        is_archived=team.is_archived,
+    )
+
+
+async def list_channels(client: GraphServiceClient, *, team_id: str, limit: int) -> ChannelList:
+    """The channels of `team_id` the signed-in user can see, up to `limit`."""
+    assert 1 <= limit <= MAX_LISTED, f"limit must be within 1..{MAX_LISTED}, got {limit}"
+
+    configuration = RequestConfiguration[_ChannelsQuery](
+        query_parameters=ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters(
+            select=list(_CHANNEL_FIELDS)
+        )
+    )
+    with graph_errors():
+        first_page = await client.teams.by_team_id(team_id).channels.get(
+            request_configuration=configuration
+        )
+        assert first_page is not None, "Graph answered a channel listing with no collection"
+        collected = await collect_pages(first_page, client, limit=limit)
+
+    return ChannelList(
+        channels=[_channel(channel) for channel in collected.items],
+        truncated=collected.truncated,
+    )
+
+
+def _channel(channel: Channel) -> ChannelSummary:
+    assert channel.id is not None, "Graph returned a channel with no id"
+    # `ChannelMembershipType` subclasses `str`, so the member is its own wire value ("standard");
+    # a value the generated enum has no member for deserializes to None rather than raising.
+    return ChannelSummary(
+        channel_id=channel.id,
+        display_name=channel.display_name,
+        description=channel.description,
+        membership_type=channel.membership_type,
+        created_at=channel.created_date_time,
+    )
+
+
+async def browse_channel(
+    client: GraphServiceClient, *, team_id: str, channel_id: str, limit: int
+) -> ChannelPosts:
+    """Up to `limit` posts of one channel, each with the newest of its replies.
+
+    `$expand=replies` is one request for a thread rather than one per post, which matters more here
+    than anywhere else in this connector: Graph's per-channel budget is a single request a second
+    for the whole app in the tenant, so a per-post round trip would spend a minute on a page.
+
+    The system messages — somebody joining, a call ending, a channel being renamed — are dropped,
+    and Graph offers no `$filter` to drop them at the source, so they are filtered here and they
+    spend the walk's scan budget. That is what `collect_pages` bounds.
+    """
+    assert 1 <= limit <= MAX_POSTS, f"limit must be within 1..{MAX_POSTS}, got {limit}"
+
+    configuration = RequestConfiguration[_MessagesQuery](
+        query_parameters=MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters(
+            expand=["replies"], top=limit
+        )
+    )
+    with graph_errors():
+        first_page = await (
+            client.teams.by_team_id(team_id)
+            .channels.by_channel_id(channel_id)
+            .messages.get(request_configuration=configuration)
+        )
+        assert first_page is not None, "Graph answered a channel message listing with no collection"
+        collected = await collect_pages(first_page, client, limit=limit, matches=_is_a_post)
+
+    messages: list[TeamsMessage] = []
+    threads_cut = False
+    for post in collected.items:
+        assert post.id is not None, "Graph returned a channel message with no id"
+        messages.append(
+            message_of(post, handle=MessageHandle(post.id, team_id=team_id, channel_id=channel_id))
+        )
+        replies, cut = _replies(post)
+        threads_cut = threads_cut or cut
+        messages.extend(
+            message_of(
+                reply,
+                handle=MessageHandle(
+                    _reply_id(reply), team_id=team_id, channel_id=channel_id, reply_to_id=post.id
+                ),
+            )
+            for reply in replies
+        )
+
+    return ChannelPosts(messages=messages, truncated=collected.truncated or threads_cut)
+
+
+def _is_a_post(message: ChatMessage) -> bool:
+    """Whether a person wrote this, rather than Teams recording that something happened."""
+    return event_of(message) is None
+
+
+def _replies(post: ChatMessage) -> tuple[list[ChatMessage], bool]:
+    """The replies to `post`, oldest first, and whether older ones were left behind.
+
+    Sorted here because Graph publishes no order for replies — the reply collection documents
+    `$top` and nothing else — so the order they arrive in is not a contract to preserve. The newest
+    are the ones kept: a thread's recent turns are what a question about it is usually about.
+    """
+    replies = sorted((reply for reply in post.replies or [] if _is_a_post(reply)), key=_sent_at)
+    kept = replies[-MAX_REPLIES_PER_POST:]
+    return kept, len(kept) < len(replies) or _has_more_replies(post)
+
+
+def _sent_at(message: ChatMessage) -> datetime:
+    """When a message was sent, or the beginning of time for one Graph gave no timestamp."""
+    return message.created_date_time or datetime.min.replace(tzinfo=UTC)
+
+
+def _reply_id(reply: ChatMessage) -> str:
+    assert reply.id is not None, "Graph returned a channel reply with no id"
+    return reply.id
+
+
+def _has_more_replies(post: ChatMessage) -> bool:
+    """Whether Graph said this post's expanded replies were only the first page of them."""
+    extra = cast("dict[str, object]", post.additional_data)
+    return _REPLIES_NEXT_LINK in extra

--- a/services/office-mcp/src/office_mcp/features/channels.py
+++ b/services/office-mcp/src/office_mcp/features/channels.py
@@ -27,13 +27,18 @@ The last of those also has the ordering nobody expects. Graph sorts it "by the l
 of the entire reply chain, including both the root channel message and its replies", so a two-year-
 old post returns to the first page the moment somebody replies to it. That is thread activity, not
 post recency: it makes "the newest posts" the wrong reading of a page, and it makes "stop paging
-once a page is older than X" an unsound stop condition, which is why paging here is bounded by a
-count and never by a date.
+once a page is older than X" an unsound stop condition — a walk down this collection could not know
+when it had gone back far enough, which is one of the two reasons there is no walk (the other is
+below).
 
-Neither is there a sweep. Graph caps reads at "one request per second per app per tenant … on a
-given channel" (https://learn.microsoft.com/en-us/graph/throttling-limits) and that budget is per
-*app*, so walking every channel of a team degrades every other user in the tenant. One call reads
-one channel; searching across channels is `message_search`'s job.
+Neither is there a sweep — of channels, or of a channel's own pages. Graph caps reads at "one
+request per second per app per tenant … on a given channel"
+(https://learn.microsoft.com/en-us/graph/throttling-limits) and that budget is per *app*, so
+walking every channel of a team degrades every other user in the tenant, and following
+`@odata.nextLink` down one channel spends the tenant's whole budget for that channel on one
+caller. `browse_channel` therefore issues exactly one request: `$top` is the window, the single
+page Graph answers with is the answer, and `truncated` says when there was more. A caller who
+needs a wider window raises `limit`; searching across channels is `message_search`'s job.
 """
 
 from datetime import UTC, datetime
@@ -68,13 +73,22 @@ POSTS_PERMISSION = CHANNEL_PERMISSION
 # would refuse a larger one.
 MAX_LISTED = 200
 
-# Graph's documented ceiling on `$top` for a channel's messages.
+# Graph's documented ceiling on `$top` for a channel's messages, and so the widest window one
+# `browse_channel` call can answer with: the call is one request and `$top` is the whole of it.
 MAX_POSTS = 50
 
 # How many of a post's replies are returned. `$expand=replies` brings back up to 200 replies per
 # post, and 50 posts of 200 replies is a response no caller has a budget for — so the newest of
-# each thread are kept and `truncated` says when a thread had more. There is no "rest of this
-# thread" tool: a reply further back is reachable through `message_search`.
+# each thread are kept and `truncated` says when a thread had more.
+#
+# This window is the end of the line rather than a first page. Graph puts its own cursor on a post
+# whose expanded replies were themselves paged, and following it is a request per post against a
+# channel that allows the whole app one a second — the same reason the channel's own pages are not
+# walked. So a reply older than this window has no route to its full text here: `message_search`
+# can find it and report Microsoft's snippet, but Graph addresses a reply under the post it answers
+# and the search index does not name that post, so such a hit cannot be read. Browsing again
+# returns the same newest replies, which is why every surface that mentions this says so rather
+# than sending a caller back round.
 MAX_REPLIES_PER_POST = 10
 
 # What a channel listing asks for, which is everything Graph populates that identifies a channel.
@@ -190,7 +204,10 @@ class ChannelPosts(BaseModel):
             + f"more than {MAX_REPLIES_PER_POST} replies and only its newest are here. There is no "
             + "cursor, and paging deeper is not a way to reach older posts: Microsoft orders this "
             + "collection by reply-chain activity rather than by date, so use search_messages with "
-            + "`sent_before` to reach back in time."
+            + "`sent_before` to reach back in time. The older replies of a thread are a dead end "
+            + "rather than a next page — browsing again returns the same newest ones, and a search "
+            + "can find such a reply but cannot read its text — so report what is here and say the "
+            + "rest of the thread could not be retrieved."
         )
     )
 
@@ -260,15 +277,19 @@ def _channel(channel: Channel) -> ChannelSummary:
 async def browse_channel(
     client: GraphServiceClient, *, team_id: str, channel_id: str, limit: int
 ) -> ChannelPosts:
-    """Up to `limit` posts of one channel, each with the newest of its replies.
+    """Up to `limit` posts from one channel's first page, each with the newest of its replies.
 
-    `$expand=replies` is one request for a thread rather than one per post, which matters more here
-    than anywhere else in this connector: Graph's per-channel budget is a single request a second
-    for the whole app in the tenant, so a per-post round trip would spend a minute on a page.
+    One Graph request against the channel, always. Graph's per-channel budget is a single request a
+    second for the whole app in the tenant, so neither cursor Graph offers here is followed: not the
+    collection's `@odata.nextLink` and not a post's own `replies@odata.nextLink`. `$top` is the
+    window and `$expand=replies` makes a thread part of that one request rather than a round trip
+    per post; a caller who needs more raises `limit` (up to `MAX_POSTS`, Graph's own ceiling)
+    instead of the tool spending the tenant's budget on their behalf.
 
     The system messages — somebody joining, a call ending, a channel being renamed — are dropped,
-    and Graph offers no `$filter` to drop them at the source, so they are filtered here and they
-    spend the walk's scan budget. That is what `collect_pages` bounds.
+    and Graph offers no `$filter` to drop them at the source, so they are filtered out of the page
+    Graph counted them into: a page can hold fewer posts than `limit`, and `truncated` reports that
+    alongside a page Graph itself said was not the last.
     """
     assert 1 <= limit <= MAX_POSTS, f"limit must be within 1..{MAX_POSTS}, got {limit}"
 
@@ -278,17 +299,22 @@ async def browse_channel(
         )
     )
     with graph_errors():
-        first_page = await (
+        page = await (
             client.teams.by_team_id(team_id)
             .channels.by_channel_id(channel_id)
             .messages.get(request_configuration=configuration)
         )
-        assert first_page is not None, "Graph answered a channel message listing with no collection"
-        collected = await collect_pages(first_page, client, limit=limit, matches=_is_a_post)
+        assert page is not None, "Graph answered a channel message listing with no collection"
+
+    # `$top` is `limit`, so Graph returning more posts than were asked for should not happen — but
+    # the window is this tool's promise rather than Graph's, so it is applied rather than trusted.
+    posts = [message for message in (page.value or []) if _is_a_post(message)]
+    kept = posts[:limit]
+    more_posts = len(kept) < len(posts) or bool(page.odata_next_link)
 
     messages: list[TeamsMessage] = []
     threads_cut = False
-    for post in collected.items:
+    for post in kept:
         assert post.id is not None, "Graph returned a channel message with no id"
         messages.append(
             message_of(post, handle=MessageHandle(post.id, team_id=team_id, channel_id=channel_id))
@@ -305,7 +331,7 @@ async def browse_channel(
             for reply in replies
         )
 
-    return ChannelPosts(messages=messages, truncated=collected.truncated or threads_cut)
+    return ChannelPosts(messages=messages, truncated=more_posts or threads_cut)
 
 
 def _is_a_post(message: ChatMessage) -> bool:

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -12,8 +12,10 @@ Three Graph facts shape everything here, all from the list-chats reference
   `@odata.nextLink` still set — so filling a window needs the page walk `collect_pages` does, and
   a short first page is not evidence that there are no more chats.
 * `$expand=members` returns at most 25 members per chat "even if a larger `$top` value is
-  specified". That truncation is silent, which is exactly how a model comes to summarise a
-  200-person chat from 25 names, so it is reported as a field.
+  specified". The cap is silent and Graph sends no member total on this collection, which is
+  exactly how a model comes to summarise a 200-person chat from 25 names. So a list that arrives
+  full to the cap is reported as *possibly* incomplete — which is the whole of what is known: a
+  chat with exactly 25 members and one with 200 come back identical.
 """
 
 from datetime import datetime
@@ -95,11 +97,14 @@ class ChatSummary(BaseModel):
             + "has no members."
         )
     )
-    members_truncated: bool = Field(
+    members_may_be_incomplete: bool = Field(
         description=(
-            f"True when `members` hit Microsoft Graph's cap of {MEMBERS_PER_CHAT} members per "
-            + "chat on this endpoint, so people are missing from the list. Always false when "
-            + "`members` is null."
+            f"True when `members` came back full to Microsoft Graph's cap of {MEMBERS_PER_CHAT} "
+            + "members per chat on this endpoint, so the chat may have members that were not "
+            + "returned. It is not proof that any were: Graph sends no member total here, so a "
+            + f"chat with exactly {MEMBERS_PER_CHAT} members is indistinguishable from one with "
+            + 'hundreds. Either way, do not answer "who is in this chat" from a list this is '
+            + "set on. Always false when `members` is null."
         )
     )
 
@@ -158,7 +163,7 @@ def _summarise(chat: Chat, include_member_emails: bool) -> ChatSummary:
         last_message_at=preview.created_date_time if preview is not None else None,
         created_at=chat.created_date_time,
         members=members,
-        members_truncated=members is not None and len(members) >= MEMBERS_PER_CHAT,
+        members_may_be_incomplete=members is not None and len(members) >= MEMBERS_PER_CHAT,
     )
 
 

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -1,0 +1,179 @@
+"""The signed-in user's Microsoft Teams chats, most recently active first.
+
+Three Graph facts shape everything here, all from the list-chats reference
+(https://learn.microsoft.com/en-us/graph/api/chat-list):
+
+* `lastMessagePreview/createdDateTime desc` is the **only** ordering Graph will apply to this
+  collection, and it is the one that means "recently active". The chat's own
+  `lastUpdatedDateTime` looks like activity and is not: Graph documents it as when the chat was
+  renamed or its membership last changed. `services/teams-mcp` reached the same conclusion the
+  hard way ("order list_chats by recency").
+* `$top` may be at most 50, and Graph warns that a page can come back short of `$top` with an
+  `@odata.nextLink` still set — so filling a window needs the page walk `collect_pages` does, and
+  a short first page is not evidence that there are no more chats.
+* `$expand=members` returns at most 25 members per chat "even if a larger `$top` value is
+  specified". That truncation is silent, which is exactly how a model comes to summarise a
+  200-person chat from 25 names, so it is reported as a field.
+"""
+
+from datetime import datetime
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.aad_user_conversation_member import AadUserConversationMember
+from msgraph.generated.models.chat import Chat
+from msgraph.generated.users.item.chats.chats_request_builder import ChatsRequestBuilder
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import collect_pages, graph_errors
+
+# Reading a chat's `lastMessagePreview` is reading a message, which `Chat.ReadBasic` — "read the
+# names and members of chats" — does not cover; `Chat.Read` is the least privilege that does.
+GRAPH_PERMISSION = "Chat.Read"
+
+# Graph's documented `$top` ceiling on this collection. The tool's schema derives its `limit`
+# maximum from this, so the bound a caller sees is the bound Graph actually enforces.
+MAX_CHATS = 50
+
+# Graph's documented cap on `$expand=members`, per chat.
+MEMBERS_PER_CHAT = 25
+
+_RECENCY = "lastMessagePreview/createdDateTime desc"
+
+type _ChatsQuery = ChatsRequestBuilder.ChatsRequestBuilderGetQueryParameters
+
+
+class ChatMember(BaseModel):
+    display_name: str | None = Field(
+        description="The member's name as Teams shows it. Null for some external participants."
+    )
+    email: str | None = Field(
+        default=None,
+        description=(
+            "The member's email address, present only when `include_member_emails` was set. Null "
+            + "for a participant Graph has no address for, such as a room or a phone dial-in."
+        ),
+    )
+
+
+class ChatSummary(BaseModel):
+    chat_id: str = Field(
+        description=(
+            "The chat's Graph id, e.g. `19:...@thread.v2`. Pass it verbatim to any tool that "
+            + "takes a chat id; it cannot be reconstructed from a topic or a member's name."
+        )
+    )
+    chat_type: str = Field(
+        description=(
+            "`oneOnOne`, `group` or `meeting` — a meeting chat is the conversation attached to a "
+            + "Teams meeting. `unknown` if Graph reported a type this connector predates."
+        )
+    )
+    topic: str | None = Field(
+        description=(
+            "The chat's name. Null for every oneOnOne chat and for group chats nobody named — "
+            + "those are identified by `members` instead."
+        )
+    )
+    last_message_at: datetime | None = Field(
+        description=(
+            "When the last message in this chat was sent. This is the value the list is ordered "
+            + "by, and the only 'recent activity' Microsoft Graph exposes for a chat. Null when "
+            + "nobody has posted in the chat yet."
+        )
+    )
+    created_at: datetime | None = Field(
+        description=(
+            "When the chat was created (Graph `createdDateTime`) — useful to tell apart chats "
+            + "that share a topic."
+        )
+    )
+    members: list[ChatMember] | None = Field(
+        description=(
+            "Who is in the chat. Returned only for chats with no `topic`, where the people are "
+            + "the only way to name the chat; null otherwise, which is not a claim that the chat "
+            + "has no members."
+        )
+    )
+    members_truncated: bool = Field(
+        description=(
+            f"True when `members` hit Microsoft Graph's cap of {MEMBERS_PER_CHAT} members per "
+            + "chat on this endpoint, so people are missing from the list. Always false when "
+            + "`members` is null."
+        )
+    )
+
+
+class ChatList(BaseModel):
+    chats: list[ChatSummary] = Field(
+        description="The signed-in user's chats, most recently active first."
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the user has more chats than the `limit` returned here. There is no "
+            + f"cursor: raise `limit` (up to {MAX_CHATS}) to widen the window. Chats less recent "
+            + "than the window are not reachable from this tool."
+        )
+    )
+
+
+async def list_recent_chats(
+    client: GraphServiceClient, *, limit: int, include_member_emails: bool
+) -> ChatList:
+    """The `limit` most recently active chats, and whether the user has more than that."""
+    assert 1 <= limit <= MAX_CHATS, f"limit must be within 1..{MAX_CHATS}, got {limit}"
+
+    configuration = RequestConfiguration[_ChatsQuery](
+        query_parameters=ChatsRequestBuilder.ChatsRequestBuilderGetQueryParameters(
+            # `$select` is rejected on this collection as an unsupported parameter, so the
+            # expansions are what bring back the fields below.
+            expand=["members", "lastMessagePreview"],
+            orderby=[_RECENCY],
+            top=limit,
+        )
+    )
+    with graph_errors():
+        first_page = await client.me.chats.get(request_configuration=configuration)
+        assert first_page is not None, "Graph answered GET /me/chats with no collection"
+        collected = await collect_pages(first_page, client, limit=limit)
+
+    return ChatList(
+        chats=[_summarise(chat, include_member_emails) for chat in collected.items],
+        truncated=collected.truncated,
+    )
+
+
+def _summarise(chat: Chat, include_member_emails: bool) -> ChatSummary:
+    assert chat.id is not None, "Graph returned a chat with no id"
+    preview = chat.last_message_preview
+    members = _members(chat, include_member_emails) if chat.topic is None else None
+    # `ChatType` subclasses `str`, so the member *is* its wire value ("group") and pydantic
+    # narrows it to a plain `str` on the way in. Its `.value` would be the obvious thing to reach
+    # for and is typed as a one-tuple, because the generated members carry trailing commas
+    # (`OneOnOne = "oneOnOne",`).
+    return ChatSummary(
+        chat_id=chat.id,
+        chat_type=chat.chat_type if chat.chat_type is not None else "unknown",
+        topic=chat.topic,
+        last_message_at=preview.created_date_time if preview is not None else None,
+        created_at=chat.created_date_time,
+        members=members,
+        members_truncated=members is not None and len(members) >= MEMBERS_PER_CHAT,
+    )
+
+
+def _members(chat: Chat, include_emails: bool) -> list[ChatMember]:
+    """The chat's expanded members.
+
+    Only `aadUserConversationMember` carries an email; a room, a phone participant or an
+    anonymous meeting guest is a different subtype with a display name and nothing to match on.
+    """
+    return [
+        ChatMember(
+            display_name=member.display_name,
+            email=member.email
+            if include_emails and isinstance(member, AadUserConversationMember)
+            else None,
+        )
+        for member in chat.members or []
+    ]

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -61,8 +61,11 @@ class ChatMember(BaseModel):
 class ChatSummary(BaseModel):
     chat_id: str = Field(
         description=(
-            "The chat's Graph id, e.g. `19:...@thread.v2`. Pass it verbatim to any tool that "
-            + "takes a chat id; it cannot be reconstructed from a topic or a member's name."
+            "The chat's Graph id, e.g. `19:...@thread.v2`. It is the same id search_messages "
+            + "reports as `chat_id` on a chat message, so it is how to tell which of these chats a "
+            + "found message came from. No tool here takes a chat id as an argument — a message is "
+            + "read by the `uri` handle search_messages emits, which this id cannot be assembled "
+            + "into — and it cannot be reconstructed from a topic or a member's name either."
         )
     )
     chat_type: str = Field(
@@ -115,9 +118,10 @@ class ChatList(BaseModel):
     )
     truncated: bool = Field(
         description=(
-            "True when the user has more chats than the `limit` returned here. There is no "
-            + f"cursor: raise `limit` (up to {MAX_CHATS}) to widen the window. Chats less recent "
-            + "than the window are not reachable from this tool."
+            "True when the user has more chats than this `limit` holds — the same 'there is more' "
+            + "flag every list-shaped tool here reports. There is no cursor to page with: raise "
+            + f"`limit` (up to {MAX_CHATS}) to widen the window. Chats less recent than the window "
+            + "are not reachable from this tool."
         )
     )
 

--- a/services/office-mcp/src/office_mcp/features/chats.py
+++ b/services/office-mcp/src/office_mcp/features/chats.py
@@ -16,6 +16,15 @@ Three Graph facts shape everything here, all from the list-chats reference
   exactly how a model comes to summarise a 200-person chat from 25 names. So a list that arrives
   full to the cap is reported as *possibly* incomplete — which is the whole of what is known: a
   chat with exactly 25 members and one with 200 come back identical.
+
+A meeting chat carries one thing more, and it is why there is no separate meeting-discovery tool:
+`chat.onlineMeetingInfo.joinWebUrl` is the only value a delegated caller is given that addresses the
+`onlineMeeting` behind the chat, and a join URL is how Graph's transcript chain starts. It is a
+property of this collection's default projection rather than something asked for — the endpoint
+supports `$expand`, `$top`, `$filter` and `$orderby` and nothing else, so it could not be
+`$select`ed even if it were absent. Turning it into a handle is `transcripts`' job, which is where
+the meeting handle grammar lives; this module only asks for it, and reports its absence as an
+absence.
 """
 
 from datetime import datetime
@@ -27,6 +36,7 @@ from msgraph.generated.users.item.chats.chats_request_builder import ChatsReques
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
+from office_mcp.features.transcripts import meeting_uri_for
 from office_mcp.graph_client import collect_pages, graph_errors
 
 # Reading a chat's `lastMessagePreview` is reading a message, which `Chat.ReadBasic` — "read the
@@ -78,6 +88,19 @@ class ChatSummary(BaseModel):
         description=(
             "The chat's name. Null for every oneOnOne chat and for group chats nobody named — "
             + "those are identified by `members` instead."
+        )
+    )
+    meeting_uri: str | None = Field(
+        description=(
+            "For a meeting chat, a handle for the Teams meeting behind it — pass it verbatim to "
+            + "list_meeting_transcripts to find out whether the meeting was transcribed and "
+            + "to read what was said in it. This is the only route from a conversation to a "
+            + "transcript: Microsoft addresses a meeting by the join URL this handle carries, and "
+            + "nothing turns a chat id, a topic or a date into one.\n"
+            + "Null for every chat whose `chat_type` is not `meeting`, and also null for a meeting "
+            + "chat Microsoft returned no join URL for — in which case that meeting's transcripts "
+            + "are unreachable from this connector, there is no other route to try, and the honest "
+            + "answer is to say so rather than to search for one."
         )
     )
     last_message_at: datetime | None = Field(
@@ -160,10 +183,12 @@ def _summarise(chat: Chat, include_member_emails: bool) -> ChatSummary:
     # narrows it to a plain `str` on the way in. Its `.value` would be the obvious thing to reach
     # for and is typed as a one-tuple, because the generated members carry trailing commas
     # (`OneOnOne = "oneOnOne",`).
+    meeting = chat.online_meeting_info
     return ChatSummary(
         chat_id=chat.id,
         chat_type=chat.chat_type if chat.chat_type is not None else "unknown",
         topic=chat.topic,
+        meeting_uri=meeting_uri_for(meeting.join_web_url) if meeting is not None else None,
         last_message_at=preview.created_date_time if preview is not None else None,
         created_at=chat.created_date_time,
         members=members,

--- a/services/office-mcp/src/office_mcp/features/identity.py
+++ b/services/office-mcp/src/office_mcp/features/identity.py
@@ -27,19 +27,23 @@ class SignedInUser(BaseModel):
 
     Field names are snake_case here and in every other tool payload, which is the one place this
     connector deliberately does not echo Graph's spelling — the field descriptions name the Graph
-    property wherever the two differ.
+    property wherever the two differ. Two of them differ by more than case, so that one thing has
+    one name across this server's whole surface: a person's Entra object id is `user_id` here as it
+    is on a message's sender and on a mention, and an email address is `email` here as it is on a
+    sender and on a chat member. Graph calls them `id` and `mail`.
     """
 
-    id: str = Field(
+    user_id: str = Field(
         description=(
-            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier "
-            + "safe to compare against user ids from other tools; names and addresses change."
+            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier safe "
+            + "to compare against the `user_id` of a message's sender or of a mention; names and "
+            + "addresses change."
         )
     )
     display_name: str | None = Field(
         description="The user's name as Microsoft 365 shows it. Null only on incomplete accounts."
     )
-    mail: str | None = Field(
+    email: str | None = Field(
         description=(
             "The canonical primary SMTP address (Graph `mail`), and the right thing to match a "
             + "sender or recipient address against. Null for guest and unlicensed accounts — "
@@ -50,7 +54,7 @@ class SignedInUser(BaseModel):
         description=(
             "The sign-in name (Graph `userPrincipalName`). Usually looks like an email address "
             + "but is not guaranteed to be one: a tenant may issue it on a different domain than "
-            + "`mail`, so treat it as an identifier rather than an address unless `mail` is null."
+            + "`email`, so treat it as an identifier rather than an address unless `email` is null."
         )
     )
     job_title: str | None = Field(
@@ -71,9 +75,9 @@ async def get_signed_in_user(client: GraphServiceClient) -> SignedInUser:
     assert user is not None, "Graph answered GET /me with no user object"
     assert user.id is not None, "Graph answered GET /me with a user that has no id"
     return SignedInUser(
-        id=user.id,
+        user_id=user.id,
         display_name=user.display_name,
-        mail=user.mail,
+        email=user.mail,
         user_principal_name=user.user_principal_name,
         job_title=user.job_title,
     )

--- a/services/office-mcp/src/office_mcp/features/identity.py
+++ b/services/office-mcp/src/office_mcp/features/identity.py
@@ -1,0 +1,79 @@
+"""Who the caller is, according to Microsoft Graph.
+
+Every other feature answers questions about "my" mail, "my" chats or "my" meetings, and each of
+them is answered as the signed-in user. This module is how a model finds out who that is.
+"""
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.users.item.user_item_request_builder import UserItemRequestBuilder
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_errors
+
+# The delegated Microsoft Graph permission this module's one call needs. Declared beside the call
+# rather than in the server layer so that the permission and the request that requires it cannot
+# drift apart: `server/` both requests it at sign-in and names it when Graph refuses.
+GRAPH_PERMISSION = "User.Read"
+
+# `/me` returns a large default projection; these are the five properties the model is told about.
+_SELECT = ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
+
+type _MeQuery = UserItemRequestBuilder.UserItemRequestBuilderGetQueryParameters
+
+
+class SignedInUser(BaseModel):
+    """The signed-in user's own profile, as the MCP client sees it.
+
+    Field names are snake_case here and in every other tool payload, which is the one place this
+    connector deliberately does not echo Graph's spelling — the field descriptions name the Graph
+    property wherever the two differ.
+    """
+
+    id: str = Field(
+        description=(
+            "The user's immutable Microsoft Entra object id (Graph `id`). The only identifier "
+            + "safe to compare against user ids from other tools; names and addresses change."
+        )
+    )
+    display_name: str | None = Field(
+        description="The user's name as Microsoft 365 shows it. Null only on incomplete accounts."
+    )
+    mail: str | None = Field(
+        description=(
+            "The canonical primary SMTP address (Graph `mail`), and the right thing to match a "
+            + "sender or recipient address against. Null for guest and unlicensed accounts — "
+            + "fall back to user_principal_name."
+        )
+    )
+    user_principal_name: str | None = Field(
+        description=(
+            "The sign-in name (Graph `userPrincipalName`). Usually looks like an email address "
+            + "but is not guaranteed to be one: a tenant may issue it on a different domain than "
+            + "`mail`, so treat it as an identifier rather than an address unless `mail` is null."
+        )
+    )
+    job_title: str | None = Field(
+        description="The user's job title, when the directory records one."
+    )
+
+
+async def get_signed_in_user(client: GraphServiceClient) -> SignedInUser:
+    """`GET /me`, projected onto the five properties this connector promises."""
+    configuration = RequestConfiguration[_MeQuery](
+        query_parameters=UserItemRequestBuilder.UserItemRequestBuilderGetQueryParameters(
+            select=_SELECT
+        )
+    )
+    with graph_errors():
+        user = await client.me.get(request_configuration=configuration)
+
+    assert user is not None, "Graph answered GET /me with no user object"
+    assert user.id is not None, "Graph answered GET /me with a user that has no id"
+    return SignedInUser(
+        id=user.id,
+        display_name=user.display_name,
+        mail=user.mail,
+        user_principal_name=user.user_principal_name,
+        job_title=user.job_title,
+    )

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -21,7 +21,10 @@ What a read has to survive, all of it documented and none of it optional:
 * **The body is Teams HTML.** `itemBody.contentType` is `html` or `text`, and the HTML is wrapper
   divs, `<at>` mention tags, `<emoji alt="👀">`, hostedContents `<img>` and `<attachment>`
   placeholders. Handing that to a model is a quality bug, so it is normalised to text here — the
-  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented.
+  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented, with one
+  deliberate divergence: that port decides a message is an adaptive card when its *text* starts
+  with `{` and contains `"type"`, which discards any message somebody pasted JSON into. The card
+  signal here is attachment metadata instead, per `_is_card` below.
 * **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
   (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
   *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
@@ -35,13 +38,17 @@ What a read has to survive, all of it documented and none of it optional:
   properties of `chatMessage`; a tombstone must not be presented as live content.
 * **`mentions[]` and `attachments[]` are the key to the body.** The body carries `<at id="0">` and
   `<attachment id="…">` placeholders whose meaning is in those collections, so both are returned
-  resolved.
+  resolved. A *card* is one of those attachments and nothing else: Graph marks it by the
+  attachment's `contentType`, so that — never the shape of the body text — is what says a message
+  is a card here.
 """
 
 import html
+import json
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from typing import cast
 from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -120,9 +127,11 @@ class MessageAttachment(BaseModel):
     content_type: str | None = Field(
         description=(
             "Microsoft's `contentType`: `reference` for a link to a file, "
-            + "`forwardedMessageReference` for a forwarded message, "
-            + "`application/vnd.microsoft.card.codesnippet` for a code snippet, or a Bot Framework "
-            + "card type. It says what the attachment is, not what format the file is in."
+            + "`forwardedMessageReference` for a forwarded message, or a card type such as "
+            + "`application/vnd.microsoft.card.adaptive` for an adaptive card and "
+            + "`application/vnd.microsoft.card.codesnippet` for a code snippet. It says what the "
+            + "attachment is, not what format the file is in — and it is the only thing that says "
+            + "a message carries a card, which is why `[card]` in `text` comes from here."
         )
     )
     url: str | None = Field(
@@ -169,10 +178,12 @@ class TeamsMessage(BaseModel):
         description=(
             "The message, as plain text. Teams HTML is normalised: mentions read as `@Name`, list "
             + "items as `- `, emoji as themselves, an inline image as `[image]`, an attachment as "
-            + "`[attachment: name]` and an adaptive card as `[card]`, with every remaining tag "
-            + "removed and every HTML entity decoded. Null when the message has no text of its "
-            + "own — a system event, a deleted message, or a post that was only an image or a "
-            + "card. This is the full body, not search's `summary` snippet."
+            + "`[attachment: name]` and a card as `[card]`, with every remaining tag removed and "
+            + "every HTML entity decoded. Null when the message has no text of its own — a system "
+            + "event, a deleted message, or a post that was only an image or a card. This is the "
+            + "whole message, never abridged: text that happens to look like JSON or code is a "
+            + "person's own words and is reported verbatim, and `[card]` appears only where "
+            + "`attachments` names a card. This is the full body, not search's `summary` snippet."
         )
     )
     event: str | None = Field(
@@ -440,9 +451,30 @@ _IMAGE = re.compile(r"<img[^>]*>", re.IGNORECASE)
 _ANY_TAG = re.compile(r"<[^>]*>")
 _BLANK_LINES = re.compile(r"\n{3,}")
 
-# An adaptive card whose JSON Teams put in the body rather than in `attachments`. Dumping it would
-# spend a model's context on layout; `services/teams-mcp` found this the hard way.
+_ATTACHMENT = "[attachment]"
 _CARD = "[card]"
+
+# A card is *attachment metadata*, not something to sniff out of body text. Graph names it in
+# `attachments[].contentType` — "If the attachment is a rich card, set the property to the rich card
+# object" of `content` — and the documented value for an adaptive card is
+# `application/vnd.microsoft.card.adaptive`, one of two card namespaces Teams publishes
+# (https://learn.microsoft.com/en-us/graph/api/resources/chatmessageattachment,
+# https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference):
+#
+#     application/vnd.microsoft.card.adaptive              an adaptive card
+#     application/vnd.microsoft.card.hero                  a hero card
+#     application/vnd.microsoft.card.thumbnail             a thumbnail card
+#     application/vnd.microsoft.card.receipt               a receipt card
+#     application/vnd.microsoft.card.signin                a sign-in card
+#     application/vnd.microsoft.card.codesnippet           a code snippet
+#     application/vnd.microsoft.card.announcement          an announcement header
+#     application/vnd.microsoft.teams.card.list            a list card
+#     application/vnd.microsoft.teams.card.o365connector   a connector card for Microsoft 365 Groups
+#
+# The two prefixes are matched rather than those nine values enumerated, for the same reason
+# `_EVENT_TYPE` reads an event's name instead of tabulating the 31 subtypes that exist today: the
+# namespace is the documented shape, and Teams keeps adding card types to it.
+_CARD_CONTENT_TYPES = ("application/vnd.microsoft.card.", "application/vnd.microsoft.teams.card.")
 
 
 def _text(
@@ -475,8 +507,10 @@ def _from_html(
     mention_texts = {
         mention.id: mention.mention_text for mention in mentions if mention.id is not None
     }
-    names = {
-        attachment.id: attachment.name for attachment in attachments if attachment.id is not None
+    markers = {
+        attachment.id: _attachment_marker(attachment)
+        for attachment in attachments
+        if attachment.id is not None
     }
 
     text = _PARAGRAPH_END.sub("\n", content)
@@ -485,16 +519,14 @@ def _from_html(
     text = _LIST_ITEM.sub("- ", text)
     text = _MENTION_TAG.sub(lambda tag: _mention_text(tag, mention_texts), text)
     text = _EMOJI.sub(lambda tag: tag.group(1), text)
-    text = _ATTACHMENT_TAG.sub(lambda tag: _attachment_text(tag, names), text)
+    text = _ATTACHMENT_TAG.sub(lambda tag: markers.get(tag.group(1), _ATTACHMENT), text)
     text = _IMAGE.sub("[image]", text)
     text = _ANY_TAG.sub("", text)
     # A non-breaking space is what Teams puts between pasted words; a model reads it as a word
     # joiner rather than as the space it is meant to be.
     text = html.unescape(text).replace("\xa0", " ")
     text = _BLANK_LINES.sub("\n\n", text).strip()
-    if text.startswith("{") and '"type"' in text:
-        return _CARD
-    return text
+    return _CARD if _is_card_payload(text, attachments) else text
 
 
 def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> str:
@@ -511,6 +543,46 @@ def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> s
     return f"@{name}" if name else "[mention]"
 
 
-def _attachment_text(tag: re.Match[str], names: dict[str, str | None]) -> str:
-    name = names.get(tag.group(1))
-    return f"[attachment: {name}]" if name else "[attachment]"
+def _attachment_marker(attachment: ChatMessageAttachment) -> str:
+    """How one attachment reads where the body's `<attachment id="…">` placeholder sat.
+
+    Teams gives a card no `name`, so a card would otherwise read as an anonymous `[attachment]`.
+    Its `contentType` is what says it is a card, and that is where `[card]` comes from.
+    """
+    if attachment.name:
+        return f"[attachment: {attachment.name}]"
+    return _CARD if _is_card(attachment) else _ATTACHMENT
+
+
+def _is_card(attachment: ChatMessageAttachment) -> bool:
+    """Whether Graph marked this attachment as a card, by the only property that says so."""
+    return (attachment.content_type or "").lower().startswith(_CARD_CONTENT_TYPES)
+
+
+def _is_card_payload(text: str, attachments: list[ChatMessageAttachment]) -> bool:
+    """Whether `text` is nothing but the payload of a card this message already carries.
+
+    Teams sometimes leaves a card's own JSON in `body.content` instead of the
+    `<attachment id="…">` placeholder, and handing a model a screenful of layout JSON spends its
+    context on nothing. But *looking* like JSON is not evidence of a card — a developer pasting a
+    config fragment or an API response into Teams writes a brace-and-`"type"` object too, and a
+    guard that went by the shape of the text silently threw those messages away, in the one tool
+    that is the only route to a message's text. So a body is only dropped when the message carries
+    a card attachment whose `content` *is* that payload, compared parsed so that indentation and
+    escaping do not decide it. Everything else is what somebody wrote, and is returned in full.
+    """
+    payload = _json(text)
+    if payload is None:
+        return False
+    cards = (attachment for attachment in attachments if _is_card(attachment))
+    return any(_json(card.content) == payload for card in cards)
+
+
+def _json(value: str | None) -> object | None:
+    """`value` parsed, or None when it is not a JSON object or array to begin with."""
+    if value is None or not value.lstrip().startswith(("{", "[")):
+        return None
+    try:
+        return cast("object", json.loads(value))
+    except ValueError:
+        return None

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -6,15 +6,11 @@ properties defined in chatMessage. You can use the Teams API to retrieve more de
 single message" (https://learn.microsoft.com/en-us/graph/search-concept-chat-messages) — so a hit
 is metadata plus a handle, and this is the module that turns the handle back into a message.
 
-The handle is `message_search`'s contract, and exactly two shapes exist because Graph addresses a
-Teams message two ways (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
-
-    teams:///chats/{chatId}/messages/{messageId}
-    teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
-
-Nothing else is accepted. `mail:///`, `site:///` and friends are not "not yet implemented" — this
-connector is scoped to Teams, and a reader that advertises schemes it cannot serve teaches a model
-to ask for things that will always fail.
+The handle is `message_search`'s contract, so `MessageHandle` and its parser live there, with the
+search that mints them, and this module takes them from there rather than spelling the two shapes a
+second time. `MessageSender` and `sender_of` arrive the same way and for the same reason: a message
+means the same thing whichever of the two tools produced it, and that is a property of there being
+one definition rather than of two agreeing.
 
 What a read has to survive, all of it documented and none of it optional:
 
@@ -28,8 +24,8 @@ What a read has to survive, all of it documented and none of it optional:
 * **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
   (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
   *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
-  `emailAddress`. Both go through `message_search.sender_of`, so a sender means the same thing
-  whichever tool produced it.
+  `emailAddress`. Both go through `sender_of`, which is why a `sender` here has the same three
+  fields as a search hit's, with different ones filled in.
 * **System / event messages have no text anywhere.** `from` is null and `body.content` is the
   literal `<systemEventMessage/>`; the "Ada joined the chat" sentence is rendered by the Teams
   client and Graph never sends it (https://learn.microsoft.com/en-us/graph/system-messages). Search
@@ -46,10 +42,8 @@ What a read has to survive, all of it documented and none of it optional:
 import html
 import json
 import re
-from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
-from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
 from kiota_abstractions.headers_collection import HeadersCollection
@@ -67,19 +61,20 @@ from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
-from office_mcp.features.message_search import MessageSender, sender_of
+from office_mcp.features.message_search import (
+    CHANNEL_PERMISSION,
+    CHAT_PERMISSION,
+    MessageHandle,
+    MessageSender,
+    sender_of,
+)
 from office_mcp.graph_client import graph_errors
 
-# Reading a message is `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the
-# permissions are per surface (https://learn.microsoft.com/en-us/graph/api/chatmessage-get), and a
-# handle says which surface it addresses. That is why `MessageHandle.permission` exists: a 403 on a
-# chat read can only be about `Chat.Read`, and naming the other one alongside it would send an
-# administrator after a permission that was never missing.
-CHAT_PERMISSION = "Chat.Read"
-CHANNEL_PERMISSION = "ChannelMessage.Read.All"
-
-# What the token exchange has to ask for. Both, because the exchange happens before the tool sees
-# its argument and so before anything knows which surface this call will read.
+# What the token exchange has to ask for: both, because the exchange happens before the tool sees
+# its argument and so before anything knows which surface this call will read. Reading a message is
+# `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the permissions are per surface
+# (https://learn.microsoft.com/en-us/graph/api/chatmessage-get) — and `MessageHandle.permission` is
+# what names the one a given read was actually made under.
 GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
 
 # `messageType` is an evolvable enum: without this header Graph answers `systemEventMessage` as
@@ -107,10 +102,10 @@ class MessageMention(BaseModel):
     )
     user_id: str | None = Field(
         description=(
-            "The mentioned person's Microsoft Entra object id, comparable against `id` from whoami "
-            + "and the `mentions` parameter of search_messages. Null when the mention was not a "
-            + "person — Teams also mentions teams, channels, chats, tags and everyone at once — so "
-            + "a null here is not a failure to resolve a user."
+            "The mentioned person's Microsoft Entra object id, comparable against `user_id` from "
+            + "get_me and the `mentions` parameter of search_messages. Null when the mention was "
+            + "not a person — Teams also mentions teams, channels, chats, tags and everyone at "
+            + "once — so a null here is not a failure to resolve a user."
         )
     )
 
@@ -242,71 +237,6 @@ class TeamsMessage(BaseModel):
             + "not unpacked."
         )
     )
-
-
-@dataclass(frozen=True, slots=True)
-class MessageHandle:
-    """A parsed `teams:///` handle: which message, and under which permission it is read."""
-
-    message_id: str
-    chat_id: str | None = None
-    team_id: str | None = None
-    channel_id: str | None = None
-
-    @property
-    def permission(self) -> str:
-        """The one delegated Graph permission the read this handle addresses is made under."""
-        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
-
-    @property
-    def uri(self) -> str:
-        """The handle again, canonically — identical to the `uri` a search hit carried."""
-        if self.chat_id is not None:
-            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
-        assert self.team_id is not None and self.channel_id is not None, (
-            "a handle addresses either a chat or a team channel"
-        )
-        return (
-            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
-            + f"/messages/{_segment(self.message_id)}"
-        )
-
-
-# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
-# `message_search` percent-encodes each one — a Teams id is full of `:` and `@` and would otherwise
-# be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was already
-# readable exactly as it is, so a handle a caller copied out of a log still resolves.
-_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
-_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
-
-
-def message_handle(uri: str) -> MessageHandle | None:
-    """`uri` as a handle, or None if it is not one this connector can read.
-
-    None rather than an exception with a message: what to tell the caller about a malformed handle
-    is the tool boundary's business, and this module is not allowed to speak MCP.
-    """
-    chat = _CHAT_HANDLE.match(uri)
-    if chat is not None:
-        chat_id, message_id = (unquote(part) for part in chat.groups())
-        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
-    channel = _CHANNEL_HANDLE.match(uri)
-    if channel is not None:
-        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
-        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
-    return None
-
-
-def _handle(handle: MessageHandle) -> MessageHandle | None:
-    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
-    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
-    if any(value is not None and not value.strip() for value in ids):
-        return None
-    return handle
-
-
-def _segment(value: str) -> str:
-    return quote(value, safe="")
 
 
 async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> TeamsMessage:

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -7,8 +7,10 @@ single message" (https://learn.microsoft.com/en-us/graph/search-concept-chat-mes
 is metadata plus a handle, and this is the module that turns the handle back into a message.
 
 The handle is `message_search`'s contract, so `MessageHandle` and its parser live there, with the
-search that mints them, and this module takes them from there rather than spelling the two shapes a
-second time. `MessageSender` and `sender_of` arrive the same way and for the same reason: a message
+search that mints them, and this module takes them from there rather than spelling the three shapes
+a second time — including the reply shape, which `channels.browse_channel` mints and which is read
+here under its parent post, the only way Graph addresses a reply at all.
+`MessageSender` and `sender_of` arrive the same way and for the same reason: a message
 means the same thing whichever of the two tools produced it, and that is a property of there being
 one definition rather than of two agreeing.
 
@@ -58,6 +60,9 @@ from msgraph.generated.models.chat_message_type import ChatMessageType
 from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_request_builder import (  # noqa: E501
     ChatMessageItemRequestBuilder as ChannelMessageRequestBuilder,
 )
+from msgraph.generated.teams.item.channels.item.messages.item.replies.item.chat_message_item_request_builder import (  # noqa: E501
+    ChatMessageItemRequestBuilder as ChannelReplyRequestBuilder,
+)
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
@@ -88,6 +93,7 @@ type _ChatMessageQuery = ChatMessageRequestBuilder.ChatMessageItemRequestBuilder
 type _ChannelMessageQuery = (
     ChannelMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
 )
+type _ChannelReplyQuery = ChannelReplyRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
 
 
 class MessageMention(BaseModel):
@@ -249,7 +255,7 @@ async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> 
         message = await _get(client, handle)
 
     assert message is not None, "Graph answered a message read with no message"
-    return _message(message, handle)
+    return message_of(message, handle=handle)
 
 
 async def _get(client: GraphServiceClient, handle: MessageHandle) -> ChatMessage | None:
@@ -262,11 +268,20 @@ async def _get(client: GraphServiceClient, handle: MessageHandle) -> ChatMessage
     assert handle.team_id is not None and handle.channel_id is not None, (
         "a handle addresses either a chat or a team channel"
     )
-    return await (
-        client.teams.by_team_id(handle.team_id)
-        .channels.by_channel_id(handle.channel_id)
-        .messages.by_chat_message_id(handle.message_id)
-        .get(request_configuration=RequestConfiguration[_ChannelMessageQuery](headers=_headers()))
+    messages = (
+        client.teams.by_team_id(handle.team_id).channels.by_channel_id(handle.channel_id).messages
+    )
+    if handle.reply_to_id is not None:
+        # A reply is addressed under the post it replies to, never beside it — the reply id alone
+        # is a 404. `by_chat_message_id1` is the generated name for the second message id in that
+        # path, the first being the parent post's.
+        return await (
+            messages.by_chat_message_id(handle.reply_to_id)
+            .replies.by_chat_message_id1(handle.message_id)
+            .get(request_configuration=RequestConfiguration[_ChannelReplyQuery](headers=_headers()))
+        )
+    return await messages.by_chat_message_id(handle.message_id).get(
+        request_configuration=RequestConfiguration[_ChannelMessageQuery](headers=_headers())
     )
 
 
@@ -282,7 +297,14 @@ def _headers() -> HeadersCollection:
     return headers
 
 
-def _message(message: ChatMessage, handle: MessageHandle) -> TeamsMessage:
+def message_of(message: ChatMessage, *, handle: MessageHandle) -> TeamsMessage:
+    """`message` as this connector reports a Teams message, addressed by `handle`.
+
+    Public because `channels.browse_channel` gets whole messages back from Graph rather than a
+    projection — a channel message list carries every field a single read does — so browsing a
+    channel and reading one message answer with the same shape, normalised the same way, because
+    they are the same function rather than two that agree.
+    """
     mentions = message.mentions or []
     attachments = message.attachments or []
     return TeamsMessage(
@@ -293,11 +315,13 @@ def _message(message: ChatMessage, handle: MessageHandle) -> TeamsMessage:
         channel_id=handle.channel_id,
         sender=sender_of(message.from_),
         text=_text(message, mentions=mentions, attachments=attachments),
-        event=_event(message),
+        event=event_of(message),
         created_at=message.created_date_time,
         last_edited_at=message.last_edited_date_time,
         deleted_at=message.deleted_date_time,
-        reply_to_id=message.reply_to_id,
+        # The handle is the fallback rather than the source: it names a parent only for a reply,
+        # while Graph sets `replyToId` on every message in a channel thread.
+        reply_to_id=message.reply_to_id or handle.reply_to_id,
         subject=message.subject,
         # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
         importance=message.importance,
@@ -336,12 +360,17 @@ _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
 _UNDESCRIBED_EVENT = "a system event Microsoft Graph sent no detail for"
 
 
-def _event(message: ChatMessage) -> str | None:
+def event_of(message: ChatMessage) -> str | None:
     """What this message is an event *of*, or None if a person wrote it.
 
     Three independent signals, because no one of them is reliable alone: `eventDetail` is only
     populated for `systemEventMessage`, `messageType` needs the `Prefer` header above to be legible
     at all, and a null `from` is what Graph actually sends for every one of them.
+
+    Public because it is also the test for "is this a message somebody wrote", which is what
+    `channels.browse_channel` filters a channel listing by: Graph offers no server-side
+    `messageType` filter on that collection, so the filtering is client-side there, and it has to
+    ask the same question this does or the two tools disagree about what a message is.
     """
     detail = message.event_detail
     if detail is not None:

--- a/services/office-mcp/src/office_mcp/features/message_read.py
+++ b/services/office-mcp/src/office_mcp/features/message_read.py
@@ -1,0 +1,516 @@
+"""Reading one Microsoft Teams message, from the handle a search result carries.
+
+`message_search` cannot answer "what did they actually say". Graph's search index returns a
+reduced `chatMessage` projection with **no `body`** — "The search Teams API doesn't return all
+properties defined in chatMessage. You can use the Teams API to retrieve more details about any
+single message" (https://learn.microsoft.com/en-us/graph/search-concept-chat-messages) — so a hit
+is metadata plus a handle, and this is the module that turns the handle back into a message.
+
+The handle is `message_search`'s contract, and exactly two shapes exist because Graph addresses a
+Teams message two ways (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
+
+    teams:///chats/{chatId}/messages/{messageId}
+    teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+
+Nothing else is accepted. `mail:///`, `site:///` and friends are not "not yet implemented" — this
+connector is scoped to Teams, and a reader that advertises schemes it cannot serve teaches a model
+to ask for things that will always fail.
+
+What a read has to survive, all of it documented and none of it optional:
+
+* **The body is Teams HTML.** `itemBody.contentType` is `html` or `text`, and the HTML is wrapper
+  divs, `<at>` mention tags, `<emoji alt="👀">`, hostedContents `<img>` and `<attachment>`
+  placeholders. Handing that to a model is a quality bug, so it is normalised to text here — the
+  same normalisation `services/teams-mcp` ships merged, ported rather than reinvented.
+* **The sender is a different shape from search's.** A read gives `teamworkUserIdentity`
+  (https://learn.microsoft.com/en-us/graph/api/resources/teamworkuseridentity): an id, an
+  *optional* display name, and **no email property at all**. Search gives a mailbox-shaped
+  `emailAddress`. Both go through `message_search.sender_of`, so a sender means the same thing
+  whichever tool produced it.
+* **System / event messages have no text anywhere.** `from` is null and `body.content` is the
+  literal `<systemEventMessage/>`; the "Ada joined the chat" sentence is rendered by the Teams
+  client and Graph never sends it (https://learn.microsoft.com/en-us/graph/system-messages). Search
+  drops these; a read that lands on one has to say what the event *was*, from `eventDetail`.
+* **Deleted and edited messages exist.** `deletedDateTime` and `lastEditedDateTime` are read-only
+  properties of `chatMessage`; a tombstone must not be presented as live content.
+* **`mentions[]` and `attachments[]` are the key to the body.** The body carries `<at id="0">` and
+  `<attachment id="…">` placeholders whose meaning is in those collections, so both are returned
+  resolved.
+"""
+
+import html
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import quote, unquote
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from kiota_abstractions.headers_collection import HeadersCollection
+from msgraph.generated.chats.item.messages.item.chat_message_item_request_builder import (
+    ChatMessageItemRequestBuilder as ChatMessageRequestBuilder,
+)
+from msgraph.generated.models.body_type import BodyType
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.models.chat_message_attachment import ChatMessageAttachment
+from msgraph.generated.models.chat_message_mention import ChatMessageMention
+from msgraph.generated.models.chat_message_type import ChatMessageType
+from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_request_builder import (  # noqa: E501
+    ChatMessageItemRequestBuilder as ChannelMessageRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.features.message_search import MessageSender, sender_of
+from office_mcp.graph_client import graph_errors
+
+# Reading a message is `Chat.Read` in a chat and `ChannelMessage.Read.All` in a channel — the
+# permissions are per surface (https://learn.microsoft.com/en-us/graph/api/chatmessage-get), and a
+# handle says which surface it addresses. That is why `MessageHandle.permission` exists: a 403 on a
+# chat read can only be about `Chat.Read`, and naming the other one alongside it would send an
+# administrator after a permission that was never missing.
+CHAT_PERMISSION = "Chat.Read"
+CHANNEL_PERMISSION = "ChannelMessage.Read.All"
+
+# What the token exchange has to ask for. Both, because the exchange happens before the tool sees
+# its argument and so before anything knows which surface this call will read.
+GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
+
+# `messageType` is an evolvable enum: without this header Graph answers `systemEventMessage` as
+# `unknownFutureValue` (https://learn.microsoft.com/en-us/graph/api/resources/chatmessage). Nothing
+# below *depends* on the type — a null `from` and a populated `eventDetail` identify a system
+# message either way — but `chatEvent` and `typing` carry neither, and the type is the only thing
+# that names them.
+_PREFER_UNKNOWN_ENUMS = ("Prefer", "include-unknown-enum-members")
+
+type _ChatMessageQuery = ChatMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
+type _ChannelMessageQuery = (
+    ChannelMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
+)
+
+
+class MessageMention(BaseModel):
+    """One @-mention, resolved: the body only carries an `<at id="N">` placeholder."""
+
+    text: str | None = Field(
+        description=(
+            "How the mention reads in the message, e.g. a person's display name or a team's name. "
+            + "This is Microsoft's `mentionText`, and it is what the `@…` in `text` was rendered "
+            + "from."
+        )
+    )
+    user_id: str | None = Field(
+        description=(
+            "The mentioned person's Microsoft Entra object id, comparable against `id` from whoami "
+            + "and the `mentions` parameter of search_messages. Null when the mention was not a "
+            + "person — Teams also mentions teams, channels, chats, tags and everyone at once — so "
+            + "a null here is not a failure to resolve a user."
+        )
+    )
+
+
+class MessageAttachment(BaseModel):
+    """One attachment. The body only carries an `<attachment id="…">` placeholder."""
+
+    name: str | None = Field(
+        description=(
+            "The attachment's name, which is what `[attachment: …]` in `text` shows. Null for "
+            + "attachments Teams gives no name, such as an adaptive card or a forwarded message."
+        )
+    )
+    content_type: str | None = Field(
+        description=(
+            "Microsoft's `contentType`: `reference` for a link to a file, "
+            + "`forwardedMessageReference` for a forwarded message, "
+            + "`application/vnd.microsoft.card.codesnippet` for a code snippet, or a Bot Framework "
+            + "card type. It says what the attachment is, not what format the file is in."
+        )
+    )
+    url: str | None = Field(
+        description=(
+            "Where the attachment's content lives, when Microsoft gave a URL. This connector does "
+            + "not download attachments, and the URL may need Microsoft 365 credentials to open, "
+            + "so treat it as a reference to show a person rather than something to fetch."
+        )
+    )
+
+
+class TeamsMessage(BaseModel):
+    """One Teams message, as fully as Microsoft Graph will describe it."""
+
+    uri: str = Field(
+        description=(
+            "The handle this message was read from, in the canonical form search_messages emits. "
+            + "Echoed so a message can be quoted, cached or re-read without reassembling it."
+        )
+    )
+    message_id: str = Field(
+        description=(
+            "The message's Graph `id`. Unique only within its own chat, channel or reply thread, "
+            + "so identify a message by `uri` rather than by this."
+        )
+    )
+    chat_id: str | None = Field(
+        description="The chat this message is in. Null for a channel message."
+    )
+    team_id: str | None = Field(description="The team, for a channel message. Null in a chat.")
+    channel_id: str | None = Field(
+        description="The channel, for a channel message. Null in a chat."
+    )
+    sender: MessageSender | None = Field(
+        description=(
+            "Who wrote the message, in the same shape search_messages reports. Null only when "
+            + "nobody wrote it: Microsoft Graph sends no author for a system event message, which "
+            + "`event` then describes. A read identifies a sender by Entra object id rather than "
+            + "by email — the Teams identity Graph answers a read with carries no email address at "
+            + "all — so `email` is normally null here even though search fills it in."
+        )
+    )
+    text: str | None = Field(
+        description=(
+            "The message, as plain text. Teams HTML is normalised: mentions read as `@Name`, list "
+            + "items as `- `, emoji as themselves, an inline image as `[image]`, an attachment as "
+            + "`[attachment: name]` and an adaptive card as `[card]`, with every remaining tag "
+            + "removed and every HTML entity decoded. Null when the message has no text of its "
+            + "own — a system event, a deleted message, or a post that was only an image or a "
+            + "card. This is the full body, not search's `summary` snippet."
+        )
+    )
+    event: str | None = Field(
+        description=(
+            "What happened, when this is a system event message rather than something a person "
+            + "wrote: `members joined`, `chat renamed`, `call ended` and so on, from Microsoft's "
+            + "`eventDetail` type. Null for an ordinary message. Microsoft Graph does not send the "
+            + "sentence Teams displays for these ('Ada joined the chat') — the Teams client writes "
+            + "it — so this naming of the event is all there is, and there is no text to quote. "
+            + "Who took part in the event is not returned by this connector."
+        )
+    )
+    created_at: datetime | None = Field(description="When the message was sent.")
+    last_edited_at: datetime | None = Field(
+        description=(
+            "When the message was last edited by its author, or null if it never was — this is "
+            + "Microsoft's `lastEditedDateTime`, the property behind the 'Edited' flag in Teams. "
+            + "Unlike `lastModifiedDateTime` it does not move when somebody adds a reaction."
+        )
+    )
+    deleted_at: datetime | None = Field(
+        description=(
+            "When the message was deleted, or null if it is still live. When this is set, `text` "
+            + "is null and the message's content is gone: say the message was deleted rather than "
+            + "reporting it as empty."
+        )
+    )
+    reply_to_id: str | None = Field(
+        description=(
+            "The id of the channel post this message replies to, for a reply in a channel thread; "
+            + "null for a root post and for every chat message, which Teams does not thread."
+        )
+    )
+    subject: str | None = Field(
+        description="The message subject. Usually null: Teams sets one only on some channel posts."
+    )
+    importance: str | None = Field(
+        description="`normal`, `high` or `urgent`, as the sender marked the message."
+    )
+    web_url: str | None = Field(
+        description=(
+            "A link that opens the message in Microsoft Teams. Populated for channel messages; "
+            + "Graph gives chat messages no such link, so it is null there."
+        )
+    )
+    mentions: list[MessageMention] = Field(
+        description=(
+            "Everyone and everything this message @-mentions, in the order Microsoft lists them. "
+            + "Empty when it mentions nobody."
+        )
+    )
+    attachments: list[MessageAttachment] = Field(
+        description=(
+            "What was attached: files, cards, code snippets, forwarded messages. Empty when "
+            + "nothing was. The contents are not downloaded and a forwarded message's own body is "
+            + "not unpacked."
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MessageHandle:
+    """A parsed `teams:///` handle: which message, and under which permission it is read."""
+
+    message_id: str
+    chat_id: str | None = None
+    team_id: str | None = None
+    channel_id: str | None = None
+
+    @property
+    def permission(self) -> str:
+        """The one delegated Graph permission the read this handle addresses is made under."""
+        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
+
+    @property
+    def uri(self) -> str:
+        """The handle again, canonically — identical to the `uri` a search hit carried."""
+        if self.chat_id is not None:
+            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
+        assert self.team_id is not None and self.channel_id is not None, (
+            "a handle addresses either a chat or a team channel"
+        )
+        return (
+            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+            + f"/messages/{_segment(self.message_id)}"
+        )
+
+
+# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
+# `message_search` percent-encodes each one — a Teams id is full of `:` and `@` and would otherwise
+# be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was already
+# readable exactly as it is, so a handle a caller copied out of a log still resolves.
+_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
+_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+
+
+def message_handle(uri: str) -> MessageHandle | None:
+    """`uri` as a handle, or None if it is not one this connector can read.
+
+    None rather than an exception with a message: what to tell the caller about a malformed handle
+    is the tool boundary's business, and this module is not allowed to speak MCP.
+    """
+    chat = _CHAT_HANDLE.match(uri)
+    if chat is not None:
+        chat_id, message_id = (unquote(part) for part in chat.groups())
+        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    channel = _CHANNEL_HANDLE.match(uri)
+    if channel is not None:
+        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
+        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
+    return None
+
+
+def _handle(handle: MessageHandle) -> MessageHandle | None:
+    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
+    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    if any(value is not None and not value.strip() for value in ids):
+        return None
+    return handle
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
+
+
+async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> TeamsMessage:
+    """The message `handle` addresses. One Graph request, whichever surface it lives on.
+
+    `chatmessage-get` "doesn't support the OData query parameters", so there is no `$select` to
+    narrow it with and no `$expand` to widen it: mentions and attachments arrive with the message.
+    """
+    with graph_errors():
+        message = await _get(client, handle)
+
+    assert message is not None, "Graph answered a message read with no message"
+    return _message(message, handle)
+
+
+async def _get(client: GraphServiceClient, handle: MessageHandle) -> ChatMessage | None:
+    if handle.chat_id is not None:
+        return await (
+            client.chats.by_chat_id(handle.chat_id)
+            .messages.by_chat_message_id(handle.message_id)
+            .get(request_configuration=RequestConfiguration[_ChatMessageQuery](headers=_headers()))
+        )
+    assert handle.team_id is not None and handle.channel_id is not None, (
+        "a handle addresses either a chat or a team channel"
+    )
+    return await (
+        client.teams.by_team_id(handle.team_id)
+        .channels.by_channel_id(handle.channel_id)
+        .messages.by_chat_message_id(handle.message_id)
+        .get(request_configuration=RequestConfiguration[_ChannelMessageQuery](headers=_headers()))
+    )
+
+
+def _headers() -> HeadersCollection:
+    """A `HeadersCollection` of our own, carrying the `Prefer` header.
+
+    Built per request on purpose: `RequestConfiguration.headers` defaults to a single
+    `HeadersCollection` instance shared by every configuration in the process, so adding a header
+    to the default would add it to every other Graph request this connector makes.
+    """
+    headers = HeadersCollection()
+    headers.add(*_PREFER_UNKNOWN_ENUMS)
+    return headers
+
+
+def _message(message: ChatMessage, handle: MessageHandle) -> TeamsMessage:
+    mentions = message.mentions or []
+    attachments = message.attachments or []
+    return TeamsMessage(
+        uri=handle.uri,
+        message_id=message.id or handle.message_id,
+        chat_id=handle.chat_id,
+        team_id=handle.team_id,
+        channel_id=handle.channel_id,
+        sender=sender_of(message.from_),
+        text=_text(message, mentions=mentions, attachments=attachments),
+        event=_event(message),
+        created_at=message.created_date_time,
+        last_edited_at=message.last_edited_date_time,
+        deleted_at=message.deleted_date_time,
+        reply_to_id=message.reply_to_id,
+        subject=message.subject,
+        # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
+        importance=message.importance,
+        web_url=message.web_url,
+        mentions=[_mention(mention) for mention in mentions],
+        attachments=[_attachment(attachment) for attachment in attachments],
+    )
+
+
+def _mention(mention: ChatMessageMention) -> MessageMention:
+    mentioned = mention.mentioned
+    user = mentioned.user if mentioned is not None else None
+    return MessageMention(text=mention.mention_text, user_id=user.id if user is not None else None)
+
+
+def _attachment(attachment: ChatMessageAttachment) -> MessageAttachment:
+    return MessageAttachment(
+        name=attachment.name,
+        content_type=attachment.content_type,
+        # `content` and `contentUrl` are documented as mutually exclusive, and `content` is a card
+        # payload or a forwarded message's JSON rather than a location — so only the URL is a URL.
+        url=attachment.content_url,
+    )
+
+
+# Every `eventMessageDetail` subtype is named `<what happened>EventMessageDetail`, and Microsoft
+# lists all 31 (https://learn.microsoft.com/en-us/graph/system-messages) — so the `@odata.type` of
+# the one Graph sent *is* the event. Reading the name is what makes this cover the subtypes
+# Microsoft adds next as well as the ones that exist today; a table of the 31 would answer
+# "unknown event" for the 32nd.
+_EVENT_TYPE = re.compile(r"\A#?microsoft\.graph\.(.+?)EventMessageDetail\Z")
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+# What Teams renders itself and Graph describes to nobody: `chatEvent` and `typing` messages carry
+# no `eventDetail`, and a `systemEventMessage` whose detail Graph omitted carries nothing either.
+_UNDESCRIBED_EVENT = "a system event Microsoft Graph sent no detail for"
+
+
+def _event(message: ChatMessage) -> str | None:
+    """What this message is an event *of*, or None if a person wrote it.
+
+    Three independent signals, because no one of them is reliable alone: `eventDetail` is only
+    populated for `systemEventMessage`, `messageType` needs the `Prefer` header above to be legible
+    at all, and a null `from` is what Graph actually sends for every one of them.
+    """
+    detail = message.event_detail
+    if detail is not None:
+        return _event_name(detail.odata_type) or _UNDESCRIBED_EVENT
+    if message.from_ is None or (
+        message.message_type is not None and message.message_type != ChatMessageType.Message
+    ):
+        return _UNDESCRIBED_EVENT
+    return None
+
+
+def _event_name(odata_type: str | None) -> str | None:
+    """`#microsoft.graph.membersJoinedEventMessageDetail` → `members joined`."""
+    if odata_type is None:
+        return None
+    matched = _EVENT_TYPE.match(odata_type)
+    if matched is None:
+        return None
+    return _CAMEL_BOUNDARY.sub(" ", matched.group(1)).lower()
+
+
+# Teams HTML, in the order it has to be unwound. Everything here is a documented shape rather than
+# a defensive guess: `services/teams-mcp` ships this same pipeline merged, and Microsoft's own
+# examples are where the `<emoji alt>`, hostedContents `<img>` and `<attachment>` placeholder cases
+# come from (https://learn.microsoft.com/en-us/graph/api/resources/chatmessage).
+_PARAGRAPH_END = re.compile(r"</p\s*>", re.IGNORECASE)
+_LINE_BREAK = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_LIST_ITEM_END = re.compile(r"</li\s*>", re.IGNORECASE)
+_LIST_ITEM = re.compile(r"<li[^>]*>", re.IGNORECASE)
+_MENTION_TAG = re.compile(r"<at([^>]*)>(.*?)</at\s*>", re.IGNORECASE | re.DOTALL)
+_MENTION_INDEX = re.compile(r'\bid="(\d+)"', re.IGNORECASE)
+# `<emoji id="1f440_eyes" alt="👀" title="Eyes">` — the character is in the attribute, so stripping
+# the tag without reading it deletes the emoji from the message.
+_EMOJI = re.compile(r'<(?:custom)?emoji[^>]*\balt="([^"]*)"[^>]*>', re.IGNORECASE)
+_ATTACHMENT_TAG = re.compile(r'<attachment[^>]*\bid="([^"]+)"[^>]*>', re.IGNORECASE)
+_IMAGE = re.compile(r"<img[^>]*>", re.IGNORECASE)
+_ANY_TAG = re.compile(r"<[^>]*>")
+_BLANK_LINES = re.compile(r"\n{3,}")
+
+# An adaptive card whose JSON Teams put in the body rather than in `attachments`. Dumping it would
+# spend a model's context on layout; `services/teams-mcp` found this the hard way.
+_CARD = "[card]"
+
+
+def _text(
+    message: ChatMessage,
+    *,
+    mentions: list[ChatMessageMention],
+    attachments: list[ChatMessageAttachment],
+) -> str | None:
+    """The message as plain text, or None when it has none.
+
+    A deleted message has no content to normalise whatever `body` says, and returning what Graph
+    happens to leave in a tombstone would present a deleted message as live text.
+    """
+    if message.deleted_date_time is not None:
+        return None
+    body = message.body
+    if body is None or body.content is None:
+        return None
+    if body.content_type != BodyType.Html:
+        return body.content.strip() or None
+    return _from_html(body.content, mentions=mentions, attachments=attachments) or None
+
+
+def _from_html(
+    content: str,
+    *,
+    mentions: list[ChatMessageMention],
+    attachments: list[ChatMessageAttachment],
+) -> str:
+    mention_texts = {
+        mention.id: mention.mention_text for mention in mentions if mention.id is not None
+    }
+    names = {
+        attachment.id: attachment.name for attachment in attachments if attachment.id is not None
+    }
+
+    text = _PARAGRAPH_END.sub("\n", content)
+    text = _LINE_BREAK.sub("\n", text)
+    text = _LIST_ITEM_END.sub("\n", text)
+    text = _LIST_ITEM.sub("- ", text)
+    text = _MENTION_TAG.sub(lambda tag: _mention_text(tag, mention_texts), text)
+    text = _EMOJI.sub(lambda tag: tag.group(1), text)
+    text = _ATTACHMENT_TAG.sub(lambda tag: _attachment_text(tag, names), text)
+    text = _IMAGE.sub("[image]", text)
+    text = _ANY_TAG.sub("", text)
+    # A non-breaking space is what Teams puts between pasted words; a model reads it as a word
+    # joiner rather than as the space it is meant to be.
+    text = html.unescape(text).replace("\xa0", " ")
+    text = _BLANK_LINES.sub("\n\n", text).strip()
+    if text.startswith("{") and '"type"' in text:
+        return _CARD
+    return text
+
+
+def _mention_text(tag: re.Match[str], mention_texts: dict[int, str | None]) -> str:
+    """`<at id="0">Ada Lovelace</at>` → `@Ada Lovelace`.
+
+    The tag's `id` indexes `mentions[]` — Microsoft documents the correspondence — and that is the
+    authority, because the element's own text is sometimes empty. Its text is the fallback, and if
+    neither names anybody the mention is still marked: an `<at>` that vanished would read as the
+    author addressing nobody, and a bare `<at id="0">` left in the text would be a key to nothing.
+    """
+    index = _MENTION_INDEX.search(tag.group(1))
+    resolved = mention_texts.get(int(index.group(1))) if index is not None else None
+    name = (resolved or _ANY_TAG.sub("", tag.group(2))).strip()
+    return f"@{name}" if name else "[mention]"
+
+
+def _attachment_text(tag: re.Match[str], names: dict[str, str | None]) -> str:
+    name = names.get(tag.group(1))
+    return f"[attachment: {name}]" if name else "[attachment]"

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -405,7 +405,7 @@ def _message(hit: SearchHit) -> MessageHit | None:
     resource = hit.resource
     if not isinstance(resource, ChatMessage) or resource.id is None:
         return None
-    sender = _sender(resource.from_)
+    sender = sender_of(resource.from_)
     if sender is None:
         # A system event message — "Ada joined the chat", a call ending, a channel being renamed.
         # Graph sends `from: null` and a body of the literal `<systemEventMessage/>` for these,
@@ -461,8 +461,17 @@ def _segment(value: str) -> str:
     return quote(value, safe="")
 
 
-def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
-    """The sender, or None when the identity set names nobody at all."""
+def sender_of(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
+    """The sender, or None when the identity set names nobody at all.
+
+    Public because a search hit and a read of the same message must report the same sender, and the
+    two arrive in different shapes: search's mailbox `emailAddress` and the Teams
+    `teamworkUserIdentity` every read API answers with. One function over both shapes is what makes
+    that consistency a property of the code rather than of two implementations agreeing.
+
+    A null `from` — and an identity set that named nobody — is how Graph sends a system event
+    message, so None is also the signal `message_search` filters those hits out by.
+    """
     if identity is None:
         return None
     mailbox_name, mailbox_address = _mailbox_identity(identity)
@@ -472,8 +481,11 @@ def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None
     if display_name is None and application is not None:
         display_name = application.display_name
     sender = MessageSender(
-        display_name=display_name or mailbox_name,
-        email=mailbox_address,
+        # Empty strings are collapsed to null: `displayName` is documented Optional and Graph does
+        # send it blank, and a name that is present-but-empty reads as an unnamed sender rather
+        # than as the "Graph did not say" that `user_id` is there to work around.
+        display_name=_present(display_name) or _present(mailbox_name),
+        email=_present(mailbox_address),
         user_id=user.id if user is not None else None,
     )
     if (sender.display_name, sender.email, sender.user_id) == (None, None, None):
@@ -499,3 +511,8 @@ def _mailbox_identity(identity: ChatMessageFromIdentitySet) -> tuple[str | None,
 
 def _string(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _present(value: str | None) -> str | None:
+    """`value` if it says anything, else None."""
+    return value if value is not None and value.strip() else None

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -1,0 +1,501 @@
+"""Full-text search across the Microsoft Teams messages the signed-in user can see.
+
+`POST /search/query` with `entityTypes: ["chatMessage"]` is the only full-text path Microsoft
+Graph offers over Teams messages, and it runs in delegated context only
+(https://learn.microsoft.com/en-us/graph/search-concept-chat-messages). Four of its documented
+properties shape everything below.
+
+* **The hit is a projection, not a message.** The retrievable set is `channelIdentity`, `chatId`,
+  `createdDateTime`, `etag`, `from`, `id`, `importance`, `lastModifiedDateTime`, `subject` and
+  `webUrl` — no `body`. Graph says so outright: "The search Teams API doesn't return all
+  properties defined in chatMessage." The only text a hit carries is the `summary` snippet. A
+  result is therefore metadata plus a handle by necessity, and the handle is what a reader tool
+  resolves into the message itself.
+* **`total` is not a match count.** "For Teams messages, the total property of the
+  searchHitsContainer type contains the number of results on the page, not the total number of
+  matching results." It is not read here and no total is reported: `moreResultsAvailable` is the
+  only honest "keep going" signal Graph gives.
+* **Sorting is unsupported.** "The search API doesn't support custom sort for … chatMessage …", so
+  there is no ordering knob to expose, and none is invented.
+* **Paging is stateless.** `from`/`size` integers rather than an opaque `@odata.nextLink`, which is
+  why `graph_client.collect_pages` has nothing to do here and why a caller can resume a search on
+  a later, unrelated call.
+
+Deliberately absent: the per-chat scan that the connector this one replaces falls back to when it
+lacks a permission or is given a date filter. Graph caps reads at "one request per second per app
+per tenant … on a given channel or chat" (https://learn.microsoft.com/en-us/graph/throttling), and
+that budget is *per app*, so one user's sweep of fifty chats degrades every other user in the
+tenant. Date bounds go into the query string instead, where the index applies them for the price
+of the one request that was being made anyway.
+"""
+
+import re
+from dataclasses import dataclass, fields
+from datetime import date, datetime
+from typing import cast
+from urllib.parse import quote
+from uuid import UUID
+
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.models.chat_message_from_identity_set import ChatMessageFromIdentitySet
+from msgraph.generated.models.entity_type import EntityType
+from msgraph.generated.models.search_hit import SearchHit
+from msgraph.generated.models.search_hits_container import SearchHitsContainer
+from msgraph.generated.models.search_query import SearchQuery
+from msgraph.generated.models.search_request import SearchRequest
+from msgraph.generated.search.query.query_post_request_body import QueryPostRequestBody
+from msgraph.generated.search.query.query_post_response import QueryPostResponse
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_errors
+
+# `Chat.Read` is what `/search/query` accepts for the `chatMessage` entity; Graph's own search
+# overview promises a search never returns more than the equivalent GET would, and every
+# channel-message GET in v1.0 requires `ChannelMessage.Read.All` — so without it a search silently
+# covers chats only. Both are requested rather than one, so a tenant that withholds the broad one
+# is refused at consent time instead of being served half an answer at query time. The broad one is
+# named separately because the tool's description has to tell a model what channel coverage costs.
+CHANNEL_PERMISSION = "ChannelMessage.Read.All"
+GRAPH_PERMISSIONS: tuple[str, ...] = ("Chat.Read", CHANNEL_PERMISSION)
+
+# Graph documents `size` as defaulting to 25 with a maximum of 1000, but the paragraph that caps a
+# page at 25 names only the `message` and `event` entities, and no chatMessage-specific ceiling is
+# published. 50 is the largest page this connector will claim on undocumented ground.
+MAX_RESULTS = 50
+
+
+class MessageSender(BaseModel):
+    """Who sent a matched message, from whichever identity shape Graph used.
+
+    Two shapes, because Teams messages are indexed out of the substrate mailbox: a search hit
+    carries an Exchange-style `emailAddress` (a name and an address), while every Teams read API
+    returns a `teamworkUserIdentity` (an id and an optional display name, and no email at all).
+    Which fields are populated therefore says which shape Graph answered with, and a null is not
+    evidence that the sender has no name or no address.
+    """
+
+    display_name: str | None = Field(
+        description=(
+            "The sender's name as Teams shows it. Microsoft documents this as optional and it is "
+            + "genuinely absent on some messages, including messages from external and federated "
+            + "users — a null is not an anonymous sender."
+        )
+    )
+    email: str | None = Field(
+        description=(
+            "The sender's email address. Present when Graph answered with the mailbox-shaped "
+            + "identity that search hits normally carry, and null otherwise; the Teams identity "
+            + "has no email property at all, so compare `user_id` when this is null."
+        )
+    )
+    user_id: str | None = Field(
+        description=(
+            "The sender's Microsoft Entra object id, when Graph answered with the Teams-shaped "
+            + "identity. This is the value the `mentions` search parameter takes, and the only "
+            + "sender field safe to compare against ids from other tools. Null for a message sent "
+            + "by an application (a bot or a connector), and null when Graph gave an email "
+            + "address instead."
+        )
+    )
+
+
+class MessageHit(BaseModel):
+    """One matched message: all Graph's search index will say about it, and how to read the rest."""
+
+    uri: str | None = Field(
+        description=(
+            "A handle for this exact message, e.g. "
+            + "`teams:///chats/{chatId}/messages/{messageId}` or "
+            + "`teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}`, with each id "
+            + "percent-encoded. Pass it verbatim to a tool that reads a message resource; this "
+            + "search returns no message body, so it is the only route to the full text, the "
+            + "attachments and the mentions. Null in the rare case where Graph returned a hit "
+            + "with neither a chat nor a channel identity, which cannot be addressed."
+        )
+    )
+    message_id: str = Field(
+        description=(
+            "The message's Graph `id`. Unique only within its own chat, channel or reply thread — "
+            + "Microsoft documents that the same id may recur elsewhere — so identify a message by "
+            + "`uri`, never by this alone."
+        )
+    )
+    chat_id: str | None = Field(
+        description=(
+            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. Null for a channel "
+            + "message; `team_id` and `channel_id` are set instead."
+        )
+    )
+    team_id: str | None = Field(
+        description="The team a channel message belongs to. Null for a chat message."
+    )
+    channel_id: str | None = Field(
+        description="The channel a channel message was posted in. Null for a chat message."
+    )
+    subject: str | None = Field(
+        description=(
+            "The message subject. Usually null or empty: Teams only sets one on some channel root "
+            + "posts, never on ordinary chat messages."
+        )
+    )
+    summary: str | None = Field(
+        description=(
+            "Microsoft's own snippet of the matching text, truncated with `...` where it was cut. "
+            + "This is the ONLY message content this search returns — Graph's search projection "
+            + "has no body — so do not quote it as the whole message or infer from its absence. "
+            + "Read `uri` for the real text."
+        )
+    )
+    sender: MessageSender = Field(description="Who sent the message.")
+    created_at: datetime | None = Field(
+        description=(
+            "When the message was sent. Compare this when order matters: Graph refuses to sort a "
+            + "message search, so the sequence results arrive in is not a contract."
+        )
+    )
+    last_modified_at: datetime | None = Field(
+        description=(
+            "When the message was last modified. Microsoft counts adding or removing a reaction "
+            + "as a modification, so a difference from `created_at` is not evidence of an edit."
+        )
+    )
+    importance: str | None = Field(
+        description="`normal`, `high` or `urgent`, as the sender marked the message."
+    )
+    web_url: str | None = Field(
+        description=(
+            "A link that opens the message in Microsoft Teams. Populated for channel messages and "
+            + "null for chat messages, which Graph gives no such link — use `uri` to read those."
+        )
+    )
+
+
+class MessageSearchResults(BaseModel):
+    messages: list[MessageHit] = Field(description="The matching messages on this page of results.")
+    more_results_available: bool = Field(
+        description=(
+            "Whether Microsoft's index has further matches beyond this page. This is the only "
+            + "signal Graph gives: it reports no match total for Teams messages, so neither does "
+            + "this tool."
+        )
+    )
+    next_offset: int | None = Field(
+        description=(
+            "The `offset` that reaches the next page, or null when there is none. It counts the "
+            + "hits Graph returned rather than the messages listed here, because offsets index "
+            + "Graph's own unfiltered results."
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SearchCriteria:
+    """What to match, before it becomes a query string.
+
+    Every field is optional and Microsoft ANDs them together. All of them unset would ask for
+    every message the user can see, which is not a question anyone asked — `is_empty` is what the
+    tool boundary refuses.
+    """
+
+    query: str | None = None
+    sender: str | None = None
+    recipient: str | None = None
+    mentions: UUID | None = None
+    sent_after: date | None = None
+    sent_before: date | None = None
+    has_attachment: bool | None = None
+    is_read: bool | None = None
+    mentions_me: bool | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether these criteria would match on nothing at all."""
+        return not _query_string(self)
+
+
+# The criteria a caller may set, in declaration order. The tool advertises this as a JSON Schema
+# `anyOf` of one-element `required` lists, which is how "at least one of these" becomes something
+# a client can check rather than a sentence in a description it may not read.
+CRITERIA: tuple[str, ...] = tuple(field.name for field in fields(SearchCriteria))
+
+# The characters that would let a value be read as Keyword Query Language instead of as text:
+# whitespace separates terms, `:` `<` `>` `=` introduce a property restriction or a comparison,
+# `(` and `)` group, and `"` would close the quoting applied here. A value holding any of them is
+# quoted — which is what turns `sent>2020-01-01` into something to look for rather than a filter
+# the caller was never offered. A value holding none of them cannot express a restriction, so it is
+# left alone and stays a keyword. This is the guard `services/teams-mcp` ships merged, and it is
+# for a *filter value* — one scope term's argument, e.g. the `from:` in `from:"ada lovelace"`.
+_KQL_OPERATORS = re.compile(r'[\s:"<>=()]')
+
+
+def _quoted(value: str) -> str:
+    """A filter value, safe to put after a scope term. One value, therefore at most one term."""
+    if _KQL_OPERATORS.search(value) is None:
+        return value
+    return _phrase(value)
+
+
+# A caller's free text is not a filter value, and quoting it like one costs them every match whose
+# words are not adjacent — Microsoft is explicit about both halves of this
+# (https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference):
+# a quoted phrase "returns only the items in which the words in your phrase are located next to each
+# other", while "if there are multiple free-text expressions without any operators in between them,
+# the query behavior is the same as using the AND operator". So free text is guarded one word at a
+# time and the words reach Graph as separate terms it will AND — every word must appear, anywhere in
+# the message, in any order. Adjacency is still available: a caller who wants it quotes the words
+# themselves, and this is what tells those two apart.
+_PHRASE = re.compile(r'"([^"]*)"')
+
+# Beyond the operator characters above, a *word* has two further ways to be read as KQL. `*` is the
+# wildcard, and KQL's boolean and proximity operators are themselves words — "the operators are
+# case-sensitive (uppercase)", which is why the comparison below is too. Neither can smuggle in a
+# scope term, but both change what the search *means* rather than what it looks for: a bare `OR`
+# between two of the caller's words turns the AND they were promised into an OR. `-` is KQL's
+# documented shorthand for NOT and negates the word it precedes. (`+` is the shorthand for AND,
+# which is the default anyway, so it needs no handling.) All of these are quoted into literal text,
+# so every word of the query is looked for and none of it is obeyed.
+_KQL_WILDCARD = "*"
+_KQL_KEYWORDS = frozenset({"AND", "OR", "NOT", "NEAR", "ONEAR"})
+
+
+def _free_text(query: str) -> str:
+    """A caller's own words, as terms Graph will AND. Empty when they typed nothing to look for.
+
+    Whatever the caller put in double quotes stays one phrase — the only adjacency this tool asks
+    Graph for, because it is the only one anybody asked for. Everything outside those quotes is
+    words, and an unbalanced quote is just a character in one of them.
+    """
+    terms: list[str] = []
+    words_from = 0
+    for phrase in _PHRASE.finditer(query):
+        terms.extend(_keywords(query[words_from : phrase.start()]))
+        quoted = phrase.group(1).strip()
+        if quoted:
+            terms.append(_phrase(quoted))
+        words_from = phrase.end()
+    terms.extend(_keywords(query[words_from:]))
+    return " ".join(terms)
+
+
+def _keywords(text: str) -> list[str]:
+    """The words of `text`, each one safe to hand to Graph as a term of its own."""
+    return [_keyword(word) for word in text.split()]
+
+
+def _keyword(word: str) -> str:
+    if (
+        _KQL_OPERATORS.search(word) is not None
+        or _KQL_WILDCARD in word
+        or word.startswith("-")
+        or word in _KQL_KEYWORDS
+    ):
+        return _phrase(word)
+    return word
+
+
+def _phrase(text: str) -> str:
+    """`text` as a KQL phrase: matched where those words are adjacent, and read as no operator.
+
+    The quoting is the guard as much as it is the phrase — everything inside a quoted phrase is
+    text — so the only thing left to handle is a quote in the text itself, which KQL escapes by
+    doubling it. That keeps the number of quotes in the query even, and so keeps the quoting
+    unclosable from inside.
+    """
+    return '"' + text.replace('"', '""') + '"'
+
+
+def _flag(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _query_string(criteria: SearchCriteria) -> str:
+    """The `queryString` these criteria become. Empty exactly when nothing was asked for.
+
+    The scope terms are the ones Microsoft documents for `chatMessage`: `from`, `to`,
+    `hasAttachment`, `IsRead`, `IsMentioned`, `mentions` and `sent`, in their documented spellings
+    (the casing is Microsoft's, not a mistake). `sent` is the one that is not a `term:value` pair
+    at all — it is a comparison, `sent > 2022-07-14` — and `>=`/`<=` are used so that a bound
+    lands on the day the caller named rather than the day after it, which is what `sent_after` and
+    `sent_before` promise.
+
+    `query` is the one input that is not a scope term's value, and it is the one that becomes more
+    than one term: it is free text, so it becomes the caller's words, ANDed with everything else
+    here. A query of nothing but punctuation therefore contributes nothing, which is what makes
+    this string — rather than the arguments it was built from — the honest test of `is_empty`.
+    """
+    terms: list[str] = []
+    if criteria.query:
+        free_text = _free_text(criteria.query)
+        if free_text:
+            terms.append(free_text)
+    if criteria.sender:
+        terms.append(f"from:{_quoted(criteria.sender)}")
+    if criteria.recipient:
+        terms.append(f"to:{_quoted(criteria.recipient)}")
+    if criteria.mentions is not None:
+        # Microsoft's example is a user id "without '-'", which is exactly `UUID.hex`. Typing the
+        # parameter as a UUID is also what makes this the one term needing no quoting.
+        terms.append(f"mentions:{criteria.mentions.hex}")
+    if criteria.sent_after is not None:
+        terms.append(f"sent>={criteria.sent_after.isoformat()}")
+    if criteria.sent_before is not None:
+        terms.append(f"sent<={criteria.sent_before.isoformat()}")
+    if criteria.has_attachment is not None:
+        terms.append(f"hasAttachment:{_flag(criteria.has_attachment)}")
+    if criteria.is_read is not None:
+        terms.append(f"IsRead:{_flag(criteria.is_read)}")
+    if criteria.mentions_me is not None:
+        terms.append(f"IsMentioned:{_flag(criteria.mentions_me)}")
+    return " ".join(terms)
+
+
+async def search_messages(
+    client: GraphServiceClient, *, criteria: SearchCriteria, offset: int, size: int
+) -> MessageSearchResults:
+    """One page of matches for `criteria`, starting at `offset`.
+
+    Exactly one Graph request, whatever the criteria: there is no fan-out and no second call to
+    fill in content. Callers that want the text of a match read its `uri`.
+    """
+    query = _query_string(criteria)
+    assert query, "search_messages needs at least one criterion; the tool refuses an empty set"
+    assert 1 <= size <= MAX_RESULTS, f"size must be within 1..{MAX_RESULTS}, got {size}"
+    assert offset >= 0, f"offset must not be negative, got {offset}"
+
+    body = QueryPostRequestBody(
+        requests=[
+            SearchRequest(
+                entity_types=[EntityType.ChatMessage],
+                query=SearchQuery(query_string=query),
+                from_=offset,
+                size=size,
+            )
+        ]
+    )
+    with graph_errors():
+        response = await client.search.query.post(body)
+
+    assert response is not None, "Graph answered POST /search/query with no response"
+    container = _hits_container(response)
+    hits = (container.hits or []) if container is not None else []
+    more_results_available = bool(container.more_results_available) if container else False
+
+    return MessageSearchResults(
+        messages=[message for message in (_message(hit) for hit in hits) if message is not None],
+        more_results_available=more_results_available,
+        next_offset=offset + len(hits) if more_results_available else None,
+    )
+
+
+def _hits_container(response: QueryPostResponse) -> SearchHitsContainer | None:
+    """The one container this request can produce.
+
+    Graph "currently supports only a single searchRequest at a time" and one entity type, so the
+    nesting — a response per request, a container per entity type — only ever holds one of each.
+    """
+    for search_response in response.value or []:
+        for container in search_response.hits_containers or []:
+            return container
+    return None
+
+
+def _message(hit: SearchHit) -> MessageHit | None:
+    """One hit as a result, or None for a hit that is not a message a person wrote."""
+    resource = hit.resource
+    if not isinstance(resource, ChatMessage) or resource.id is None:
+        return None
+    sender = _sender(resource.from_)
+    if sender is None:
+        # A system event message — "Ada joined the chat", a call ending, a channel being renamed.
+        # Graph sends `from: null` and a body of the literal `<systemEventMessage/>` for these,
+        # and the human-readable sentence Teams shows is rendered by the client and never sent, so
+        # such a hit has neither an author nor any text. The `messageType` and `eventDetail`
+        # properties that would name it are not in search's retrievable set, which leaves the
+        # missing author as the signal — and it is the one Microsoft's own examples show.
+        return None
+    channel = resource.channel_identity
+    team_id = channel.team_id if channel is not None else None
+    channel_id = channel.channel_id if channel is not None else None
+    return MessageHit(
+        uri=_uri(
+            message_id=resource.id,
+            chat_id=resource.chat_id,
+            team_id=team_id,
+            channel_id=channel_id,
+        ),
+        message_id=resource.id,
+        chat_id=resource.chat_id,
+        team_id=team_id,
+        channel_id=channel_id,
+        subject=resource.subject,
+        summary=hit.summary,
+        sender=sender,
+        created_at=resource.created_date_time,
+        last_modified_at=resource.last_modified_date_time,
+        # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
+        importance=resource.importance,
+        web_url=resource.web_url,
+    )
+
+
+def _uri(
+    *, message_id: str, chat_id: str | None, team_id: str | None, channel_id: str | None
+) -> str | None:
+    """The handle a reader resolves back into this message.
+
+    Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
+    (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford ambiguity.
+    """
+    if team_id is not None and channel_id is not None:
+        return (
+            f"teams:///teams/{_segment(team_id)}/channels/{_segment(channel_id)}"
+            + f"/messages/{_segment(message_id)}"
+        )
+    if chat_id is not None:
+        return f"teams:///chats/{_segment(chat_id)}/messages/{_segment(message_id)}"
+    return None
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _sender(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:
+    """The sender, or None when the identity set names nobody at all."""
+    if identity is None:
+        return None
+    mailbox_name, mailbox_address = _mailbox_identity(identity)
+    user = identity.user
+    application = identity.application
+    display_name = user.display_name if user is not None else None
+    if display_name is None and application is not None:
+        display_name = application.display_name
+    sender = MessageSender(
+        display_name=display_name or mailbox_name,
+        email=mailbox_address,
+        user_id=user.id if user is not None else None,
+    )
+    if (sender.display_name, sender.email, sender.user_id) == (None, None, None):
+        return None
+    return sender
+
+
+def _mailbox_identity(identity: ChatMessageFromIdentitySet) -> tuple[str | None, str | None]:
+    """The `emailAddress` a search hit carries instead of a Teams identity, as (name, address).
+
+    Search reads Teams messages out of the substrate mailbox, so `POST /search/query` answers with
+    `from: {"emailAddress": {"name": ..., "address": ...}}` where the Teams APIs answer with
+    `from: {"user": {...}}`. The SDK's identity set has no field for the mailbox shape, so it
+    arrives in `additional_data` — untyped by construction, hence the narrowing here.
+    """
+    extra = cast("dict[str, object]", identity.additional_data)
+    mailbox = extra.get("emailAddress")
+    if not isinstance(mailbox, dict):
+        return (None, None)
+    fields_ = cast("dict[str, object]", mailbox)
+    return (_string(fields_.get("name")), _string(fields_.get("address")))
+
+
+def _string(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -242,9 +242,12 @@ class MessageHit(BaseModel):
             + "identity, which cannot be addressed. One handle here can fail to read: Microsoft "
             + "addresses a reply in a channel thread under its parent post and its search index "
             + "does not say which post that is, so a hit that is a reply gets the root-post form "
-            + "above and read_message may answer that it could not be read. Reach that reply by "
-            + "browsing its channel with browse_channel, which knows each reply's parent and "
-            + "emits the reply's own handle."
+            + "above and read_message may answer that it could not be read. browse_channel is the "
+            + "only tool that emits a reply's own handle, and it reaches only the newest replies "
+            + "of each post on the channel's first page, following no cursor further back. If "
+            + "the reply is not in that window there is no route to its full text and browsing "
+            + "again returns the same window: report this `summary` with the sender and date "
+            + "here, say the full text could not be retrieved, and stop looking."
         )
     )
     message_id: str = Field(

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -77,21 +77,31 @@ class MessageHandle:
     second time. Two modules that each knew how to write `teams:///chats/…` would be free to
     disagree, and the disagreement would look like a message that cannot be read.
 
-    Exactly two shapes exist, because Graph addresses a Teams message exactly two ways
+    Three shapes exist, because Graph addresses a Teams message exactly three ways
     (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
 
         teams:///chats/{chatId}/messages/{messageId}
         teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+        teams:///teams/{teamId}/channels/{channelId}/messages/{rootId}/replies/{replyId}
+
+    The third is the one a search cannot mint. Graph addresses a reply in a channel thread *under*
+    its parent post, and the search projection carries no `replyToId` — so a channel hit that is
+    really a reply becomes the second shape, which Graph answers 404 to. `browse_channel` walks a
+    channel post by post and therefore knows each reply's parent, which is why it is what mints
+    this shape and why the shape lives here rather than there: a handle means the same thing
+    whichever tool produced it only while there is one definition of it.
 
     Nothing else is a handle. `mail:///`, `site:///` and friends are not "not yet implemented" —
     this connector is scoped to Teams, and advertising a scheme it cannot serve teaches a model to
-    ask for things that will always fail.
+    ask for things that will always fail. A chat has no replies in Graph's addressing, so a
+    `teams:///chats/…/replies/…` is not a handle either.
     """
 
     message_id: str
     chat_id: str | None = None
     team_id: str | None = None
     channel_id: str | None = None
+    reply_to_id: str | None = None
 
     @property
     def permission(self) -> str:
@@ -117,18 +127,24 @@ class MessageHandle:
         assert self.team_id is not None and self.channel_id is not None, (
             "a handle addresses either a chat or a team channel"
         )
-        return (
-            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
-            + f"/messages/{_segment(self.message_id)}"
-        )
+        channel = f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+        if self.reply_to_id is not None:
+            return (
+                f"{channel}/messages/{_segment(self.reply_to_id)}"
+                + f"/replies/{_segment(self.message_id)}"
+            )
+        return f"{channel}/messages/{_segment(self.message_id)}"
 
 
-# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
+# The three handle shapes, and only those. Ids are matched as "anything but a separator" because
 # `MessageHandle.uri` percent-encodes each one — a Teams id is full of `:` and `@` and would
 # otherwise be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was
 # already readable exactly as it is, so a handle a caller copied out of a log still resolves.
 _CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
 _CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+_REPLY_HANDLE = re.compile(
+    r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)/replies/([^/]+)\Z"
+)
 
 
 def message_handle(uri: str) -> MessageHandle | None:
@@ -141,6 +157,17 @@ def message_handle(uri: str) -> MessageHandle | None:
     if chat is not None:
         chat_id, message_id = (unquote(part) for part in chat.groups())
         return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    reply = _REPLY_HANDLE.match(uri)
+    if reply is not None:
+        team_id, channel_id, root_id, message_id = (unquote(part) for part in reply.groups())
+        return _handle(
+            MessageHandle(
+                message_id=message_id,
+                team_id=team_id,
+                channel_id=channel_id,
+                reply_to_id=root_id,
+            )
+        )
     channel = _CHANNEL_HANDLE.match(uri)
     if channel is not None:
         team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
@@ -150,7 +177,13 @@ def message_handle(uri: str) -> MessageHandle | None:
 
 def _handle(handle: MessageHandle) -> MessageHandle | None:
     """The handle, unless a segment decoded to nothing — `%20` is not an id."""
-    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    ids = (
+        handle.message_id,
+        handle.chat_id,
+        handle.team_id,
+        handle.channel_id,
+        handle.reply_to_id,
+    )
     if any(value is not None and not value.strip() for value in ids):
         return None
     return handle
@@ -206,7 +239,12 @@ class MessageHit(BaseModel):
             + "percent-encoded. Pass it verbatim to read_message; this search returns no message "
             + "body, so it is the only route to the full text, the attachments and the mentions. "
             + "Null in the rare case where Graph returned a hit with neither a chat nor a channel "
-            + "identity, which cannot be addressed."
+            + "identity, which cannot be addressed. One handle here can fail to read: Microsoft "
+            + "addresses a reply in a channel thread under its parent post and its search index "
+            + "does not say which post that is, so a hit that is a reply gets the root-post form "
+            + "above and read_message may answer that it could not be read. Reach that reply by "
+            + "browsing its channel with browse_channel, which knows each reply's parent and "
+            + "emits the reply's own handle."
         )
     )
     message_id: str = Field(

--- a/services/office-mcp/src/office_mcp/features/message_search.py
+++ b/services/office-mcp/src/office_mcp/features/message_search.py
@@ -33,7 +33,7 @@ import re
 from dataclasses import dataclass, fields
 from datetime import date, datetime
 from typing import cast
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from uuid import UUID
 
 from msgraph.generated.models.chat_message import ChatMessage
@@ -54,15 +54,110 @@ from office_mcp.graph_client import graph_errors
 # overview promises a search never returns more than the equivalent GET would, and every
 # channel-message GET in v1.0 requires `ChannelMessage.Read.All` — so without it a search silently
 # covers chats only. Both are requested rather than one, so a tenant that withholds the broad one
-# is refused at consent time instead of being served half an answer at query time. The broad one is
-# named separately because the tool's description has to tell a model what channel coverage costs.
+# is refused at consent time instead of being served half an answer at query time. Each is named
+# separately because both a tool description and a handle's own surface have to speak about one of
+# them alone: channel coverage is what the broad one buys, and `MessageHandle.permission` below
+# picks whichever one the surface a handle addresses is read under.
+CHAT_PERMISSION = "Chat.Read"
 CHANNEL_PERMISSION = "ChannelMessage.Read.All"
-GRAPH_PERMISSIONS: tuple[str, ...] = ("Chat.Read", CHANNEL_PERMISSION)
+GRAPH_PERMISSIONS: tuple[str, ...] = (CHAT_PERMISSION, CHANNEL_PERMISSION)
 
 # Graph documents `size` as defaulting to 25 with a maximum of 1000, but the paragraph that caps a
 # page at 25 names only the `message` and `event` entities, and no chatMessage-specific ceiling is
 # published. 50 is the largest page this connector will claim on undocumented ground.
 MAX_RESULTS = 50
+
+
+@dataclass(frozen=True, slots=True)
+class MessageHandle:
+    """Which message, in the one form this connector passes between tools.
+
+    A handle is minted here — a search hit is the only thing that produces one — which is why the
+    shape lives in this module and `message_read` takes it from here rather than spelling it a
+    second time. Two modules that each knew how to write `teams:///chats/…` would be free to
+    disagree, and the disagreement would look like a message that cannot be read.
+
+    Exactly two shapes exist, because Graph addresses a Teams message exactly two ways
+    (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
+
+        teams:///chats/{chatId}/messages/{messageId}
+        teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+
+    Nothing else is a handle. `mail:///`, `site:///` and friends are not "not yet implemented" —
+    this connector is scoped to Teams, and advertising a scheme it cannot serve teaches a model to
+    ask for things that will always fail.
+    """
+
+    message_id: str
+    chat_id: str | None = None
+    team_id: str | None = None
+    channel_id: str | None = None
+
+    @property
+    def permission(self) -> str:
+        """The one delegated Graph permission the message this handle addresses is read under.
+
+        Graph's permissions for a message read are per surface, and the handle is the only thing
+        that knows which surface: a 403 reading a chat can only be about `Chat.Read`, and naming
+        the channel permission alongside it would send an administrator after one that was never
+        missing.
+        """
+        return CHAT_PERMISSION if self.chat_id is not None else CHANNEL_PERMISSION
+
+    @property
+    def uri(self) -> str:
+        """The handle as a string — what a search hit carries and a read echoes back.
+
+        Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
+        (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford
+        ambiguity.
+        """
+        if self.chat_id is not None:
+            return f"teams:///chats/{_segment(self.chat_id)}/messages/{_segment(self.message_id)}"
+        assert self.team_id is not None and self.channel_id is not None, (
+            "a handle addresses either a chat or a team channel"
+        )
+        return (
+            f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+            + f"/messages/{_segment(self.message_id)}"
+        )
+
+
+# The two handle shapes, and only those. Ids are matched as "anything but a separator" because
+# `MessageHandle.uri` percent-encodes each one — a Teams id is full of `:` and `@` and would
+# otherwise be ambiguous — but the encoding is not *required* here: `unquote` leaves an id that was
+# already readable exactly as it is, so a handle a caller copied out of a log still resolves.
+_CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
+_CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+
+
+def message_handle(uri: str) -> MessageHandle | None:
+    """`uri` as a handle, or None if it is not one this connector can read.
+
+    None rather than an exception with a message: what to tell the caller about a malformed handle
+    is the tool boundary's business, and a feature module is not allowed to speak MCP.
+    """
+    chat = _CHAT_HANDLE.match(uri)
+    if chat is not None:
+        chat_id, message_id = (unquote(part) for part in chat.groups())
+        return _handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    channel = _CHANNEL_HANDLE.match(uri)
+    if channel is not None:
+        team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
+        return _handle(MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id))
+    return None
+
+
+def _handle(handle: MessageHandle) -> MessageHandle | None:
+    """The handle, unless a segment decoded to nothing — `%20` is not an id."""
+    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    if any(value is not None and not value.strip() for value in ids):
+        return None
+    return handle
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
 
 
 class MessageSender(BaseModel):
@@ -108,10 +203,10 @@ class MessageHit(BaseModel):
             "A handle for this exact message, e.g. "
             + "`teams:///chats/{chatId}/messages/{messageId}` or "
             + "`teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}`, with each id "
-            + "percent-encoded. Pass it verbatim to a tool that reads a message resource; this "
-            + "search returns no message body, so it is the only route to the full text, the "
-            + "attachments and the mentions. Null in the rare case where Graph returned a hit "
-            + "with neither a chat nor a channel identity, which cannot be addressed."
+            + "percent-encoded. Pass it verbatim to read_message; this search returns no message "
+            + "body, so it is the only route to the full text, the attachments and the mentions. "
+            + "Null in the rare case where Graph returned a hit with neither a chat nor a channel "
+            + "identity, which cannot be addressed."
         )
     )
     message_id: str = Field(
@@ -123,8 +218,10 @@ class MessageHit(BaseModel):
     )
     chat_id: str | None = Field(
         description=(
-            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. Null for a channel "
-            + "message; `team_id` and `channel_id` are set instead."
+            "The chat this message is in, unencoded, e.g. `19:...@thread.v2`. It is the same id "
+            + "list_chats reports as `chat_id`, which is how to put a topic and members to the "
+            + "chat a hit came from. Null for a channel message; `team_id` and `channel_id` are "
+            + "set instead."
         )
     )
     team_id: str | None = Field(
@@ -157,7 +254,9 @@ class MessageHit(BaseModel):
     last_modified_at: datetime | None = Field(
         description=(
             "When the message was last modified. Microsoft counts adding or removing a reaction "
-            + "as a modification, so a difference from `created_at` is not evidence of an edit."
+            + "as a modification, so a difference from `created_at` is not evidence of an edit — "
+            + "read_message reports `last_edited_at`, which is the property behind Teams' own "
+            + "'Edited' flag and is what to read when an edit is the question."
         )
     )
     importance: str | None = Field(
@@ -173,17 +272,18 @@ class MessageHit(BaseModel):
 
 class MessageSearchResults(BaseModel):
     messages: list[MessageHit] = Field(description="The matching messages on this page of results.")
-    more_results_available: bool = Field(
+    truncated: bool = Field(
         description=(
-            "Whether Microsoft's index has further matches beyond this page. This is the only "
-            + "signal Graph gives: it reports no match total for Teams messages, so neither does "
-            + "this tool."
+            "True when Microsoft's index has more matches than this page holds — the same "
+            + "'there is more' flag every list-shaped tool here reports. Page on with "
+            + "`next_offset`. It is the only completeness signal Graph gives for a message "
+            + "search: it reports no match total for Teams messages, so neither does this tool."
         )
     )
     next_offset: int | None = Field(
         description=(
-            "The `offset` that reaches the next page, or null when there is none. It counts the "
-            + "hits Graph returned rather than the messages listed here, because offsets index "
+            "The `offset` that reaches the next page, or null when `truncated` is false. It counts "
+            + "the hits Graph returned rather than the messages listed here, because offsets index "
             + "Graph's own unfiltered results."
         )
     )
@@ -379,12 +479,12 @@ async def search_messages(
     assert response is not None, "Graph answered POST /search/query with no response"
     container = _hits_container(response)
     hits = (container.hits or []) if container is not None else []
-    more_results_available = bool(container.more_results_available) if container else False
+    truncated = bool(container.more_results_available) if container else False
 
     return MessageSearchResults(
         messages=[message for message in (_message(hit) for hit in hits) if message is not None],
-        more_results_available=more_results_available,
-        next_offset=offset + len(hits) if more_results_available else None,
+        truncated=truncated,
+        next_offset=offset + len(hits) if truncated else None,
     )
 
 
@@ -418,7 +518,7 @@ def _message(hit: SearchHit) -> MessageHit | None:
     team_id = channel.team_id if channel is not None else None
     channel_id = channel.channel_id if channel is not None else None
     return MessageHit(
-        uri=_uri(
+        uri=_hit_uri(
             message_id=resource.id,
             chat_id=resource.chat_id,
             team_id=team_id,
@@ -439,26 +539,15 @@ def _message(hit: SearchHit) -> MessageHit | None:
     )
 
 
-def _uri(
+def _hit_uri(
     *, message_id: str, chat_id: str | None, team_id: str | None, channel_id: str | None
 ) -> str | None:
-    """The handle a reader resolves back into this message.
-
-    Ids are percent-encoded because Teams ids are full of `:`, `@` and `/`-adjacent characters
-    (`19:...@thread.v2`), and a handle that has to be parsed back apart cannot afford ambiguity.
-    """
+    """This hit's handle, or None for a hit Graph gave nothing addressable."""
     if team_id is not None and channel_id is not None:
-        return (
-            f"teams:///teams/{_segment(team_id)}/channels/{_segment(channel_id)}"
-            + f"/messages/{_segment(message_id)}"
-        )
+        return MessageHandle(message_id=message_id, team_id=team_id, channel_id=channel_id).uri
     if chat_id is not None:
-        return f"teams:///chats/{_segment(chat_id)}/messages/{_segment(message_id)}"
+        return MessageHandle(message_id=message_id, chat_id=chat_id).uri
     return None
-
-
-def _segment(value: str) -> str:
-    return quote(value, safe="")
 
 
 def sender_of(identity: ChatMessageFromIdentitySet | None) -> MessageSender | None:

--- a/services/office-mcp/src/office_mcp/features/recordings.py
+++ b/services/office-mcp/src/office_mcp/features/recordings.py
@@ -32,9 +32,11 @@ transcript answer actionable replaced by something a model has to unpick. It wou
 one thing a 403 here is good for: every tool in this connector names only the permissions its own
 request was made under, so an administrator is sent after the permission that was actually missing.
 
-What is shared is shared for real rather than copied: the meeting handle, the join-URL resolve and
-the occurrence window all live in `transcripts`, which owns that handle family (layering rule 9),
-and this module imports them. The bridge between the two answers is `content_correlation_id`,
+What is shared is shared for real rather than copied: the meeting handle, the join-URL resolve, the
+occurrence window and the windowed newest-first walk (`newest_in_window`, which is also where both
+listers' `truncated` and their "the scan stopped short, so nothing about absence is known" verdict
+come from) all live in `transcripts`, which owns that handle family (layering rule 9), and this
+module imports them. The bridge between the two answers is `content_correlation_id`,
 Microsoft's own "unique identifier that links the transcript with its corresponding recording" —
 present on both artifacts, so a model holding one list can pair it with the other.
 
@@ -88,14 +90,15 @@ from pydantic import BaseModel, Field
 
 from office_mcp.features import identity
 from office_mcp.features.transcripts import (
+    MAX_ARTIFACT_SCAN,
     MEETING_PERMISSION,
     MeetingHandle,
     OccurrenceWindow,
     as_utc,
-    began_at,
+    newest_in_window,
     resolve_meeting,
 )
-from office_mcp.graph_client import collect_pages, graph_errors
+from office_mcp.graph_client import graph_errors
 
 # The delegated permission this module's own request needs. Admin-consented, like transcript
 # access and separately from it — a tenant may grant either without the other, which is why the
@@ -199,6 +202,12 @@ class MeetingRecordings(BaseModel):
             + "identical and cannot be distinguished: Microsoft's meeting-artifact APIs stop "
             + "serving a meeting once it expires (about 60 days after a one-off), so a recording "
             + "that once existed can read as never having existed.\n"
+            + "- `scan_incomplete` — this meeting has more recordings than one call looks through "
+            + f"({MAX_ARTIFACT_SCAN}) and none of the ones looked at fall in your window, so "
+            + "whether one exists there is NOT known and is not being claimed either way. Narrow "
+            + "`started_after`/`started_before` to the occurrence you mean and ask again. Never "
+            + "report this as 'the call was not recorded'. `truncated` is true for the same "
+            + "reason.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
             + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
             + "calendar, or one this user was never invited to, answers the same way. Do not retry "
@@ -237,14 +246,22 @@ class MeetingRecordings(BaseModel):
     recordings: list[RecordingSummary] = Field(
         description=(
             "The recordings of this meeting that fall inside the requested window, newest first. "
-            + "Empty for every status other than `available`."
+            + "The order is over the whole collection rather than over one page of it, so the "
+            + "first entry is the latest recording of the window — which for a recurring series "
+            + "is how to reach the most recent occurrence. Empty for every status other than "
+            + "`available`."
         )
     )
     truncated: bool = Field(
         description=(
-            "True when the meeting has more recordings than this `limit` holds — the same 'there "
-            + "is more' flag every list-shaped tool here reports. Raise `limit` (up to "
-            + f"{MAX_RECORDINGS}) or narrow `started_after`/`started_before`; there is no cursor."
+            "True when there is more — the same 'there is more' flag every list-shaped tool here "
+            + "reports. Two things set it, and both mean the same thing for what you may conclude: "
+            + "the window holds more recordings than this `limit` (the ones here are still the "
+            + f"newest of them; raise `limit`, up to {MAX_RECORDINGS}), or the meeting has more "
+            + f"recordings in total than one call looks through ({MAX_ARTIFACT_SCAN}), "
+            + "in which case narrow `started_after`/`started_before`. There is no cursor. When "
+            + "this is true and nothing came back, `status` is `scan_incomplete` and no absence is "
+            + "claimed."
         )
     )
 
@@ -290,14 +307,16 @@ async def list_meeting_recordings(
             meeting.id
         ).recordings.get()
         assert first_page is not None, "Graph answered a recording listing with no collection"
-        collected = await collect_pages(first_page, client, limit=limit, matches=window.holds)
-        found = sorted(collected.items, key=began_at, reverse=True)
+        collected = await newest_in_window(first_page, client, window=window, limit=limit)
+        found = collected.items
         # Asked for last and only when it changes an answer: with nothing to report there is no
         # organiser to compare anybody with, and the request would be spent on every empty listing.
         caller = (await identity.get_signed_in_user(client)).user_id if found else None
 
     return MeetingRecordings(
-        status="available" if found else _absence(window.settled(meeting)),
+        status="available"
+        if found
+        else _absence(scan_stopped_short=collected.truncated, settled=window.settled(meeting)),
         meeting_id=meeting.id,
         subject=meeting.subject,
         meeting_type=meeting.meeting_type,
@@ -308,14 +327,19 @@ async def list_meeting_recordings(
     )
 
 
-def _absence(settled: bool) -> str:
-    """Which of the two empty answers to give: the one that means stop, or the one that means wait.
+def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
+    """Which empty answer to give: the one that means stop, the one that means wait, or neither.
 
-    The evidence is `OccurrenceWindow.settled`, shared with the transcript listing because the
-    inference is the same one — Microsoft publishes neither a processing status nor a latency SLA
-    for either artifact — and only the word for it differs, because "was not transcribed" and "was
-    not recorded" are different facts about a meeting.
+    The same three-way decision the transcript lister makes, in the same order and for the same
+    reasons: a walk cut short by the scan cap knows nothing about absence and says so
+    (`scan_incomplete`, which is shared vocabulary because the situation is not about recordings),
+    and otherwise the evidence is `OccurrenceWindow.settled` — shared with the transcript listing
+    because the inference is the same one, Microsoft publishing neither a processing status nor a
+    latency SLA for either artifact. Only the settled word differs, because "was not transcribed"
+    and "was not recorded" are different facts about a meeting.
     """
+    if scan_stopped_short:
+        return "scan_incomplete"
     return "not_recorded" if settled else "not_ready"
 
 

--- a/services/office-mcp/src/office_mcp/features/recordings.py
+++ b/services/office-mcp/src/office_mcp/features/recordings.py
@@ -202,12 +202,15 @@ class MeetingRecordings(BaseModel):
             + "identical and cannot be distinguished: Microsoft's meeting-artifact APIs stop "
             + "serving a meeting once it expires (about 60 days after a one-off), so a recording "
             + "that once existed can read as never having existed.\n"
-            + "- `scan_incomplete` — this meeting has more recordings than one call looks through "
-            + f"({MAX_ARTIFACT_SCAN}) and none of the ones looked at fall in your window, so "
-            + "whether one exists there is NOT known and is not being claimed either way. Narrow "
-            + "`started_after`/`started_before` to the occurrence you mean and ask again. Never "
-            + "report this as 'the call was not recorded'. `truncated` is true for the same "
-            + "reason.\n"
+            + "- `scan_incomplete` — this meeting has more recordings than one call reads "
+            + f"({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether "
+            + "one exists there is NOT known and is not being claimed either way. There is nothing "
+            + "to try: the window is applied to the recordings after Microsoft has answered, not "
+            + "by Microsoft while answering, so changing `started_after`/`started_before` — "
+            + "narrower, wider, anything — reads the same recordings and returns this same status. "
+            + "Stop, and report that whether that occurrence was recorded could not be determined. "
+            + "Never report this as 'the call was not recorded', and do not ask again. `truncated` "
+            + "is true for the same reason.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
             + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
             + "calendar, or one this user was never invited to, answers the same way. Do not retry "
@@ -246,22 +249,34 @@ class MeetingRecordings(BaseModel):
     recordings: list[RecordingSummary] = Field(
         description=(
             "The recordings of this meeting that fall inside the requested window, newest first. "
-            + "The order is over the whole collection rather than over one page of it, so the "
-            + "first entry is the latest recording of the window — which for a recurring series "
-            + "is how to reach the most recent occurrence. Empty for every status other than "
+            + "The order is over every recording this call read rather than over one page of "
+            + f"Microsoft's answer, and one call reads up to {MAX_ARTIFACT_SCAN} of them. For a "
+            + "meeting with no more recordings than that — every meeting bar a series recorded "
+            + "daily for most of a year — those are all of them, so the first entry is the latest "
+            + "recording of the window outright, which for a recurring series is how to reach the "
+            + "most recent occurrence. Past that cap the first entry is the latest of what was "
+            + "READ: Microsoft returns this collection in an order of its own and offers no way to "
+            + "ask for the newest, so a newer recording can sit among the ones never read. "
+            + "`truncated` is true whenever that happened. Empty for every status other than "
             + "`available`."
         )
     )
     truncated: bool = Field(
         description=(
             "True when there is more — the same 'there is more' flag every list-shaped tool here "
-            + "reports. Two things set it, and both mean the same thing for what you may conclude: "
-            + "the window holds more recordings than this `limit` (the ones here are still the "
-            + f"newest of them; raise `limit`, up to {MAX_RECORDINGS}), or the meeting has more "
-            + f"recordings in total than one call looks through ({MAX_ARTIFACT_SCAN}), "
-            + "in which case narrow `started_after`/`started_before`. There is no cursor. When "
-            + "this is true and nothing came back, `status` is `scan_incomplete` and no absence is "
-            + "claimed."
+            + "reports. Two things set it, and they differ in what you may conclude:\n"
+            + "- The window holds more recordings than this `limit`. The ones here are still the "
+            + f"newest of the window; raise `limit`, up to {MAX_RECORDINGS}.\n"
+            + "- The meeting has more recordings in total than one call reads "
+            + f"({MAX_ARTIFACT_SCAN}). Then `recordings` is ordered over the ones read and not "
+            + "over the meeting, so the first entry may not be the meeting's latest, and no "
+            + "argument to this tool reads further — the window is applied after the read, so "
+            + "narrowing it changes nothing.\n"
+            + "Which of the two happened is not always visible, so do not call the first entry the "
+            + "meeting's most recent recording while this is true unless you say it is the most "
+            + "recent of what was read. Fewer entries than you asked for with this true is always "
+            + "the second case. There is no cursor. When this is true and nothing came back, "
+            + "`status` is `scan_incomplete` and no absence is claimed."
         )
     )
 
@@ -280,12 +295,14 @@ async def list_meeting_recordings(
     collection, and — only then — ask who the caller is, which is what turns Microsoft's
     organiser-only rule from a sentence into an answer about this user.
 
-    The window is applied while paging rather than as a `$filter`. Graph documents `$filter` on
-    this collection and documents exactly one filterable property by example, `contentCorrelationId`
+    The listing goes out bare and the window is applied while paging rather than as a `$filter`.
+    Graph documents `$select`, `$filter` and `$top` on this collection and no `$orderby`, and it
+    documents exactly one filterable property by example, `contentCorrelationId`
     (https://learn.microsoft.com/en-us/graph/api/callrecording-get, Example 5) — never a date — so
     a server-side date bound would be unverified, and a wrong one returns nothing rather than
     failing. The same window then decides both which recordings are kept and what an empty answer
-    means, exactly as it does for transcripts.
+    means, exactly as it does for transcripts — and, exactly as there, it is no route further into
+    a collection the scan cap cut short, because it is applied to what came back.
     """
     assert 1 <= limit <= MAX_RECORDINGS, f"limit must be within 1..{MAX_RECORDINGS}, got {limit}"
     window = OccurrenceWindow.of(started_after, started_before)
@@ -332,7 +349,9 @@ def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
 
     The same three-way decision the transcript lister makes, in the same order and for the same
     reasons: a walk cut short by the scan cap knows nothing about absence and says so
-    (`scan_incomplete`, which is shared vocabulary because the situation is not about recordings),
+    (`scan_incomplete`, which is shared vocabulary because the situation is not about recordings,
+    down to its having no remedy — the window cannot send the next call further into the
+    collection, so what the caller is told is to stop rather than to narrow and retry),
     and otherwise the evidence is `OccurrenceWindow.settled` — shared with the transcript listing
     because the inference is the same one, Microsoft publishing neither a processing status nor a
     latency SLA for either artifact. Only the settled word differs, because "was not transcribed"

--- a/services/office-mcp/src/office_mcp/features/recordings.py
+++ b/services/office-mcp/src/office_mcp/features/recordings.py
@@ -1,0 +1,377 @@
+"""Meeting recordings: whether a call was recorded, how long it ran, and who may get at the video.
+
+Nothing here returns video, and nothing in this connector can. A Teams meeting runs up to thirty
+hours (https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams), Graph serves
+`…/recordings/{id}/content` as one inline `video/mp4` byte stream with no ranged-fetch contract
+documented on that path, and a model cannot watch video: an MP4 encoded into a tool result is
+hundreds of megabytes of text that answers nothing. `recordingContentUrl` is no better — it is a
+Graph URL that only this connector's bearer token opens, so handing it to a caller is either
+useless or a token leak. What is worth returning is what a caller can act on: that a recording
+exists, when it ran and for how long, whether Microsoft would let this user download it, and which
+transcript is the same call. `tests/test_layering.py` rule 10 is the ratchet on that decision — no
+module here may address a single recording, which is the only way to reach its bytes.
+
+## Why this is a sibling of `list_meeting_transcripts` and not one artifact tool
+
+The two answer about the same meeting from the same handle over the same window, so one tool
+listing both artifacts is the obvious shape and it is the wrong one, for a reason that is
+Microsoft's rather than ours: **the two are gated independently, and one gate is shut by default.**
+Graph access to transcripts is a tenant-wide Teams switch that is off until an administrator turns
+it on, and while it is off every transcript call answers `403` with no request-side workaround —
+whereas that control "applies to transcript resources only; recording subscriptions are
+unaffected" (https://learn.microsoft.com/en-us/graph/teams-changenotifications-callrecording-and-calltranscript),
+and neither recordings reference page mentions a tenant switch or any inner error code of its own.
+The two delegated permissions are separate and separately admin-consented, too
+(`OnlineMeetingTranscript.Read.All`, `OnlineMeetingRecording.Read.All`), so a tenant can grant
+either without the other.
+
+A combined tool in a default tenant therefore has two options and both are bad: fail the whole
+call, answering nothing about a recording that was perfectly reachable, or carry a status per
+artifact — two verdicts, two refusals-as-data, and the "read `status` first" shape that makes the
+transcript answer actionable replaced by something a model has to unpick. It would also blunt the
+one thing a 403 here is good for: every tool in this connector names only the permissions its own
+request was made under, so an administrator is sent after the permission that was actually missing.
+
+What is shared is shared for real rather than copied: the meeting handle, the join-URL resolve and
+the occurrence window all live in `transcripts`, which owns that handle family (layering rule 9),
+and this module imports them. The bridge between the two answers is `content_correlation_id`,
+Microsoft's own "unique identifier that links the transcript with its corresponding recording" —
+present on both artifacts, so a model holding one list can pair it with the other.
+
+## Duration is derived, because Graph does not publish one
+
+`callRecording` carries `id`, `meetingId`, `callId`, `createdDateTime`, `endDateTime`,
+`contentCorrelationId`, `meetingOrganizer` and `recordingContentUrl` — and no duration, no size and
+no media type (https://learn.microsoft.com/en-us/graph/api/resources/callrecording). So the "how
+long" half of the question is `endDateTime - createdDateTime` and nothing better exists; where
+Graph sent either timestamp as null, `duration_seconds` is null rather than a guess. Both bounds
+are the recording's own, which is not the meeting's: a recording started ten minutes late and
+stopped early is shorter than the meeting, and that is the honest answer to "how long is the
+recording".
+
+## The organiser-only constraint, and why the caller's own id is fetched to report it
+
+Microsoft is explicit and this is the fact that has to reach a model:
+
+> In delegated permission scenarios, getting callRecording content is supported only for the
+> meeting organizer. Meeting participants don't have permission to download meeting recordings.
+> … For online meetings, tenant admins can unblock meeting participants to download meeting
+> recordings. (https://learn.microsoft.com/en-us/graph/api/callrecording-get)
+
+Note the asymmetry with the *metadata*, which the same page says "is also available to users who
+are part of the meeting calendar invite": for most meetings a participant asks about, the recording
+is visible and its content is out of reach. Answering "there is no recording" in that case would be
+a wrong answer a caller cannot detect, so the existence and the reachability are separate fields and
+an unreachable recording is always listed.
+
+Reporting the constraint as a constant string on every recording would say nothing, and reporting
+only the organiser's identity would not answer the question either: Graph's own documented samples
+return `meetingOrganizer.user.displayName` as null, so a model would be handed a bare object id to
+compare against something it has not fetched. So the comparison is made here — one extra
+`GET /me`, under `User.Read`, which needs no admin consent and which this connector already asks
+for at sign-in — and `content_access` says which side of the constraint the signed-in user is on.
+It is asked for only when there is a recording to say it about, so the common "nothing was
+recorded" answer still costs two requests.
+
+`content_access` is deliberately not a promise about a download: an administrator can block
+recording downloads tenant-wide from SharePoint and OneDrive
+(https://learn.microsoft.com/en-us/MicrosoftTeams/block-download-meeting-recording), and can
+equally have unblocked participants. It says what Microsoft's documented default makes of *this*
+user, which is the most a caller can be told without guessing.
+"""
+
+from datetime import date, datetime
+
+from msgraph.generated.models.call_recording import CallRecording
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.features import identity
+from office_mcp.features.transcripts import (
+    MEETING_PERMISSION,
+    MeetingHandle,
+    OccurrenceWindow,
+    as_utc,
+    began_at,
+    resolve_meeting,
+)
+from office_mcp.graph_client import collect_pages, graph_errors
+
+# The delegated permission this module's own request needs. Admin-consented, like transcript
+# access and separately from it — a tenant may grant either without the other, which is why the
+# two artifacts are listed by two tools that redeem two different tokens.
+RECORDING_PERMISSION = "OnlineMeetingRecording.Read.All"
+
+# What listing a meeting's recordings costs: resolving the join URL, reading the collection, and
+# finding out who the caller is so that the organiser-only constraint can be answered rather than
+# merely recited. In that order, under one token — Entra redeems them together or not at all.
+LISTING_PERMISSIONS: tuple[str, ...] = (
+    MEETING_PERMISSION,
+    RECORDING_PERMISSION,
+    identity.GRAPH_PERMISSION,
+)
+
+# How many recordings one listing returns. A one-off meeting has one (or two, where somebody
+# stopped and restarted); a recurring series accumulates one per occurrence in the same collection,
+# which is what makes a window necessary. Graph documents `$top` here but publishes no ceiling, so
+# this is ours, and it is the transcript lister's for the same reason.
+MAX_RECORDINGS = 50
+
+
+class RecordingSummary(BaseModel):
+    recording_id: str = Field(
+        description=(
+            "The recording's Graph id. Opaque, and no tool here takes it: this connector never "
+            + "returns or fetches recording video, so there is no handle for one and nothing to "
+            + "pass it to. Report it only if a person needs to identify the file elsewhere."
+        )
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When recording began (Microsoft's `createdDateTime`) — the recording's own start, not "
+            + "the meeting's. For a recurring meeting this is what tells one occurrence from "
+            + "another: every occurrence's recording lands in the same collection and Microsoft "
+            + "gives no occurrence id."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When recording stopped (Microsoft's `endDateTime`)."
+    )
+    duration_seconds: float | None = Field(
+        description=(
+            "How long the recording runs, computed as `ended_at - started_at`. Microsoft publishes "
+            + "no duration, size or media-type property on a recording, so this is derived and it "
+            + "is null when either timestamp is missing — there is no better source and inventing "
+            + "one would be a fabrication. It is the recording's length rather than the meeting's."
+        )
+    )
+    content_access: str = Field(
+        description=(
+            "Whether Microsoft would let the SIGNED-IN user download this recording's video. It "
+            + "says nothing about this connector, which never returns video at all. One of:\n"
+            + "- `you_are_the_organizer` — the signed-in user organised the meeting, and Microsoft "
+            + "permits the organiser to download the recording (in Teams or SharePoint, not here). "
+            + "An administrator can still have blocked recording downloads tenant-wide.\n"
+            + "- `organizer_only` — the signed-in user is not the organiser. Microsoft: 'Meeting "
+            + "participants don't have permission to download meeting recordings', unless a tenant "
+            + "administrator has unblocked participants. `organizer_user_id` says whose it is. "
+            + "This is NOT a missing recording: the recording exists and its details here are "
+            + "real, so say it exists and that the video is out of this user's reach, and offer "
+            + "the transcript instead.\n"
+            + "- `unknown` — Microsoft named no organiser for this recording, so which of the two "
+            + "above applies cannot be told."
+        )
+    )
+    organizer_user_id: str | None = Field(
+        description=(
+            "The meeting organiser's Microsoft Entra object id, or null where Microsoft named "
+            + "nobody. The person to ask for the video when `content_access` is `organizer_only`. "
+            + "Microsoft leaves the organiser's display name null on this resource, so this id is "
+            + "all there is — it is comparable with the `user_id` get_me returns and with a "
+            + "message sender's `user_id`, and a name is not."
+        )
+    )
+    content_correlation_id: str | None = Field(
+        description=(
+            "Microsoft's identifier linking this recording to the transcript of the same call. "
+            + "This is the bridge to the readable artifact: call list_meeting_transcripts for the "
+            + "same meeting and the transcript carrying this same value is this call, so a "
+            + "recording nobody may download can still be answered from its transcript."
+        )
+    )
+
+
+class MeetingRecordings(BaseModel):
+    status: str = Field(
+        description=(
+            "What was found, and therefore what to do next. Exactly one of:\n"
+            + "- `available` — `recordings` lists them, with their durations and whether the "
+            + "signed-in user may download each. No video is returned or reachable here.\n"
+            + "- `not_ready` — nothing is there for the window you asked about and something may "
+            + "still arrive: that window has only just closed, or you asked for no window and the "
+            + "meeting itself has not ended or ended recently. Microsoft publishes no availability "
+            + "SLA and no 'processing' status for a recording, so this is inferred: it means wait "
+            + "and ask again later, and it is NOT evidence that the call was never recorded. A "
+            + "window that has demonstrably passed is never reported this way, however far in the "
+            + "future a recurring series runs.\n"
+            + "- `not_recorded` — the window is over, nothing is there, and nothing is expected: "
+            + "the call was not recorded. Retrying will not change this. One other cause looks "
+            + "identical and cannot be distinguished: Microsoft's meeting-artifact APIs stop "
+            + "serving a meeting once it expires (about 60 days after a one-off), so a recording "
+            + "that once existed can read as never having existed.\n"
+            + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
+            + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
+            + "calendar, or one this user was never invited to, answers the same way. Do not retry "
+            + "and do not rebuild the handle."
+        )
+    )
+    meeting_id: str | None = Field(
+        description=(
+            "The resolved meeting's Graph id, or null when `status` is `meeting_not_found`. "
+            + "Opaque, and no tool here takes it."
+        )
+    )
+    subject: str | None = Field(
+        description=(
+            "The meeting's subject as Microsoft holds it, which is how to confirm this is the "
+            + "meeting that was meant. It may differ from the chat's topic."
+        )
+    )
+    meeting_type: str | None = Field(
+        description=(
+            "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null when Microsoft did "
+            + "not say. `recurring` is the one to act on: a whole series is ONE meeting to "
+            + "Microsoft, so every occurrence's recording is in this one collection and "
+            + "`started_after`/`started_before` are how to reach a single occurrence."
+        )
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When the meeting starts. For a recurring series this is Microsoft's single value for "
+            + "the whole series, not the occurrence you asked about."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When the meeting ends, on the same caveat as `started_at`."
+    )
+    recordings: list[RecordingSummary] = Field(
+        description=(
+            "The recordings of this meeting that fall inside the requested window, newest first. "
+            + "Empty for every status other than `available`."
+        )
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the meeting has more recordings than this `limit` holds — the same 'there "
+            + "is more' flag every list-shaped tool here reports. Raise `limit` (up to "
+            + f"{MAX_RECORDINGS}) or narrow `started_after`/`started_before`; there is no cursor."
+        )
+    )
+
+
+async def list_meeting_recordings(
+    client: GraphServiceClient,
+    *,
+    handle: MeetingHandle,
+    started_after: date | datetime | None,
+    started_before: date | datetime | None,
+    limit: int,
+) -> MeetingRecordings:
+    """The recordings of the meeting `handle` addresses, and what a caller should do about them.
+
+    Two Graph requests, or three where something was found: resolve the join URL, list the
+    collection, and — only then — ask who the caller is, which is what turns Microsoft's
+    organiser-only rule from a sentence into an answer about this user.
+
+    The window is applied while paging rather than as a `$filter`. Graph documents `$filter` on
+    this collection and documents exactly one filterable property by example, `contentCorrelationId`
+    (https://learn.microsoft.com/en-us/graph/api/callrecording-get, Example 5) — never a date — so
+    a server-side date bound would be unverified, and a wrong one returns nothing rather than
+    failing. The same window then decides both which recordings are kept and what an empty answer
+    means, exactly as it does for transcripts.
+    """
+    assert 1 <= limit <= MAX_RECORDINGS, f"limit must be within 1..{MAX_RECORDINGS}, got {limit}"
+    window = OccurrenceWindow.of(started_after, started_before)
+
+    with graph_errors():
+        meeting = await resolve_meeting(client, handle)
+        if meeting is None or meeting.id is None:
+            return MeetingRecordings(
+                status="meeting_not_found",
+                meeting_id=None,
+                subject=None,
+                meeting_type=None,
+                started_at=None,
+                ended_at=None,
+                recordings=[],
+                truncated=False,
+            )
+        first_page = await client.me.online_meetings.by_online_meeting_id(
+            meeting.id
+        ).recordings.get()
+        assert first_page is not None, "Graph answered a recording listing with no collection"
+        collected = await collect_pages(first_page, client, limit=limit, matches=window.holds)
+        found = sorted(collected.items, key=began_at, reverse=True)
+        # Asked for last and only when it changes an answer: with nothing to report there is no
+        # organiser to compare anybody with, and the request would be spent on every empty listing.
+        caller = (await identity.get_signed_in_user(client)).user_id if found else None
+
+    return MeetingRecordings(
+        status="available" if found else _absence(window.settled(meeting)),
+        meeting_id=meeting.id,
+        subject=meeting.subject,
+        meeting_type=meeting.meeting_type,
+        started_at=meeting.start_date_time,
+        ended_at=meeting.end_date_time,
+        recordings=[_summary(recording, caller) for recording in found],
+        truncated=collected.truncated,
+    )
+
+
+def _absence(settled: bool) -> str:
+    """Which of the two empty answers to give: the one that means stop, or the one that means wait.
+
+    The evidence is `OccurrenceWindow.settled`, shared with the transcript listing because the
+    inference is the same one — Microsoft publishes neither a processing status nor a latency SLA
+    for either artifact — and only the word for it differs, because "was not transcribed" and "was
+    not recorded" are different facts about a meeting.
+    """
+    return "not_recorded" if settled else "not_ready"
+
+
+def _summary(recording: CallRecording, caller: str | None) -> RecordingSummary:
+    assert recording.id is not None, "Graph returned a recording with no id"
+    organizer = _organizer_user_id(recording)
+    return RecordingSummary(
+        recording_id=recording.id,
+        started_at=recording.created_date_time,
+        ended_at=recording.end_date_time,
+        duration_seconds=_duration_seconds(recording),
+        content_access=_content_access(organizer, caller),
+        organizer_user_id=organizer,
+        content_correlation_id=recording.content_correlation_id,
+    )
+
+
+def _organizer_user_id(recording: CallRecording) -> str | None:
+    """The organiser's Entra object id, or None where Graph named nobody.
+
+    Graph sends the organiser as an `identitySet`, and the `@odata.type` on the user inside it is
+    not always one the SDK knows — Microsoft's own list-recordings sample sends
+    `#Microsoft.Teams.GraphSvc.teamworkUserIdentity` rather than `#microsoft.graph.…`. An unknown
+    discriminator deserializes to the base `identity`, which still carries the id, so nothing here
+    depends on the subtype.
+    """
+    organizer = recording.meeting_organizer
+    if organizer is None or organizer.user is None:
+        return None
+    return organizer.user.id
+
+
+def _content_access(organizer: str | None, caller: str | None) -> str:
+    """Which side of Microsoft's organiser-only download rule the signed-in user is on.
+
+    `None` for either id means it cannot be told, which is its own answer: guessing "organiser"
+    would promise a download Microsoft refuses, and guessing "participant" would send a caller to
+    ask somebody for a file they already have. Ids are compared case-insensitively — an Entra
+    object id is a GUID and its casing is not part of its identity.
+    """
+    if organizer is None or caller is None:
+        return "unknown"
+    theirs = organizer.casefold() == caller.casefold()
+    return "you_are_the_organizer" if theirs else "organizer_only"
+
+
+def _duration_seconds(recording: CallRecording) -> float | None:
+    """How long the recording runs, or None where Graph did not say enough to know.
+
+    Both timestamps are resolved on the same UTC assumption the occurrence window uses, so a
+    payload that omitted its `Z` cannot make this subtraction raise. A negative result is not a
+    duration — Graph's negative offsets are a property of *content* cue times, not of these two
+    fields — so it is reported as unknown rather than as a negative number of seconds.
+    """
+    began, ended = recording.created_date_time, recording.end_date_time
+    if began is None or ended is None:
+        return None
+    seconds = (as_utc(ended) - as_utc(began)).total_seconds()
+    return seconds if seconds >= 0 else None

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -89,19 +89,29 @@ and a window quietly built in the wrong zone is worse than one that was refused.
   that has demonstrably passed is answered `not_transcribed` even for a series still running, or a
   model is sent back to poll for an occurrence that ended last month. Graph publishes no status for
   availability and no latency SLA, so both halves are an inference over one generous allowance;
-  `OccurrenceWindow.absence` is the whole of it and `MeetingTranscripts.status` admits it as one.
+  `OccurrenceWindow.settled` is the whole of it and `MeetingTranscripts.status` admits it as one.
 
 `SpeakerAttributionNotAllowed` is a fourth Graph answer and the one this module handles rather than
 reports: a tenant may permit transcripts and forbid speaker names, and the documented response is
 to ask again for the unattributed format. That degrades the answer instead of losing it, and
 `Transcript.speaker_attribution` says which one came back.
+
+## What `recordings` borrows from here, and why it is a separate module
+
+A meeting's recordings are answered by `features/recordings.py`, which takes `MeetingHandle`,
+`resolve_meeting`, `OccurrenceWindow` and the two helpers below from here: this module owns the
+meeting handle family (layering rule 9), so the join URL, the escaping and the window have exactly
+one home whichever artifact is being asked about. What it does not share is the outcome word — "was
+not transcribed" and "was not recorded" are different facts — or the refusal above, which Microsoft
+scopes to transcripts alone. That asymmetry is why the two artifacts are two tools;
+`features/recordings.py` argues it where the decision was made.
 """
 
 import html
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
-from typing import Self
+from typing import Protocol, Self
 from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -139,13 +149,14 @@ MAX_TRANSCRIPTS = 50
 MAX_TURNS = 500
 
 # How long after a window closes — or after a meeting ends, where no window was asked for — a
-# missing transcript is still called "not ready" rather than "never transcribed". Microsoft
-# publishes no SLA and no "processing" status for transcript availability, so this is not a promise
-# about Graph — it is which of two opposite pieces of advice to give when the evidence is the same
-# empty collection. Generous on purpose: telling a caller to wait once when nothing will ever
-# arrive costs one call, while telling it a transcript does not exist when it is ten minutes away
-# is a wrong answer it cannot detect.
-TRANSCRIPT_DELAY_ALLOWANCE = timedelta(hours=4)
+# missing artifact is still called "not ready" rather than "never made". Microsoft publishes no SLA
+# and no "processing" status for the availability of a transcript or of a recording, so this is not
+# a promise about Graph — it is which of two opposite pieces of advice to give when the evidence is
+# the same empty collection. Generous on purpose: telling a caller to wait once when nothing will
+# ever arrive costs one call, while telling it a transcript does not exist when it is ten minutes
+# away is a wrong answer it cannot detect. Named for artifacts rather than for transcripts because
+# `OccurrenceWindow.settled` is what recordings answer their own absence with too.
+ARTIFACT_DELAY_ALLOWANCE = timedelta(hours=4)
 
 # The inner code Graph sends when a tenant permits transcripts but forbids speaker names. Branched
 # on rather than the message, as Microsoft's own documentation instructs.
@@ -245,6 +256,19 @@ def _segment(value: str) -> str:
     return quote(value, safe="")
 
 
+class MeetingArtifact(Protocol):
+    """The one property a window needs of a meeting artifact: when it began.
+
+    Structural rather than nominal because there are two of these and they are unrelated generated
+    classes: `callTranscript` and `callRecording` both carry `createdDateTime` and nothing else
+    below is read. Naming the protocol instead of one of them is what lets recordings scope a
+    recurring series with the same window rather than with a second implementation of it.
+    """
+
+    @property
+    def created_date_time(self) -> datetime | None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class OccurrenceWindow:
     """Which occurrence was asked about, as two instants that are always timezone-aware.
@@ -275,39 +299,42 @@ class OccurrenceWindow:
         """
         return cls(_first_instant(started_after), _last_instant(started_before))
 
-    def holds(self, transcript: CallTranscript) -> bool:
-        """Whether this transcript began inside the window.
+    def holds(self, artifact: MeetingArtifact) -> bool:
+        """Whether this transcript or recording began inside the window.
 
-        A transcript Graph gave no `createdDateTime` for is kept when no window was asked for and
+        An artifact Graph gave no `createdDateTime` for is kept when no window was asked for and
         dropped when one was: it cannot be shown to be the occurrence the caller meant.
         """
         if self.started_after is None and self.started_before is None:
             return True
-        began = transcript.created_date_time
+        began = artifact.created_date_time
         if began is None:
             return False
         # Aware even though Graph's own timestamps carry `Z`: this comparison is the one that used
         # to raise, and it must not depend on a payload's punctuation to stay safe.
-        began = _utc(began)
+        began = as_utc(began)
         if self.started_after is not None and began < self.started_after:
             return False
         return not (self.started_before is not None and began > self.started_before)
 
-    def absence(self, meeting: OnlineMeeting) -> str:
-        """Which of the two empty answers this is, for the window that was actually asked about.
+    def settled(self, meeting: OnlineMeeting) -> bool:
+        """Whether an empty answer for this window means "there is none" rather than "not yet".
 
         Two independent pieces of evidence, either of which settles it: the window's own end is far
         enough past that anything falling inside it would have landed, or the *meeting* is — the
         second being what answers a caller who asked for no window at all, and what stops a window
-        mistakenly set in the future promising a transcript for a meeting that is long over.
+        mistakenly set in the future promising an artifact for a meeting that is long over.
 
         Absent evidence never settles anything: no `started_before` and no `endDateTime` both mean
-        nothing says transcription has finished, and of the two wrong answers the one that costs a
-        caller a second call is the cheaper one.
+        nothing says the meeting's artifacts have finished being made, and of the two wrong answers
+        the one that costs a caller a second call is the cheaper one.
+
+        A predicate rather than the verdict itself, because the verdict is a different word per
+        artifact and each lister owns its own vocabulary — the *inference* is what must not exist
+        twice.
         """
         now = datetime.now(UTC)
-        settled = _settled_by(self.started_before, now) or _settled_by(meeting.end_date_time, now)
-        return "not_transcribed" if settled else "not_ready"
+        return _settled_by(self.started_before, now) or _settled_by(meeting.end_date_time, now)
 
 
 def _first_instant(bound: date | datetime | None) -> datetime | None:
@@ -316,7 +343,7 @@ def _first_instant(bound: date | datetime | None) -> datetime | None:
         return None
     # `datetime` subclasses `date`, so this order is the whole of the distinction.
     if isinstance(bound, datetime):
-        return _utc(bound)
+        return as_utc(bound)
     return datetime.combine(bound, time.min, tzinfo=UTC)
 
 
@@ -325,18 +352,23 @@ def _last_instant(bound: date | datetime | None) -> datetime | None:
     if bound is None:
         return None
     if isinstance(bound, datetime):
-        return _utc(bound)
+        return as_utc(bound)
     return datetime.combine(bound, time.max, tzinfo=UTC)
 
 
-def _utc(moment: datetime) -> datetime:
-    """`moment` as an aware datetime, reading one that named no timezone as already being UTC."""
+def as_utc(moment: datetime) -> datetime:
+    """`moment` as an aware datetime, reading one that named no timezone as already being UTC.
+
+    Public because the UTC assumption belongs to the window and the window has one home: anything
+    comparing or subtracting Graph timestamps — here, or in the recordings lister deriving a
+    duration from two of them — resolves them through this and cannot meet a naive one.
+    """
     return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
 
 
 def _settled_by(moment: datetime | None, now: datetime) -> bool:
-    """Whether `moment` is far enough past that a transcript belonging to it would have arrived."""
-    return moment is not None and _utc(moment) + TRANSCRIPT_DELAY_ALLOWANCE < now
+    """Whether `moment` is far enough past that an artifact belonging to it would have arrived."""
+    return moment is not None and as_utc(moment) + ARTIFACT_DELAY_ALLOWANCE < now
 
 
 class TranscriptSummary(BaseModel):
@@ -517,7 +549,7 @@ async def list_meeting_transcripts(
     window = OccurrenceWindow.of(started_after, started_before)
 
     with graph_errors():
-        meeting = await _resolve_meeting(client, handle)
+        meeting = await resolve_meeting(client, handle)
         if meeting is None or meeting.id is None:
             return MeetingTranscripts(
                 status="meeting_not_found",
@@ -535,9 +567,9 @@ async def list_meeting_transcripts(
         assert first_page is not None, "Graph answered a transcript listing with no collection"
         collected = await collect_pages(first_page, client, limit=limit, matches=window.holds)
 
-    found = sorted(collected.items, key=_started_at, reverse=True)
+    found = sorted(collected.items, key=began_at, reverse=True)
     return MeetingTranscripts(
-        status="available" if found else window.absence(meeting),
+        status="available" if found else _absence(window.settled(meeting)),
         meeting_id=meeting.id,
         subject=meeting.subject,
         # `OnlineMeetingBase.meetingType` is a generated enum subclassing `str`, so the member is
@@ -550,10 +582,24 @@ async def list_meeting_transcripts(
     )
 
 
-async def _resolve_meeting(
+def _absence(settled: bool) -> str:
+    """Which of the two empty answers to give: the one that means stop, or the one that means wait.
+
+    The evidence is `OccurrenceWindow.settled` and the word is this module's, because a meeting that
+    was recorded but not transcribed is answered `not_transcribed` here and `available` by the
+    recordings lister — the same evidence about two different artifacts.
+    """
+    return "not_transcribed" if settled else "not_ready"
+
+
+async def resolve_meeting(
     client: GraphServiceClient, handle: MeetingHandle
 ) -> OnlineMeeting | None:
     """The meeting whose stored `joinWebUrl` is `handle`'s, or None if Graph matched none.
+
+    Public because every meeting-side feature needs it and the `$filter` below must exist once:
+    this module owns the meeting handle family, so it owns the one request that redeems a handle.
+    Its permission is `MEETING_PERMISSION`, which is why the two travel together.
 
     The filter is built with the join URL doubled-quote-escaped and otherwise untouched: the SDK
     percent-encodes a query parameter's value on expansion, which is precisely the single encoding
@@ -575,14 +621,16 @@ async def _resolve_meeting(
     return meetings[0] if meetings else None
 
 
-def _started_at(transcript: CallTranscript) -> datetime:
-    """The sort key: when transcription began, or the beginning of time where Graph did not say.
+def began_at(artifact: MeetingArtifact) -> datetime:
+    """The sort key: when the artifact began, or the beginning of time where Graph did not say.
 
     Aware for the same reason `OccurrenceWindow.holds` is — one naive value among aware ones makes
     the sort itself raise, which is a crash in the middle of an answer that was already complete.
+    Shared with the recordings lister so that both artifacts come back newest first by the same
+    rule: Graph documents no `$orderby` on either collection, so the order is ours either way.
     """
-    began = transcript.created_date_time
-    return _utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)
+    began = artifact.created_date_time
+    return as_utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)
 
 
 def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -1,0 +1,654 @@
+"""Meeting transcripts: from a meeting chat to speaker-attributed, timestamped turns.
+
+This is the one surface where a delegated connector can answer better than a link. Microsoft's own
+M365 connector reaches a transcript only through an opaque URI obtained from a calendar read and
+returns whatever that yields; the chain here ends in `/transcripts/{id}/content`, which Graph
+answers with WebVTT carrying `<v Speaker>` voice tags and cue timestamps — who said what, when.
+
+## How a meeting is addressed, and the one place the chain can break
+
+Graph documents exactly three delegated ways to reach an `onlineMeeting`
+(https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get): by its own `id`, by `joinWebUrl`,
+or by `joinMeetingIdSettings/joinMeetingId`. A chat id is not one of them, and neither is a chat's
+`webUrl`. So the only route from Teams' conversation side to the meeting side is the join URL, and
+the only place a delegated caller is given one is `chat.onlineMeetingInfo.joinWebUrl` — a property
+of the `chat` resource, present in the default projection of `GET /me/chats` (that collection
+supports `$expand`, `$top`, `$filter` and `$orderby` and nothing else, so it could not be asked for
+explicitly even if it were absent), and documented as "empty" when the chat is not a meeting's.
+
+**What is verified and what is not.** Meeting chats being enumerable with a descriptive `topic` and
+a recency timestamp is confirmed against a live tenant. That `onlineMeetingInfo.joinWebUrl` is
+*populated* — in general, and specifically for a meeting the signed-in user did not organise — is
+**not**: the property is documented on the resource and modelled by the SDK, and no doc says it is
+organiser-only, but no live call has been made that asked for it. So a null join URL is a first-
+class outcome here rather than an impossible one: `list_chats` reports no `meeting_uri` for that
+chat, and there is no fallback, because there is no documented second route. `onlineMeeting` does
+carry a `chatInfo.threadId`, and a `$filter` on it would be exactly the invented path this module
+refuses to ship: Graph documents neither that property as filterable nor any lookup by it.
+
+Two further limits belong to the caller rather than to the code. The resolve step is documented for
+attendees — "These request URLs accept both the organizer's and the invited attendee's user token
+(delegated permission)" — but the transcript *list* is not: its reference page documents
+`OnlineMeetingTranscript.Read.All` and says nothing about non-organisers, so a participant may be
+refused where the organiser succeeds. And every artifact API "works for a meeting only if the
+meeting has not expired", which is roughly 60 days for a one-off
+(https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams#meeting-expiration).
+
+## The `$filter` on the join URL, and the bug class around it
+
+Graph's note is one line — "**joinWebUrl** must be URL encoded" — and its worked example shows how
+far that goes: a `%3a` already inside the stored URL arrives as `%253a`, because the `%` is itself
+escaped. `services/teams-mcp` gets this wrong today (`src/transcript/tools/ingest-meeting.tool.ts`
+doubles the quote and then hands the raw URL to a JavaScript SDK that concatenates query parameters
+without encoding), and the failure is silent: a join URL carrying `&` or `#` — real ones do — makes
+Graph parse a truncated filter and answer `200 OK` with an empty `value`, which reads exactly like
+"no such meeting".
+
+Here the two transforms are separated, and only the first is ours:
+
+1. **OData literal escape.** A single quote inside an OData string literal is doubled. Required for
+   correctness and to stop a crafted URL closing the literal and appending predicates of its own.
+2. **Percent-encoding**, which the Python SDK does correctly and which is therefore not repeated:
+   `$filter` is a query parameter of a URI template, and form-style expansion escapes everything
+   outside the unreserved set — including `%`, `&`, `#`, `?` and `=`. Encoding it a second time
+   would produce `%2525…` and, again, an empty `value`. `test_transcripts.py` pins the bytes that
+   reach the wire, because this is the failure that looks like an answer.
+
+`200 OK` with `value: []` is Graph's documented "no match" for this filter — it never 404s — so it
+is reported as its own outcome and not as an error.
+
+## Three failures a caller must act on differently
+
+`GET …/transcripts` returning nothing is not one answer but two, and the tenant switch is a third:
+
+* **`GraphAccessToTranscriptsDisabled`** — a `403` whose remedy names a Teams administrator, not a
+  Graph permission. Microsoft Graph access to transcripts is off by default and "no app can access
+  meeting transcripts, regardless of app-level permissions"; there is "no request-side workaround".
+  It is recognised by inner code in `server/errors.py`, where every other refusal is worded.
+* **No transcript** — the meeting was never recorded or never transcribed. Retrying is pointless.
+* **Not ready yet** — the meeting has just ended and the transcript has not landed. Retrying is the
+  *only* thing that helps, which is why this must never be reported as the case above. Graph
+  publishes no status for it and no latency SLA, so it is derived from the meeting's end time and a
+  deliberately generous allowance; `MeetingTranscripts.status` says exactly what that means.
+
+`SpeakerAttributionNotAllowed` is a fourth Graph answer and the one this module handles rather than
+reports: a tenant may permit transcripts and forbid speaker names, and the documented response is
+to ask again for the unattributed format. That degrades the answer instead of losing it, and
+`Transcript.speaker_attribution` says which one came back.
+"""
+
+import html
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from urllib.parse import quote, unquote
+
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from kiota_abstractions.headers_collection import HeadersCollection
+from msgraph.generated.models.call_transcript import CallTranscript
+from msgraph.generated.models.online_meeting import OnlineMeeting
+from msgraph.generated.users.item.online_meetings.online_meetings_request_builder import (
+    OnlineMeetingsRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import GraphForbidden, collect_pages, graph_errors
+
+# Resolving a join URL to a meeting is `OnlineMeetings.Read`, the least privilege Graph documents
+# for the filter, and needs no admin consent. Reading a transcript is a different, admin-consented
+# permission — and a tenant can grant one and withhold the other, which is why they are named
+# separately and why the two tools over them exchange different tokens.
+MEETING_PERMISSION = "OnlineMeetings.Read"
+TRANSCRIPT_PERMISSION = "OnlineMeetingTranscript.Read.All"
+
+# What listing a meeting's transcripts costs: the resolve and the list, in that order, under one
+# token. Reading content needs only the second — the handle already carries the resolved meeting id.
+LISTING_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
+
+# How many transcripts one listing returns. A one-off meeting has one; a recurring series
+# accumulates one per occurrence in the same collection, which is what makes a window necessary at
+# all. Graph documents `$top` here but publishes no ceiling, so this is ours.
+MAX_TRANSCRIPTS = 50
+
+# How many turns one read returns, and the default window. A turn is one WebVTT cue — a sentence or
+# two — so an hour of meeting is some hundreds of them and a 30-hour one (Teams' own limit) is tens
+# of thousands. The whole transcript is fetched either way; this bounds what crosses into a model's
+# context per call.
+MAX_TURNS = 500
+
+# How long after a meeting ends a missing transcript is still called "not ready" rather than "never
+# transcribed". Microsoft publishes no SLA and no "processing" status for transcript availability,
+# so this is not a promise about Graph — it is which of two opposite pieces of advice to give when
+# the evidence is the same empty collection. Generous on purpose: telling a caller to wait once
+# when nothing will ever arrive costs one call, while telling it a transcript does not exist when it
+# is ten minutes away is a wrong answer it cannot detect.
+TRANSCRIPT_DELAY_ALLOWANCE = timedelta(hours=4)
+
+# The inner code Graph sends when a tenant permits transcripts but forbids speaker names. Branched
+# on rather than the message, as Microsoft's own documentation instructs.
+_SPEAKER_ATTRIBUTION_REFUSED = "SpeakerAttributionNotAllowed"
+
+# The two formats `/content` serves. VTT is the default and the one worth having — it is the only
+# one carrying `<v Speaker>` voice tags. The other is the documented fallback for a tenant with
+# speaker attribution switched off, and is selectable *only* by this header ("the
+# application/vnd.microsoft.graph.transcript+text format is supported only through this header"),
+# which is why neither is requested with `$format`.
+_ATTRIBUTED_FORMAT = "text/vtt"
+_UNATTRIBUTED_FORMAT = "application/vnd.microsoft.graph.transcript+text"
+
+type _MeetingsQuery = OnlineMeetingsRequestBuilder.OnlineMeetingsRequestBuilderGetQueryParameters
+
+
+@dataclass(frozen=True, slots=True)
+class MeetingHandle:
+    """Which meeting, as the only thing a chat can say about one: its join URL.
+
+    A handle rather than a bare URL because a join URL is not an argument a model should be
+    composing or re-encoding — Graph warns that "users shouldn't rely on any information extracted
+    from parsing the URL" and the `$filter` match is byte-for-byte against what Graph stored.
+    Wrapping it means the tool takes something that came from a tool result, and the encoding
+    happens in one place.
+    """
+
+    join_web_url: str
+
+    @property
+    def uri(self) -> str:
+        return f"teams:///meetings/{_segment(self.join_web_url)}"
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptHandle:
+    """Which transcript, by the two ids Graph's content path is built from.
+
+    The meeting id and not the join URL, because the resolve has already happened: a reader that
+    carried the join URL would repeat it, spend a second Graph request and a second permission, and
+    give a 403 that could be about either of them. Graph's own `transcriptContentUrl` is not used —
+    the published samples are malformed (`…/transcripts/('…')/content`) — so the path is built from
+    the ids, which is what Microsoft's reference shows.
+    """
+
+    meeting_id: str
+    transcript_id: str
+
+    @property
+    def uri(self) -> str:
+        return f"teams:///transcripts/{_segment(self.meeting_id)}/{_segment(self.transcript_id)}"
+
+
+# The two meeting-side handle shapes. Distinct first segments rather than one nested grammar: a
+# `teams:///meetings/{x}/transcripts/{y}` would make `{x}` a join URL in one shape and a meeting id
+# in the other, and a parser cannot tell those apart.
+_MEETING_HANDLE = re.compile(r"\Ateams:///meetings/([^/]+)\Z")
+_TRANSCRIPT_HANDLE = re.compile(r"\Ateams:///transcripts/([^/]+)/([^/]+)\Z")
+
+
+def meeting_handle(uri: str) -> MeetingHandle | None:
+    """`uri` as a meeting handle, or None if it is not one.
+
+    None rather than an exception with advice, for the same reason `message_handle` returns None:
+    what to tell a caller about a malformed handle is the tool boundary's business.
+    """
+    match = _MEETING_HANDLE.match(uri)
+    if match is None:
+        return None
+    join_web_url = unquote(match.group(1))
+    return MeetingHandle(join_web_url) if join_web_url.strip() else None
+
+
+def transcript_handle(uri: str) -> TranscriptHandle | None:
+    """`uri` as a transcript handle, or None if it is not one."""
+    match = _TRANSCRIPT_HANDLE.match(uri)
+    if match is None:
+        return None
+    meeting_id, transcript_id = (unquote(part) for part in match.groups())
+    if not meeting_id.strip() or not transcript_id.strip():
+        return None
+    return TranscriptHandle(meeting_id, transcript_id)
+
+
+def meeting_uri_for(join_web_url: str | None) -> str | None:
+    """A meeting handle for `join_web_url`, or None when Graph gave none.
+
+    Public so that `chats` can put a transcript route on a meeting chat without spelling a handle:
+    the grammar has one home per family, and this is the meeting family's.
+    """
+    if join_web_url is None or not join_web_url.strip():
+        return None
+    return MeetingHandle(join_web_url).uri
+
+
+def _segment(value: str) -> str:
+    return quote(value, safe="")
+
+
+class TranscriptSummary(BaseModel):
+    uri: str = Field(
+        description=(
+            "A handle for this transcript. Pass it verbatim to read_transcript, which is the only "
+            + "route to the words that were said — nothing here contains any of them."
+        )
+    )
+    transcript_id: str = Field(
+        description="The transcript's Graph id. Identify a transcript by `uri`, not by this alone."
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When transcription began (Microsoft's `createdDateTime`). For a recurring meeting "
+            + "this is what tells one occurrence from another: every occurrence's transcript lands "
+            + "in the same collection, and Microsoft gives no occurrence id."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When transcription ended (Microsoft's `endDateTime`)."
+    )
+    content_correlation_id: str | None = Field(
+        description=(
+            "Microsoft's identifier linking this transcript to the recording of the same call. "
+            + "Nothing here fetches recordings; it is returned because it is the exact link, and "
+            + "two transcripts sharing it are two views of one call rather than of two."
+        )
+    )
+
+
+class MeetingTranscripts(BaseModel):
+    status: str = Field(
+        description=(
+            "What was found, and therefore what to do next. Exactly one of:\n"
+            + "- `available` — `transcripts` lists them; read one.\n"
+            + "- `not_ready` — the meeting has not ended, or ended recently enough that a "
+            + "transcript may still be processing. Microsoft publishes no availability SLA and no "
+            + "'processing' status, so this is inferred from the meeting's end time: it means wait "
+            + "and ask again later, and it is NOT evidence that no transcript will ever exist.\n"
+            + "- `not_transcribed` — the meeting is over, nothing is there, and nothing is "
+            + "expected: it was not recorded or transcribed. Retrying will not change this. One "
+            + "other cause looks identical and cannot be distinguished: Microsoft's "
+            + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
+            + "one-off), so a transcript that once existed can read as never having existed.\n"
+            + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
+            + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
+            + "calendar, or one this user was never invited to, answers the same way. Do not retry "
+            + "and do not rebuild the handle."
+        )
+    )
+    meeting_id: str | None = Field(
+        description=(
+            "The resolved meeting's Graph id, or null when `status` is `meeting_not_found`. "
+            + "Opaque, and no tool here takes it — a transcript's `uri` already carries it."
+        )
+    )
+    subject: str | None = Field(
+        description=(
+            "The meeting's subject as Microsoft holds it, which is how to confirm this is the "
+            + "meeting that was meant. It may differ from the chat's topic."
+        )
+    )
+    meeting_type: str | None = Field(
+        description=(
+            "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null when Microsoft did "
+            + "not say. `recurring` is the one to act on: a whole series is ONE meeting to "
+            + "Microsoft, so every occurrence's transcript is in this one collection and "
+            + "`started_after`/`started_before` are how to reach a single occurrence."
+        )
+    )
+    started_at: datetime | None = Field(
+        description=(
+            "When the meeting starts. For a recurring series this is Microsoft's single value for "
+            + "the whole series, not the occurrence you asked about."
+        )
+    )
+    ended_at: datetime | None = Field(
+        description="When the meeting ends, on the same caveat as `started_at`."
+    )
+    transcripts: list[TranscriptSummary] = Field(
+        description=(
+            "The transcripts of this meeting that fall inside the requested window, newest first. "
+            + "Empty for every status other than `available`."
+        )
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the meeting has more transcripts than this `limit` holds — the same 'there "
+            + "is more' flag every list-shaped tool here reports. Raise `limit` (up to "
+            + f"{MAX_TRANSCRIPTS}) or narrow `started_after`/`started_before`; there is no cursor."
+        )
+    )
+
+
+class TranscriptTurn(BaseModel):
+    speaker: str | None = Field(
+        description=(
+            "Who spoke, as Teams attributed them. Null when this transcript has no speaker "
+            + "attribution at all (see `speaker_attribution`) and null for the occasional turn "
+            + "Microsoft attributed to nobody — a null is not an unidentified person."
+        )
+    )
+    start_seconds: float = Field(
+        description=(
+            "When this turn starts, in seconds from the beginning of transcription — not from the "
+            + "start of the meeting, and not a wall-clock time. Add it to the transcript's "
+            + "`started_at` for that. It can be NEGATIVE: Microsoft documents negative offsets as "
+            + "meaning transcription began while the conversation was already under way."
+        )
+    )
+    end_seconds: float = Field(description="When this turn ends, on the same scale.")
+    text: str = Field(description="What was said, with Teams' own cue markup removed.")
+
+
+class Transcript(BaseModel):
+    uri: str = Field(description="The handle this transcript was read by, echoed back.")
+    meeting_id: str = Field(description="The meeting this transcript belongs to.")
+    transcript_id: str = Field(description="The transcript's Graph id.")
+    speaker_attribution: bool = Field(
+        description=(
+            "True when Microsoft named the speakers, which is the normal case. False when this "
+            + "tenant has speaker attribution switched off: the words and the timings are all "
+            + "still here and every `speaker` is null. Do not guess who spoke from the content, "
+            + "and say so if the answer depends on who said something."
+        )
+    )
+    turns: list[TranscriptTurn] = Field(
+        description="What was said, in order, one turn per utterance Microsoft timestamped."
+    )
+    truncated: bool = Field(
+        description=(
+            "True when the transcript has more turns than this page holds — the same 'there is "
+            + "more' flag every list-shaped tool here reports. Pass `next_offset` back as `offset` "
+            + "to continue. Never summarise a truncated transcript as the whole meeting."
+        )
+    )
+    next_offset: int | None = Field(
+        description="The `offset` that reaches the next turns, or null when `truncated` is false."
+    )
+
+
+async def list_meeting_transcripts(
+    client: GraphServiceClient,
+    *,
+    handle: MeetingHandle,
+    started_after: datetime | None,
+    started_before: datetime | None,
+    limit: int,
+) -> MeetingTranscripts:
+    """The transcripts of the meeting `handle` addresses, and what a caller should do about them.
+
+    Two Graph requests at most: resolve the join URL, then list. The window is applied while paging
+    the listing rather than as a `$filter` — Graph advertises `$filter` on this collection without
+    documenting a single filterable property, so a server-side date bound is unverifiable and a
+    wrong one would silently return nothing.
+    """
+    assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
+
+    with graph_errors():
+        meeting = await _resolve_meeting(client, handle)
+        if meeting is None or meeting.id is None:
+            return MeetingTranscripts(
+                status="meeting_not_found",
+                meeting_id=None,
+                subject=None,
+                meeting_type=None,
+                started_at=None,
+                ended_at=None,
+                transcripts=[],
+                truncated=False,
+            )
+        first_page = await client.me.online_meetings.by_online_meeting_id(
+            meeting.id
+        ).transcripts.get()
+        assert first_page is not None, "Graph answered a transcript listing with no collection"
+        collected = await collect_pages(
+            first_page,
+            client,
+            limit=limit,
+            matches=lambda transcript: _within(transcript, started_after, started_before),
+        )
+
+    found = sorted(collected.items, key=_started_at, reverse=True)
+    return MeetingTranscripts(
+        status="available" if found else _absence(meeting),
+        meeting_id=meeting.id,
+        subject=meeting.subject,
+        # `OnlineMeetingBase.meetingType` is a generated enum subclassing `str`, so the member is
+        # its own wire value; a value the SDK predates deserializes to None rather than raising.
+        meeting_type=meeting.meeting_type,
+        started_at=meeting.start_date_time,
+        ended_at=meeting.end_date_time,
+        transcripts=[_summary(meeting.id, transcript) for transcript in found],
+        truncated=collected.truncated,
+    )
+
+
+async def _resolve_meeting(
+    client: GraphServiceClient, handle: MeetingHandle
+) -> OnlineMeeting | None:
+    """The meeting whose stored `joinWebUrl` is `handle`'s, or None if Graph matched none.
+
+    The filter is built with the join URL doubled-quote-escaped and otherwise untouched: the SDK
+    percent-encodes a query parameter's value on expansion, which is precisely the single encoding
+    Graph's note requires, and doing it here as well would send `%2525…`.
+
+    Graph documents this filter as returning "a collection that contains only one onlineMeeting
+    object", and no match as `200 OK` with an empty `value` rather than a 404 — so None here is an
+    answer and never an error.
+    """
+    escaped = handle.join_web_url.replace("'", "''")
+    configuration = RequestConfiguration[_MeetingsQuery](
+        query_parameters=OnlineMeetingsRequestBuilder.OnlineMeetingsRequestBuilderGetQueryParameters(
+            filter=f"JoinWebUrl eq '{escaped}'"
+        )
+    )
+    matched = await client.me.online_meetings.get(request_configuration=configuration)
+    assert matched is not None, "Graph answered GET /me/onlineMeetings with no collection"
+    meetings = matched.value or []
+    return meetings[0] if meetings else None
+
+
+def _within(
+    transcript: CallTranscript, started_after: datetime | None, started_before: datetime | None
+) -> bool:
+    """Whether this transcript began inside the requested window.
+
+    A transcript Graph gave no `createdDateTime` for is kept when no window was asked for and
+    dropped when one was: it cannot be shown to be the occurrence the caller meant.
+    """
+    if started_after is None and started_before is None:
+        return True
+    began = transcript.created_date_time
+    if began is None:
+        return False
+    if started_after is not None and began < started_after:
+        return False
+    return not (started_before is not None and began > started_before)
+
+
+def _absence(meeting: OnlineMeeting) -> str:
+    """Which of the two empty answers this is: worth waiting for, or not.
+
+    An end time Graph did not send counts as "not ready" rather than "never transcribed", because
+    without it there is no evidence transcription has finished — and of the two wrong answers, the
+    one that costs a caller a second call is the cheaper one.
+    """
+    ended = meeting.end_date_time
+    if ended is None or datetime.now(UTC) < ended + TRANSCRIPT_DELAY_ALLOWANCE:
+        return "not_ready"
+    return "not_transcribed"
+
+
+def _started_at(transcript: CallTranscript) -> datetime:
+    return transcript.created_date_time or datetime.min.replace(tzinfo=UTC)
+
+
+def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
+    assert transcript.id is not None, "Graph returned a transcript with no id"
+    return TranscriptSummary(
+        uri=TranscriptHandle(meeting_id, transcript.id).uri,
+        transcript_id=transcript.id,
+        started_at=transcript.created_date_time,
+        ended_at=transcript.end_date_time,
+        content_correlation_id=transcript.content_correlation_id,
+    )
+
+
+async def read_transcript(
+    client: GraphServiceClient, *, handle: TranscriptHandle, offset: int, limit: int
+) -> Transcript:
+    """The turns of one transcript, from `offset`, up to `limit` of them.
+
+    One Graph request, or two where the tenant refuses speaker attribution. Paging is over the
+    parsed turns rather than over Graph — `/content` is a single stream with no ranged contract —
+    so a later page costs the same fetch again, which is what makes `limit` worth widening rather
+    than looping.
+    """
+    assert 1 <= limit <= MAX_TURNS, f"limit must be within 1..{MAX_TURNS}, got {limit}"
+    assert offset >= 0, f"offset must not be negative, got {offset}"
+
+    content, attributed = await _content(client, handle)
+
+    turns = _turns(content, attributed=attributed)
+    page = turns[offset : offset + limit]
+    truncated = offset + len(page) < len(turns)
+    return Transcript(
+        uri=handle.uri,
+        meeting_id=handle.meeting_id,
+        transcript_id=handle.transcript_id,
+        speaker_attribution=attributed,
+        turns=page,
+        truncated=truncated,
+        next_offset=offset + len(page) if truncated else None,
+    )
+
+
+async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tuple[bytes, bool]:
+    """The transcript's bytes, and whether they carry speaker names.
+
+    The attributed format is asked for first because it is the one worth having and the default. The
+    single retry is Graph's own documented remedy for a tenant that permits transcripts and forbids
+    speaker names — "Retry the same request asking for the unattributed format … which succeeds" —
+    and it is scoped to that inner code alone: the tenant-wide switch reports itself the same way
+    (`403 Forbidden`) and has no request-side workaround, so retrying it would be one wasted call
+    and a message about the wrong remedy.
+
+    Each attempt gets its own `graph_errors` rather than one around both. The branch is on a
+    *classified* failure — the SDK's raw `APIError` has no inner code on it — so the translation has
+    to have happened before the `except` can decide anything, which a block enclosing the whole
+    function would defer until after it had already given up.
+    """
+    endpoint = (
+        client.me.online_meetings.by_online_meeting_id(handle.meeting_id)
+        .transcripts.by_call_transcript_id(handle.transcript_id)
+        .content
+    )
+    try:
+        with graph_errors():
+            attributed = await endpoint.get(
+                request_configuration=RequestConfiguration(headers=_accepting(_ATTRIBUTED_FORMAT))
+            )
+    except GraphForbidden as refusal:
+        if refusal.inner_code != _SPEAKER_ATTRIBUTION_REFUSED:
+            raise
+        with graph_errors():
+            unattributed = await endpoint.get(
+                request_configuration=RequestConfiguration(headers=_accepting(_UNATTRIBUTED_FORMAT))
+            )
+        return (unattributed or b"", False)
+    return (attributed or b"", True)
+
+
+def _accepting(media_type: str) -> HeadersCollection:
+    """A `HeadersCollection` of our own asking for `media_type`.
+
+    Built per request: `RequestConfiguration.headers` defaults to one instance shared by every
+    configuration in the process, so adding to the default would add to every other Graph request
+    this connector makes. The generated builder adds its own `Accept` with `try_add`, which is a
+    no-op once this one is present — which is how a format gets selected at all.
+    """
+    headers = HeadersCollection()
+    headers.add("Accept", media_type)
+    return headers
+
+
+# One WebVTT cue's timing line. The hours field is optional in WebVTT and Teams omits it in some
+# transcripts; the leading sign is what Microsoft's "negative offsets" note requires.
+_TIMESTAMP = r"-?(?:\d+:)?\d{1,2}:\d{1,2}[.,]\d{1,3}"
+_CUE_TIMING = re.compile(rf"^(?P<start>{_TIMESTAMP})\s*-->\s*(?P<end>{_TIMESTAMP})")
+
+# A voice span, which is where a speaker's name lives: `<v Ada Lovelace>text</v>`. The class suffix
+# (`<v.loud Ada>`) is part of WebVTT and Teams may emit it.
+_VOICE = re.compile(r"<v(?:\.[^\s>]+)?\s+(?P<speaker>[^>]*)>(?P<said>.*?)(?:</v>|\Z)", re.DOTALL)
+
+# Every other cue-payload tag: `<i>`, `<c.colorE5E5E5>`, `<00:00:01.000>` timestamps, `<lang en>`.
+_MARKUP = re.compile(r"<[^>]*>")
+
+_BLANK_LINE = re.compile(r"\n[ \t]*\n")
+
+
+def _turns(content: bytes, *, attributed: bool) -> list[TranscriptTurn]:
+    """`content` as speaker-attributed, timestamped turns.
+
+    One cue is one turn: Teams emits an utterance per cue, so merging them would be inventing a
+    grouping Microsoft did not make. Anything that is not a cue — the `WEBVTT` header, `NOTE`,
+    `STYLE` and `REGION` blocks, a cue identifier line — is skipped rather than guessed at, and a
+    cue with a timing line but no words is dropped: an empty turn reads as a silence somebody sat
+    through.
+
+    `attributed` is what the request asked for, and it decides whether an unparsed `<v …>` could
+    have been there at all — the unattributed format has none by construction.
+    """
+    text = content.decode("utf-8-sig", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+    turns: list[TranscriptTurn] = []
+    for block in _BLANK_LINE.split(text):
+        turn = _turn(block, attributed=attributed)
+        if turn is not None:
+            turns.append(turn)
+    return turns
+
+
+def _turn(block: str, *, attributed: bool) -> TranscriptTurn | None:
+    """One cue block as a turn, or None if it is not a cue (or is one with nothing said)."""
+    lines = [line for line in block.split("\n") if line.strip()]
+    timing = next(
+        ((index, match) for index, line in enumerate(lines) if (match := _CUE_TIMING.match(line))),
+        None,
+    )
+    if timing is None:
+        return None
+    index, match = timing
+    speaker, said = _spoken("\n".join(lines[index + 1 :]), attributed=attributed)
+    if not said:
+        return None
+    return TranscriptTurn(
+        speaker=speaker,
+        start_seconds=_seconds(match.group("start")),
+        end_seconds=_seconds(match.group("end")),
+        text=said,
+    )
+
+
+def _spoken(payload: str, *, attributed: bool) -> tuple[str | None, str]:
+    """A cue payload as (speaker, words).
+
+    The voice span is read before the markup is stripped, because stripping it first would take the
+    speaker's name with it. An attributed transcript whose cue carries no voice span keeps a null
+    speaker rather than borrowing the previous turn's: Teams does leave some utterances
+    unattributed, and attributing them to whoever spoke last would put words in someone's mouth.
+    """
+    voice = _VOICE.search(payload) if attributed else None
+    speaker = voice.group("speaker").strip() if voice is not None else None
+    said = voice.group("said") if voice is not None else payload
+    words = html.unescape(_MARKUP.sub("", said)).replace("\xa0", " ")
+    return (speaker or None, " ".join(words.split()))
+
+
+def _seconds(timestamp: str) -> float:
+    """A WebVTT timestamp as seconds, keeping its sign.
+
+    `HH:MM:SS.mmm` and `MM:SS.mmm` are both legal; the comma decimal separator is not WebVTT but is
+    what SubRip uses and costs nothing to accept.
+    """
+    negative = timestamp.startswith("-")
+    parts = timestamp.lstrip("-").replace(",", ".").split(":")
+    total = 0.0
+    for part in parts:
+        total = total * 60 + float(part)
+    return -total if negative else total

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -468,17 +468,30 @@ class Transcript(BaseModel):
         )
     )
     turns: list[TranscriptTurn] = Field(
-        description="What was said, in order, one turn per utterance Microsoft timestamped."
+        description=(
+            "What was said, in order, one turn per utterance Microsoft timestamped — the turns "
+            + "matching `from_seconds`, `to_seconds` and `speaker` where any of those was given, "
+            + "and every turn of the transcript where none was. Empty means nothing matched what "
+            + "was asked for, which is not the same as the meeting having no words in it."
+        )
     )
     truncated: bool = Field(
         description=(
-            "True when the transcript has more turns than this page holds — the same 'there is "
-            + "more' flag every list-shaped tool here reports. Pass `next_offset` back as `offset` "
-            + "to continue. Never summarise a truncated transcript as the whole meeting."
+            "True when more turns match than this page holds — the same 'there is more' flag every "
+            + "list-shaped tool here reports. It is counted over the turns left after "
+            + "`from_seconds`, `to_seconds` and `speaker` were applied, so 'there is more' always "
+            + "means more of what was asked for rather than more of the meeting. Pass "
+            + "`next_offset` back as `offset` to continue. Never summarise a truncated transcript "
+            + "as the whole meeting."
         )
     )
     next_offset: int | None = Field(
-        description="The `offset` that reaches the next turns, or null when `truncated` is false."
+        description=(
+            "The `offset` that reaches the next matching turns, or null when `truncated` is false. "
+            + "It indexes the turns the filters kept, so send the same `from_seconds`, "
+            + "`to_seconds` and `speaker` with it — changing one of them renumbers what it points "
+            + "at."
+        )
     )
 
 
@@ -584,21 +597,45 @@ def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
 
 
 async def read_transcript(
-    client: GraphServiceClient, *, handle: TranscriptHandle, offset: int, limit: int
+    client: GraphServiceClient,
+    *,
+    handle: TranscriptHandle,
+    offset: int,
+    limit: int,
+    from_seconds: float | None = None,
+    to_seconds: float | None = None,
+    speaker: str | None = None,
 ) -> Transcript:
-    """The turns of one transcript, from `offset`, up to `limit` of them.
+    """The turns of one transcript matching the filters, from `offset`, up to `limit` of them.
 
     One Graph request, or two where the tenant refuses speaker attribution. Paging is over the
     parsed turns rather than over Graph — `/content` is a single stream with no ranged contract —
     so a later page costs the same fetch again, which is what makes `limit` worth widening rather
-    than looping.
+    than looping. The filters are the same bargain: the whole transcript is fetched and parsed
+    whatever they are, so they make the answer smaller and never the call cheaper.
+
+    They are applied *before* the page is cut, and `truncated`/`next_offset` are counted over what
+    they left. That is the only version of "there is more" a caller can act on: paging the whole
+    transcript while filtering each page would make the flag mean "more of the meeting" while the
+    turns meant "the ones you asked for", and a caller following `next_offset` to the end would
+    walk pages that hold nothing.
     """
     assert 1 <= limit <= MAX_TURNS, f"limit must be within 1..{MAX_TURNS}, got {limit}"
     assert offset >= 0, f"offset must not be negative, got {offset}"
+    assert from_seconds is None or to_seconds is None or from_seconds <= to_seconds, (
+        f"from_seconds must not be after to_seconds, got {from_seconds} and {to_seconds}"
+    )
 
+    # TODO: every page refetches and reparses the whole transcript, because `/content` has no
+    # ranged contract. Caching the parsed turns per handle is the fix.
     content, attributed = await _content(client, handle)
 
-    turns = _turns(content, attributed=attributed)
+    turns = _matching(
+        _turns(content, attributed=attributed),
+        from_seconds=from_seconds,
+        to_seconds=to_seconds,
+        speaker=speaker,
+    )
     page = turns[offset : offset + limit]
     truncated = offset + len(page) < len(turns)
     return Transcript(
@@ -610,6 +647,43 @@ async def read_transcript(
         truncated=truncated,
         next_offset=offset + len(page) if truncated else None,
     )
+
+
+def _matching(
+    turns: list[TranscriptTurn],
+    *,
+    from_seconds: float | None,
+    to_seconds: float | None,
+    speaker: str | None,
+) -> list[TranscriptTurn]:
+    """The turns of `turns` that all of the given filters keep, in the order they were said.
+
+    **The time test is overlap, and both bounds are inclusive.** A turn is one utterance of a
+    sentence or two, and the moment a caller asks about lands in the middle of one about as often
+    as it lands between two — so a turn that straddles a bound is kept whole rather than dropped or
+    cut. Comparing a turn's *start* to both bounds instead would silently lose the sentence already
+    under way at `from_seconds`, which is exactly the sentence that says what the stretch is about.
+
+    **The speaker test is a case-insensitive substring of the display name.** A model asking about
+    a person has a name it read somewhere, not the string Teams stores, and those differ by case,
+    by a middle name, by a title or by the parenthesised suffix a tenant appends. An exact match
+    would answer "that person said nothing" to a spelling difference.
+
+    A turn Microsoft attributed to nobody never matches a speaker filter: `speaker` is null there,
+    and there is nothing to compare. Neither does *any* turn of a transcript from a tenant with
+    speaker attribution switched off, where every `speaker` is null by construction — this is not
+    refused and not degraded to "everything", because a filter that quietly stopped filtering would
+    be worse than an empty answer. `Transcript.speaker_attribution` is the flag that explains that
+    answer, and every description over this argument says to read the two together.
+    """
+    wanted = speaker.casefold() if speaker is not None else None
+    return [
+        turn
+        for turn in turns
+        if (from_seconds is None or turn.end_seconds >= from_seconds)
+        and (to_seconds is None or turn.start_seconds <= to_seconds)
+        and (wanted is None or (turn.speaker is not None and wanted in turn.speaker.casefold()))
+    ]
 
 
 async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tuple[bytes, bool]:

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -74,9 +74,19 @@ midnight-to-midnight would be an empty window reported as an answer. The assumpt
 each parameter's own description, where a model reads it: `09:00` is a different instant in Zurich,
 and a window quietly built in the wrong zone is worse than one that was refused.
 
-## Three failures a caller must act on differently
+## Newest first, and what it costs
 
-`GET …/transcripts` returning nothing is not one answer but two, and the tenant switch is a third:
+"The latest transcript of this series" is the question this tool exists for, so the order has to be
+a property of the *collection* and not of the page Graph happened to answer with — Graph documents
+no `$orderby` here, and a walk that stopped at `limit` before sorting would return an arbitrary
+`limit` transcripts sorted among themselves and call them the newest. That is a wrong answer with
+the shape of a right one. `newest_in_window` is where the sort and the cut happen in that order, for
+both artifacts, bounded by `MAX_ARTIFACT_SCAN` artifacts looked at per call.
+
+## Four failures a caller must act on differently
+
+`GET …/transcripts` returning nothing is not one answer but three, and the tenant switch is a
+fourth:
 
 * **`GraphAccessToTranscriptsDisabled`** — a `403` whose remedy names a Teams administrator, not a
   Graph permission. Microsoft Graph access to transcripts is off by default and "no app can access
@@ -90,8 +100,13 @@ and a window quietly built in the wrong zone is worse than one that was refused.
   model is sent back to poll for an occurrence that ended last month. Graph publishes no status for
   availability and no latency SLA, so both halves are an inference over one generous allowance;
   `OccurrenceWindow.settled` is the whole of it and `MeetingTranscripts.status` admits it as one.
+* **Not known** — the walk hit `MAX_ARTIFACT_SCAN` before the collection ended, so the transcripts
+  it did not reach might hold the one asked for. Neither absence verdict above is available here:
+  both assert something about a collection that was not read to the end, and the caller cannot tell
+  from the outside. `scan_incomplete` is that answer, and it is exactly the case where `truncated`
+  is true — an answer saying both "there is more" and "there is none" is one no caller can act on.
 
-`SpeakerAttributionNotAllowed` is a fourth Graph answer and the one this module handles rather than
+`SpeakerAttributionNotAllowed` is a fifth Graph answer and the one this module handles rather than
 reports: a tenant may permit transcripts and forbid speaker names, and the documented response is
 to ask again for the unattributed format. That degrades the answer instead of losing it, and
 `Transcript.speaker_attribution` says which one came back.
@@ -99,12 +114,12 @@ to ask again for the unattributed format. That degrades the answer instead of lo
 ## What `recordings` borrows from here, and why it is a separate module
 
 A meeting's recordings are answered by `features/recordings.py`, which takes `MeetingHandle`,
-`resolve_meeting`, `OccurrenceWindow` and the two helpers below from here: this module owns the
-meeting handle family (layering rule 9), so the join URL, the escaping and the window have exactly
-one home whichever artifact is being asked about. What it does not share is the outcome word — "was
-not transcribed" and "was not recorded" are different facts — or the refusal above, which Microsoft
-scopes to transcripts alone. That asymmetry is why the two artifacts are two tools;
-`features/recordings.py` argues it where the decision was made.
+`resolve_meeting`, `OccurrenceWindow`, `newest_in_window` and `as_utc` from here: this module owns
+the meeting handle family (layering rule 9), so the join URL, the escaping, the window and the order
+the artifacts come back in have exactly one home whichever artifact is being asked about. What it
+does not share is the outcome word — "was not transcribed" and "was not recorded" are different
+facts — or the refusal above, which Microsoft scopes to transcripts alone. That asymmetry is why the
+two artifacts are two tools; `features/recordings.py` argues it where the decision was made.
 """
 
 import html
@@ -124,7 +139,13 @@ from msgraph.generated.users.item.online_meetings.online_meetings_request_builde
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import BaseModel, Field
 
-from office_mcp.graph_client import GraphForbidden, collect_pages, graph_errors
+from office_mcp.graph_client import (
+    CollectedItems,
+    GraphCollection,
+    GraphForbidden,
+    collect_pages,
+    graph_errors,
+)
 
 # Resolving a join URL to a meeting is `OnlineMeetings.Read`, the least privilege Graph documents
 # for the filter, and needs no admin consent. Reading a transcript is a different, admin-consented
@@ -141,6 +162,20 @@ LISTING_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSIO
 # accumulates one per occurrence in the same collection, which is what makes a window necessary at
 # all. Graph documents `$top` here but publishes no ceiling, so this is ours.
 MAX_TRANSCRIPTS = 50
+
+# How many of a meeting's artifacts one listing may look at, whichever artifact it is. This is what
+# "newest first" costs: Graph documents no `$orderby` on either collection, so the newest can only
+# be known by looking at the collection, and a walk that stopped at `limit` would be sorting an
+# arbitrary handful of it (see `newest_in_window`). The bound is on artifacts rather than on
+# requests because that is what `collect_pages` can bound — Graph chooses the page size here and
+# publishes none — so the honest statement of the cost is "at most this many artifacts are looked
+# at, in however many pages Graph answers them in".
+#
+# 200 is four times the largest `limit` either lister offers and far past any real meeting: a
+# meeting accumulates one artifact per occurrence, so reaching this takes a series that has run
+# daily for the better part of a year *and* been recorded every time. A meeting that does exceed it
+# is not answered with a guess — the scan is reported as incomplete and no absence is asserted.
+MAX_ARTIFACT_SCAN = 200
 
 # How many turns one read returns, and the default window. A turn is one WebVTT cue — a sentence or
 # two — so an hour of meeting is some hundreds of them and a 30-hour one (Teams' own limit) is tens
@@ -417,6 +452,11 @@ class MeetingTranscripts(BaseModel):
             + "other cause looks identical and cannot be distinguished: Microsoft's "
             + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
             + "one-off), so a transcript that once existed can read as never having existed.\n"
+            + "- `scan_incomplete` — this meeting has more transcripts than one call looks through "
+            + f"({MAX_ARTIFACT_SCAN}) and none of the ones looked at fall in your window, so "
+            + "whether one exists there is NOT known and is not being claimed either way. Narrow "
+            + "`started_after`/`started_before` to the occurrence you mean and ask again. Never "
+            + "report this as 'there is no transcript'. `truncated` is true for the same reason.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
             + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
             + "calendar, or one this user was never invited to, answers the same way. Do not retry "
@@ -455,14 +495,21 @@ class MeetingTranscripts(BaseModel):
     transcripts: list[TranscriptSummary] = Field(
         description=(
             "The transcripts of this meeting that fall inside the requested window, newest first. "
-            + "Empty for every status other than `available`."
+            + "The order is over the whole collection rather than over one page of it, so the "
+            + "first entry is the latest transcript of the window — which for a recurring series "
+            + "is how to reach the most recent occurrence. Empty for every status other than "
+            + "`available`."
         )
     )
     truncated: bool = Field(
         description=(
-            "True when the meeting has more transcripts than this `limit` holds — the same 'there "
-            + "is more' flag every list-shaped tool here reports. Raise `limit` (up to "
-            + f"{MAX_TRANSCRIPTS}) or narrow `started_after`/`started_before`; there is no cursor."
+            "True when there is more — the same 'there is more' flag every list-shaped tool here "
+            + "reports. Two things set it, and both mean the same thing for what you may conclude: "
+            + "the window holds more transcripts than this `limit` (the ones here are still the "
+            + f"newest of them; raise `limit`, up to {MAX_TRANSCRIPTS}), or the meeting has more "
+            + f"transcripts in total than one call looks through ({MAX_ARTIFACT_SCAN}), in which "
+            + "case narrow `started_after`/`started_before`. There is no cursor. When this is true "
+            + "and nothing came back, `status` is `scan_incomplete` and no absence is claimed."
         )
     )
 
@@ -565,11 +612,13 @@ async def list_meeting_transcripts(
             meeting.id
         ).transcripts.get()
         assert first_page is not None, "Graph answered a transcript listing with no collection"
-        collected = await collect_pages(first_page, client, limit=limit, matches=window.holds)
+        collected = await newest_in_window(first_page, client, window=window, limit=limit)
 
-    found = sorted(collected.items, key=began_at, reverse=True)
+    found = collected.items
     return MeetingTranscripts(
-        status="available" if found else _absence(window.settled(meeting)),
+        status="available"
+        if found
+        else _absence(scan_stopped_short=collected.truncated, settled=window.settled(meeting)),
         meeting_id=meeting.id,
         subject=meeting.subject,
         # `OnlineMeetingBase.meetingType` is a generated enum subclassing `str`, so the member is
@@ -582,13 +631,22 @@ async def list_meeting_transcripts(
     )
 
 
-def _absence(settled: bool) -> str:
-    """Which of the two empty answers to give: the one that means stop, or the one that means wait.
+def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
+    """Which empty answer to give: the one that means stop, the one that means wait, or neither.
 
-    The evidence is `OccurrenceWindow.settled` and the word is this module's, because a meeting that
-    was recorded but not transcribed is answered `not_transcribed` here and `available` by the
-    recordings lister — the same evidence about two different artifacts.
+    A scan that stopped short is checked first, and it is the whole of the second fix here: the
+    walk having been cut means the artifacts it did not reach might hold the one asked for, so
+    nothing about absence is known — and "not transcribed / retrying will not help" is exactly the
+    assertion that must not be made. Reported instead as `scan_incomplete`, alongside the
+    `truncated: true` that comes from the same value, so that "there is more" and "there is none"
+    can never both be said of one answer.
+
+    Otherwise the evidence is `OccurrenceWindow.settled` and the word is this module's, because a
+    meeting that was recorded but not transcribed is answered `not_transcribed` here and
+    `available` by the recordings lister — the same evidence about two different artifacts.
     """
+    if scan_stopped_short:
+        return "scan_incomplete"
     return "not_transcribed" if settled else "not_ready"
 
 
@@ -621,16 +679,57 @@ async def resolve_meeting(
     return meetings[0] if meetings else None
 
 
-def began_at(artifact: MeetingArtifact) -> datetime:
+def _began_at(artifact: MeetingArtifact) -> datetime:
     """The sort key: when the artifact began, or the beginning of time where Graph did not say.
 
     Aware for the same reason `OccurrenceWindow.holds` is — one naive value among aware ones makes
     the sort itself raise, which is a crash in the middle of an answer that was already complete.
-    Shared with the recordings lister so that both artifacts come back newest first by the same
-    rule: Graph documents no `$orderby` on either collection, so the order is ours either way.
     """
     began = artifact.created_date_time
     return as_utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)
+
+
+async def newest_in_window[T: MeetingArtifact](
+    first_page: GraphCollection[T],
+    client: GraphServiceClient,
+    *,
+    window: OccurrenceWindow,
+    limit: int,
+) -> CollectedItems[T]:
+    """The `limit` newest artifacts of a meeting that fall inside `window`, newest first.
+
+    Shared by both meeting listers, and the reason it is one function rather than four lines
+    written twice: the order, the bound and the meaning of `truncated` are the same promise about
+    two artifacts, and the two got it wrong the same way.
+
+    **Newest first is a property of the collection, not of the page Graph chose to answer with.**
+    Graph documents no `$orderby` on either collection, so it answers in an order of its own; a
+    walk that stopped at `limit` and sorted afterwards would return an arbitrary `limit` artifacts
+    sorted among themselves, which is the opposite of what "the latest transcript of this series"
+    asks for and is undetectable — the answer looks exactly like the right one. So the walk keeps
+    everything the window holds, sorts, and only then cuts to `limit`.
+
+    **What that costs, and the bound on it.** Up to `MAX_ARTIFACT_SCAN` artifacts are looked at,
+    however many pages Graph answers them in, rather than up to `limit`. For any real meeting that
+    is the same single page it always was — a meeting has one artifact per occurrence — and the cap
+    is what stops a pathological collection turning one tool call into an unbounded walk.
+
+    **`truncated` means "there is more", and both ways of there being more set it**: matching
+    artifacts older than the ones returned, and a collection larger than the scan cap. The second
+    is also the case in which an empty answer proves nothing, which is why the flag and the verdict
+    are read from the same value — see `_absence` in each lister.
+    """
+    collected = await collect_pages(
+        first_page,
+        client,
+        limit=MAX_ARTIFACT_SCAN,
+        matches=window.holds,
+        max_scanned=MAX_ARTIFACT_SCAN,
+    )
+    newest = sorted(collected.items, key=_began_at, reverse=True)
+    return CollectedItems(
+        items=newest[:limit], truncated=collected.truncated or len(newest) > limit
+    )
 
 
 def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -57,6 +57,23 @@ Here the two transforms are separated, and only the first is ours:
 `200 OK` with `value: []` is Graph's documented "no match" for this filter — it never 404s — so it
 is reported as its own outcome and not as an error.
 
+## The occurrence window, and the shapes a model actually sends
+
+`started_after`/`started_before` exist for one reason: a recurring series is a single meeting to
+Graph, so its occurrences share one transcript collection and the only thing telling them apart is
+when transcription began. That makes the window the thing a model reaches for most, and it arrives
+in whatever shape the model wrote — `2026-08-11T09:00:00+02:00`, but just as often
+`2026-08-11T09:00:00` or `2026-08-11`, because that is how a date gets written when nobody is
+watching. All three are accepted and resolved against UTC, in `OccurrenceWindow` and nowhere else:
+Graph timestamps every transcript in UTC, so UTC is the assumption that needs no second piece of
+information, and resolving once at the edge of the module is what stops anything downstream
+comparing a naive datetime with an aware one — which is a `TypeError` raised at a caller who did
+nothing wrong, not a wrong answer it could notice. A bare date is a whole UTC day rather than its
+first instant, because writing the same date in both bounds is how one occurrence gets bracketed and
+midnight-to-midnight would be an empty window reported as an answer. The assumption is stated in
+each parameter's own description, where a model reads it: `09:00` is a different instant in Zurich,
+and a window quietly built in the wrong zone is worse than one that was refused.
+
 ## Three failures a caller must act on differently
 
 `GET …/transcripts` returning nothing is not one answer but two, and the tenant switch is a third:
@@ -66,10 +83,13 @@ is reported as its own outcome and not as an error.
   meeting transcripts, regardless of app-level permissions"; there is "no request-side workaround".
   It is recognised by inner code in `server/errors.py`, where every other refusal is worded.
 * **No transcript** — the meeting was never recorded or never transcribed. Retrying is pointless.
-* **Not ready yet** — the meeting has just ended and the transcript has not landed. Retrying is the
-  *only* thing that helps, which is why this must never be reported as the case above. Graph
-  publishes no status for it and no latency SLA, so it is derived from the meeting's end time and a
-  deliberately generous allowance; `MeetingTranscripts.status` says exactly what that means.
+* **Not ready yet** — nothing has landed for the window asked about and something still might.
+  Retrying is the *only* thing that helps, which is why this must never be reported as the case
+  above — and, just as importantly, why the case above must not be reported as this one: a window
+  that has demonstrably passed is answered `not_transcribed` even for a series still running, or a
+  model is sent back to poll for an occurrence that ended last month. Graph publishes no status for
+  availability and no latency SLA, so both halves are an inference over one generous allowance;
+  `OccurrenceWindow.absence` is the whole of it and `MeetingTranscripts.status` admits it as one.
 
 `SpeakerAttributionNotAllowed` is a fourth Graph answer and the one this module handles rather than
 reports: a tenant may permit transcripts and forbid speaker names, and the documented response is
@@ -80,7 +100,8 @@ to ask again for the unattributed format. That degrades the answer instead of lo
 import html
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Self
 from urllib.parse import quote, unquote
 
 from kiota_abstractions.base_request_configuration import RequestConfiguration
@@ -117,12 +138,13 @@ MAX_TRANSCRIPTS = 50
 # context per call.
 MAX_TURNS = 500
 
-# How long after a meeting ends a missing transcript is still called "not ready" rather than "never
-# transcribed". Microsoft publishes no SLA and no "processing" status for transcript availability,
-# so this is not a promise about Graph — it is which of two opposite pieces of advice to give when
-# the evidence is the same empty collection. Generous on purpose: telling a caller to wait once
-# when nothing will ever arrive costs one call, while telling it a transcript does not exist when it
-# is ten minutes away is a wrong answer it cannot detect.
+# How long after a window closes — or after a meeting ends, where no window was asked for — a
+# missing transcript is still called "not ready" rather than "never transcribed". Microsoft
+# publishes no SLA and no "processing" status for transcript availability, so this is not a promise
+# about Graph — it is which of two opposite pieces of advice to give when the evidence is the same
+# empty collection. Generous on purpose: telling a caller to wait once when nothing will ever
+# arrive costs one call, while telling it a transcript does not exist when it is ten minutes away
+# is a wrong answer it cannot detect.
 TRANSCRIPT_DELAY_ALLOWANCE = timedelta(hours=4)
 
 # The inner code Graph sends when a tenant permits transcripts but forbids speaker names. Branched
@@ -223,6 +245,100 @@ def _segment(value: str) -> str:
     return quote(value, safe="")
 
 
+@dataclass(frozen=True, slots=True)
+class OccurrenceWindow:
+    """Which occurrence was asked about, as two instants that are always timezone-aware.
+
+    A type rather than two arguments threaded through, because the window decides two things that
+    have to agree: which transcripts are kept, and — when none are — whether an empty answer means
+    "wait" or "there is none". Reading the second off the *meeting* instead was a wrong answer no
+    caller could detect: a recurring series whose `endDateTime` is in the future (or absent) made
+    every empty window "still processing", including one bracketing an occurrence that ended weeks
+    ago and was never transcribed, which is an instruction to poll forever.
+
+    `of` is the only constructor a caller should use: it takes the shapes a model actually sends and
+    resolves them, so that no comparison downstream can meet a naive datetime.
+    """
+
+    started_after: datetime | None
+    started_before: datetime | None
+
+    @classmethod
+    def of(
+        cls, started_after: date | datetime | None, started_before: date | datetime | None
+    ) -> Self:
+        """A window from bounds as given, resolving anything that named no timezone against UTC.
+
+        A bare date names a whole UTC day: `started_after` takes its first instant and
+        `started_before` its last, so the same date in both is that one day rather than the empty
+        span between one midnight and itself.
+        """
+        return cls(_first_instant(started_after), _last_instant(started_before))
+
+    def holds(self, transcript: CallTranscript) -> bool:
+        """Whether this transcript began inside the window.
+
+        A transcript Graph gave no `createdDateTime` for is kept when no window was asked for and
+        dropped when one was: it cannot be shown to be the occurrence the caller meant.
+        """
+        if self.started_after is None and self.started_before is None:
+            return True
+        began = transcript.created_date_time
+        if began is None:
+            return False
+        # Aware even though Graph's own timestamps carry `Z`: this comparison is the one that used
+        # to raise, and it must not depend on a payload's punctuation to stay safe.
+        began = _utc(began)
+        if self.started_after is not None and began < self.started_after:
+            return False
+        return not (self.started_before is not None and began > self.started_before)
+
+    def absence(self, meeting: OnlineMeeting) -> str:
+        """Which of the two empty answers this is, for the window that was actually asked about.
+
+        Two independent pieces of evidence, either of which settles it: the window's own end is far
+        enough past that anything falling inside it would have landed, or the *meeting* is — the
+        second being what answers a caller who asked for no window at all, and what stops a window
+        mistakenly set in the future promising a transcript for a meeting that is long over.
+
+        Absent evidence never settles anything: no `started_before` and no `endDateTime` both mean
+        nothing says transcription has finished, and of the two wrong answers the one that costs a
+        caller a second call is the cheaper one.
+        """
+        now = datetime.now(UTC)
+        settled = _settled_by(self.started_before, now) or _settled_by(meeting.end_date_time, now)
+        return "not_transcribed" if settled else "not_ready"
+
+
+def _first_instant(bound: date | datetime | None) -> datetime | None:
+    """The earliest instant `bound` includes, or None where there is no bound."""
+    if bound is None:
+        return None
+    # `datetime` subclasses `date`, so this order is the whole of the distinction.
+    if isinstance(bound, datetime):
+        return _utc(bound)
+    return datetime.combine(bound, time.min, tzinfo=UTC)
+
+
+def _last_instant(bound: date | datetime | None) -> datetime | None:
+    """The latest instant `bound` includes, or None where there is no bound."""
+    if bound is None:
+        return None
+    if isinstance(bound, datetime):
+        return _utc(bound)
+    return datetime.combine(bound, time.max, tzinfo=UTC)
+
+
+def _utc(moment: datetime) -> datetime:
+    """`moment` as an aware datetime, reading one that named no timezone as already being UTC."""
+    return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
+
+
+def _settled_by(moment: datetime | None, now: datetime) -> bool:
+    """Whether `moment` is far enough past that a transcript belonging to it would have arrived."""
+    return moment is not None and _utc(moment) + TRANSCRIPT_DELAY_ALLOWANCE < now
+
+
 class TranscriptSummary(BaseModel):
     uri: str = Field(
         description=(
@@ -257,11 +373,14 @@ class MeetingTranscripts(BaseModel):
         description=(
             "What was found, and therefore what to do next. Exactly one of:\n"
             + "- `available` — `transcripts` lists them; read one.\n"
-            + "- `not_ready` — the meeting has not ended, or ended recently enough that a "
-            + "transcript may still be processing. Microsoft publishes no availability SLA and no "
-            + "'processing' status, so this is inferred from the meeting's end time: it means wait "
-            + "and ask again later, and it is NOT evidence that no transcript will ever exist.\n"
-            + "- `not_transcribed` — the meeting is over, nothing is there, and nothing is "
+            + "- `not_ready` — nothing is there for the window you asked about and something may "
+            + "still arrive: that window has only just closed, or you asked for no window and the "
+            + "meeting itself has not ended or ended recently. Microsoft publishes no availability "
+            + "SLA and no 'processing' status, so this is inferred: it means wait and ask again "
+            + "later, and it is NOT evidence that no transcript will ever exist. A window that has "
+            + "demonstrably passed is never reported this way, however far in the future a "
+            + "recurring series runs.\n"
+            + "- `not_transcribed` — the window is over, nothing is there, and nothing is "
             + "expected: it was not recorded or transcribed. Retrying will not change this. One "
             + "other cause looks identical and cannot be distinguished: Microsoft's "
             + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
@@ -367,8 +486,8 @@ async def list_meeting_transcripts(
     client: GraphServiceClient,
     *,
     handle: MeetingHandle,
-    started_after: datetime | None,
-    started_before: datetime | None,
+    started_after: date | datetime | None,
+    started_before: date | datetime | None,
     limit: int,
 ) -> MeetingTranscripts:
     """The transcripts of the meeting `handle` addresses, and what a caller should do about them.
@@ -377,8 +496,12 @@ async def list_meeting_transcripts(
     the listing rather than as a `$filter` — Graph advertises `$filter` on this collection without
     documenting a single filterable property, so a server-side date bound is unverifiable and a
     wrong one would silently return nothing.
+
+    The bounds are whatever the caller passed — `OccurrenceWindow.of` is what makes them instants —
+    and the same window then decides both which transcripts are kept and what an empty answer means.
     """
     assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
+    window = OccurrenceWindow.of(started_after, started_before)
 
     with graph_errors():
         meeting = await _resolve_meeting(client, handle)
@@ -397,16 +520,11 @@ async def list_meeting_transcripts(
             meeting.id
         ).transcripts.get()
         assert first_page is not None, "Graph answered a transcript listing with no collection"
-        collected = await collect_pages(
-            first_page,
-            client,
-            limit=limit,
-            matches=lambda transcript: _within(transcript, started_after, started_before),
-        )
+        collected = await collect_pages(first_page, client, limit=limit, matches=window.holds)
 
     found = sorted(collected.items, key=_started_at, reverse=True)
     return MeetingTranscripts(
-        status="available" if found else _absence(meeting),
+        status="available" if found else window.absence(meeting),
         meeting_id=meeting.id,
         subject=meeting.subject,
         # `OnlineMeetingBase.meetingType` is a generated enum subclassing `str`, so the member is
@@ -444,39 +562,14 @@ async def _resolve_meeting(
     return meetings[0] if meetings else None
 
 
-def _within(
-    transcript: CallTranscript, started_after: datetime | None, started_before: datetime | None
-) -> bool:
-    """Whether this transcript began inside the requested window.
-
-    A transcript Graph gave no `createdDateTime` for is kept when no window was asked for and
-    dropped when one was: it cannot be shown to be the occurrence the caller meant.
-    """
-    if started_after is None and started_before is None:
-        return True
-    began = transcript.created_date_time
-    if began is None:
-        return False
-    if started_after is not None and began < started_after:
-        return False
-    return not (started_before is not None and began > started_before)
-
-
-def _absence(meeting: OnlineMeeting) -> str:
-    """Which of the two empty answers this is: worth waiting for, or not.
-
-    An end time Graph did not send counts as "not ready" rather than "never transcribed", because
-    without it there is no evidence transcription has finished — and of the two wrong answers, the
-    one that costs a caller a second call is the cheaper one.
-    """
-    ended = meeting.end_date_time
-    if ended is None or datetime.now(UTC) < ended + TRANSCRIPT_DELAY_ALLOWANCE:
-        return "not_ready"
-    return "not_transcribed"
-
-
 def _started_at(transcript: CallTranscript) -> datetime:
-    return transcript.created_date_time or datetime.min.replace(tzinfo=UTC)
+    """The sort key: when transcription began, or the beginning of time where Graph did not say.
+
+    Aware for the same reason `OccurrenceWindow.holds` is — one naive value among aware ones makes
+    the sort itself raise, which is a crash in the middle of an answer that was already complete.
+    """
+    began = transcript.created_date_time
+    return _utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)
 
 
 def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:

--- a/services/office-mcp/src/office_mcp/features/transcripts.py
+++ b/services/office-mcp/src/office_mcp/features/transcripts.py
@@ -74,14 +74,25 @@ midnight-to-midnight would be an empty window reported as an answer. The assumpt
 each parameter's own description, where a model reads it: `09:00` is a different instant in Zurich,
 and a window quietly built in the wrong zone is worse than one that was refused.
 
-## Newest first, and what it costs
+## Newest first, exactly as far as it is true
 
 "The latest transcript of this series" is the question this tool exists for, so the order has to be
-a property of the *collection* and not of the page Graph happened to answer with — Graph documents
-no `$orderby` here, and a walk that stopped at `limit` before sorting would return an arbitrary
-`limit` transcripts sorted among themselves and call them the newest. That is a wrong answer with
-the shape of a right one. `newest_in_window` is where the sort and the cut happen in that order, for
-both artifacts, bounded by `MAX_ARTIFACT_SCAN` artifacts looked at per call.
+a property of what was *read* and not of the page Graph happened to answer with — Graph documents
+`$select`, `$filter` and `$top` on this collection and no `$orderby` at all
+(https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-transcripts), and a walk that
+stopped at `limit` before sorting would return an arbitrary `limit` transcripts sorted among
+themselves and call them the newest. That is a wrong answer with the shape of a right one.
+`newest_in_window` is where the sort and the cut happen in that order, for both artifacts.
+
+What the promise is worth is bounded by `MAX_ARTIFACT_SCAN`, and every sentence a model reads is
+worded to that bound rather than to "the newest of this meeting". Up to that many artifacts are
+read, in whatever order Graph chose; for a meeting with no more than that they are the whole
+collection and the first entry is the latest outright, which covers every meeting but a series
+recorded daily for the better part of a year. Past it the first entry is the newest of the
+artifacts that were *read*, a newer one can sit in the part that was not, and `truncated` is true.
+Raising the cap would move that boundary rather than remove it: with no `$orderby` to ask the
+newest for, nothing short of reading the whole collection makes the word exact, and Graph publishes
+no ceiling on how large that collection can be.
 
 ## Four failures a caller must act on differently
 
@@ -105,6 +116,16 @@ fourth:
   both assert something about a collection that was not read to the end, and the caller cannot tell
   from the outside. `scan_incomplete` is that answer, and it is exactly the case where `truncated`
   is true — an answer saying both "there is more" and "there is none" is one no caller can act on.
+  It is also the one answer here with **no remedy**, and every place it is described says so. The
+  window is applied to the artifacts *after* they are read: Graph documents no filterable date on
+  either collection — the one filterable property either reference shows by example is
+  `contentCorrelationId` (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example
+  11) — so the request is bare and the same `MAX_ARTIFACT_SCAN` artifacts are read whatever window
+  is asked for. "Narrow `started_after`/`started_before` and ask again" was therefore advice a model
+  could follow forever without progress: the next call reads the same artifacts and answers the same
+  way. That is the defect class the channel browser already paid for with its circular reply advice,
+  and the fix is the same one — a dead end stated plainly beats an actionable-sounding loop, so what
+  a caller is told is to stop and report that it is not known.
 
 `SpeakerAttributionNotAllowed` is a fifth Graph answer and the one this module handles rather than
 reports: a tenant may permit transcripts and forbid speaker names, and the documented response is
@@ -174,7 +195,12 @@ MAX_TRANSCRIPTS = 50
 # 200 is four times the largest `limit` either lister offers and far past any real meeting: a
 # meeting accumulates one artifact per occurrence, so reaching this takes a series that has run
 # daily for the better part of a year *and* been recorded every time. A meeting that does exceed it
-# is not answered with a guess — the scan is reported as incomplete and no absence is asserted.
+# is not answered with a guess — the scan is reported as incomplete, no absence is asserted, and
+# "newest first" is stated as what it then is, an order over the artifacts that were read.
+#
+# Raising it is not the fix for either of those, which is why the number is boring: a bigger cap
+# moves the boundary and leaves both statements needing the same qualification, because Graph
+# offers no `$orderby` to ask the newest for and no date `$filter` to make the window the server's.
 MAX_ARTIFACT_SCAN = 200
 
 # How many turns one read returns, and the default window. A turn is one WebVTT cue — a sentence or
@@ -452,11 +478,15 @@ class MeetingTranscripts(BaseModel):
             + "other cause looks identical and cannot be distinguished: Microsoft's "
             + "meeting-artifact APIs stop serving a meeting once it expires (about 60 days after a "
             + "one-off), so a transcript that once existed can read as never having existed.\n"
-            + "- `scan_incomplete` — this meeting has more transcripts than one call looks through "
-            + f"({MAX_ARTIFACT_SCAN}) and none of the ones looked at fall in your window, so "
-            + "whether one exists there is NOT known and is not being claimed either way. Narrow "
-            + "`started_after`/`started_before` to the occurrence you mean and ask again. Never "
-            + "report this as 'there is no transcript'. `truncated` is true for the same reason.\n"
+            + "- `scan_incomplete` — this meeting has more transcripts than one call reads "
+            + f"({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether "
+            + "one exists there is NOT known and is not being claimed either way. There is nothing "
+            + "to try: the window is applied to the transcripts after Microsoft has answered, not "
+            + "by Microsoft while answering, so changing `started_after`/`started_before` — "
+            + "narrower, wider, anything — reads the same transcripts and returns this same "
+            + "status. Stop, and report that whether a transcript exists for that occurrence could "
+            + "not be determined. Never report this as 'there is no transcript', and do not ask "
+            + "again. `truncated` is true for the same reason.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
             + "see. Not an error and not proof the meeting is gone; a meeting created outside a "
             + "calendar, or one this user was never invited to, answers the same way. Do not retry "
@@ -495,21 +525,34 @@ class MeetingTranscripts(BaseModel):
     transcripts: list[TranscriptSummary] = Field(
         description=(
             "The transcripts of this meeting that fall inside the requested window, newest first. "
-            + "The order is over the whole collection rather than over one page of it, so the "
-            + "first entry is the latest transcript of the window — which for a recurring series "
-            + "is how to reach the most recent occurrence. Empty for every status other than "
+            + "The order is over every transcript this call read rather than over one page of "
+            + f"Microsoft's answer, and one call reads up to {MAX_ARTIFACT_SCAN} of them. For a "
+            + "meeting with no more transcripts than that — every meeting bar a series recorded "
+            + "daily for most of a year — those are all of them, so the first entry is the latest "
+            + "transcript of the window outright, which for a recurring series is how to reach the "
+            + "most recent occurrence. Past that cap the first entry is the latest of what was "
+            + "READ: Microsoft returns this collection in an order of its own and offers no way to "
+            + "ask for the newest, so a newer transcript can sit among the ones never read. "
+            + "`truncated` is true whenever that happened. Empty for every status other than "
             + "`available`."
         )
     )
     truncated: bool = Field(
         description=(
             "True when there is more — the same 'there is more' flag every list-shaped tool here "
-            + "reports. Two things set it, and both mean the same thing for what you may conclude: "
-            + "the window holds more transcripts than this `limit` (the ones here are still the "
-            + f"newest of them; raise `limit`, up to {MAX_TRANSCRIPTS}), or the meeting has more "
-            + f"transcripts in total than one call looks through ({MAX_ARTIFACT_SCAN}), in which "
-            + "case narrow `started_after`/`started_before`. There is no cursor. When this is true "
-            + "and nothing came back, `status` is `scan_incomplete` and no absence is claimed."
+            + "reports. Two things set it, and they differ in what you may conclude:\n"
+            + "- The window holds more transcripts than this `limit`. The ones here are still the "
+            + f"newest of the window; raise `limit`, up to {MAX_TRANSCRIPTS}.\n"
+            + "- The meeting has more transcripts in total than one call reads "
+            + f"({MAX_ARTIFACT_SCAN}). Then `transcripts` is ordered over the ones read and not "
+            + "over the meeting, so the first entry may not be the meeting's latest, and no "
+            + "argument to this tool reads further — the window is applied after the read, so "
+            + "narrowing it changes nothing.\n"
+            + "Which of the two happened is not always visible, so do not call the first entry the "
+            + "meeting's most recent transcript while this is true unless you say it is the most "
+            + "recent of what was read. Fewer entries than you asked for with this true is always "
+            + "the second case. There is no cursor. When this is true and nothing came back, "
+            + "`status` is `scan_incomplete` and no absence is claimed."
         )
     )
 
@@ -584,10 +627,14 @@ async def list_meeting_transcripts(
 ) -> MeetingTranscripts:
     """The transcripts of the meeting `handle` addresses, and what a caller should do about them.
 
-    Two Graph requests at most: resolve the join URL, then list. The window is applied while paging
-    the listing rather than as a `$filter` — Graph advertises `$filter` on this collection without
-    documenting a single filterable property, so a server-side date bound is unverifiable and a
-    wrong one would silently return nothing.
+    Two Graph requests at most: resolve the join URL, then list. The listing goes out bare, and the
+    window is applied while paging it rather than as a `$filter`: Graph advertises `$select`,
+    `$filter` and `$top` here and no `$orderby`, and the only filterable property either artifact's
+    reference shows is `contentCorrelationId`
+    (https://learn.microsoft.com/en-us/graph/api/calltranscript-get, Example 11) — never a date. So
+    a server-side date bound is unverified, and a wrong one returns `200 OK` with nothing rather
+    than failing. That is also why the window is no help to a caller whose scan stopped short: it
+    is ours, applied to what came back, so it cannot make Graph send different artifacts.
 
     The bounds are whatever the caller passed — `OccurrenceWindow.of` is what makes them instants —
     and the same window then decides both which transcripts are kept and what an empty answer means.
@@ -640,6 +687,11 @@ def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
     assertion that must not be made. Reported instead as `scan_incomplete`, alongside the
     `truncated: true` that comes from the same value, so that "there is more" and "there is none"
     can never both be said of one answer.
+
+    It is also the one verdict here that offers a caller nothing to do, and its description says so
+    in as many words: the window is applied after the artifacts are read, so no window sends the
+    next call further into the collection. The advice is to stop and report the uncertainty, which
+    is the only advice that is true — see the module docstring's fourth failure.
 
     Otherwise the evidence is `OccurrenceWindow.settled` and the word is this module's, because a
     meeting that was recorded but not transcribed is answered `not_transcribed` here and
@@ -702,22 +754,29 @@ async def newest_in_window[T: MeetingArtifact](
     written twice: the order, the bound and the meaning of `truncated` are the same promise about
     two artifacts, and the two got it wrong the same way.
 
-    **Newest first is a property of the collection, not of the page Graph chose to answer with.**
+    **Newest first is a property of what was read, not of the page Graph chose to answer with.**
     Graph documents no `$orderby` on either collection, so it answers in an order of its own; a
     walk that stopped at `limit` and sorted afterwards would return an arbitrary `limit` artifacts
     sorted among themselves, which is the opposite of what "the latest transcript of this series"
     asks for and is undetectable — the answer looks exactly like the right one. So the walk keeps
     everything the window holds, sorts, and only then cuts to `limit`.
 
-    **What that costs, and the bound on it.** Up to `MAX_ARTIFACT_SCAN` artifacts are looked at,
-    however many pages Graph answers them in, rather than up to `limit`. For any real meeting that
-    is the same single page it always was — a meeting has one artifact per occurrence — and the cap
-    is what stops a pathological collection turning one tool call into an unbounded walk.
+    **What was read is the collection up to `MAX_ARTIFACT_SCAN` artifacts, and no further.** That
+    bound is where the promise stops being "the newest of this meeting" and starts being "the
+    newest of the artifacts read": for a collection no larger than the cap the two coincide, which
+    is every meeting bar a daily series recorded for most of a year, and past it the artifacts
+    never read are in Graph's arbitrary order and can hold a newer one. Nothing in this function
+    can close that gap — with no `$orderby`, the only way to know the newest is to read everything,
+    and the cap exists because a collection with no documented ceiling must not turn one tool call
+    into an unbounded walk. So the gap is not hidden: it is what the second `truncated` cause
+    below means, and every description over these two listers is worded to the prefix rather than
+    to the collection.
 
     **`truncated` means "there is more", and both ways of there being more set it**: matching
     artifacts older than the ones returned, and a collection larger than the scan cap. The second
-    is also the case in which an empty answer proves nothing, which is why the flag and the verdict
-    are read from the same value — see `_absence` in each lister.
+    is the case in which the order is only over the prefix, and the same case in which an empty
+    answer proves nothing — which is why the flag and the verdict are read from the same value; see
+    `_absence` in each lister.
     """
     collected = await collect_pages(
         first_page,

--- a/services/office-mcp/src/office_mcp/graph_client/__init__.py
+++ b/services/office-mcp/src/office_mcp/graph_client/__init__.py
@@ -16,6 +16,7 @@ from office_mcp.graph_client.errors import (
 from office_mcp.graph_client.pagination import (
     MAX_SCANNED_ITEMS,
     CollectedItems,
+    GraphCollection,
     collect_pages,
 )
 from office_mcp.graph_client.settings import GraphSettings
@@ -23,6 +24,7 @@ from office_mcp.graph_client.settings import GraphSettings
 __all__ = [
     "MAX_SCANNED_ITEMS",
     "CollectedItems",
+    "GraphCollection",
     "GraphFailure",
     "GraphForbidden",
     "GraphNotFound",

--- a/services/office-mcp/src/office_mcp/graph_client/errors.py
+++ b/services/office-mcp/src/office_mcp/graph_client/errors.py
@@ -15,10 +15,21 @@ distinctions are drawn once, here, and only the ones Graph actually makes:
 Anything else (a 400 from a malformed `$filter`, a 409) raises the base `GraphFailure`: it is a
 Graph failure with a status and a code, and inventing a category per status code Graph might
 return would be guessing at remedies that don't exist.
+
+One thing above the status code is carried too: `inner_code`, Graph's `error.innerError.code`.
+Where a status and an outer code are the same for two failures with opposite remedies, that is
+the only field that tells them apart — the transcript APIs answer both "your tenant has switched
+Graph access to transcripts off, and no app can switch it back on" and "this tenant will not give
+you speaker names, ask for the unattributed format" as `403 Forbidden` / `code: Forbidden`, and
+Microsoft's own instruction is to "branch on the `innerError.code` value, not the message text.
+Messages are subject to change" (https://learn.microsoft.com/en-us/graph/api/calltranscript-get).
+It is data like `status` is, not a category: a subclass per inner code would be a subclass per
+Graph feature.
 """
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import cast
 
 import httpx
 from kiota_abstractions.api_error import APIError
@@ -31,7 +42,8 @@ class GraphFailure(Exception):
     `status` and `code` are carried even where the subclass implies them. The subclass is the
     remedy — what a caller does about it — while these are the evidence: 401 and 403 are both
     `GraphForbidden` but only one of them is fixed by signing in again, and `request_id` is what
-    Microsoft support asks for.
+    Microsoft support asks for. `inner_code` defaults to `None` because most Graph errors carry no
+    inner code worth branching on; where one does, it is the whole of the difference.
     """
 
     def __init__(
@@ -41,11 +53,13 @@ class GraphFailure(Exception):
         status: int | None,
         code: str | None,
         request_id: str | None,
+        inner_code: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status: int | None = status
         self.code: str | None = code
         self.request_id: str | None = request_id
+        self.inner_code: str | None = inner_code
 
 
 class GraphThrottled(GraphFailure):
@@ -68,8 +82,11 @@ class GraphThrottled(GraphFailure):
         code: str | None,
         request_id: str | None,
         retry_after_seconds: float | None,
+        inner_code: str | None = None,
     ) -> None:
-        super().__init__(message, status=status, code=code, request_id=request_id)
+        super().__init__(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
         self.retry_after_seconds: float | None = retry_after_seconds
 
 
@@ -127,6 +144,7 @@ def _classify(error: APIError) -> GraphFailure:
     status = error.response_status_code
     headers = _lowercase_headers(error)
     code = error.error.code if isinstance(error, ODataError) and error.error else None
+    inner_code = _inner_code(error)
     request_id = headers.get("request-id")
     message = f"Microsoft Graph returned {status}" + (f" ({code})" if code else "")
 
@@ -136,15 +154,41 @@ def _classify(error: APIError) -> GraphFailure:
             status=status,
             code=code,
             request_id=request_id,
+            inner_code=inner_code,
             retry_after_seconds=_retry_after_seconds(headers),
         )
     if status in (401, 403):
-        return GraphForbidden(message, status=status, code=code, request_id=request_id)
+        return GraphForbidden(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
     if status == 404:
-        return GraphNotFound(message, status=status, code=code, request_id=request_id)
+        return GraphNotFound(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
     if status is not None and status >= 500:
-        return GraphUnavailable(message, status=status, code=code, request_id=request_id)
-    return GraphFailure(message, status=status, code=code, request_id=request_id)
+        return GraphUnavailable(
+            message, status=status, code=code, request_id=request_id, inner_code=inner_code
+        )
+    return GraphFailure(
+        message, status=status, code=code, request_id=request_id, inner_code=inner_code
+    )
+
+
+def _inner_code(error: APIError) -> str | None:
+    """Graph's `error.innerError.code`, if it sent one.
+
+    The SDK's generated `innerError` has typed fields for `request-id`, `client-request-id` and
+    `date` and none for `code`, so the property Microsoft tells callers to branch on arrives in the
+    model's `additional_data` — untyped by construction, hence the narrowing.
+    """
+    if not isinstance(error, ODataError) or error.error is None:
+        return None
+    inner = error.error.inner_error
+    if inner is None:
+        return None
+    extra = cast("dict[str, object]", inner.additional_data)
+    value = extra.get("code")
+    return value if isinstance(value, str) else None
 
 
 def _lowercase_headers(error: APIError) -> dict[str, str]:

--- a/services/office-mcp/src/office_mcp/graph_client/pagination.py
+++ b/services/office-mcp/src/office_mcp/graph_client/pagination.py
@@ -24,7 +24,10 @@ are. This is the one place they are set out together:
    walk cannot stop at `limit` — it has to see the collection before it can say which of it is
    newest. `max_scanned` is what bounds that, and the meeting listers pass their own
    (`features/transcripts.MAX_ARTIFACT_SCAN`) rather than this module's default, because a
-   per-meeting collection is a small thing to walk 1000 items of.
+   per-meeting collection is a small thing to walk 1000 items of. The cap is also the limit of
+   what "newest" can mean: a walk stopped by it saw a prefix of the collection in Graph's own
+   order, `truncated` says so, and the listers' own prose is worded to that prefix rather than
+   promising the newest of a collection nobody read to the end.
 3. **Do not walk at all.** Where the request budget is the point — a channel's messages, at 1
    request per second per app per tenant for a given channel
    (https://learn.microsoft.com/en-us/graph/throttling-limits) — the feature reading them makes

--- a/services/office-mcp/src/office_mcp/graph_client/pagination.py
+++ b/services/office-mcp/src/office_mcp/graph_client/pagination.py
@@ -5,10 +5,13 @@ replayed verbatim, never decomposed (https://learn.microsoft.com/en-us/graph/pag
 `PageIterator` does that walk, so this module is only the two lessons teams-mcp paid for in
 `src/msgraph/graph-pagination.ts`:
 
-* a scan cap as well as an item cap. Where a collection is filtered after the fact — channel
-  messages are mostly system messages about members joining — "give me 20" can otherwise walk
-  the entire history of a busy channel one page at a time, at 1 request per second per chat per
-  tenant for the whole app (https://learn.microsoft.com/en-us/graph/throttling-limits).
+* a scan cap as well as an item cap. Where a collection is filtered after the fact, "give me 20"
+  can otherwise walk a long way for nothing, so a cap has to bound what was *looked at* and not
+  only what was kept. What it does not bound is requests: a page Graph chooses to answer short
+  leaves the cap unspent and the walk goes on, so this is a cap on work rather than a request
+  budget. Where the budget is the point — a channel's messages, at 1 request per second per app
+  per tenant for a given channel (https://learn.microsoft.com/en-us/graph/throttling-limits) —
+  the feature reading them makes one request and does not page at all.
 * saying so. A truncated answer that looks complete is the failure mode, because the caller
   above is a language model that will summarise 20 of 4000 messages as "the discussion".
 

--- a/services/office-mcp/src/office_mcp/graph_client/pagination.py
+++ b/services/office-mcp/src/office_mcp/graph_client/pagination.py
@@ -9,11 +9,29 @@ replayed verbatim, never decomposed (https://learn.microsoft.com/en-us/graph/pag
   can otherwise walk a long way for nothing, so a cap has to bound what was *looked at* and not
   only what was kept. What it does not bound is requests: a page Graph chooses to answer short
   leaves the cap unspent and the walk goes on, so this is a cap on work rather than a request
-  budget. Where the budget is the point — a channel's messages, at 1 request per second per app
-  per tenant for a given channel (https://learn.microsoft.com/en-us/graph/throttling-limits) —
-  the feature reading them makes one request and does not page at all.
+  budget.
 * saying so. A truncated answer that looks complete is the failure mode, because the caller
   above is a language model that will summarise 20 of 4000 messages as "the discussion".
+
+Three ways of bounding a read live in this connector, and they are three because the collections
+are. This is the one place they are set out together:
+
+1. **Walk, bounded by items kept.** The inventories — `/me/chats`, `/me/joinedTeams`,
+   `/teams/{id}/channels` — are unfiltered, so `limit` items kept *is* the work done and
+   `MAX_SCANNED_ITEMS` never binds. Nothing filters them after the fact, so nothing more is needed.
+2. **Walk, bounded by items scanned, at a tighter cap.** A meeting's transcripts and its
+   recordings are filtered here (an occurrence window) *and* sorted here (newest first), so the
+   walk cannot stop at `limit` — it has to see the collection before it can say which of it is
+   newest. `max_scanned` is what bounds that, and the meeting listers pass their own
+   (`features/transcripts.MAX_ARTIFACT_SCAN`) rather than this module's default, because a
+   per-meeting collection is a small thing to walk 1000 items of.
+3. **Do not walk at all.** Where the request budget is the point — a channel's messages, at 1
+   request per second per app per tenant for a given channel
+   (https://learn.microsoft.com/en-us/graph/throttling-limits) — the feature reading them makes
+   one request, uses `$top` as the window, and never comes here.
+
+So the item budget and the request budget are not two competing strategies: a cap on items is what
+bounds a walk, and where a walk is what the throttle cannot afford, there is no walk.
 
 Search paging is deliberately not here. `POST /search/query` takes `from`/`size` offsets instead
 of an opaque cursor, so a stateless MCP tool resumes a search by re-issuing it with a larger
@@ -48,7 +66,8 @@ class GraphCollection[T](Protocol):
 
 # How many items may be looked at to satisfy one request, however few of them are kept. A
 # safety valve on request count, not a tuning knob: a caller that needs more than this from a
-# filtered collection is asking the wrong endpoint (use search).
+# filtered collection is asking the wrong endpoint (use search). A caller with a smaller
+# collection and a tighter budget passes its own `max_scanned` — see shape 2 above.
 MAX_SCANNED_ITEMS = 1000
 
 

--- a/services/office-mcp/src/office_mcp/server/__init__.py
+++ b/services/office-mcp/src/office_mcp/server/__init__.py
@@ -1,16 +1,17 @@
 """MCP server concerns: how the features are exposed, not what they do.
 
-Tool declarations (`tools`), FastMCP/ASGI middleware (`middleware`), and the process-wide
-service holder (`runtime`) that exists only because FastMCP calls tool functions with a plain
-signature and so denies them constructor injection. None of those exist yet — the one thing
-this package exposes today is `readiness`, the `/ready` route body, which is an
-exposure concern in exactly the same sense: an HTTP endpoint over what the service can reach.
+Three things, all entered here. `tools` declares the MCP tools over the features and states the
+Graph permissions sign-in must ask for; `errors` turns a Graph failure into advice a language
+model can act on, which every tool shares; `readiness` is the `/ready` route body, an exposure
+concern in exactly the same sense — an HTTP endpoint over what the service can reach.
 
 This side may import freely from `features/`. The reverse is a layering violation — see
-`features/__init__.py`. This package is entered through this `__init__`, never through its
-modules; `tests/test_layering.py` enforces that too.
+`features/__init__.py`. What this side must not do is talk to Microsoft Graph itself: the Graph
+SDK belongs to `graph_client/` and the requests belong to `features/`. This package is entered
+through this `__init__`, never through its modules; `tests/test_layering.py` enforces all of that.
 """
 
 from office_mcp.server.readiness import ready_response
+from office_mcp.server.tools import GRAPH_SCOPES, register_tools
 
-__all__ = ["ready_response"]
+__all__ = ["GRAPH_SCOPES", "ready_response", "register_tools"]

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -1,0 +1,106 @@
+"""Turning a Graph failure into something the model on the other end can act on.
+
+`graph_client` classifies what Graph said; this decides what to tell the caller to do about it,
+because the caller is a language model and its only options are: retry, retry later, ask the user
+to sign in, ask an administrator for a permission, or stop. A message that does not name one of
+those is a message it will answer by calling the same tool again.
+
+Two of them are only distinguishable with information Graph does not send. `GraphForbidden`
+covers both 401 and 403 and carries `status` for exactly this reason: 401 means the token was
+rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
+administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
+the message says *which* permission, which Graph never does; the tool does, so every mapping
+here is scoped to the permission the failing call was made with.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from fastmcp.exceptions import ToolError
+
+from office_mcp.graph_client import (
+    GraphFailure,
+    GraphForbidden,
+    GraphNotFound,
+    GraphThrottled,
+    GraphUnavailable,
+)
+
+
+@contextmanager
+def graph_tool_errors(permission: str) -> Generator[None]:
+    """Map any Graph failure raised in this block onto an actionable MCP tool error.
+
+    `permission` is the delegated Graph permission the enclosed calls were made with, e.g.
+    `Chat.Read` — it is what makes a 403 fixable rather than merely reported.
+    """
+    try:
+        yield
+    except GraphFailure as failure:
+        raise ToolError(_advice(failure, permission)) from failure
+
+
+def _advice(failure: GraphFailure, permission: str) -> str:
+    return _remedy(failure, permission) + _diagnostics(failure)
+
+
+def _remedy(failure: GraphFailure, permission: str) -> str:
+    if isinstance(failure, GraphThrottled):
+        if failure.retry_after_seconds is None:
+            return (
+                "Microsoft 365 is rate-limiting this connector. Wait before retrying, and do not "
+                + "repeat the call in a loop — throttling is per tenant and retrying makes it "
+                + "last longer."
+            )
+        return (
+            "Microsoft 365 is rate-limiting this connector and asked to be left alone for "
+            + f"{failure.retry_after_seconds:g} seconds. Retry after that, not sooner."
+        )
+    if isinstance(failure, GraphForbidden):
+        if failure.status == 401:
+            return (
+                "Microsoft 365 rejected the signed-in user's credentials. Ask the user to sign "
+                + "in to this connector again; the request itself was fine, so retrying it "
+                + "unchanged will fail the same way."
+            )
+        return (
+            f"Microsoft 365 refused this request: the connector may not use {permission} on "
+            + "behalf of this user. Ask a Microsoft 365 administrator to grant the delegated "
+            + f"permission {permission} to this connector's app registration (and consent to it "
+            + "for the organisation). Retrying will not help, and no other arguments will "
+            + "succeed either."
+        )
+    if isinstance(failure, GraphNotFound):
+        return (
+            "Microsoft 365 has no such item — or the signed-in user is not allowed to know it "
+            + "exists, which Graph reports identically. Check the id came from a tool response "
+            + "verbatim rather than being constructed."
+        )
+    if isinstance(failure, GraphUnavailable):
+        return (
+            "Microsoft 365 could not be reached or failed internally. Retry once; if it fails "
+            + "again the same way, stop and report it — some Graph 500s are permanent for "
+            + "particular content rather than transient."
+        )
+    return (
+        "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
+        + "permission problem, so retrying it unchanged will fail identically."
+    )
+
+
+def _diagnostics(failure: GraphFailure) -> str:
+    """The evidence an operator needs, appended once rather than woven into every message.
+
+    `request_id` is what Microsoft support asks for first, and it is only ever in this response —
+    losing it means the failure cannot be traced afterwards.
+    """
+    parts = [
+        f"{label} {value}"
+        for label, value in (
+            ("HTTP", failure.status),
+            ("Graph error code", failure.code),
+            ("Graph request id", failure.request_id),
+        )
+        if value is not None
+    ]
+    return f" ({', '.join(parts)})" if parts else ""

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -11,8 +11,14 @@ rejected (sign in again), 403 means the token was fine and the permission is mis
 administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
 the message says *which* permission, which Graph never does; the tool does, so every mapping
 here is scoped to the permission the failing call was made with.
+
+The same missing permission also has an earlier, uglier shape: if it was never consented to,
+Entra refuses the On-Behalf-Of exchange (AADSTS65001) and Graph is never reached at all. That
+failure is `entra_token_errors`, and it says the same thing as the 403 above — because from the
+caller's side it *is* the same thing, and the remedy is identical.
 """
 
+import re
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -38,6 +44,52 @@ def graph_tool_errors(permission: str) -> Generator[None]:
         yield
     except GraphFailure as failure:
         raise ToolError(_advice(failure, permission)) from failure
+
+
+# Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
+# or administrator has not consented"). It is the one part of a multi-line azure-identity error
+# worth repeating to the caller, and what an operator searches for.
+_ENTRA_CODE = re.compile(r"AADSTS\d+")
+
+
+@contextmanager
+def entra_token_errors(permission: str) -> Generator[None]:
+    """Map a failed On-Behalf-Of exchange in this block onto an actionable MCP tool error.
+
+    Wrap the *acquisition* of a Graph token, not the Graph call: this is the failure that happens
+    before any request is made, and the one FastMCP would otherwise report as "Failed to resolve
+    dependency 'graph_token'" — a message that names neither the missing permission nor the
+    remedy, because FastMCP's dependency resolver knows neither. It re-raises `ToolError`
+    untouched (`fastmcp.server.dependencies` lets `FastMCPError` subclasses out of dependency
+    resolution unwrapped, which is what makes this interception point work at all).
+    """
+    try:
+        yield
+    except Exception as failure:
+        raise ToolError(_token_advice(failure, permission)) from failure
+
+
+def _token_advice(failure: BaseException, permission: str) -> str:
+    """What to do about an On-Behalf-Of exchange that did not produce a token.
+
+    One message for every cause, because the two the exchange can actually fail for share the
+    first remedy: the permission was never consented to (AADSTS65001, overwhelmingly the common
+    one), or this connector's own Entra credentials are wrong. Splitting them would mean
+    classifying Entra error codes this connector has never observed, and the cost of guessing
+    wrong is advice that sends the caller after the wrong fix.
+    """
+    code = _ENTRA_CODE.search(str(failure))
+    diagnostics = code.group() if code is not None else type(failure).__name__
+    return (
+        "Microsoft 365 would not issue this connector a token to act for the signed-in user with "
+        + f"the delegated permission {permission}, so this call never reached Microsoft Graph. "
+        + f"Usually that means {permission} was never consented to: ask a Microsoft 365 "
+        + f"administrator to grant the delegated permission {permission} to this connector's app "
+        + "registration (and consent to it for the organisation), then have the user sign in to "
+        + "this connector again. If it is already granted, this connector's Entra configuration "
+        + "is broken and only an operator can fix it. Either way, retrying will not help and no "
+        + f"other arguments will succeed either. (Entra {diagnostics})"
+    )
 
 
 def _advice(failure: GraphFailure, permission: str) -> str:

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -10,12 +10,14 @@ covers both 401 and 403 and carries `status` for exactly this reason: 401 means 
 rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
 administrator) — opposite remedies behind one exception class. And a 403 is only actionable if
 the message says *which* permission, which Graph never does; the tool does, so every mapping
-here is scoped to the permission the failing call was made with.
+here is scoped to the permissions the failing call was made under.
 
 The same missing permission also has an earlier, uglier shape: if it was never consented to,
 Entra refuses the On-Behalf-Of exchange (AADSTS65001) and Graph is never reached at all. That
 failure is `entra_token_errors`, and it says the same thing as the 403 above — because from the
-caller's side it *is* the same thing, and the remedy is identical.
+caller's side it *is* the same thing, and the remedy is identical. It is scoped to permissions
+rather than to one for the same reason the 403 is: an exchange that asks for several is refused
+as a whole, and Entra names which one was missing no more reliably than Graph does.
 """
 
 import re
@@ -34,16 +36,19 @@ from office_mcp.graph_client import (
 
 
 @contextmanager
-def graph_tool_errors(permission: str) -> Generator[None]:
+def graph_tool_errors(*permissions: str) -> Generator[None]:
     """Map any Graph failure raised in this block onto an actionable MCP tool error.
 
-    `permission` is the delegated Graph permission the enclosed calls were made with, e.g.
-    `Chat.Read` — it is what makes a 403 fixable rather than merely reported.
+    `permissions` are the delegated Graph permissions the enclosed calls were made with, e.g.
+    `Chat.Read` — they are what make a 403 fixable rather than merely reported. Where a call needs
+    more than one, name them all: Graph never says which of them it refused, so an administrator
+    given only one name may grant the wrong permission and see the same failure.
     """
+    assert permissions, "a Graph call is made under at least one permission"
     try:
         yield
     except GraphFailure as failure:
-        raise ToolError(_advice(failure, permission)) from failure
+        raise ToolError(_advice(failure, permissions)) from failure
 
 
 # Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
@@ -53,7 +58,7 @@ _ENTRA_CODE = re.compile(r"AADSTS\d+")
 
 
 @contextmanager
-def entra_token_errors(permission: str) -> Generator[None]:
+def entra_token_errors(*permissions: str) -> Generator[None]:
     """Map a failed On-Behalf-Of exchange in this block onto an actionable MCP tool error.
 
     Wrap the *acquisition* of a Graph token, not the Graph call: this is the failure that happens
@@ -62,41 +67,53 @@ def entra_token_errors(permission: str) -> Generator[None]:
     remedy, because FastMCP's dependency resolver knows neither. It re-raises `ToolError`
     untouched (`fastmcp.server.dependencies` lets `FastMCPError` subclasses out of dependency
     resolution unwrapped, which is what makes this interception point work at all).
+
+    `permissions` are the delegated Graph permissions the exchange asked for, and where it asked
+    for more than one, all of them are named: an exchange is refused as a whole, so an
+    administrator given only one name may grant the wrong permission and see the same failure —
+    the same reason `graph_tool_errors` names them all for a 403.
     """
+    assert permissions, "a token exchange asks for at least one permission"
     try:
         yield
     except Exception as failure:
-        raise ToolError(_token_advice(failure, permission)) from failure
+        raise ToolError(_token_advice(failure, permissions)) from failure
 
 
-def _token_advice(failure: BaseException, permission: str) -> str:
+def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     """What to do about an On-Behalf-Of exchange that did not produce a token.
 
     One message for every cause, because the two the exchange can actually fail for share the
-    first remedy: the permission was never consented to (AADSTS65001, overwhelmingly the common
+    first remedy: a permission was never consented to (AADSTS65001, overwhelmingly the common
     one), or this connector's own Entra credentials are wrong. Splitting them would mean
     classifying Entra error codes this connector has never observed, and the cost of guessing
     wrong is advice that sends the caller after the wrong fix.
     """
     code = _ENTRA_CODE.search(str(failure))
     diagnostics = code.group() if code is not None else type(failure).__name__
+    named = _named(permissions)
+    several = len(permissions) > 1
+    noun = "permissions" if several else "permission"
+    consented = "were never consented to" if several else "was never consented to"
+    them = "them" if several else "it"
+    granted = "they are already granted" if several else "it is already granted"
     return (
         "Microsoft 365 would not issue this connector a token to act for the signed-in user with "
-        + f"the delegated permission {permission}, so this call never reached Microsoft Graph. "
-        + f"Usually that means {permission} was never consented to: ask a Microsoft 365 "
-        + f"administrator to grant the delegated permission {permission} to this connector's app "
-        + "registration (and consent to it for the organisation), then have the user sign in to "
-        + "this connector again. If it is already granted, this connector's Entra configuration "
-        + "is broken and only an operator can fix it. Either way, retrying will not help and no "
-        + f"other arguments will succeed either. (Entra {diagnostics})"
+        + f"the delegated {noun} {named}, so this call never reached Microsoft Graph. "
+        + f"Usually that means {named} {consented}: ask a Microsoft 365 administrator to grant "
+        + f"the delegated {noun} {named} to this connector's app registration (and consent to "
+        + f"{them} for the organisation), then have the user sign in to this connector again. If "
+        + f"{granted}, this connector's Entra configuration is broken and only an operator can "
+        + "fix it. Either way, retrying will not help and no other arguments will succeed "
+        + f"either. (Entra {diagnostics})"
     )
 
 
-def _advice(failure: GraphFailure, permission: str) -> str:
-    return _remedy(failure, permission) + _diagnostics(failure)
+def _advice(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
+    return _remedy(failure, permissions) + _diagnostics(failure)
 
 
-def _remedy(failure: GraphFailure, permission: str) -> str:
+def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
     if isinstance(failure, GraphThrottled):
         if failure.retry_after_seconds is None:
             return (
@@ -115,12 +132,13 @@ def _remedy(failure: GraphFailure, permission: str) -> str:
                 + "in to this connector again; the request itself was fine, so retrying it "
                 + "unchanged will fail the same way."
             )
+        named = _named(permissions)
+        noun = "permissions" if len(permissions) > 1 else "permission"
         return (
-            f"Microsoft 365 refused this request: the connector may not use {permission} on "
-            + "behalf of this user. Ask a Microsoft 365 administrator to grant the delegated "
-            + f"permission {permission} to this connector's app registration (and consent to it "
-            + "for the organisation). Retrying will not help, and no other arguments will "
-            + "succeed either."
+            f"Microsoft 365 refused this request: the connector may not use {named} on behalf of "
+            + f"this user. Ask a Microsoft 365 administrator to grant the delegated {noun} "
+            + f"{named} to this connector's app registration, and to consent for the "
+            + "organisation. Retrying will not help, and no other arguments will succeed either."
         )
     if isinstance(failure, GraphNotFound):
         return (
@@ -138,6 +156,13 @@ def _remedy(failure: GraphFailure, permission: str) -> str:
         "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
         + "permission problem, so retrying it unchanged will fail identically."
     )
+
+
+def _named(permissions: tuple[str, ...]) -> str:
+    """The permissions as a phrase, so the message reads as a sentence rather than a list."""
+    if len(permissions) == 1:
+        return permissions[0]
+    return " and ".join((", ".join(permissions[:-1]), permissions[-1]))
 
 
 def _diagnostics(failure: GraphFailure) -> str:

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -5,6 +5,14 @@ because the caller is a language model and its only options are: retry, retry la
 to sign in, ask an administrator for a permission, or stop. A message that does not name one of
 those is a message it will answer by calling the same tool again.
 
+Every message here is written to one shape, because a model reads them all as one voice. The thing
+that refused comes first and is always "Microsoft 365" — not "Microsoft Graph", which is the name of
+an API the caller is not calling. Then the remedy, and whether retrying could possibly help. Then,
+in a parenthesis at the end rather than woven through the advice, the evidence an operator needs.
+Graph is named after that opening only where it is the explanation (one 404 meaning three different
+things, a 500 that recurs) or where an operator needs its own label — `Graph request id` is what
+Microsoft support asks for, by that name.
+
 Two of them are only distinguishable with information Graph does not send. `GraphForbidden`
 covers both 401 and 403 and carries `status` for exactly this reason: 401 means the token was
 rejected (sign in again), 403 means the token was fine and the permission is missing (ask an
@@ -161,7 +169,7 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str 
             + "particular content rather than transient."
         )
     return (
-        "Microsoft Graph rejected this request. This is a bad request rather than an outage or a "
+        "Microsoft 365 rejected this request. This is a bad request rather than an outage or a "
         + "permission problem, so retrying it unchanged will fail identically."
     )
 

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -36,19 +36,25 @@ from office_mcp.graph_client import (
 
 
 @contextmanager
-def graph_tool_errors(*permissions: str) -> Generator[None]:
+def graph_tool_errors(*permissions: str, not_found: str | None = None) -> Generator[None]:
     """Map any Graph failure raised in this block onto an actionable MCP tool error.
 
     `permissions` are the delegated Graph permissions the enclosed calls were made with, e.g.
     `Chat.Read` — they are what make a 403 fixable rather than merely reported. Where a call needs
     more than one, name them all: Graph never says which of them it refused, so an administrator
     given only one name may grant the wrong permission and see the same failure.
+
+    `not_found` replaces the advice for a 404. The default tells the caller to check that the id it
+    sent came from a tool response verbatim, which is the likeliest cause when a tool takes an id —
+    and is misleading advice for one that takes a handle another tool just produced, where the
+    remaining causes are deletion and lost access. Pass the sentence that is true of this call; the
+    diagnostics Graph sent are appended either way.
     """
     assert permissions, "a Graph call is made under at least one permission"
     try:
         yield
     except GraphFailure as failure:
-        raise ToolError(_advice(failure, permissions)) from failure
+        raise ToolError(_advice(failure, permissions, not_found)) from failure
 
 
 # Entra puts a machine-readable code in every token-endpoint failure (`AADSTS65001` is "the user
@@ -109,11 +115,11 @@ def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     )
 
 
-def _advice(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
-    return _remedy(failure, permissions) + _diagnostics(failure)
+def _advice(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
+    return _remedy(failure, permissions, not_found) + _diagnostics(failure)
 
 
-def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
+def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
     if isinstance(failure, GraphThrottled):
         if failure.retry_after_seconds is None:
             return (
@@ -141,6 +147,8 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...]) -> str:
             + "organisation. Retrying will not help, and no other arguments will succeed either."
         )
     if isinstance(failure, GraphNotFound):
+        if not_found is not None:
+            return not_found
         return (
             "Microsoft 365 has no such item — or the signed-in user is not allowed to know it "
             + "exists, which Graph reports identically. Check the id came from a tool response "

--- a/services/office-mcp/src/office_mcp/server/errors.py
+++ b/services/office-mcp/src/office_mcp/server/errors.py
@@ -20,6 +20,16 @@ administrator) — opposite remedies behind one exception class. And a 403 is on
 the message says *which* permission, which Graph never does; the tool does, so every mapping
 here is scoped to the permissions the failing call was made under.
 
+One 403 is not about a permission at all, and naming one would send an administrator after
+something that was never missing. Microsoft Graph access to Teams meeting transcripts is a
+*tenant* switch, off by default, that "no app can access meeting transcripts, regardless of
+app-level permissions" until a Teams administrator turns it on — and Microsoft is explicit that
+there is "no request-side workaround". Graph marks it with an inner error code, which is the only
+thing distinguishing it from an ordinary refusal, so that is what it is recognised by (never the
+message text, which Microsoft documents as subject to change). This connector already learned this
+lesson once, in `services/teams-mcp` (PR #762) and in `docs/recordings-and-transcripts/`; the
+remedy names a person in the Teams admin centre and explicitly rules out re-consent.
+
 The same missing permission also has an earlier, uglier shape: if it was never consented to,
 Entra refuses the On-Behalf-Of exchange (AADSTS65001) and Graph is never reached at all. That
 failure is `entra_token_errors`, and it says the same thing as the 403 above — because from the
@@ -123,6 +133,25 @@ def _token_advice(failure: BaseException, permissions: tuple[str, ...]) -> str:
     )
 
 
+# Graph's inner error code for the tenant switch, and the advice for it. Branched on rather than the
+# message, as Microsoft's transcript reference instructs twice.
+_TRANSCRIPT_ACCESS_DISABLED = "GraphAccessToTranscriptsDisabled"
+
+_TRANSCRIPTS_SWITCHED_OFF = (
+    "Microsoft 365 refused this request because this organisation has Microsoft Graph access to "
+    + "Teams meeting transcripts switched OFF. This is a tenant-wide Teams setting, off by "
+    + "default, and it blocks every transcript read regardless of which permissions this connector "
+    + "holds — so it is NOT a consent problem and asking the user to sign in again will not change "
+    + "it. A Microsoft Teams administrator has to turn it on: Teams admin centre → Meetings → "
+    + "Meeting settings → Transcript API access → Microsoft Graph access, or "
+    + "`Set-CsTeamsMeetingConfiguration -EnableGraphTranscriptAccess $true -Identity Global`. "
+    + "Microsoft documents no request-side workaround: until an administrator acts, every "
+    + "transcript call from this connector fails identically, so do not retry this one and do not "
+    + "try another meeting or another transcript. Everything else this connector does — chats, "
+    + "channels, message search — is unaffected."
+)
+
+
 def _advice(failure: GraphFailure, permissions: tuple[str, ...], not_found: str | None) -> str:
     return _remedy(failure, permissions, not_found) + _diagnostics(failure)
 
@@ -146,6 +175,8 @@ def _remedy(failure: GraphFailure, permissions: tuple[str, ...], not_found: str 
                 + "in to this connector again; the request itself was fine, so retrying it "
                 + "unchanged will fail the same way."
             )
+        if failure.inner_code == _TRANSCRIPT_ACCESS_DISABLED:
+            return _TRANSCRIPTS_SWITCHED_OFF
         named = _named(permissions)
         noun = "permissions" if len(permissions) > 1 else "permission"
         return (

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -28,7 +28,7 @@ from fastmcp.tools import Tool
 from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import chats, identity, message_search
+from office_mcp.features import chats, identity, message_read, message_search
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -58,6 +58,7 @@ GRAPH_SCOPES: tuple[str, ...] = tuple(
             identity.GRAPH_PERMISSION,
             chats.GRAPH_PERMISSION,
             *message_search.GRAPH_PERMISSIONS,
+            *message_read.GRAPH_PERMISSIONS,
         )
     )
 )
@@ -128,6 +129,7 @@ def _graph_token(*permissions: str) -> str:
 _IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
 _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
+_READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -181,7 +183,7 @@ need to know who the user is.
 A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
 view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
 truncated with `...` where it was cut — is the only text here. Every hit carries a `uri` handle \
-identifying that exact message; read that resource for the real text, the attachments and the \
+identifying that exact message; pass it to read_message for the real text, the attachments and the \
 mentions. Never present `summary` as the whole message, and never conclude from it that the \
 message does not say more.
 
@@ -216,6 +218,61 @@ _NO_CRITERIA = (
     + ", ".join(message_search.CRITERIA)
     + ". Searching with none of them would return an arbitrary sample of every message the user "
     + "can see, not an answer. Add the keywords, person or date range the question is about."
+)
+
+_READ_MESSAGE = """\
+Read one Microsoft Teams message in full, from the `uri` handle a search_messages result carries: \
+the whole message text, who sent it, who was @-mentioned, what was attached, and whether it has \
+been edited or deleted.
+
+This is the other half of search_messages, and the only route to a message's text. Microsoft's \
+search index answers with a reduced view of a message that contains no body at all, so a search \
+result carries only Microsoft's `summary` snippet. Read the message here whenever the answer \
+depends on what somebody actually said rather than on the fact that a matching message exists — \
+and never present a snippet as the message.
+
+`uri` takes a handle this connector produced, in one of exactly two shapes:
+  teams:///chats/{chat_id}/messages/{message_id}
+  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}
+Nothing else is readable. This connector serves Microsoft Teams messages, so no handle here names \
+mail, a calendar event, a file, a SharePoint page or a meeting transcript, and nothing turns a \
+person's name or a chat topic into one — pass the `uri` from a search result verbatim.
+
+`text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
+`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and an adaptive card as \
+`[card]`. `mentions` and `attachments` say who and what those refer to.
+
+Two messages have no text and must not be reported as empty ones. A deleted message returns \
+`deleted_at` and no text: say it was deleted. A system event message — somebody joining, a call \
+ending, a chat being renamed — has no author and no text anywhere in Microsoft Graph, because the \
+sentence Teams displays is written by the Teams client and never sent. For those, `event` names \
+what happened, and inventing the wording of one is a fabrication.\
+"""
+
+# What the tool says when `uri` is not a handle at all. This is the failure that is *our* fault to
+# explain — the two below are Microsoft's answers — so it is the one that shows the shapes.
+_BAD_HANDLE = (
+    "read_message takes a `uri` handle that search_messages produced, and this is not one. A "
+    + "readable handle has one of exactly two shapes:\n"
+    + "  teams:///chats/{chat_id}/messages/{message_id}\n"
+    + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}\n"
+    + "with the ids percent-encoded, e.g. "
+    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a search "
+    + "result rather than assembling one, and note that this connector reads Teams messages only — "
+    + "no mail, files, sites or meetings are addressable here. Retrying this value will fail "
+    + "identically."
+)
+
+# Graph's 404 on a well-formed handle, which is a different failure from a malformed one and must
+# not be reported as the message never having existed.
+_UNREADABLE = (
+    "Microsoft 365 would not return this message. The handle is well formed, so this is not a bad "
+    + "argument — and it is not evidence that the message does not exist: Graph answers 'deleted', "
+    + "'never existed' and 'the signed-in user may not see it' with the same 404, and does not say "
+    + "which of them it meant. Report that the message could not be read, never that it was never "
+    + "written. Retrying will not help and this connector has no other route to the text. (A reply "
+    + "inside a channel thread is also addressed under its parent post, which this handle shape "
+    + "cannot express.)"
 )
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
@@ -411,6 +468,40 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             )
 
     _require_a_criterion(mcp.add_tool(search_messages))
+
+    @mcp.tool(
+        name="read_message",
+        title="Read a Teams Message",
+        description=_READ_MESSAGE,
+        annotations=_READ_ONLY,
+    )
+    async def read_message(
+        uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The handle of the message to read, exactly as a search_messages result gave "
+                    + "it: `teams:///chats/{chat_id}/messages/{message_id}` or "
+                    + "`teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}`. No "
+                    + "other scheme or shape is readable, and nothing else identifies a Teams "
+                    + "message — a chat topic, a person's name or a Teams web link cannot be "
+                    + "turned into one."
+                ),
+            ),
+        ],
+        graph_token: str = _READ_TOKEN,
+    ) -> message_read.TeamsMessage:
+        handle = message_read.message_handle(uri)
+        if handle is None:
+            raise ToolError(_BAD_HANDLE)
+        # One permission, not both: the handle says which surface is being read, and Graph's 403
+        # there can only be about that one. The token was exchanged for both because a dependency
+        # is resolved before the tool sees its argument.
+        with graph_tool_errors(handle.permission, not_found=_UNREADABLE):
+            return await message_read.read_message(
+                graph_client_for(transport, graph_token), handle=handle
+            )
 
 
 def _require_a_criterion(tool: Tool) -> None:

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -172,7 +172,10 @@ Return the signed-in Microsoft 365 user's own profile: `user_id`, `display_name`
 
 Call this before anything that turns on who "I", "me" or "my" is: filtering a message search to \
 the signed-in user, deciding which participant of a chat is them, or addressing them by name. It \
-is one cheap request and its answer is stable for the session.
+is one cheap request and its answer is stable for the session. Its `user_id` is the value \
+search_messages matches `mentions` on — a name will not work there — and the one to compare a \
+recording's `organizer_user_id` against; `email` is what a chat member from list_chats is matched \
+by, because that list carries no ids at all.
 
 `email` is the canonical primary SMTP address (Microsoft's `mail`) and the right value to match a \
 sender or recipient against — but it is null for guest and unlicensed accounts, and \
@@ -452,8 +455,8 @@ neither. Both bounds take a date (`2026-08-11`, meaning that whole UTC day) or a
 or without a timezone offset — one without is read as UTC, so pass the offset when you are working \
 from a local time.
 
-**Read `status` before anything else. It has four values and they mean four different actions:**
-- `available` — transcripts are listed; read one with read_transcript.
+**Read `status` before anything else. It has five values and they mean five different actions:**
+- `available` — transcripts are listed, newest first; read one with read_transcript.
 - `not_ready` — nothing has landed for the window you asked about and something still might: that \
 window has only just closed, or you asked for no window and the meeting has not ended or ended \
 recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
@@ -465,6 +468,11 @@ last-month occurrence "still processing".
 or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
 meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
 transcripts once the meeting expires, roughly 60 days after a one-off.)
+- `scan_incomplete` — this meeting has more transcripts than one call looks through \
+({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones looked at are in your window, so whether \
+one exists there is not known. This is the one answer that claims nothing: narrow \
+`started_after`/`started_before` to the occurrence you mean and ask again. Never report it as \
+"there is no transcript".
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
 see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
 
@@ -554,8 +562,8 @@ identifier for "these two are the same call". Reach for this tool when the quest
 recording itself — was there one, how long, who has it — or when list_meeting_transcripts has \
 already said `not_transcribed` and the remaining question is whether anything was captured at all.
 
-**Read `status` before anything else. It has four values and they mean four different actions:**
-- `available` — recordings are listed, with durations and access.
+**Read `status` before anything else. It has five values and they mean five different actions:**
+- `available` — recordings are listed, newest first, with durations and access.
 - `not_ready` — nothing has landed for the window you asked about and something still might: that \
 window has only just closed, or you asked for no window and the meeting has not ended or ended \
 recently. Wait and call again later. This is NOT "the call was not recorded", and reporting it as \
@@ -565,6 +573,11 @@ window that is already well past never answers this.
 - `not_recorded` — the window you asked about is over and nothing is there: nobody recorded it. \
 Retrying will not help. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
 artifacts once the meeting expires, roughly 60 days after a one-off.)
+- `scan_incomplete` — this meeting has more recordings than one call looks through \
+({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones looked at are in your window, so whether \
+one exists there is not known. This is the one answer that claims nothing: narrow \
+`started_after`/`started_before` to the occurrence you mean and ask again. Never report it as "the \
+call was not recorded".
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
 see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
 
@@ -1052,10 +1065,14 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=transcripts.MAX_TRANSCRIPTS,
                 description=(
-                    "How many transcripts to return, newest first. Default 20, maximum "
-                    + f"{transcripts.MAX_TRANSCRIPTS}. One meeting has one transcript per "
+                    "How many transcripts to return. Default 20, maximum "
+                    + f"{transcripts.MAX_TRANSCRIPTS}. They are the NEWEST that many of the "
+                    + "window, not the first that many Microsoft happens to answer with: the "
+                    + f"meeting's transcripts are read (up to {transcripts.MAX_ARTIFACT_SCAN} of "
+                    + "them, which is this call's whole cost) and ordered before this cuts them, "
+                    + "so asking for 3 gives the 3 latest. One meeting has one transcript per "
                     + "occurrence that was transcribed, so only a long-running recurring series "
-                    + "reaches this; `truncated` says when the window was too small."
+                    + "reaches either bound; `truncated` says when one was reached."
                 ),
             ),
         ] = 20,
@@ -1238,11 +1255,15 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=recordings.MAX_RECORDINGS,
                 description=(
-                    "How many recordings to return, newest first. Default 20, maximum "
-                    + f"{recordings.MAX_RECORDINGS}. A meeting has one recording per occurrence "
-                    + "that was recorded — two if somebody stopped and restarted — so only a "
-                    + "long-running recurring series reaches this; `truncated` says when the "
-                    + "window was too small."
+                    "How many recordings to return. Default 20, maximum "
+                    + f"{recordings.MAX_RECORDINGS}. They are the NEWEST that many of the window, "
+                    + "not the first that many Microsoft happens to answer with: the meeting's "
+                    + f"recordings are read (up to {transcripts.MAX_ARTIFACT_SCAN} of them, which "
+                    + "is this call's whole cost) and ordered before this cuts them, so asking for "
+                    + "3 gives the 3 latest. A meeting has one recording per occurrence that was "
+                    + "recorded — two if somebody stopped and restarted — so only a long-running "
+                    + "recurring series reaches either bound; `truncated` says when one was "
+                    + "reached."
                 ),
             ),
         ] = 20,

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -498,7 +498,18 @@ which Microsoft defines as transcription having started after the conversation d
 
 `speaker_attribution` is false when the organisation has turned speaker names off. The words and \
 timings still come back and every `speaker` is null: do not infer who spoke from the content, and \
-say the transcript is unattributed if the answer turns on who said something.
+say the transcript is unattributed if the answer turns on who said something. **A `speaker` filter \
+matches nothing at all on such a transcript** — there is no name on any turn for it to match — so \
+read an empty answer next to this flag before reporting that the person never spoke, and drop the \
+filter to see the turns themselves.
+
+`from_seconds`/`to_seconds` and `speaker` narrow what comes back, and everything else is counted \
+over what they left: `truncated` and `next_offset` page through the MATCHING turns rather than \
+through the meeting. The time bounds are inclusive and match by overlap, so a turn already under \
+way at `from_seconds` is kept whole instead of being cut at it; `speaker` matches any part of the \
+name Teams shows, ignoring case, because a display name is not something to spell from memory. \
+Filtering does not make the call cheaper — the whole transcript is fetched and parsed either \
+way — it makes the answer smaller.
 
 A long meeting is more turns than fit in one answer. `truncated` says there are more and \
 `next_offset` is where to continue — the same convention every list-shaped tool here uses. Each \
@@ -528,6 +539,27 @@ _NOT_A_TRANSCRIPT_HANDLE = (
     + "`meeting_uri` and pass the `uri` of the transcript you want, verbatim. A `meeting_uri` is "
     + "not a transcript handle — one meeting can have many transcripts — and neither is a Teams "
     + "message handle. Retrying this value will fail identically."
+)
+
+# The two things `read_transcript`'s filters can be asked that a signature cannot refuse. A schema
+# bounds one argument at a time, so neither a window whose ends are the wrong way round nor a filter
+# value that is nothing but spaces is expressible in it — and both would otherwise be answered with
+# an empty page, which is the one failure a model reads as a real answer.
+_INVERTED_TIME_WINDOW = (
+    "read_transcript was given a `from_seconds` later than its `to_seconds`, which selects no part "
+    + "of the meeting: no turn can both end after the one and start before the other, so this "
+    + "would come back empty and read like a silent meeting. Both are offsets in seconds from the "
+    + "moment transcription began, counting upwards, so the earlier moment is the smaller number — "
+    + "swap them if they were written the wrong way round, or drop one to leave that end open."
+)
+
+_BLANK_SPEAKER = (
+    "read_transcript was given a blank `speaker`. A blank filter is not the same as no filter, and "
+    + "it is not treated as one: omit `speaker` entirely to read every turn, or pass any part of "
+    + "the name Teams shows for the person — matching ignores case and matches anywhere in the "
+    + "display name, so `ada` finds `Ada Lovelace`. Note that a transcript whose "
+    + "`speaker_attribution` is false carries no names at all, and any `speaker` filter matches "
+    + "nothing on it."
 )
 
 # Graph's 404 on a well-formed transcript handle. Distinct advice from the message reader's, because
@@ -1002,18 +1034,77 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 description=(
                     "How many turns to return. Default 200, maximum "
                     + f"{transcripts.MAX_TURNS}. Every call fetches the whole transcript from "
-                    + "Microsoft, so widening this is cheaper than paging."
+                    + "Microsoft, so widening this is cheaper than paging. It counts the turns "
+                    + "left after `from_seconds`, `to_seconds` and `speaker`, not the meeting's."
                 ),
             ),
         ] = 200,
+        from_seconds: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Only turns reaching this moment or later, in seconds from when transcription "
+                    + "began — the same scale as a turn's `start_seconds`, which is NOT a "
+                    + "wall-clock time and NOT an offset from the start of the meeting. Inclusive, "
+                    + "and matched by overlap: a turn already under way at this moment is kept "
+                    + "whole rather than cut at it, which is usually the sentence that says what "
+                    + "the stretch is about. Negative values are legal — Microsoft uses them for "
+                    + "transcription that began after the conversation did. This narrows the "
+                    + "answer, not the call: the whole transcript is fetched and parsed either way."
+                )
+            ),
+        ] = None,
+        to_seconds: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Only turns beginning at this moment or earlier, on the same scale and the "
+                    + "same inclusive overlap rule: a turn still running at this moment is kept "
+                    + "whole. Pair it with `from_seconds` to read one stretch of a long meeting, "
+                    + "and keep the two in that order — a `from_seconds` later than this is "
+                    + "refused rather than answered with an empty page."
+                )
+            ),
+        ] = None,
+        speaker: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only turns whose speaker's name contains this, ignoring case — `ada` matches "
+                    + "`Ada Lovelace`. A substring rather than a whole name on purpose: Teams "
+                    + "display names carry middle names, titles and tenant suffixes, and an exact "
+                    + "match would answer 'they said nothing' to a spelling difference. **If the "
+                    + "transcript's `speaker_attribution` is false this matches NOTHING** — that "
+                    + "organisation records no speaker names, so every turn's `speaker` is null "
+                    + "and no filter can match one. Read an empty answer together with that flag "
+                    + "before concluding the person did not speak, and drop this filter to see the "
+                    + "turns themselves. Omit it to read every speaker; a blank value is refused "
+                    + "rather than read as 'everyone'."
+                ),
+            ),
+        ] = None,
         graph_token: str = _TRANSCRIPT_TOKEN,
     ) -> transcripts.Transcript:
         handle = transcripts.transcript_handle(uri)
         if handle is None:
             raise ToolError(_NOT_A_TRANSCRIPT_HANDLE)
+        # The two rules a schema cannot carry, refused here for the reason search_messages refuses
+        # a criterion-less search: each would otherwise be answered with an empty page, and an
+        # empty page is indistinguishable from a meeting in which nobody said anything.
+        if from_seconds is not None and to_seconds is not None and from_seconds > to_seconds:
+            raise ToolError(_INVERTED_TIME_WINDOW)
+        if speaker is not None and not speaker.strip():
+            raise ToolError(_BLANK_SPEAKER)
         with graph_tool_errors(transcripts.TRANSCRIPT_PERMISSION, not_found=_TRANSCRIPT_UNREADABLE):
             return await transcripts.read_transcript(
-                graph_client_for(transport, graph_token), handle=handle, offset=offset, limit=limit
+                graph_client_for(transport, graph_token),
+                handle=handle,
+                offset=offset,
+                limit=limit,
+                from_seconds=from_seconds,
+                to_seconds=to_seconds,
+                speaker=speaker,
             )
 
 

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -456,7 +456,9 @@ or without a timezone offset — one without is read as UTC, so pass the offset 
 from a local time.
 
 **Read `status` before anything else. It has five values and they mean five different actions:**
-- `available` — transcripts are listed, newest first; read one with read_transcript.
+- `available` — transcripts are listed, newest first; read one with read_transcript. "Newest" is \
+over the transcripts this call read, which is every transcript the meeting has unless `truncated` \
+says the read stopped at the cap below.
 - `not_ready` — nothing has landed for the window you asked about and something still might: that \
 window has only just closed, or you asked for no window and the meeting has not ended or ended \
 recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
@@ -468,11 +470,14 @@ last-month occurrence "still processing".
 or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
 meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
 transcripts once the meeting expires, roughly 60 days after a one-off.)
-- `scan_incomplete` — this meeting has more transcripts than one call looks through \
-({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones looked at are in your window, so whether \
-one exists there is not known. This is the one answer that claims nothing: narrow \
-`started_after`/`started_before` to the occurrence you mean and ask again. Never report it as \
-"there is no transcript".
+- `scan_incomplete` — this meeting has more transcripts than one call reads \
+({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones read are in your window, so whether one \
+exists there is not known. This is the one answer that claims nothing, and the one with nothing to \
+try: the window is applied to the transcripts after Microsoft has answered them, so a narrower \
+`started_after`/`started_before` reads the same transcripts and returns this same answer, however \
+many times you ask. Stop here. Report that this meeting has too many transcripts to read through \
+and that whether the occurrence you meant was transcribed could not be determined — that \
+uncertainty is the answer. Never report it as "there is no transcript".
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
 see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
 
@@ -563,7 +568,9 @@ recording itself — was there one, how long, who has it — or when list_meetin
 already said `not_transcribed` and the remaining question is whether anything was captured at all.
 
 **Read `status` before anything else. It has five values and they mean five different actions:**
-- `available` — recordings are listed, newest first, with durations and access.
+- `available` — recordings are listed, newest first, with durations and access. "Newest" is over \
+the recordings this call read, which is every recording the meeting has unless `truncated` says \
+the read stopped at the cap below.
 - `not_ready` — nothing has landed for the window you asked about and something still might: that \
 window has only just closed, or you asked for no window and the meeting has not ended or ended \
 recently. Wait and call again later. This is NOT "the call was not recorded", and reporting it as \
@@ -573,11 +580,14 @@ window that is already well past never answers this.
 - `not_recorded` — the window you asked about is over and nothing is there: nobody recorded it. \
 Retrying will not help. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
 artifacts once the meeting expires, roughly 60 days after a one-off.)
-- `scan_incomplete` — this meeting has more recordings than one call looks through \
-({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones looked at are in your window, so whether \
-one exists there is not known. This is the one answer that claims nothing: narrow \
-`started_after`/`started_before` to the occurrence you mean and ask again. Never report it as "the \
-call was not recorded".
+- `scan_incomplete` — this meeting has more recordings than one call reads \
+({transcripts.MAX_ARTIFACT_SCAN}) and none of the ones read are in your window, so whether one \
+exists there is not known. This is the one answer that claims nothing, and the one with nothing to \
+try: the window is applied to the recordings after Microsoft has answered them, so a narrower \
+`started_after`/`started_before` reads the same recordings and returns this same answer, however \
+many times you ask. Stop here. Report that this meeting has too many recordings to read through \
+and that whether the occurrence you meant was recorded could not be determined — that uncertainty \
+is the answer. Never report it as "the call was not recorded".
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
 see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
 
@@ -1070,9 +1080,14 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                     + "window, not the first that many Microsoft happens to answer with: the "
                     + f"meeting's transcripts are read (up to {transcripts.MAX_ARTIFACT_SCAN} of "
                     + "them, which is this call's whole cost) and ordered before this cuts them, "
-                    + "so asking for 3 gives the 3 latest. One meeting has one transcript per "
-                    + "occurrence that was transcribed, so only a long-running recurring series "
-                    + "reaches either bound; `truncated` says when one was reached."
+                    + "so asking for 3 gives the 3 newest OF THE ONES READ. Those are the 3 latest "
+                    + "outright whenever the meeting has no more transcripts than that cap, which "
+                    + "is every meeting except a series recorded daily for most of a year: one "
+                    + "meeting has one transcript per occurrence that was transcribed. Past the "
+                    + "cap the read stops mid-collection, in whatever order Microsoft answered in "
+                    + "(it offers no way to ask for the newest), so a newer transcript can be one "
+                    + "that was never read — `truncated` is true whenever either bound was "
+                    + "reached, and raising `limit` does not read further."
                 ),
             ),
         ] = 20,
@@ -1260,10 +1275,14 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                     + "not the first that many Microsoft happens to answer with: the meeting's "
                     + f"recordings are read (up to {transcripts.MAX_ARTIFACT_SCAN} of them, which "
                     + "is this call's whole cost) and ordered before this cuts them, so asking for "
-                    + "3 gives the 3 latest. A meeting has one recording per occurrence that was "
-                    + "recorded — two if somebody stopped and restarted — so only a long-running "
-                    + "recurring series reaches either bound; `truncated` says when one was "
-                    + "reached."
+                    + "3 gives the 3 newest OF THE ONES READ. Those are the 3 latest outright "
+                    + "whenever the meeting has no more recordings than that cap, which is every "
+                    + "meeting except a series recorded daily for most of a year: a meeting has "
+                    + "one recording per occurrence that was recorded, two if somebody stopped and "
+                    + "restarted. Past the cap the read stops mid-collection, in whatever order "
+                    + "Microsoft answered in (it offers no way to ask for the newest), so a newer "
+                    + "recording can be one that was never read — `truncated` is true whenever "
+                    + "either bound was reached, and raising `limit` does not read further."
                 ),
             ),
         ] = 20,

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -253,7 +253,9 @@ Reach for this when the question is "what is going on in this channel" rather th
 mentioned". Do not call it for channel after channel: Microsoft rate-limits reads of a given \
 channel to about one request a second for this whole connector across the tenant, so a sweep is \
 slow for you and harmful to everyone else on it — search_messages covers every channel in one \
-request.
+request. This call spends exactly one request of that budget: it reads the single page Microsoft \
+answers with and never pages deeper, so `limit` is the whole window and widening `limit` — not \
+calling again — is how to see more.
 
 **The order is not what it looks like.** Microsoft sorts this collection by the last modified time \
 of the entire reply chain, so a two-year-old post returns to the front the moment somebody replies \
@@ -269,11 +271,16 @@ answered by a wider `limit` (up to {channels.MAX_POSTS}, Microsoft's own maximum
 
 Replies come with their posts: up to {channels.MAX_REPLIES_PER_POST} of the newest per post, \
 oldest first, each carrying the post it answers in `reply_to_id`. `truncated` is also set when a \
-thread had more replies than that. Every message is complete — the same fields, and the same plain \
-text normalised out of Teams' HTML, that read_message returns — so a message here needs no second \
-call to read it. Its `uri` is a handle for quoting or re-reading it, and for a reply it is the \
-only handle that exists: Microsoft addresses a reply under its parent post, which a search result \
-cannot express.
+thread had more replies than that, and those older replies are out of reach rather than one call \
+away — Microsoft's cursor into a thread is a request per post against the same one-a-second \
+budget, so it is not followed and browsing again returns the same newest replies. Every message is \
+complete — the same fields, and the same plain text normalised out of Teams' HTML, that \
+read_message returns — so a message here needs no second call to read it. Its `uri` is a handle \
+for quoting or re-reading it, and for a reply it is the only handle that exists: Microsoft \
+addresses a reply under its parent post, which a search result cannot express. That is also the \
+limit of what this tool can rescue: when a search hit is a reply older than the window above, \
+there is no route to its full text anywhere in this connector — report the search snippet, say so, \
+and do not browse again for it.
 
 System messages are dropped — somebody joining, a call ending, a channel being renamed — because \
 Microsoft gives them no author and no text. That is why a page can hold fewer posts than `limit`, \
@@ -394,8 +401,15 @@ _UNREADABLE = (
     + "written. Retrying will not help and this connector has no other route to the text. One "
     + "well-formed handle always fails this way: a reply in a channel thread is addressed under "
     + "the post it answers, and a search result does not identify that post — so a search hit that "
-    + "is a reply cannot be read from its own handle. Browse that channel with browse_channel, "
-    + "which emits the reply's own handle and returns its text outright."
+    + "is a reply cannot be read from its own handle. browse_channel is the only tool that emits a "
+    + "reply's own handle, and it reaches the newest "
+    + f"{channels.MAX_REPLIES_PER_POST} replies of each post on the channel's first page and no "
+    + "further: it follows neither Microsoft's cursor into an older part of a thread nor the one "
+    + "into older posts, because a given channel allows this whole connector about one request a "
+    + "second across the tenant. So browse that channel once; if the reply is not in what comes "
+    + "back there is no route to its full text, and a second browse returns the same window. "
+    + "Report the search snippet with its sender and date, say the full text could not be "
+    + "retrieved, and stop looking."
 )
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
@@ -547,8 +561,9 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 description=(
                     "How many posts to return, each with its replies. Default 20 and maximum "
                     + f"{channels.MAX_POSTS} — both Microsoft Graph's own, for this collection. "
-                    + "System messages are dropped after Graph counts them, so a page can hold "
-                    + "fewer posts than this."
+                    + "One call is one request against the channel and this is the whole of its "
+                    + "window: widen it to see more rather than calling again. System messages are "
+                    + "dropped after Graph counts them, so a page can hold fewer posts than this."
                 ),
             ),
         ] = 20,

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -9,8 +9,9 @@ otherwise need a process-wide service holder for.
 Three conventions hold across every tool here, and a new one is expected to keep them, because a
 model reads this surface as one thing:
 
-* **A name is `verb_noun`** — `get_me`, `list_chats`, `search_messages`, `read_message` — naming
-  what the tool does and what it does it to. `whoami` was the one exception and is now `get_me`:
+* **A name is `verb_noun`** — `get_me`, `list_chats`, `list_teams`, `list_channels`,
+  `browse_channel`, `search_messages`, `read_message` — naming what the tool does and what it does
+  it to. `whoami` was the one exception and is now `get_me`:
   the shell idiom made the odd tool out of the very tool a model calls first, and renaming a tool
   is a breaking change best spent before there are more of them. (Microsoft's own M365 connector
   arrived at `get_me` independently, which is one less name for a model to have to learn twice.)
@@ -42,7 +43,7 @@ from fastmcp.tools import Tool
 from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import chats, identity, message_read, message_search
+from office_mcp.features import channels, chats, identity, message_read, message_search
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -71,6 +72,9 @@ GRAPH_SCOPES: tuple[str, ...] = tuple(
         for permission in (
             identity.GRAPH_PERMISSION,
             chats.GRAPH_PERMISSION,
+            channels.TEAMS_PERMISSION,
+            channels.CHANNELS_PERMISSION,
+            channels.POSTS_PERMISSION,
             *message_search.GRAPH_PERMISSIONS,
             *message_read.GRAPH_PERMISSIONS,
         )
@@ -142,6 +146,9 @@ def _graph_token(*permissions: str) -> str:
 # nothing but its permissions.
 _IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
 _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
+_TEAMS_TOKEN: str = _graph_token(channels.TEAMS_PERMISSION)
+_CHANNELS_TOKEN: str = _graph_token(channels.CHANNELS_PERMISSION)
+_POSTS_TOKEN: str = _graph_token(channels.POSTS_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 _READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 
@@ -170,11 +177,11 @@ unnamed chats) its members.
 
 Reach for this to see which conversations are live, who is in them, and when each was last posted \
 in — never for what was said in them: no message text is returned here, and search_messages is the \
-only route to any. The other use is naming: a `chat_id` here is the same id search_messages puts \
+route to any. The other use is naming: a `chat_id` here is the same id search_messages puts \
 on every chat message it finds, so this list is how a found message gets a topic and a set of \
 participants. It is not an argument to anything — no tool here takes a chat id, and a search \
-cannot be narrowed to one chat. This returns chats only: Teams channels live inside teams and are \
-not part of this list.
+cannot be narrowed to one chat. This returns chats only: Teams channels live inside teams, are \
+listed by list_teams and list_channels, and are read by browse_channel.
 
 Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
 the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
@@ -196,12 +203,90 @@ member is matched by display name or, with `include_member_emails`, by email —
 no user ids).\
 """
 
+_LIST_TEAMS = f"""\
+List the Microsoft Teams teams the signed-in user is a member of, with each team's id, name, \
+description and archived flag.
+
+This is the first step into the channel side of Teams, which list_chats does not cover at all: a \
+`team_id` here is what list_channels takes, and browsing what was posted in a channel starts from \
+that. It answers "which teams am I in" and nothing more — no channels, no members, no messages, \
+and no activity date, because Microsoft Graph populates none of those on this collection whether \
+or not they are asked for.
+
+`is_archived` marks a team that is read-only in Teams, which usually means finished; together with \
+`description` it is what tells apart two teams sharing a display name. Teams that merely host a \
+shared channel the user belongs to are not listed — Microsoft returns only teams the user is a \
+member of.
+
+There is no pagination and no ordering: Microsoft Graph accepts no page size on this collection, \
+and applies no order to it, so `limit` is a window over whatever order it answered in and \
+`truncated` says the user is in more teams than fit. Widen `limit` (up to {channels.MAX_LISTED}) \
+rather than looking for a cursor.\
+"""
+
+_LIST_CHANNELS = f"""\
+List the channels of one Microsoft Teams team, identified by the `team_id` list_teams returned: \
+each channel's id, name, description, membership type and creation date.
+
+Call this to find the channel to browse, then pass `team_id` and `channel_id` together to \
+browse_channel — a channel id alone addresses nothing. Channel names are unique only inside their \
+own team (every team has a `General`), which is why the pair is always needed. No message content \
+is returned here.
+
+The list is already trimmed to what the signed-in user may see: Microsoft omits private and shared \
+channels they are not a member of, so an absent channel is not evidence that the team has no such \
+channel. `membership_type` says which kind each one is — `standard`, `private` or `shared`.
+
+There is no pagination and no ordering, for the same reason as list_teams: Microsoft accepts no \
+page size on this collection either. `truncated` says the team has more channels than this `limit` \
+holds; widen it (up to {channels.MAX_LISTED}).\
+"""
+
+_BROWSE_CHANNEL = f"""\
+Read what was posted in one Microsoft Teams channel: its posts with their full text, each followed \
+by the replies to it. Takes the `team_id` and `channel_id` list_teams and list_channels returned.
+
+This is the one thing the other message tools cannot do — walk a single channel in order. \
+search_messages finds messages by keyword across every chat and channel at once but cannot be \
+scoped to one channel, and read_message reads a single message you already have a handle for. \
+Reach for this when the question is "what is going on in this channel" rather than "where was this \
+mentioned". Do not call it for channel after channel: Microsoft rate-limits reads of a given \
+channel to about one request a second for this whole connector across the tenant, so a sweep is \
+slow for you and harmful to everyone else on it — search_messages covers every channel in one \
+request.
+
+**The order is not what it looks like.** Microsoft sorts this collection by the last modified time \
+of the entire reply chain, so a two-year-old post returns to the front the moment somebody replies \
+to it. The first message here is the most recently *active* thread, not the most recent post. Read \
+`created_at` before saying when anything was written, never the position in this list, and do not \
+report the top of the list as "the latest news in the channel".
+
+It cannot be date-filtered, and this is Microsoft's limit rather than a missing parameter: this \
+collection accepts no filter and no sort at all. To bound by date use search_messages with \
+`sent_after`/`sent_before`, which the search index applies and which covers channels. For the same \
+reason, paging deeper is not a way to reach older posts — there is no cursor, and `truncated` is \
+answered by a wider `limit` (up to {channels.MAX_POSTS}, Microsoft's own maximum) or by searching.
+
+Replies come with their posts: up to {channels.MAX_REPLIES_PER_POST} of the newest per post, \
+oldest first, each carrying the post it answers in `reply_to_id`. `truncated` is also set when a \
+thread had more replies than that. Every message is complete — the same fields, and the same plain \
+text normalised out of Teams' HTML, that read_message returns — so a message here needs no second \
+call to read it. Its `uri` is a handle for quoting or re-reading it, and for a reply it is the \
+only handle that exists: Microsoft addresses a reply under its parent post, which a search result \
+cannot express.
+
+System messages are dropped — somebody joining, a call ending, a channel being renamed — because \
+Microsoft gives them no author and no text. That is why a page can hold fewer posts than `limit`, \
+and it is not evidence that the channel is quiet.\
+"""
+
 _SEARCH_MESSAGES = f"""\
 Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
 chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
 and read state. Messages from ANY participant match, not only the user's own; call get_me if you \
-need to know who the user is. This is the only tool here that returns messages at all, and the \
-only way to reach a message's text: it finds them, read_message reads one.
+need to know who the user is. It is the only tool here that searches: it finds messages anywhere, \
+read_message reads one of them in full, and browse_channel is what walks a single channel when the \
+question is about that channel rather than about a keyword.
 
 A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
 view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
@@ -254,18 +339,22 @@ Read one Microsoft Teams message in full, from the `uri` handle a search_message
 the whole message text, who sent it, who was @-mentioned, what was attached, and whether it has \
 been edited or deleted.
 
-This is the other half of search_messages, and the only route to a message's text. Microsoft's \
-search index answers with a reduced view of a message that contains no body at all, so a search \
-result carries only Microsoft's `summary` snippet. Read the message here whenever the answer \
-depends on what somebody actually said rather than on the fact that a matching message exists — \
-and never present a snippet as the message.
+This is the other half of search_messages, and the only route to the text of a message a search \
+found. Microsoft's search index answers with a reduced view of a message that contains no body at \
+all, so a search result carries only Microsoft's `summary` snippet. Read the message here whenever \
+the answer depends on what somebody actually said rather than on the fact that a matching message \
+exists — and never present a snippet as the message. A message browse_channel returned needs no \
+read: that tool answers with the whole message already.
 
-`uri` takes a handle this connector produced, in one of exactly two shapes:
+`uri` takes a handle this connector produced, in one of exactly three shapes:
   teams:///chats/{chat_id}/messages/{message_id}
   teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}
+  teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}
 Nothing else is readable. This connector serves Microsoft Teams messages, so no handle here names \
 mail, a calendar event, a file, a SharePoint page or a meeting transcript, and nothing turns a \
-person's name or a chat topic into one — pass the `uri` from a search result verbatim.
+person's name or a chat topic into one — pass the `uri` from a tool result verbatim. The third \
+shape is the one only browse_channel emits: Microsoft addresses a reply in a channel thread under \
+the post it answers, and a search result does not say which post that is.
 
 `text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
 `- `, an attachment as `[attachment: name]`, an inline image as `[image]` and a card as `[card]`. \
@@ -283,12 +372,13 @@ what happened, and inventing the wording of one is a fabrication.\
 # What the tool says when `uri` is not a handle at all. This is the failure that is *our* fault to
 # explain — the two below are Microsoft's answers — so it is the one that shows the shapes.
 _BAD_HANDLE = (
-    "read_message takes a `uri` handle that search_messages produced, and this is not one. A "
-    + "readable handle has one of exactly two shapes:\n"
+    "read_message takes a `uri` handle that search_messages or browse_channel produced, and this "
+    + "is not one. A readable handle has one of exactly three shapes:\n"
     + "  teams:///chats/{chat_id}/messages/{message_id}\n"
     + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}\n"
+    + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}\n"
     + "with the ids percent-encoded, e.g. "
-    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a search "
+    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a tool "
     + "result rather than assembling one, and note that this connector reads Teams messages only — "
     + "no mail, files, sites or meetings are addressable here. Retrying this value will fail "
     + "identically."
@@ -301,9 +391,11 @@ _UNREADABLE = (
     + "argument — and it is not evidence that the message does not exist: Graph answers 'deleted', "
     + "'never existed' and 'the signed-in user may not see it' with the same 404, and does not say "
     + "which of them it meant. Report that the message could not be read, never that it was never "
-    + "written. Retrying will not help and this connector has no other route to the text. (A reply "
-    + "inside a channel thread is also addressed under its parent post, which this handle shape "
-    + "cannot express.)"
+    + "written. Retrying will not help and this connector has no other route to the text. One "
+    + "well-formed handle always fails this way: a reply in a channel thread is addressed under "
+    + "the post it answers, and a search result does not identify that post — so a search hit that "
+    + "is a reply cannot be read from its own handle. Browse that channel with browse_channel, "
+    + "which emits the reply's own handle and returns its text outright."
 )
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
@@ -356,6 +448,118 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 graph_client_for(transport, graph_token),
                 limit=limit,
                 include_member_emails=include_member_emails,
+            )
+
+    @mcp.tool(
+        name="list_teams",
+        title="List My Teams",
+        description=_LIST_TEAMS,
+        annotations=_READ_ONLY,
+    )
+    async def list_teams(
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=channels.MAX_LISTED,
+                description=(
+                    "How many teams to return. Default 50, maximum "
+                    + f"{channels.MAX_LISTED} — Microsoft Graph applies no page size to this "
+                    + "collection, so this is a window this connector applies while paging it."
+                ),
+            ),
+        ] = 50,
+        graph_token: str = _TEAMS_TOKEN,
+    ) -> channels.TeamList:
+        with graph_tool_errors(channels.TEAMS_PERMISSION):
+            return await channels.list_teams(graph_client_for(transport, graph_token), limit=limit)
+
+    @mcp.tool(
+        name="list_channels",
+        title="List a Team's Channels",
+        description=_LIST_CHANNELS,
+        annotations=_READ_ONLY,
+    )
+    async def list_channels(
+        team_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The team whose channels to list, exactly as list_teams reported its "
+                    + "`team_id`. Opaque — a team's name is not one, and one cannot be "
+                    + "constructed."
+                ),
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=channels.MAX_LISTED,
+                description=(
+                    "How many channels to return. Default 50, maximum "
+                    + f"{channels.MAX_LISTED} — as with list_teams, Microsoft Graph applies no "
+                    + "page size here and this is the window applied while paging."
+                ),
+            ),
+        ] = 50,
+        graph_token: str = _CHANNELS_TOKEN,
+    ) -> channels.ChannelList:
+        with graph_tool_errors(channels.CHANNELS_PERMISSION):
+            return await channels.list_channels(
+                graph_client_for(transport, graph_token), team_id=team_id, limit=limit
+            )
+
+    @mcp.tool(
+        name="browse_channel",
+        title="Browse a Teams Channel",
+        description=_BROWSE_CHANNEL,
+        annotations=_READ_ONLY,
+    )
+    async def browse_channel(
+        team_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The team the channel belongs to, exactly as list_teams reported its "
+                    + "`team_id`. A channel id alone does not address a channel."
+                ),
+            ),
+        ],
+        channel_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The channel to read, exactly as list_channels reported its `channel_id` (or "
+                    + "as search_messages reported `channel_id` on a channel message). Opaque — a "
+                    + "channel's name is not one."
+                ),
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=channels.MAX_POSTS,
+                description=(
+                    "How many posts to return, each with its replies. Default 20 and maximum "
+                    + f"{channels.MAX_POSTS} — both Microsoft Graph's own, for this collection. "
+                    + "System messages are dropped after Graph counts them, so a page can hold "
+                    + "fewer posts than this."
+                ),
+            ),
+        ] = 20,
+        graph_token: str = _POSTS_TOKEN,
+    ) -> channels.ChannelPosts:
+        with graph_tool_errors(channels.POSTS_PERMISSION):
+            return await channels.browse_channel(
+                graph_client_for(transport, graph_token),
+                team_id=team_id,
+                channel_id=channel_id,
+                limit=limit,
             )
 
     # Declared and registered in two steps rather than with `@mcp.tool`, which does both and hands

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -11,7 +11,7 @@ model reads this surface as one thing:
 
 * **A name is `verb_noun`** — `get_me`, `list_chats`, `list_teams`, `list_channels`,
   `browse_channel`, `search_messages`, `read_message`, `list_meeting_transcripts`,
-  `read_transcript` — naming what the tool does and what it does
+  `read_transcript`, `list_meeting_recordings` — naming what the tool does and what it does
   it to. `whoami` was the one exception and is now `get_me`:
   the shell idiom made the odd tool out of the very tool a model calls first, and renaming a tool
   is a breaking change best spent before there are more of them. (Microsoft's own M365 connector
@@ -50,6 +50,7 @@ from office_mcp.features import (
     identity,
     message_read,
     message_search,
+    recordings,
     transcripts,
 )
 from office_mcp.graph_client import graph_client_for
@@ -86,6 +87,7 @@ GRAPH_SCOPES: tuple[str, ...] = tuple(
             *message_search.GRAPH_PERMISSIONS,
             *message_read.GRAPH_PERMISSIONS,
             *transcripts.LISTING_PERMISSIONS,
+            *recordings.LISTING_PERMISSIONS,
         )
     )
 )
@@ -162,6 +164,7 @@ _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 _READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 _TRANSCRIPT_LIST_TOKEN: str = _graph_token(*transcripts.LISTING_PERMISSIONS)
 _TRANSCRIPT_TOKEN: str = _graph_token(transcripts.TRANSCRIPT_PERMISSION)
+_RECORDING_LIST_TOKEN: str = _graph_token(*recordings.LISTING_PERMISSIONS)
 
 _GET_ME = """\
 Return the signed-in Microsoft 365 user's own profile: `user_id`, `display_name`, `email`, \
@@ -196,8 +199,9 @@ listed by list_teams and list_channels, and are read by browse_channel.
 
 **This is also how a meeting is found.** A `meeting` chat is the conversation attached to a Teams \
 meeting, its `topic` is the meeting's subject, and it carries `meeting_uri` — the handle \
-list_meeting_transcripts takes. So "what was decided in the pricing call last Tuesday" starts \
-here: find the meeting chat by topic and recency, then follow its `meeting_uri`. There is no \
+list_meeting_transcripts and list_meeting_recordings both take. So "what was decided in the \
+pricing call last Tuesday" and "was that call recorded" both start here: find the meeting chat by \
+topic and recency, then follow its `meeting_uri`. There is no \
 separate meeting-search tool because this list already answers which meeting, and no Microsoft \
 calendar permission is involved. `meeting_uri` is null on every non-meeting chat, and null on a \
 meeting chat Microsoft returned no join URL for — that meeting's transcript is then unreachable \
@@ -464,9 +468,12 @@ transcripts once the meeting expires, roughly 60 days after a one-off.)
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
 see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
 
-This connector reads transcripts, not recordings: no video is returned or reachable here, and a \
-transcript is the better artifact for answering a question about a meeting anyway — it is text, \
-with who said what and when.
+This tool answers about transcripts only. Whether the meeting was RECORDED is a separate question \
+with a separate answer — list_meeting_recordings, which takes the same `meeting_uri` — because \
+Microsoft gates the two independently: the tenant setting below blocks transcripts and leaves \
+recordings alone, so when this call is refused that one may still answer. No video is returned or \
+reachable anywhere in this connector; a transcript is the better artifact for a question about a \
+meeting anyway, being text with who said what and when.
 
 Two things can refuse this call outright, and both are somebody's decision rather than a bug. \
 Reading transcripts over Microsoft Graph is an organisation-wide Teams setting that is OFF by \
@@ -518,18 +525,86 @@ call re-fetches the whole transcript from Microsoft, so a wider `limit` (up to \
 summarised as the whole meeting.\
 """
 
+_LIST_MEETING_RECORDINGS = f"""\
+Find out whether a Teams meeting was recorded, how long the recording runs, and whether the \
+signed-in user is allowed to download it. Takes the same `meeting_uri` that list_chats reports on \
+a meeting chat.
+
+This is the only tool here that answers "was Tuesday's call recorded" — and it answers it with \
+metadata, never with video. **No video is returned or reachable anywhere in this connector.** A \
+Teams meeting can run 30 hours, Microsoft serves a recording as one MP4 byte stream, and a model \
+cannot watch video, so returning it would be neither possible nor useful. What comes back is what \
+can actually be acted on: that a recording exists, when it started and stopped, how long it runs, \
+who may download it, and which transcript is the same call.
+
+**`content_access` is the "can I get at it" answer, and it is not about this connector.** \
+Microsoft documents recording download as ORGANISER-ONLY under delegated access — "Meeting \
+participants don't have permission to download meeting recordings" — unless a tenant administrator \
+has unblocked participants. So `organizer_only` means the recording is real and its video is out \
+of this user's reach: say it exists, say who has it (`organizer_user_id`, comparable with get_me's \
+`user_id`), and offer the transcript instead. \
+Never report an `organizer_only` recording as a missing one. \
+`you_are_the_organizer` means Microsoft permits this user to download it in Teams or SharePoint — \
+not here, and an administrator can still have blocked recording downloads tenant-wide.
+
+**The readable artifact is the transcript, and `content_correlation_id` is the exact link to it.** \
+For any question about what was said, call list_meeting_transcripts for the same meeting and read \
+the transcript whose `content_correlation_id` matches this recording's: that is Microsoft's own \
+identifier for "these two are the same call". Reach for this tool when the question is about the \
+recording itself — was there one, how long, who has it — or when list_meeting_transcripts has \
+already said `not_transcribed` and the remaining question is whether anything was captured at all.
+
+**Read `status` before anything else. It has four values and they mean four different actions:**
+- `available` — recordings are listed, with durations and access.
+- `not_ready` — nothing has landed for the window you asked about and something still might: that \
+window has only just closed, or you asked for no window and the meeting has not ended or ended \
+recently. Wait and call again later. This is NOT "the call was not recorded", and reporting it as \
+one is wrong: Microsoft publishes no availability SLA for a recording, so this tool infers it from \
+how recently the window (or the meeting) ended and errs towards telling you to wait. An occurrence \
+window that is already well past never answers this.
+- `not_recorded` — the window you asked about is over and nothing is there: nobody recorded it. \
+Retrying will not help. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
+artifacts once the meeting expires, roughly 60 days after a one-off.)
+- `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
+see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
+
+`duration_seconds` is computed from the recording's own start and end, because Microsoft publishes \
+no duration property at all; it is null where either timestamp is missing, and it is the \
+recording's length rather than the meeting's. Scope a recurring series to one occurrence with \
+`started_after`/`started_before`, exactly as with list_meeting_transcripts — a whole series is one \
+meeting to Microsoft, so every occurrence's recording is in the same collection. Both bounds take \
+a date (`2026-08-11`, meaning that whole UTC day) or a timestamp with or without an offset; one \
+without is read as UTC.
+
+Unlike transcripts, recordings are NOT behind the tenant-wide Teams switch for Graph transcript \
+access, so this tool can succeed in an organisation where list_meeting_transcripts is refused \
+outright. Reading recordings does need its own admin-consented permission \
+({recordings.RECORDING_PERMISSION}); when Microsoft refuses this call the error names it.\
+"""
+
 # What each reader says when its `uri` is not one of its own handles. Separate texts because the two
 # handle families are separate: pointing a caller at the wrong tool is the failure these prevent.
-_NOT_A_MEETING_HANDLE = (
-    "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
-    + "and this is not one. A meeting handle has exactly one shape:\n"
-    + "  teams:///meetings/{join_web_url}\n"
-    + "with the join URL percent-encoded. It cannot be assembled — Microsoft addresses a meeting "
-    + "by the join URL of the Teams meeting itself, which only Microsoft can supply — so call "
-    + "list_chats, find the `meeting` chat for the meeting in question, and pass its `meeting_uri` "
-    + "verbatim. A chat id, a chat topic, a Teams web link and a `teams:///transcripts/...` handle "
-    + "are none of them a meeting handle. Retrying this value will fail identically."
-)
+
+
+def _not_a_meeting_handle(tool: str) -> str:
+    """The refusal for a `meeting_uri` that is not a meeting handle, named for the tool that got it.
+
+    One text with the tool's name substituted rather than one per tool: both meeting listers take
+    the same handle from the same place, so the advice differs in exactly one word and two copies of
+    it would be free to drift.
+    """
+    return (
+        f"{tool} takes the `meeting_uri` that list_chats reports on a meeting chat, "
+        + "and this is not one. A meeting handle has exactly one shape:\n"
+        + "  teams:///meetings/{join_web_url}\n"
+        + "with the join URL percent-encoded. It cannot be assembled — Microsoft addresses a "
+        + "meeting by the join URL of the Teams meeting itself, which only Microsoft can supply — "
+        + "so call list_chats, find the `meeting` chat for the meeting in question, and pass its "
+        + "`meeting_uri` verbatim. A chat id, a chat topic, a Teams web link and a "
+        + "`teams:///transcripts/...` handle are none of them a meeting handle. Retrying this "
+        + "value will fail identically."
+    )
+
 
 _NOT_A_TRANSCRIPT_HANDLE = (
     "read_transcript takes the `uri` of a transcript that list_meeting_transcripts returned, and "
@@ -988,7 +1063,7 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
     ) -> transcripts.MeetingTranscripts:
         handle = transcripts.meeting_handle(meeting_uri)
         if handle is None:
-            raise ToolError(_NOT_A_MEETING_HANDLE)
+            raise ToolError(_not_a_meeting_handle("list_meeting_transcripts"))
         with graph_tool_errors(*transcripts.LISTING_PERMISSIONS):
             return await transcripts.list_meeting_transcripts(
                 graph_client_for(transport, graph_token),
@@ -1105,6 +1180,84 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 from_seconds=from_seconds,
                 to_seconds=to_seconds,
                 speaker=speaker,
+            )
+
+    @mcp.tool(
+        name="list_meeting_recordings",
+        title="List a Meeting's Recordings",
+        description=_LIST_MEETING_RECORDINGS,
+        annotations=_READ_ONLY,
+    )
+    async def list_meeting_recordings(
+        meeting_uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The meeting whose recordings to list, exactly as list_chats reported "
+                    + "`meeting_uri` on a meeting chat: `teams:///meetings/{join_web_url}` — the "
+                    + "same handle list_meeting_transcripts takes. Copy it verbatim; it carries "
+                    + "the meeting's join URL, which Microsoft matches character for character."
+                ),
+            ),
+        ],
+        started_after: Annotated[
+            date | datetime | None,
+            Field(
+                description=(
+                    "Only recordings that began at or after this moment. This is how to reach one "
+                    + "occurrence of a recurring meeting, whose occurrences all share a single "
+                    + "meeting and therefore a single recording collection. Three shapes are "
+                    + "accepted and none of them fails: `2026-08-11T09:00:00+02:00` (or `...Z`) "
+                    + "means the instant it names; `2026-08-11T09:00:00`, which names no offset, "
+                    + "IS READ AS UTC; and a bare `2026-08-11` means that whole UTC day, starting "
+                    + "at its first instant here. Pass the offset whenever what you know is a "
+                    + "local time — 09:00 in Zurich is 07:00Z. A window with no recording inside "
+                    + "it is an answer and not an error: `not_recorded` once the window is past, "
+                    + "`not_ready` while it is recent."
+                )
+            ),
+        ] = None,
+        started_before: Annotated[
+            date | datetime | None,
+            Field(
+                description=(
+                    "Only recordings that began at or before this moment. Pair it with "
+                    + "`started_after` to bracket one occurrence; the same three shapes are "
+                    + "accepted on the same UTC assumption, except that a bare `2026-08-11` here "
+                    + "means the END of that UTC day — so the same date in both bounds is that one "
+                    + "whole day. This bound is also what decides an empty answer: a window whose "
+                    + "end is already well past reports `not_recorded` rather than sending you "
+                    + "back to wait, even for a recurring series with occurrences still to come."
+                )
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=recordings.MAX_RECORDINGS,
+                description=(
+                    "How many recordings to return, newest first. Default 20, maximum "
+                    + f"{recordings.MAX_RECORDINGS}. A meeting has one recording per occurrence "
+                    + "that was recorded — two if somebody stopped and restarted — so only a "
+                    + "long-running recurring series reaches this; `truncated` says when the "
+                    + "window was too small."
+                ),
+            ),
+        ] = 20,
+        graph_token: str = _RECORDING_LIST_TOKEN,
+    ) -> recordings.MeetingRecordings:
+        handle = transcripts.meeting_handle(meeting_uri)
+        if handle is None:
+            raise ToolError(_not_a_meeting_handle("list_meeting_recordings"))
+        with graph_tool_errors(*recordings.LISTING_PERMISSIONS):
+            return await recordings.list_meeting_recordings(
+                graph_client_for(transport, graph_token),
+                handle=handle,
+                started_after=started_after,
+                started_before=started_before,
+                limit=limit,
             )
 
 

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -9,19 +9,23 @@ otherwise need a process-wide service holder for.
 The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
 token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
 for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
-tool's input schema — the model cannot see it and cannot supply it.
+tool's input schema — the model cannot see it and cannot supply it. `_GraphToken` wraps it for
+one reason: a dependency is resolved *outside* the tool body, so an exchange Entra refuses cannot
+be explained by anything the body does.
 """
 
-from typing import Annotated
+from types import TracebackType
+from typing import Annotated, cast, override
 
 import httpx
 from fastmcp import FastMCP
+from fastmcp.dependencies import Dependency
 from fastmcp.server.auth.providers.azure import EntraOBOToken
 from pydantic import Field
 
 from office_mcp.features import chats, identity
 from office_mcp.graph_client import graph_client_for
-from office_mcp.server.errors import graph_tool_errors
+from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 # A Graph delegated permission, as a scope the On-Behalf-Of exchange can ask for. Graph accepts a
 # bare permission name at the authorize endpoint too, but only because it is the default resource;
@@ -43,14 +47,63 @@ GRAPH_SCOPES: tuple[str, ...] = (
     _scope(chats.GRAPH_PERMISSION),
 )
 
-# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per Graph
-# permission. Built here rather than inline because a call inside a parameter default rebuilds the
-# descriptor on every registration and is a lint error in both of this repo's checkers. Sharing one
-# instance is safe: FastMCP enters it per call and it holds nothing but its scopes. The declared
-# type is `str` because a token is what FastMCP injects in its place — the tool body never sees
-# this object.
-_IDENTITY_TOKEN: str = EntraOBOToken([_scope(identity.GRAPH_PERMISSION)])
-_CHATS_TOKEN: str = EntraOBOToken([_scope(chats.GRAPH_PERMISSION)])
+
+class _GraphToken(Dependency[str]):
+    """`EntraOBOToken` for one permission, with the refusal explained in terms of it.
+
+    The wrapping exists because of *where* the exchange happens. FastMCP resolves a dependency
+    before it calls the tool, so a failure there never enters the tool body and never reaches the
+    `graph_tool_errors` block inside it; FastMCP reports it as "Failed to resolve dependency
+    'graph_token' for list_chats", which tells a model nothing it can act on. The one thing it
+    does pass through untouched is a `FastMCPError` — so raising `ToolError` here, from the
+    permission this instance was built for, is what makes an unconsented permission as fixable
+    before the Graph call as a 403 is after it.
+
+    The exchange itself is untouched: `__aenter__` delegates to FastMCP's dependency, which owns
+    the credential cache, and `__aexit__` delegates so any cleanup it grows is not dropped.
+    """
+
+    def __init__(self, permission: str) -> None:
+        self._permission: str = permission
+        # `EntraOBOToken` is annotated `-> str` (a lie for the type checker's benefit, so a tool
+        # can annotate the token as the string it receives); the value is the dependency object.
+        # Casting back to what it is has to go through `object` — the two types do not overlap.
+        self._exchange: Dependency[str] = cast(
+            "Dependency[str]", cast("object", EntraOBOToken([_scope(permission)]))
+        )
+
+    @override
+    async def __aenter__(self) -> str:
+        with entra_token_errors(self._permission):
+            return await self._exchange.__aenter__()
+
+    @override
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self._exchange.__aexit__(exc_type, exc_value, traceback)
+
+
+def _graph_token(permission: str) -> str:
+    """A `_GraphToken` typed as the token FastMCP will inject in its place.
+
+    The same annotation `EntraOBOToken` uses, for the same reason: the tool body is handed a
+    string and should say so, and the dependency object it never sees would otherwise have to be
+    cast at every declaration site. The cast goes through `object` for the same reason it does
+    above — a dependency is not a string, which is precisely why FastMCP replaces it with one.
+    """
+    return cast("str", cast("object", _GraphToken(permission)))
+
+
+# The dependency each tool declares as its token parameter's default, one per Graph permission.
+# Built here rather than inline because a call inside a parameter default rebuilds the descriptor
+# on every registration and is a lint error in both of this repo's checkers. Sharing one instance
+# is safe: FastMCP enters it per call and it holds nothing but its permission.
+_IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
+_CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -84,8 +137,10 @@ defines it as when the chat was renamed or its membership changed, so a chat nob
 for a year can carry yesterday's timestamp. `last_message_at` is null for a chat with no messages.
 
 `members` is returned only for chats whose `topic` is null, because those chats have no other \
-name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and `members_truncated` \
-says when the cap was hit. Set `include_member_emails` when two members share a display name.
+name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and sends no member \
+total, so `members_may_be_incomplete` says when a list came back full to that cap — people may \
+be missing from it, and Graph will not say whether they are. Set `include_member_emails` when \
+two members share a display name.
 
 There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
 the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -14,16 +14,21 @@ one reason: a dependency is resolved *outside* the tool body, so an exchange Ent
 be explained by anything the body does.
 """
 
+from datetime import date
 from types import TracebackType
 from typing import Annotated, cast, override
+from uuid import UUID
 
 import httpx
 from fastmcp import FastMCP
 from fastmcp.dependencies import Dependency
+from fastmcp.exceptions import ToolError
 from fastmcp.server.auth.providers.azure import EntraOBOToken
+from fastmcp.tools import Tool
+from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import chats, identity
+from office_mcp.features import chats, identity, message_search
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -39,42 +44,59 @@ def _scope(permission: str) -> str:
 
 # What sign-in must ask Entra for, so that the On-Behalf-Of exchange has something to redeem: a
 # Graph permission the user (or an administrator) never consented to cannot be obtained later, and
-# the exchange fails with AADSTS65001 rather than with anything a tool could explain. `create_app`
+# the exchange fails with AADSTS65001 before the tool body runs. `_GraphToken` below turns that into
+# advice, but a failure avoided at consent time beats one explained per call. `create_app`
 # passes this to the auth provider — which is why it is the union of every tool's permission, and
 # why it lives beside the tools that determine it.
-GRAPH_SCOPES: tuple[str, ...] = (
-    _scope(identity.GRAPH_PERMISSION),
-    _scope(chats.GRAPH_PERMISSION),
+GRAPH_SCOPES: tuple[str, ...] = tuple(
+    # `dict.fromkeys` rather than a set: two tools sharing a permission must not make the scope
+    # list a different string on every process start, or the consent screen and every cached
+    # On-Behalf-Of token key change with it.
+    dict.fromkeys(
+        _scope(permission)
+        for permission in (
+            identity.GRAPH_PERMISSION,
+            chats.GRAPH_PERMISSION,
+            *message_search.GRAPH_PERMISSIONS,
+        )
+    )
 )
 
 
 class _GraphToken(Dependency[str]):
-    """`EntraOBOToken` for one permission, with the refusal explained in terms of it.
+    """`EntraOBOToken` for a tool's permissions, with the refusal explained in terms of them.
 
     The wrapping exists because of *where* the exchange happens. FastMCP resolves a dependency
     before it calls the tool, so a failure there never enters the tool body and never reaches the
     `graph_tool_errors` block inside it; FastMCP reports it as "Failed to resolve dependency
     'graph_token' for list_chats", which tells a model nothing it can act on. The one thing it
     does pass through untouched is a `FastMCPError` — so raising `ToolError` here, from the
-    permission this instance was built for, is what makes an unconsented permission as fixable
+    permissions this instance was built for, is what makes an unconsented permission as fixable
     before the Graph call as a 403 is after it.
+
+    One instance covers one exchange, however many permissions that exchange asks for, because
+    Entra redeems them together and refuses them together: a tool needing two gets one token or
+    none. Naming all of them is therefore the same requirement as it is for a 403 — the refusal
+    does not say which one was missing.
 
     The exchange itself is untouched: `__aenter__` delegates to FastMCP's dependency, which owns
     the credential cache, and `__aexit__` delegates so any cleanup it grows is not dropped.
     """
 
-    def __init__(self, permission: str) -> None:
-        self._permission: str = permission
+    def __init__(self, *permissions: str) -> None:
+        assert permissions, "a token is exchanged for at least one permission"
+        self._permissions: tuple[str, ...] = permissions
         # `EntraOBOToken` is annotated `-> str` (a lie for the type checker's benefit, so a tool
         # can annotate the token as the string it receives); the value is the dependency object.
         # Casting back to what it is has to go through `object` — the two types do not overlap.
         self._exchange: Dependency[str] = cast(
-            "Dependency[str]", cast("object", EntraOBOToken([_scope(permission)]))
+            "Dependency[str]",
+            cast("object", EntraOBOToken([_scope(permission) for permission in permissions])),
         )
 
     @override
     async def __aenter__(self) -> str:
-        with entra_token_errors(self._permission):
+        with entra_token_errors(*self._permissions):
             return await self._exchange.__aenter__()
 
     @override
@@ -87,7 +109,7 @@ class _GraphToken(Dependency[str]):
         await self._exchange.__aexit__(exc_type, exc_value, traceback)
 
 
-def _graph_token(permission: str) -> str:
+def _graph_token(*permissions: str) -> str:
     """A `_GraphToken` typed as the token FastMCP will inject in its place.
 
     The same annotation `EntraOBOToken` uses, for the same reason: the tool body is handed a
@@ -95,15 +117,17 @@ def _graph_token(permission: str) -> str:
     cast at every declaration site. The cast goes through `object` for the same reason it does
     above — a dependency is not a string, which is precisely why FastMCP replaces it with one.
     """
-    return cast("str", cast("object", _GraphToken(permission)))
+    return cast("str", cast("object", _GraphToken(*permissions)))
 
 
-# The dependency each tool declares as its token parameter's default, one per Graph permission.
-# Built here rather than inline because a call inside a parameter default rebuilds the descriptor
-# on every registration and is a lint error in both of this repo's checkers. Sharing one instance
-# is safe: FastMCP enters it per call and it holds nothing but its permission.
+# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per set of
+# Graph permissions a tool calls under. Built here rather than inline because a call inside a
+# parameter default rebuilds the descriptor on every registration and is a lint error in both of
+# this repo's checkers. Sharing one instance is safe: FastMCP enters it per call and it holds
+# nothing but its permissions.
 _IDENTITY_TOKEN: str = _graph_token(identity.GRAPH_PERMISSION)
 _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
+_SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 
 _WHOAMI = """\
 Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
@@ -147,6 +171,52 @@ the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Gra
 for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
 chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
 """
+
+_SEARCH_MESSAGES = f"""\
+Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
+chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
+and read state. Messages from ANY participant match, not only the user's own; call whoami if you \
+need to know who the user is.
+
+A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
+view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
+truncated with `...` where it was cut — is the only text here. Every hit carries a `uri` handle \
+identifying that exact message; read that resource for the real text, the attachments and the \
+mentions. Never present `summary` as the whole message, and never conclude from it that the \
+message does not say more.
+
+There is no result total, and this is not an omission: Microsoft Graph reports a per-page count \
+rather than a match count for Teams messages, so a total would be a fabrication. Page by passing \
+`next_offset` back as `offset` while `more_results_available` is true. A page can hold fewer than \
+`size` messages — offsets index Graph's own results, and system messages ("Ada joined the chat") \
+are dropped from ours because Graph gives them neither an author nor any text.
+
+Results cannot be sorted: Graph refuses sort options on a message search. Its documented default \
+for message results is newest first and relevance can be mixed in, so compare `created_at` \
+whenever order matters to the answer.
+
+At least one criterion is required and all criteria given are ANDed. `query` is matched as plain \
+words and every word must appear, anywhere in the message and in any order — the words do not have \
+to be next to each other. To require that they are, quote them yourself: `"release notes"` matches \
+only where those two words are adjacent. Search operators typed into `query` are searched for \
+literally, so put a sender in `sender`, a date in `sent_after`/`sent_before`, and so on. Those two \
+dates are inclusive whole days and are \
+applied by the index itself, so a date-bounded search still costs one request and still covers \
+channels. `recipient` is honoured by Microsoft only for one-to-one chats and will hide group and \
+channel matches, so prefer `sender`. Channel matches need the delegated \
+{message_search.CHANNEL_PERMISSION} permission, which this connector requires at sign-in rather \
+than degrading to chats-only search without saying so.\
+"""
+
+# What the tool says when it is called with nothing to look for. Graph would answer such a request
+# with an arbitrary slice of everything the user can read, which reads like a real result set and
+# is the one failure mode a model cannot detect from the response.
+_NO_CRITERIA = (
+    "search_messages needs at least one of "
+    + ", ".join(message_search.CRITERIA)
+    + ". Searching with none of them would return an arbitrary sample of every message the user "
+    + "can see, not an answer. Add the keywords, person or date range the question is about."
+)
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
 
@@ -196,3 +266,161 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 limit=limit,
                 include_member_emails=include_member_emails,
             )
+
+    # Declared and registered in two steps rather than with `@mcp.tool`, which does both and hands
+    # back the function: `add_tool` returns the registered tool, which is the only way to reach the
+    # schema `_require_a_criterion` has to add to. Same registration, same metadata.
+    @tool_metadata(
+        name="search_messages",
+        title="Search Teams Messages",
+        description=_SEARCH_MESSAGES,
+        annotations=_READ_ONLY,
+    )
+    async def search_messages(
+        query: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Keywords to find in the message text or in an attachment's contents. Every "
+                    + "word must appear, anywhere in the message and in any order; they are not "
+                    + "matched as a phrase unless you quote them, so `release notes` finds "
+                    + 'messages containing both words and `"release notes"` only messages where '
+                    + "they are adjacent. Never a query language — a search operator written here "
+                    + "is searched for as literal text, so use the other parameters for filters."
+                ),
+            ),
+        ] = None,
+        sender: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only messages from this person, by name, alias or email address. Prefer this "
+                    + "over naming the person in `query`, which would match messages that merely "
+                    + "mention them."
+                ),
+            ),
+        ] = None,
+        recipient: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only messages addressed to this person. Microsoft supports this only "
+                    + "partially, for one-to-one chats, so it hides group-chat and channel "
+                    + "matches: an empty result here is not evidence that no such message exists."
+                ),
+            ),
+        ] = None,
+        mentions: Annotated[
+            UUID | None,
+            Field(
+                description=(
+                    "Only messages that @-mention this user, by Microsoft Entra object id (the "
+                    + "`user_id` of a sender here, or `id` from whoami). A name will not work: "
+                    + "Microsoft matches this term on the id alone."
+                )
+            ),
+        ] = None,
+        sent_after: Annotated[
+            date | None,
+            Field(
+                description=(
+                    "Only messages sent on or after this date (YYYY-MM-DD), inclusive. Applied by "
+                    + "Microsoft's index, so it costs nothing extra and narrows chats and "
+                    + "channels alike."
+                )
+            ),
+        ] = None,
+        sent_before: Annotated[
+            date | None,
+            Field(description="Only messages sent on or before this date (YYYY-MM-DD), inclusive."),
+        ] = None,
+        has_attachment: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages carrying an attachment, false for only messages "
+                    + "without one. Omit to search both."
+                )
+            ),
+        ] = None,
+        is_read: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages the signed-in user has read, false for only unread "
+                    + "ones. Omit to search both."
+                )
+            ),
+        ] = None,
+        mentions_me: Annotated[
+            bool | None,
+            Field(
+                description=(
+                    "True for only messages that @-mention the signed-in user, false for only "
+                    + "messages that do not. Omit to search both."
+                )
+            ),
+        ] = None,
+        offset: Annotated[
+            int,
+            Field(
+                ge=0,
+                description=(
+                    "How many results to skip. Start at 0 and pass the previous response's "
+                    + "`next_offset` to advance; it is an index into Microsoft's results, not "
+                    + "into the messages this tool returned."
+                ),
+            ),
+        ] = 0,
+        size: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=message_search.MAX_RESULTS,
+                description=(
+                    "How many results to ask Microsoft for. Default 25, maximum "
+                    + f"{message_search.MAX_RESULTS} — Microsoft documents no page size above "
+                    + "that for message search."
+                ),
+            ),
+        ] = 25,
+        graph_token: str = _SEARCH_TOKEN,
+    ) -> message_search.MessageSearchResults:
+        criteria = message_search.SearchCriteria(
+            query=query,
+            sender=sender,
+            recipient=recipient,
+            mentions=mentions,
+            sent_after=sent_after,
+            sent_before=sent_before,
+            has_attachment=has_attachment,
+            is_read=is_read,
+            mentions_me=mentions_me,
+        )
+        if criteria.is_empty:
+            raise ToolError(_NO_CRITERIA)
+        with graph_tool_errors(*message_search.GRAPH_PERMISSIONS):
+            return await message_search.search_messages(
+                graph_client_for(transport, graph_token),
+                criteria=criteria,
+                offset=offset,
+                size=size,
+            )
+
+    _require_a_criterion(mcp.add_tool(search_messages))
+
+
+def _require_a_criterion(tool: Tool) -> None:
+    """Put "at least one criterion" in the tool's schema, where a client can enforce it.
+
+    FastMCP derives an input schema from the function signature, and a signature has no way to say
+    that a set of optional parameters cannot all be omitted — so the rule would otherwise live only
+    in the description and in the tool's own runtime check. `anyOf` over one-element `required`
+    lists is the JSON Schema spelling of it, and the registered tool's schema is where it goes.
+    The runtime check stays: FastMCP validates arguments against the signature rather than against
+    this schema, so a client that ignores it must still be refused.
+    """
+    tool.parameters["anyOf"] = [{"required": [name]} for name in message_search.CRITERIA]

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -6,6 +6,20 @@ no registry, no base class and no decorator of our own: `register_tools` closes 
 `create_app` built, which is the whole of what FastMCP's plain-function tool signature would
 otherwise need a process-wide service holder for.
 
+Three conventions hold across every tool here, and a new one is expected to keep them, because a
+model reads this surface as one thing:
+
+* **A name is `verb_noun`** — `get_me`, `list_chats`, `search_messages`, `read_message` — naming
+  what the tool does and what it does it to. `whoami` was the one exception and is now `get_me`:
+  the shell idiom made the odd tool out of the very tool a model calls first, and renaming a tool
+  is a breaking change best spent before there are more of them. (Microsoft's own M365 connector
+  arrived at `get_me` independently, which is one less name for a model to have to learn twice.)
+* **One word for "there is more".** Every tool that answers with a list reports `truncated`, and
+  says in its own description how to get the rest — a wider `limit` where there is no cursor, the
+  `next_offset` where there is. Two words for one idea is how a model comes to guess.
+* **A description teaches the traps, and the neighbours.** Each one says what it answers, when to
+  reach for it rather than for another tool here, and what its answer does *not* mean.
+
 The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
 token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
 for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
@@ -131,21 +145,22 @@ _CHATS_TOKEN: str = _graph_token(chats.GRAPH_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 _READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
 
-_WHOAMI = """\
-Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
+_GET_ME = """\
+Return the signed-in Microsoft 365 user's own profile: `user_id`, `display_name`, `email`, \
 `user_principal_name` and `job_title`.
 
-Call this before anything that turns on who "I", "me" or "my" is: filtering a mail or message \
-search to the signed-in user, deciding which participant of a chat is them, or addressing them by \
-name. It is one cheap request and its answer is stable for the session.
+Call this before anything that turns on who "I", "me" or "my" is: filtering a message search to \
+the signed-in user, deciding which participant of a chat is them, or addressing them by name. It \
+is one cheap request and its answer is stable for the session.
 
-`mail` is the canonical primary SMTP address and the right value to match a sender or recipient \
-against — but it is null for guest and unlicensed accounts, and `user_principal_name` (Microsoft's \
-`userPrincipalName`) is then the best available identifier. Do not treat the two as \
-interchangeable when both are present: a tenant can issue a user_principal_name on a different \
-domain from the mail address, so matching message addresses against it can silently return \
-nothing. Compare `id` — the immutable directory object id — against user ids from other tools; \
-compare `mail` against addresses.\
+`email` is the canonical primary SMTP address (Microsoft's `mail`) and the right value to match a \
+sender or recipient against — but it is null for guest and unlicensed accounts, and \
+`user_principal_name` (Microsoft's `userPrincipalName`) is then the best available identifier. Do \
+not treat the two as interchangeable when both are present: a tenant can issue a \
+user_principal_name on a different domain from the email address, so matching message addresses \
+against it can silently return nothing. Compare `user_id` — the immutable directory object id — \
+against the `user_id` of a message's sender or of a mention; compare `email` against an address, \
+which is all a chat's member list gives you to match on.\
 """
 
 _LIST_CHATS = f"""\
@@ -153,8 +168,13 @@ List the Microsoft Teams chats the signed-in user is a member of — one-to-one,
 chats — most recently active first, with each chat's id, type, topic, last-message time and (for \
 unnamed chats) its members.
 
-Use it to find the `chat_id` that a chat-scoped tool needs, or to see which conversations are \
-live. This returns chats only: Teams channels live inside teams and are not part of this list.
+Reach for this to see which conversations are live, who is in them, and when each was last posted \
+in — never for what was said in them: no message text is returned here, and search_messages is the \
+only route to any. The other use is naming: a `chat_id` here is the same id search_messages puts \
+on every chat message it finds, so this list is how a found message gets a topic and a set of \
+participants. It is not an argument to anything — no tool here takes a chat id, and a search \
+cannot be narrowed to one chat. This returns chats only: Teams channels live inside teams and are \
+not part of this list.
 
 Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
 the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
@@ -171,14 +191,17 @@ two members share a display name.
 There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
 the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \
 for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
-chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
+chat is usually the oneOnOne chat whose only member is them (call get_me to know who that is; a \
+member is matched by display name or, with `include_member_emails`, by email — this list carries \
+no user ids).\
 """
 
 _SEARCH_MESSAGES = f"""\
 Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
 chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
-and read state. Messages from ANY participant match, not only the user's own; call whoami if you \
-need to know who the user is.
+and read state. Messages from ANY participant match, not only the user's own; call get_me if you \
+need to know who the user is. This is the only tool here that returns messages at all, and the \
+only way to reach a message's text: it finds them, read_message reads one.
 
 A result is metadata plus a snippet, by necessity. Microsoft's search index answers with a reduced \
 view of a message that contains no message body at all, so `summary` — Microsoft's own excerpt, \
@@ -188,10 +211,16 @@ mentions. Never present `summary` as the whole message, and never conclude from 
 message does not say more.
 
 There is no result total, and this is not an omission: Microsoft Graph reports a per-page count \
-rather than a match count for Teams messages, so a total would be a fabrication. Page by passing \
-`next_offset` back as `offset` while `more_results_available` is true. A page can hold fewer than \
-`size` messages — offsets index Graph's own results, and system messages ("Ada joined the chat") \
-are dropped from ours because Graph gives them neither an author nor any text.
+rather than a match count for Teams messages, so a total would be a fabrication. `truncated` says \
+there is more — as it does on every list-shaped tool here — and here the way to get it is to pass \
+`next_offset` back as `offset`. A page can hold fewer than `size` messages: offsets index Graph's \
+own results, and system messages ("Ada joined the chat") are dropped from ours because Graph gives \
+them neither an author nor any text.
+
+The search covers every chat and channel the user belongs to and cannot be narrowed to one of \
+them — Microsoft's index offers no such scope, so there is no chat or channel parameter and a \
+`chat_id` from list_chats is not one. Narrow with `sender`, dates or more words instead, and read \
+`chat_id` (or `team_id`/`channel_id`) on each hit to see where it came from.
 
 Results cannot be sorted: Graph refuses sort options on a message search. Its documented default \
 for message results is newest first and relevance can be mixed in, so compare `created_at` \
@@ -287,13 +316,16 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
     below borrow it per call and never own it. `create_app` closes it on shutdown.
     """
 
-    @mcp.tool(name="whoami", title="Who Am I", description=_WHOAMI, annotations=_READ_ONLY)
-    async def whoami(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
+    @mcp.tool(name="get_me", title="Get My Profile", description=_GET_ME, annotations=_READ_ONLY)
+    async def get_me(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
         with graph_tool_errors(identity.GRAPH_PERMISSION):
             return await identity.get_signed_in_user(graph_client_for(transport, graph_token))
 
     @mcp.tool(
-        name="list_chats", title="List My Chats", description=_LIST_CHATS, annotations=_READ_ONLY
+        name="list_chats",
+        title="List My Teams Chats",
+        description=_LIST_CHATS,
+        annotations=_READ_ONLY,
     )
     async def list_chats(
         limit: Annotated[
@@ -377,7 +409,7 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 description=(
                     "Only messages that @-mention this user, by Microsoft Entra object id (the "
-                    + "`user_id` of a sender here, or `id` from whoami). A name will not work: "
+                    + "`user_id` of a sender here, or from get_me). A name will not work: "
                     + "Microsoft matches this term on the id alone."
                 )
             ),
@@ -494,7 +526,9 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
         ],
         graph_token: str = _READ_TOKEN,
     ) -> message_read.TeamsMessage:
-        handle = message_read.message_handle(uri)
+        # The parser lives with `message_search` because the handle does: search is the only thing
+        # that mints one, and one definition of the shape is what makes a search result readable.
+        handle = message_search.message_handle(uri)
         if handle is None:
             raise ToolError(_BAD_HANDLE)
         # One permission, not both: the handle says which surface is being read, and Graph's 403

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -443,16 +443,22 @@ what was said. Two calls rather than one because a transcript is large and becau
 meeting is a single meeting to Microsoft — every occurrence's transcript lands in the same \
 collection, distinguished only by when transcription started — so which one to read is a decision, \
 not a default. Scope to one occurrence with `started_after`/`started_before` when \
-`meeting_type` comes back `recurring`; a one-off meeting has a single transcript and needs neither.
+`meeting_type` comes back `recurring`; a one-off meeting has a single transcript and needs \
+neither. Both bounds take a date (`2026-08-11`, meaning that whole UTC day) or a timestamp, with \
+or without a timezone offset — one without is read as UTC, so pass the offset when you are working \
+from a local time.
 
 **Read `status` before anything else. It has four values and they mean four different actions:**
 - `available` — transcripts are listed; read one with read_transcript.
-- `not_ready` — the meeting has not ended, or ended recently enough that Microsoft may still be \
-processing the transcript. Wait and call again later. This is NOT "there is no transcript", and \
-reporting it as one is wrong: Microsoft publishes no availability SLA, so this tool infers it from \
-the meeting's end time and errs towards telling you to wait.
-- `not_transcribed` — the meeting is over and nothing is there: it was not recorded or not \
-transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
+- `not_ready` — nothing has landed for the window you asked about and something still might: that \
+window has only just closed, or you asked for no window and the meeting has not ended or ended \
+recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
+is wrong: Microsoft publishes no availability SLA, so this tool infers it from how recently the \
+window (or the meeting) ended and errs towards telling you to wait. An occurrence window that is \
+already well past never answers this — a series whose end date is in the future does not make a \
+last-month occurrence "still processing".
+- `not_transcribed` — the window you asked about is over and nothing is there: it was not recorded \
+or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
 meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
 transcripts once the meeting expires, roughly 60 days after a one-off.)
 - `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
@@ -902,23 +908,34 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             ),
         ],
         started_after: Annotated[
-            datetime | None,
+            date | datetime | None,
             Field(
                 description=(
                     "Only transcripts whose transcription began at or after this moment. This is "
                     + "how to reach one occurrence of a recurring meeting, whose occurrences all "
-                    + "share a single meeting and therefore a single transcript collection. Pass a "
-                    + "timestamp with a timezone offset; a bound with no transcript inside it "
-                    + "answers `not_transcribed` for that window rather than an error."
+                    + "share a single meeting and therefore a single transcript collection. Three "
+                    + "shapes are accepted and none of them fails: `2026-08-11T09:00:00+02:00` (or "
+                    + "`...Z`) means the instant it names; `2026-08-11T09:00:00`, which names no "
+                    + "offset, IS READ AS UTC; and a bare `2026-08-11` means that whole UTC day, "
+                    + "starting at its first instant here. Pass the offset whenever what you know "
+                    + "is a local time — 09:00 in Zurich is 07:00Z, and a window built in the "
+                    + "wrong zone answers about the wrong hours without saying so. A window with "
+                    + "no transcript inside it is an answer and not an error: `not_transcribed` "
+                    + "once the window is past, `not_ready` while it is recent."
                 )
             ),
         ] = None,
         started_before: Annotated[
-            datetime | None,
+            date | datetime | None,
             Field(
                 description=(
                     "Only transcripts whose transcription began at or before this moment. Pair it "
-                    + "with `started_after` to bracket one occurrence."
+                    + "with `started_after` to bracket one occurrence; the same three shapes are "
+                    + "accepted on the same UTC assumption, except that a bare `2026-08-11` here "
+                    + "means the END of that UTC day — so the same date in both bounds is that one "
+                    + "whole day. This bound is also what decides an empty answer: a window whose "
+                    + "end is already well past reports `not_transcribed` rather than sending you "
+                    + "back to wait, even for a recurring series with occurrences still to come."
                 )
             ),
         ] = None,

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -10,7 +10,8 @@ Three conventions hold across every tool here, and a new one is expected to keep
 model reads this surface as one thing:
 
 * **A name is `verb_noun`** — `get_me`, `list_chats`, `list_teams`, `list_channels`,
-  `browse_channel`, `search_messages`, `read_message` — naming what the tool does and what it does
+  `browse_channel`, `search_messages`, `read_message`, `list_meeting_transcripts`,
+  `read_transcript` — naming what the tool does and what it does
   it to. `whoami` was the one exception and is now `get_me`:
   the shell idiom made the odd tool out of the very tool a model calls first, and renaming a tool
   is a breaking change best spent before there are more of them. (Microsoft's own M365 connector
@@ -29,7 +30,7 @@ one reason: a dependency is resolved *outside* the tool body, so an exchange Ent
 be explained by anything the body does.
 """
 
-from datetime import date
+from datetime import date, datetime
 from types import TracebackType
 from typing import Annotated, cast, override
 from uuid import UUID
@@ -43,7 +44,14 @@ from fastmcp.tools import Tool
 from fastmcp.tools import tool as tool_metadata
 from pydantic import Field
 
-from office_mcp.features import channels, chats, identity, message_read, message_search
+from office_mcp.features import (
+    channels,
+    chats,
+    identity,
+    message_read,
+    message_search,
+    transcripts,
+)
 from office_mcp.graph_client import graph_client_for
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
@@ -77,6 +85,7 @@ GRAPH_SCOPES: tuple[str, ...] = tuple(
             channels.POSTS_PERMISSION,
             *message_search.GRAPH_PERMISSIONS,
             *message_read.GRAPH_PERMISSIONS,
+            *transcripts.LISTING_PERMISSIONS,
         )
     )
 )
@@ -151,6 +160,8 @@ _CHANNELS_TOKEN: str = _graph_token(channels.CHANNELS_PERMISSION)
 _POSTS_TOKEN: str = _graph_token(channels.POSTS_PERMISSION)
 _SEARCH_TOKEN: str = _graph_token(*message_search.GRAPH_PERMISSIONS)
 _READ_TOKEN: str = _graph_token(*message_read.GRAPH_PERMISSIONS)
+_TRANSCRIPT_LIST_TOKEN: str = _graph_token(*transcripts.LISTING_PERMISSIONS)
+_TRANSCRIPT_TOKEN: str = _graph_token(transcripts.TRANSCRIPT_PERMISSION)
 
 _GET_ME = """\
 Return the signed-in Microsoft 365 user's own profile: `user_id`, `display_name`, `email`, \
@@ -182,6 +193,15 @@ on every chat message it finds, so this list is how a found message gets a topic
 participants. It is not an argument to anything — no tool here takes a chat id, and a search \
 cannot be narrowed to one chat. This returns chats only: Teams channels live inside teams, are \
 listed by list_teams and list_channels, and are read by browse_channel.
+
+**This is also how a meeting is found.** A `meeting` chat is the conversation attached to a Teams \
+meeting, its `topic` is the meeting's subject, and it carries `meeting_uri` — the handle \
+list_meeting_transcripts takes. So "what was decided in the pricing call last Tuesday" starts \
+here: find the meeting chat by topic and recency, then follow its `meeting_uri`. There is no \
+separate meeting-search tool because this list already answers which meeting, and no Microsoft \
+calendar permission is involved. `meeting_uri` is null on every non-meeting chat, and null on a \
+meeting chat Microsoft returned no join URL for — that meeting's transcript is then unreachable \
+here, and no other tool or argument will reach it.
 
 Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
 the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
@@ -357,11 +377,12 @@ read: that tool answers with the whole message already.
   teams:///chats/{chat_id}/messages/{message_id}
   teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}
   teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}
-Nothing else is readable. This connector serves Microsoft Teams messages, so no handle here names \
-mail, a calendar event, a file, a SharePoint page or a meeting transcript, and nothing turns a \
-person's name or a chat topic into one — pass the `uri` from a tool result verbatim. The third \
-shape is the one only browse_channel emits: Microsoft addresses a reply in a channel thread under \
-the post it answers, and a search result does not say which post that is.
+Nothing else is readable here. No handle of this connector's names mail, a calendar event, a file \
+or a SharePoint page, and nothing turns a person's name or a chat topic into one — pass the `uri` \
+from a tool result verbatim. A meeting transcript is the one other thing this connector reads and \
+it has its own reader: a `teams:///transcripts/...` handle goes to read_transcript, not here. The \
+third shape above is the one only browse_channel emits: Microsoft addresses a reply in a channel \
+thread under the post it answers, and a search result does not say which post that is.
 
 `text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
 `- `, an attachment as `[attachment: name]`, an inline image as `[image]` and a card as `[card]`. \
@@ -386,8 +407,9 @@ _BAD_HANDLE = (
     + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}\n"
     + "with the ids percent-encoded, e.g. "
     + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a tool "
-    + "result rather than assembling one, and note that this connector reads Teams messages only — "
-    + "no mail, files, sites or meetings are addressable here. Retrying this value will fail "
+    + "result rather than assembling one. This reader serves Teams messages only: no mail, files "
+    + "or sites are addressable in this connector at all, and a meeting transcript handle "
+    + "(teams:///transcripts/...) belongs to read_transcript. Retrying this value will fail "
     + "identically."
 )
 
@@ -410,6 +432,107 @@ _UNREADABLE = (
     + "back there is no route to its full text, and a second browse returns the same window. "
     + "Report the search snippet with its sender and date, say the full text could not be "
     + "retrieved, and stop looking."
+)
+
+_LIST_MEETING_TRANSCRIPTS = f"""\
+Find out whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
+`meeting_uri` that list_chats reports on a meeting chat.
+
+This is the first half of reading a meeting: this tool says what exists, read_transcript returns \
+what was said. Two calls rather than one because a transcript is large and because a recurring \
+meeting is a single meeting to Microsoft — every occurrence's transcript lands in the same \
+collection, distinguished only by when transcription started — so which one to read is a decision, \
+not a default. Scope to one occurrence with `started_after`/`started_before` when \
+`meeting_type` comes back `recurring`; a one-off meeting has a single transcript and needs neither.
+
+**Read `status` before anything else. It has four values and they mean four different actions:**
+- `available` — transcripts are listed; read one with read_transcript.
+- `not_ready` — the meeting has not ended, or ended recently enough that Microsoft may still be \
+processing the transcript. Wait and call again later. This is NOT "there is no transcript", and \
+reporting it as one is wrong: Microsoft publishes no availability SLA, so this tool infers it from \
+the meeting's end time and errs towards telling you to wait.
+- `not_transcribed` — the meeting is over and nothing is there: it was not recorded or not \
+transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
+meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
+transcripts once the meeting expires, roughly 60 days after a one-off.)
+- `meeting_not_found` — Microsoft matched the join URL in the handle to no meeting this user can \
+see. Not an error, and not proof the meeting is gone. Do not retry and do not rebuild the handle.
+
+This connector reads transcripts, not recordings: no video is returned or reachable here, and a \
+transcript is the better artifact for answering a question about a meeting anyway — it is text, \
+with who said what and when.
+
+Two things can refuse this call outright, and both are somebody's decision rather than a bug. \
+Reading transcripts over Microsoft Graph is an organisation-wide Teams setting that is OFF by \
+default and that no application can switch on; when it is off, the error says so and names the \
+administrator who can change it. Separately, Microsoft documents transcript access under \
+{transcripts.TRANSCRIPT_PERMISSION} without stating that meeting participants get it, so a \
+participant may be refused where the meeting's organiser would succeed.\
+"""
+
+_READ_TRANSCRIPT = f"""\
+Read what was said in a Teams meeting: the transcript as speaker-attributed, timestamped turns. \
+Takes the `uri` of a transcript that list_meeting_transcripts returned.
+
+This is the payoff of the whole meeting path, and it returns the words themselves rather than a \
+link to them — who spoke, in order, with the offset into the meeting at which they spoke. Quote it \
+as you would quote a message: it is what people actually said, verbatim, and Microsoft's \
+speech-to-text is not perfect, so an odd word is likelier a mis-transcription than a real one.
+
+`uri` takes a handle this connector produced, in exactly one shape:
+  teams:///transcripts/{{meeting_id}}/{{transcript_id}}
+Nothing else is readable here, and nothing turns a meeting's name, its date, its chat or its \
+`meeting_uri` into one — call list_meeting_transcripts and pass its `uri` verbatim. read_message \
+is the reader for a Teams message and takes a different handle; neither tool accepts the other's.
+
+`start_seconds` and `end_seconds` are offsets in seconds from the moment transcription began, not \
+wall-clock times and not offsets from the start of the meeting; add them to the transcript's \
+`started_at` from list_meeting_transcripts if an absolute time is needed. They can be negative, \
+which Microsoft defines as transcription having started after the conversation did.
+
+`speaker_attribution` is false when the organisation has turned speaker names off. The words and \
+timings still come back and every `speaker` is null: do not infer who spoke from the content, and \
+say the transcript is unattributed if the answer turns on who said something.
+
+A long meeting is more turns than fit in one answer. `truncated` says there are more and \
+`next_offset` is where to continue — the same convention every list-shaped tool here uses. Each \
+call re-fetches the whole transcript from Microsoft, so a wider `limit` (up to \
+{transcripts.MAX_TURNS}) costs less than paging through it, and a truncated page must never be \
+summarised as the whole meeting.\
+"""
+
+# What each reader says when its `uri` is not one of its own handles. Separate texts because the two
+# handle families are separate: pointing a caller at the wrong tool is the failure these prevent.
+_NOT_A_MEETING_HANDLE = (
+    "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
+    + "and this is not one. A meeting handle has exactly one shape:\n"
+    + "  teams:///meetings/{join_web_url}\n"
+    + "with the join URL percent-encoded. It cannot be assembled — Microsoft addresses a meeting "
+    + "by the join URL of the Teams meeting itself, which only Microsoft can supply — so call "
+    + "list_chats, find the `meeting` chat for the meeting in question, and pass its `meeting_uri` "
+    + "verbatim. A chat id, a chat topic, a Teams web link and a `teams:///transcripts/...` handle "
+    + "are none of them a meeting handle. Retrying this value will fail identically."
+)
+
+_NOT_A_TRANSCRIPT_HANDLE = (
+    "read_transcript takes the `uri` of a transcript that list_meeting_transcripts returned, and "
+    + "this is not one. A transcript handle has exactly one shape:\n"
+    + "  teams:///transcripts/{meeting_id}/{transcript_id}\n"
+    + "with both ids percent-encoded. Call list_meeting_transcripts with a meeting chat's "
+    + "`meeting_uri` and pass the `uri` of the transcript you want, verbatim. A `meeting_uri` is "
+    + "not a transcript handle — one meeting can have many transcripts — and neither is a Teams "
+    + "message handle. Retrying this value will fail identically."
+)
+
+# Graph's 404 on a well-formed transcript handle. Distinct advice from the message reader's, because
+# the causes are different: a transcript is not deleted by a user, it ages out with its meeting.
+_TRANSCRIPT_UNREADABLE = (
+    "Microsoft 365 would not return this transcript. The handle is well formed, so this is not a "
+    + "bad argument. The likeliest cause is age: Microsoft stops serving a meeting's transcripts "
+    + "once the meeting expires, about 60 days after a one-off meeting, and it answers that "
+    + "identically to a transcript that was removed or that this user may not see. Call "
+    + "list_meeting_transcripts for the meeting again to see what it still has; if the transcript "
+    + "is no longer listed there, it is out of reach and retrying will not bring it back."
 )
 
 _READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
@@ -756,6 +879,124 @@ def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
         with graph_tool_errors(handle.permission, not_found=_UNREADABLE):
             return await message_read.read_message(
                 graph_client_for(transport, graph_token), handle=handle
+            )
+
+    @mcp.tool(
+        name="list_meeting_transcripts",
+        title="List a Meeting's Transcripts",
+        description=_LIST_MEETING_TRANSCRIPTS,
+        annotations=_READ_ONLY,
+    )
+    async def list_meeting_transcripts(
+        meeting_uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The meeting whose transcripts to list, exactly as list_chats reported "
+                    + "`meeting_uri` on a meeting chat: "
+                    + "`teams:///meetings/{join_web_url}`. Copy it verbatim — it carries the "
+                    + "meeting's join URL, which Microsoft matches character for character, and "
+                    + "nothing else identifies a meeting to this connector."
+                ),
+            ),
+        ],
+        started_after: Annotated[
+            datetime | None,
+            Field(
+                description=(
+                    "Only transcripts whose transcription began at or after this moment. This is "
+                    + "how to reach one occurrence of a recurring meeting, whose occurrences all "
+                    + "share a single meeting and therefore a single transcript collection. Pass a "
+                    + "timestamp with a timezone offset; a bound with no transcript inside it "
+                    + "answers `not_transcribed` for that window rather than an error."
+                )
+            ),
+        ] = None,
+        started_before: Annotated[
+            datetime | None,
+            Field(
+                description=(
+                    "Only transcripts whose transcription began at or before this moment. Pair it "
+                    + "with `started_after` to bracket one occurrence."
+                )
+            ),
+        ] = None,
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=transcripts.MAX_TRANSCRIPTS,
+                description=(
+                    "How many transcripts to return, newest first. Default 20, maximum "
+                    + f"{transcripts.MAX_TRANSCRIPTS}. One meeting has one transcript per "
+                    + "occurrence that was transcribed, so only a long-running recurring series "
+                    + "reaches this; `truncated` says when the window was too small."
+                ),
+            ),
+        ] = 20,
+        graph_token: str = _TRANSCRIPT_LIST_TOKEN,
+    ) -> transcripts.MeetingTranscripts:
+        handle = transcripts.meeting_handle(meeting_uri)
+        if handle is None:
+            raise ToolError(_NOT_A_MEETING_HANDLE)
+        with graph_tool_errors(*transcripts.LISTING_PERMISSIONS):
+            return await transcripts.list_meeting_transcripts(
+                graph_client_for(transport, graph_token),
+                handle=handle,
+                started_after=started_after,
+                started_before=started_before,
+                limit=limit,
+            )
+
+    @mcp.tool(
+        name="read_transcript",
+        title="Read a Meeting Transcript",
+        description=_READ_TRANSCRIPT,
+        annotations=_READ_ONLY,
+    )
+    async def read_transcript(
+        uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The transcript to read, exactly as list_meeting_transcripts reported its "
+                    + "`uri`: `teams:///transcripts/{meeting_id}/{transcript_id}`. A meeting's "
+                    + "`meeting_uri` is not one of these, and no other shape is readable here."
+                ),
+            ),
+        ],
+        offset: Annotated[
+            int,
+            Field(
+                ge=0,
+                description=(
+                    "How many turns to skip. Start at 0 and pass the previous response's "
+                    + "`next_offset` to continue through a long meeting."
+                ),
+            ),
+        ] = 0,
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=transcripts.MAX_TURNS,
+                description=(
+                    "How many turns to return. Default 200, maximum "
+                    + f"{transcripts.MAX_TURNS}. Every call fetches the whole transcript from "
+                    + "Microsoft, so widening this is cheaper than paging."
+                ),
+            ),
+        ] = 200,
+        graph_token: str = _TRANSCRIPT_TOKEN,
+    ) -> transcripts.Transcript:
+        handle = transcripts.transcript_handle(uri)
+        if handle is None:
+            raise ToolError(_NOT_A_TRANSCRIPT_HANDLE)
+        with graph_tool_errors(transcripts.TRANSCRIPT_PERMISSION, not_found=_TRANSCRIPT_UNREADABLE):
+            return await transcripts.read_transcript(
+                graph_client_for(transport, graph_token), handle=handle, offset=offset, limit=limit
             )
 
 

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -239,8 +239,10 @@ mail, a calendar event, a file, a SharePoint page or a meeting transcript, and n
 person's name or a chat topic into one — pass the `uri` from a search result verbatim.
 
 `text` is plain text, normalised from Teams' own HTML: a mention reads as `@Name`, a list item as \
-`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and an adaptive card as \
-`[card]`. `mentions` and `attachments` say who and what those refer to.
+`- `, an attachment as `[attachment: name]`, an inline image as `[image]` and a card as `[card]`. \
+`mentions` and `attachments` say who and what those refer to. Nothing else is summarised or \
+abridged — a message that happens to contain JSON, a config fragment or code is somebody's own \
+words and comes back verbatim, and `[card]` appears only where `attachments` names a card.
 
 Two messages have no text and must not be reported as empty ones. A deleted message returns \
 `deleted_at` and no text: say it was deleted. A system event message — somebody joining, a call \

--- a/services/office-mcp/src/office_mcp/server/tools.py
+++ b/services/office-mcp/src/office_mcp/server/tools.py
@@ -1,0 +1,143 @@
+"""The MCP tools, and the one seam every later tool inherits.
+
+A tool is a function that (1) is handed the caller's Microsoft Graph token, (2) borrows the shared
+HTTP transport to call Graph as that caller, and (3) reports a Graph failure as advice. There is
+no registry, no base class and no decorator of our own: `register_tools` closes over the transport
+`create_app` built, which is the whole of what FastMCP's plain-function tool signature would
+otherwise need a process-wide service holder for.
+
+The token comes from `EntraOBOToken`, FastMCP's own On-Behalf-Of dependency: it takes the Entra
+token the caller presented (audience `api://{client_id}`, useless against Graph) and exchanges it
+for a Graph one in the scopes named here. It is a dependency default, so it never appears in the
+tool's input schema — the model cannot see it and cannot supply it.
+"""
+
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.azure import EntraOBOToken
+from pydantic import Field
+
+from office_mcp.features import chats, identity
+from office_mcp.graph_client import graph_client_for
+from office_mcp.server.errors import graph_tool_errors
+
+# A Graph delegated permission, as a scope the On-Behalf-Of exchange can ask for. Graph accepts a
+# bare permission name at the authorize endpoint too, but only because it is the default resource;
+# the full form is unambiguous and is what FastMCP's own examples use.
+_GRAPH_SCOPE_PREFIX = "https://graph.microsoft.com/"
+
+
+def _scope(permission: str) -> str:
+    return f"{_GRAPH_SCOPE_PREFIX}{permission}"
+
+
+# What sign-in must ask Entra for, so that the On-Behalf-Of exchange has something to redeem: a
+# Graph permission the user (or an administrator) never consented to cannot be obtained later, and
+# the exchange fails with AADSTS65001 rather than with anything a tool could explain. `create_app`
+# passes this to the auth provider — which is why it is the union of every tool's permission, and
+# why it lives beside the tools that determine it.
+GRAPH_SCOPES: tuple[str, ...] = (
+    _scope(identity.GRAPH_PERMISSION),
+    _scope(chats.GRAPH_PERMISSION),
+)
+
+# The On-Behalf-Of dependency each tool declares as its token parameter's default, one per Graph
+# permission. Built here rather than inline because a call inside a parameter default rebuilds the
+# descriptor on every registration and is a lint error in both of this repo's checkers. Sharing one
+# instance is safe: FastMCP enters it per call and it holds nothing but its scopes. The declared
+# type is `str` because a token is what FastMCP injects in its place — the tool body never sees
+# this object.
+_IDENTITY_TOKEN: str = EntraOBOToken([_scope(identity.GRAPH_PERMISSION)])
+_CHATS_TOKEN: str = EntraOBOToken([_scope(chats.GRAPH_PERMISSION)])
+
+_WHOAMI = """\
+Return the signed-in Microsoft 365 user's own profile: `id`, `display_name`, `mail`, \
+`user_principal_name` and `job_title`.
+
+Call this before anything that turns on who "I", "me" or "my" is: filtering a mail or message \
+search to the signed-in user, deciding which participant of a chat is them, or addressing them by \
+name. It is one cheap request and its answer is stable for the session.
+
+`mail` is the canonical primary SMTP address and the right value to match a sender or recipient \
+against — but it is null for guest and unlicensed accounts, and `user_principal_name` (Microsoft's \
+`userPrincipalName`) is then the best available identifier. Do not treat the two as \
+interchangeable when both are present: a tenant can issue a user_principal_name on a different \
+domain from the mail address, so matching message addresses against it can silently return \
+nothing. Compare `id` — the immutable directory object id — against user ids from other tools; \
+compare `mail` against addresses.\
+"""
+
+_LIST_CHATS = f"""\
+List the Microsoft Teams chats the signed-in user is a member of — one-to-one, group and meeting \
+chats — most recently active first, with each chat's id, type, topic, last-message time and (for \
+unnamed chats) its members.
+
+Use it to find the `chat_id` that a chat-scoped tool needs, or to see which conversations are \
+live. This returns chats only: Teams channels live inside teams and are not part of this list.
+
+Ordering and `last_message_at` both come from the last message actually sent in the chat, which is \
+the only notion of recency Microsoft Graph will sort this collection by. The chat property that \
+looks like activity — Graph's `lastUpdatedDateTime` — is not returned here on purpose: Graph \
+defines it as when the chat was renamed or its membership changed, so a chat nobody has posted in \
+for a year can carry yesterday's timestamp. `last_message_at` is null for a chat with no messages.
+
+`members` is returned only for chats whose `topic` is null, because those chats have no other \
+name; Graph caps that list at {chats.MEMBERS_PER_CHAT} members per chat and `members_truncated` \
+says when the cap was hit. Set `include_member_emails` when two members share a display name.
+
+There is no pagination. `limit` is a window on the most recent chats and `truncated` says whether \
+the user has more than fit in it — widen `limit` (up to {chats.MAX_CHATS}, Graph's own maximum \
+for this collection) rather than looking for a cursor. The signed-in user's own notes-to-self \
+chat is usually the oneOnOne chat whose only member is them (call whoami to know who that is).\
+"""
+
+_READ_ONLY = {"readOnlyHint": True, "openWorldHint": True}
+
+
+def register_tools(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this server's tools against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tools
+    below borrow it per call and never own it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(name="whoami", title="Who Am I", description=_WHOAMI, annotations=_READ_ONLY)
+    async def whoami(graph_token: str = _IDENTITY_TOKEN) -> identity.SignedInUser:
+        with graph_tool_errors(identity.GRAPH_PERMISSION):
+            return await identity.get_signed_in_user(graph_client_for(transport, graph_token))
+
+    @mcp.tool(
+        name="list_chats", title="List My Chats", description=_LIST_CHATS, annotations=_READ_ONLY
+    )
+    async def list_chats(
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=chats.MAX_CHATS,
+                description=(
+                    "How many chats to return, most recently active first. Default 25, maximum "
+                    + f"{chats.MAX_CHATS} — Microsoft Graph refuses a larger page on this "
+                    + "collection."
+                ),
+            ),
+        ] = 25,
+        include_member_emails: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Include each listed member's email address. Off by default: it is only "
+                    + "needed to tell apart two members with the same display name."
+                )
+            ),
+        ] = False,
+        graph_token: str = _CHATS_TOKEN,
+    ) -> chats.ChatList:
+        with graph_tool_errors(chats.GRAPH_PERMISSION):
+            return await chats.list_recent_chats(
+                graph_client_for(transport, graph_token),
+                limit=limit,
+                include_member_emails=include_member_emails,
+            )

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -1,0 +1,72 @@
+"""A mocked graph.microsoft.com, and a Graph client that calls it as a synthetic user.
+
+Every payload in this directory is invented. Nothing here came from a real tenant: the ids are
+obviously fake, the domains are `.invalid`, and the names are from the public domain.
+"""
+
+from collections.abc import AsyncGenerator, Iterator, Mapping, Sequence
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphSettings, create_graph_transport, graph_client_for
+
+GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# What FastMCP's On-Behalf-Of exchange would have returned. Only its identity matters here.
+CALLER_TOKEN = "synthetic-graph-access-token"
+
+
+@pytest.fixture
+def graph() -> Iterator[respx.MockRouter]:
+    with respx.mock(base_url=GRAPH_V1, assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+async def transport() -> AsyncGenerator[httpx.AsyncClient]:
+    client = create_graph_transport(GraphSettings())
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def client(transport: httpx.AsyncClient) -> GraphServiceClient:
+    return graph_client_for(transport, CALLER_TOKEN)
+
+
+def chat_payload(
+    chat_id: str,
+    *,
+    chat_type: str = "group",
+    topic: str | None = "Release planning",
+    last_message_at: str | None = "2026-02-11T09:15:22.31Z",
+    members: Sequence[Mapping[str, object]] | None = None,
+) -> dict[str, object]:
+    """One `chat` as `GET /me/chats?$expand=members,lastMessagePreview` returns it."""
+    payload: dict[str, object] = {
+        "id": chat_id,
+        "chatType": chat_type,
+        "topic": topic,
+        "createdDateTime": "2026-01-04T12:00:00Z",
+        "lastUpdatedDateTime": "2026-02-11T09:15:22.31Z",
+        "members": list(members) if members is not None else [aad_member("Ada Lovelace")],
+    }
+    if last_message_at is not None:
+        payload["lastMessagePreview"] = {
+            "id": "1770000000000",
+            "createdDateTime": last_message_at,
+            "body": {"contentType": "text", "content": "synthetic preview"},
+        }
+    return payload
+
+
+def aad_member(display_name: str, *, email: str | None = None) -> dict[str, object]:
+    return {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        "id": f"member-{display_name.replace(' ', '-').lower()}",
+        "displayName": display_name,
+        "email": email or f"{display_name.split()[0].lower()}@example.invalid",
+    }

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -125,6 +125,62 @@ def _chat_message(*, message_id: str, sender: Mapping[str, object] | None) -> di
     }
 
 
+# The sender shape every Teams *read* API answers with: a `teamworkUserIdentity`, which has an id,
+# an optional display name and no email property at all.
+TEAMS_SENDER: dict[str, object] = {
+    "user": {
+        "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+        "id": "00000000-0000-4000-8000-000000000001",
+        "displayName": "Ada Lovelace",
+        "userIdentityType": "aadUser",
+    }
+}
+
+
+def message_payload(
+    *,
+    message_id: str = "1770000000000",
+    content: str = "<div><p>cut the release on Friday</p></div>",
+    content_type: str = "html",
+    sender: Mapping[str, object] | None = TEAMS_SENDER,
+    message_type: str = "message",
+    last_modified_at: str = "2026-02-11T09:15:22.31Z",
+    last_edited_at: str | None = None,
+    deleted_at: str | None = None,
+    reply_to_id: str | None = None,
+    web_url: str | None = None,
+    mentions: Sequence[Mapping[str, object]] = (),
+    attachments: Sequence[Mapping[str, object]] = (),
+    event_detail: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """One full `chatMessage`, as `GET /chats/{id}/messages/{id}` returns it.
+
+    Unlike a search hit this carries a `body` — which is the whole reason a reader exists — and the
+    Teams-shaped sender rather than the mailbox-shaped one.
+    """
+    return {
+        "@odata.type": "#microsoft.graph.chatMessage",
+        "id": message_id,
+        "etag": message_id,
+        "messageType": message_type,
+        "createdDateTime": "2026-02-11T09:15:22.31Z",
+        "lastModifiedDateTime": last_modified_at,
+        "lastEditedDateTime": last_edited_at,
+        "deletedDateTime": deleted_at,
+        "subject": None,
+        "importance": "normal",
+        "locale": "en-us",
+        "webUrl": web_url,
+        "replyToId": reply_to_id,
+        "from": dict(sender) if sender is not None else None,
+        "body": {"contentType": content_type, "content": content},
+        "mentions": [dict(mention) for mention in mentions],
+        "attachments": [dict(attachment) for attachment in attachments],
+        "reactions": [],
+        "eventDetail": dict(event_detail) if event_detail is not None else None,
+    }
+
+
 def search_response(
     hits: Sequence[Mapping[str, object]] | None,
     *,

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -70,3 +70,75 @@ def aad_member(display_name: str, *, email: str | None = None) -> dict[str, obje
         "displayName": display_name,
         "email": email or f"{display_name.split()[0].lower()}@example.invalid",
     }
+
+
+# The sender shape a search hit carries: Teams messages are indexed out of the substrate mailbox,
+# so `from` is an Exchange `emailAddress` rather than a Teams identity.
+MAILBOX_SENDER: dict[str, object] = {
+    "emailAddress": {"name": "Ada Lovelace", "address": "ada@example.invalid"}
+}
+
+
+def chat_hit(
+    *,
+    chat_id: str | None = "19:release@thread.v2",
+    message_id: str = "1770000000000",
+    summary: str | None = "...cut the <c0>release</c0> on Friday...",
+    sender: Mapping[str, object] | None = MAILBOX_SENDER,
+) -> dict[str, object]:
+    """One `searchHit` over a chat message, in the reduced projection Graph returns.
+
+    `sender=None` produces a system event message — Graph sends `from: null` and a body of the
+    literal `<systemEventMessage/>` for those, and the projection carries neither `messageType`
+    nor `eventDetail` to name them by.
+    """
+    resource = _chat_message(message_id=message_id, sender=sender)
+    if chat_id is not None:
+        resource["chatId"] = chat_id
+    return {"hitId": message_id, "rank": 1, "summary": summary, "resource": resource}
+
+
+def channel_hit(
+    *,
+    team_id: str = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+    channel_id: str = "19:general@thread.tacv2",
+    message_id: str = "1770000000000",
+) -> dict[str, object]:
+    """One `searchHit` over a channel message, which identifies its container differently."""
+    resource = _chat_message(message_id=message_id, sender=MAILBOX_SENDER)
+    resource["channelIdentity"] = {"teamId": team_id, "channelId": channel_id}
+    # Graph populates `webUrl` for channel messages and leaves it null for chat messages.
+    resource["webUrl"] = f"https://teams.microsoft.invalid/l/message/{channel_id}/{message_id}"
+    return {"hitId": message_id, "rank": 1, "summary": "synthetic snippet", "resource": resource}
+
+
+def _chat_message(*, message_id: str, sender: Mapping[str, object] | None) -> dict[str, object]:
+    return {
+        "@odata.type": "#microsoft.graph.chatMessage",
+        "id": message_id,
+        "createdDateTime": "2026-02-11T09:15:22.31Z",
+        "lastModifiedDateTime": "2026-02-11T09:20:00Z",
+        "etag": message_id,
+        "importance": "normal",
+        "subject": None,
+        "from": dict(sender) if sender is not None else None,
+    }
+
+
+def search_response(
+    hits: Sequence[Mapping[str, object]] | None,
+    *,
+    total: int | None = None,
+    more_results_available: bool = False,
+) -> dict[str, object]:
+    """A `POST /search/query` response around `hits`, or around no `hits` key at all.
+
+    Graph nests one response per request and one container per entity type; since it honours a
+    single request over a single entity type, there is only ever one of each.
+    """
+    container: dict[str, object] = {"moreResultsAvailable": more_results_available}
+    if hits is not None:
+        container["hits"] = list(hits)
+    if total is not None:
+        container["total"] = total
+    return {"value": [{"searchTerms": [], "hitsContainers": [container]}]}

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -120,6 +120,66 @@ def meeting_payload(
     }
 
 
+# The signed-in user, and somebody else, as `GET /me` answers and as a recording's organiser is
+# named. Two ids rather than one because the whole of the organiser-only rule is which of them the
+# recording belongs to.
+SIGNED_IN_USER_ID = "00000000-0000-4000-8000-000000000001"
+OTHER_USER_ID = "00000000-0000-4000-8000-000000000002"
+
+ME: dict[str, object] = {
+    "id": SIGNED_IN_USER_ID,
+    "displayName": "Ada Lovelace",
+    "mail": "ada@example.invalid",
+    "userPrincipalName": "ada@corp.example.invalid",
+    "jobTitle": "Analyst",
+}
+
+
+def recording_payload(
+    *,
+    recording_id: str = "7e31db25-bc6e-4fd8-96c7-e01264e9b6fc",
+    meeting_id: str = MEETING_ID,
+    created_at: str | None = "2026-02-10T14:02:41.204Z",
+    ended_at: str | None = "2026-02-10T14:49:53.117Z",
+    content_correlation_id: str | None = "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+    organizer_user_id: str | None = OTHER_USER_ID,
+    organizer_odata_type: str = "#microsoft.graph.teamworkUserIdentity",
+) -> dict[str, object]:
+    """One `callRecording`, which is metadata only — the bytes are an MP4 nothing here fetches.
+
+    `organizer_odata_type` is a parameter because Microsoft's own list-recordings sample sends
+    `#Microsoft.Teams.GraphSvc.teamworkUserIdentity` on this property, which is not a type the SDK
+    knows: an unknown discriminator has to keep deserializing rather than take the listing down.
+    There is no duration, size or media-type property on this resource; that is not an omission
+    here.
+    """
+    user = (
+        None
+        if organizer_user_id is None
+        else {
+            "@odata.type": organizer_odata_type,
+            "id": organizer_user_id,
+            # Null in every documented sample, which is why a recording's organiser can only be
+            # reported as an id.
+            "displayName": None,
+            "userIdentityType": "aadUser",
+            "tenantId": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+        }
+    )
+    return {
+        "id": recording_id,
+        "meetingId": meeting_id,
+        "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+        "createdDateTime": created_at,
+        "endDateTime": ended_at,
+        "contentCorrelationId": content_correlation_id,
+        "recordingContentUrl": (
+            f"{GRAPH_V1}/me/onlineMeetings/{meeting_id}/recordings/{recording_id}/content"
+        ),
+        "meetingOrganizer": {"application": None, "device": None, "user": user},
+    }
+
+
 def transcript_payload(
     *,
     transcript_id: str = "MSMjMCMjSYNTHETIC0001",

--- a/services/office-mcp/tests/features/conftest.py
+++ b/services/office-mcp/tests/features/conftest.py
@@ -44,14 +44,20 @@ def chat_payload(
     topic: str | None = "Release planning",
     last_message_at: str | None = "2026-02-11T09:15:22.31Z",
     members: Sequence[Mapping[str, object]] | None = None,
+    online_meeting_info: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
-    """One `chat` as `GET /me/chats?$expand=members,lastMessagePreview` returns it."""
+    """One `chat` as `GET /me/chats?$expand=members,lastMessagePreview` returns it.
+
+    `onlineMeetingInfo` is in the default projection of this collection — Graph sends it as null for
+    every chat that is not a meeting's — so it is always present here and only sometimes populated.
+    """
     payload: dict[str, object] = {
         "id": chat_id,
         "chatType": chat_type,
         "topic": topic,
         "createdDateTime": "2026-01-04T12:00:00Z",
         "lastUpdatedDateTime": "2026-02-11T09:15:22.31Z",
+        "onlineMeetingInfo": dict(online_meeting_info) if online_meeting_info is not None else None,
         "members": list(members) if members is not None else [aad_member("Ada Lovelace")],
     }
     if last_message_at is not None:
@@ -61,6 +67,115 @@ def chat_payload(
             "body": {"contentType": "text", "content": "synthetic preview"},
         }
     return payload
+
+
+# A join URL shaped like the ones Graph actually stores, and the reason the escaping is a bug class:
+# it carries `%3a` and `%40` that are already percent-escaped, a `?context=` query with `%7b`/`%22`
+# in its value, and an `&` parameter after it. Every one of those breaks a `$filter` that is encoded
+# too little, too much, or not at all — and breaks it into `200 OK` with an empty result.
+JOIN_WEB_URL = (
+    "https://teams.microsoft.invalid/l/meetup-join/"
+    + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
+    + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
+)
+
+MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+
+
+def online_meeting_info(join_web_url: str | None = JOIN_WEB_URL) -> dict[str, object]:
+    """A meeting chat's `onlineMeetingInfo`, with or without the one field that matters.
+
+    A null `joinWebUrl` is the case the whole design has to survive: it is the only documented route
+    from a chat to its meeting, and no live call has proved it is always populated.
+    """
+    return {
+        "calendarEventId": "AAMkAGSYNTHETIC",
+        "joinWebUrl": join_web_url,
+        "organizer": {
+            "user": {
+                "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+                "id": "00000000-0000-4000-8000-000000000002",
+                "displayName": "Grace Hopper",
+            }
+        },
+    }
+
+
+def meeting_payload(
+    *,
+    meeting_id: str = MEETING_ID,
+    subject: str | None = "Pricing review",
+    meeting_type: str | None = "scheduled",
+    start: str | None = "2026-02-10T14:00:00Z",
+    end: str | None = "2026-02-10T15:00:00Z",
+) -> dict[str, object]:
+    """One `onlineMeeting`, as the `JoinWebUrl` filter returns it: inside a one-element list."""
+    return {
+        "id": meeting_id,
+        "subject": subject,
+        "meetingType": meeting_type,
+        "joinWebUrl": JOIN_WEB_URL,
+        "startDateTime": start,
+        "endDateTime": end,
+    }
+
+
+def transcript_payload(
+    *,
+    transcript_id: str = "MSMjMCMjSYNTHETIC0001",
+    meeting_id: str = MEETING_ID,
+    created_at: str | None = "2026-02-10T14:03:11.204Z",
+    ended_at: str | None = "2026-02-10T14:58:02.117Z",
+    content_correlation_id: str | None = "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+) -> dict[str, object]:
+    """One `callTranscript`, which is metadata only — the words come from `/content`."""
+    return {
+        "id": transcript_id,
+        "meetingId": meeting_id,
+        "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+        "createdDateTime": created_at,
+        "endDateTime": ended_at,
+        "contentCorrelationId": content_correlation_id,
+    }
+
+
+# A synthetic WebVTT transcript in the shape Graph's `/content` returns, exercising everything the
+# parser has to survive: the header, a NOTE block, cue identifier lines, a voice tag with a class,
+# a cue wrapped over two lines, escaped entities, inline markup, a cue nobody was attributed for,
+# and the negative offset Microsoft documents for transcription that started mid-conversation.
+# Nothing anybody said: the speakers are long dead and the words are invented.
+TRANSCRIPT_VTT = """WEBVTT
+
+NOTE this transcript is synthetic
+
+-00:00:02.500 --> 00:00:01.250
+<v Ada Lovelace>Sorry, joining late &amp; muted.</v>
+
+f1f0c0de-0001
+00:00:16.246 --> 00:00:19.900
+<v.loud Grace Hopper>We should <i>raise</i> the floor price
+by three per cent.</v>
+
+f1f0c0de-0002
+00:01:02.000 --> 00:01:04.500
+<v Ada Lovelace>Agreed &lt;that&gt; works.</v>
+
+f1f0c0de-0003
+01:00:00.000 --> 01:00:02.000
+Nobody was attributed for this one.
+
+f1f0c0de-0004
+01:00:03.000 --> 01:00:04.000
+<v Ada Lovelace></v>
+"""
+
+# The same transcript as the unattributed format returns it: cue timings, no voice tags at all.
+TRANSCRIPT_UNATTRIBUTED = """00:00:16.246 --> 00:00:19.900
+We should raise the floor price by three per cent.
+
+00:01:02.000 --> 00:01:04.500
+Agreed that works.
+"""
 
 
 def aad_member(display_name: str, *, email: str | None = None) -> dict[str, object]:

--- a/services/office-mcp/tests/features/test_channels.py
+++ b/services/office-mcp/tests/features/test_channels.py
@@ -1,0 +1,553 @@
+"""`list_teams`, `list_channels` and `browse_channel`: the queries Graph accepts, and the traps.
+
+Three of the assertions here are about parameters that are *not* sent. Graph answers an
+unsupported OData parameter on these collections with a 400, and `services/teams-mcp` shipped a
+`$top` on two of them and had to take it back out, so "no `$top`" is a contract rather than an
+omission. The fourth trap is the ordering of a channel's messages, which is by reply-chain
+activity: it is the one Graph documents and the one nobody expects.
+
+Every payload is synthesised from Microsoft's documented shapes.
+"""
+
+from collections.abc import Mapping, Sequence
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import channels
+from office_mcp.features.message_search import message_handle
+from office_mcp.graph_client import GraphForbidden
+
+from .conftest import GRAPH_V1, message_payload
+
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+_CHANNELS_PATH = f"/teams/{_TEAM_ID}/channels"
+_MESSAGES_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages"
+
+
+def _team_payload(
+    team_id: str, *, display_name: str | None = "Engineering", is_archived: bool | None = False
+) -> dict[str, object]:
+    """One `team` as `GET /me/joinedTeams` returns it.
+
+    Only these five properties are populated on that endpoint; the nulls are Graph's, not this
+    fixture's shorthand.
+    """
+    return {
+        "id": team_id,
+        "displayName": display_name,
+        "description": "Synthetic team",
+        "isArchived": is_archived,
+        "tenantId": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+        "webUrl": None,
+        "createdDateTime": None,
+        "visibility": None,
+    }
+
+
+def _channel_payload(
+    channel_id: str,
+    *,
+    display_name: str = "General",
+    membership_type: str = "standard",
+) -> dict[str, object]:
+    return {
+        "id": channel_id,
+        "displayName": display_name,
+        "description": "Synthetic channel",
+        "createdDateTime": "2026-01-04T12:00:00Z",
+        "membershipType": membership_type,
+    }
+
+
+def _post_payload(
+    message_id: str,
+    *,
+    content: str = "<div><p>a synthetic post</p></div>",
+    created_at: str = "2026-02-11T09:15:22.31Z",
+    replies: Sequence[Mapping[str, object]] = (),
+    more_replies: bool = False,
+) -> dict[str, object]:
+    """One channel root post as `?$expand=replies` returns it."""
+    payload = message_payload(message_id=message_id, content=content)
+    payload["createdDateTime"] = created_at
+    payload["replies"] = [dict(reply) for reply in replies]
+    if more_replies:
+        payload["replies@odata.nextLink"] = f"{GRAPH_V1}{_MESSAGES_PATH}/{message_id}/replies"
+    return payload
+
+
+def _reply_payload(
+    message_id: str, *, root_id: str, created_at: str, content: str = "a synthetic reply"
+) -> dict[str, object]:
+    payload = message_payload(message_id=message_id, content=content, content_type="text")
+    payload["createdDateTime"] = created_at
+    payload["replyToId"] = root_id
+    return payload
+
+
+_SYSTEM_MESSAGE: dict[str, object] = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000009999",
+    # Without the `Prefer` header Graph reports this type as `unknownFutureValue`, which is what
+    # makes the authorless `from` and the populated `eventDetail` the signals worth filtering on.
+    "messageType": "unknownFutureValue",
+    "createdDateTime": "2026-02-11T10:00:00Z",
+    "from": None,
+    "body": {"contentType": "html", "content": "<systemEventMessage/>"},
+    "eventDetail": {
+        "@odata.type": "#microsoft.graph.membersAddedEventMessageDetail",
+        "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+    },
+    "replies": [],
+}
+
+
+class TestTheQueriesTheySend:
+    async def test_listing_teams_sends_no_odata_parameters_at_all(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`/me/joinedTeams` supports none of them, so a `$top` or a `$select` here is a 400 and
+        not a narrower answer. teams-mcp shipped the `$top` and had to remove it."""
+        route = graph.get("/me/joinedTeams").mock(
+            return_value=httpx.Response(200, json={"value": [_team_payload("team-a")]})
+        )
+
+        _ = await channels.list_teams(client, limit=10)
+
+        assert not route.calls.last.request.url.params, (
+            "no OData parameter is supported on this collection"
+        )
+
+    async def test_listing_channels_selects_around_the_expensive_property(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents populating a channel's `email` as an expensive operation, and `$select`
+        is the only way to decline it. `$top` is unsupported here too."""
+        route = graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [_channel_payload(_CHANNEL_ID)]})
+        )
+
+        _ = await channels.list_channels(client, team_id=_TEAM_ID, limit=10)
+
+        params = route.calls.last.request.url.params
+        assert params["$select"] == "id,displayName,description,createdDateTime,membershipType"
+        assert "email" not in params["$select"]
+        assert "$top" not in params, "$top is rejected on this collection"
+
+    async def test_browsing_a_channel_asks_for_replies_and_a_page_size(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`$top` and `$expand` are the only two parameters this collection takes — and the
+        expansion is what makes a thread one request instead of one per post, which matters where
+        Graph allows the whole app one request a second per channel."""
+        route = graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000000")]})
+        )
+
+        _ = await channels.browse_channel(client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=7)
+
+        params = route.calls.last.request.url.params
+        assert params["$top"] == "7"
+        assert params["$expand"] == "replies"
+        assert "$orderby" not in params, "no ordering is supported here"
+        assert "$filter" not in params, "no filter is supported here, which is why no date is taken"
+
+    @pytest.mark.parametrize("limit", [0, channels.MAX_LISTED + 1])
+    async def test_a_limit_outside_the_window_is_a_programming_error(
+        self, client: GraphServiceClient, limit: int
+    ) -> None:
+        """The tools' schemas bound `limit`, so a value outside it can only arrive from code that
+        bypassed them."""
+        with pytest.raises(AssertionError):
+            _ = await channels.list_teams(client, limit=limit)
+        with pytest.raises(AssertionError):
+            _ = await channels.list_channels(client, team_id=_TEAM_ID, limit=limit)
+
+    async def test_a_page_of_posts_above_graphs_ceiling_is_too(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await channels.browse_channel(
+                client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=channels.MAX_POSTS + 1
+            )
+
+
+class TestTheInventoryItReports:
+    async def test_a_team_carries_what_graph_populates_and_nothing_it_does_not(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/joinedTeams").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _team_payload("team-live", display_name="Engineering"),
+                        _team_payload("team-old", display_name="Engineering", is_archived=True),
+                    ]
+                },
+            )
+        )
+
+        listed = await channels.list_teams(client, limit=25)
+
+        assert [team.team_id for team in listed.teams] == ["team-live", "team-old"]
+        assert [team.is_archived for team in listed.teams] == [False, True], (
+            "the flag that tells two teams of the same name apart"
+        )
+        assert listed.truncated is False
+
+    async def test_a_team_graph_gave_no_archive_flag_for_is_not_claimed_to_be_live(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/joinedTeams").mock(
+            return_value=httpx.Response(
+                200, json={"value": [_team_payload("team-a", is_archived=None)]}
+            )
+        )
+
+        listed = await channels.list_teams(client, limit=25)
+
+        assert listed.teams[0].is_archived is None
+
+    async def test_a_full_window_of_teams_with_more_behind_it_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/joinedTeams").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_team_payload(f"team-{index}") for index in range(2)],
+                    "@odata.nextLink": f"{GRAPH_V1}/me/joinedTeams?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await channels.list_teams(client, limit=2)
+
+        assert len(listed.teams) == 2
+        assert listed.truncated is True
+
+    async def test_the_channel_pages_are_followed_rather_than_read_once(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """This collection takes no `$top`, so Graph chooses the page size and a second page is
+        normal. teams-mcp read only the first one until it was fixed ("page teams/channels
+        lists"), which silently hid channels from the listing.
+        """
+        graph.get(_CHANNELS_PATH, params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(
+                200, json={"value": [_channel_payload("19:second@thread.tacv2")]}
+            )
+        )
+        graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_channel_payload(_CHANNEL_ID)],
+                    "@odata.nextLink": f"{GRAPH_V1}{_CHANNELS_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await channels.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+        assert [channel.channel_id for channel in listed.channels] == [
+            _CHANNEL_ID,
+            "19:second@thread.tacv2",
+        ]
+        assert listed.truncated is False
+
+    async def test_a_channels_membership_type_comes_through_and_an_unknown_one_does_not_fail(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A `membershipType` the SDK's generated enum has no member for deserializes to None
+        rather than raising, so the channel must still be listed."""
+        graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _channel_payload(_CHANNEL_ID, membership_type="private"),
+                        _channel_payload("19:future@thread.tacv2", membership_type="hypothetical"),
+                    ]
+                },
+            )
+        )
+
+        listed = await channels.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+        assert [channel.membership_type for channel in listed.channels] == ["private", None]
+        created = listed.channels[0].created_at
+        assert created is not None and created.year == 2026
+
+
+class TestBrowsingOneChannel:
+    async def test_a_post_arrives_whole_rather_than_as_a_snippet(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The point of the tool: a channel listing carries every field a single read does, so the
+        text is normalised here and no follow-up read is needed."""
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            content="<div><p>ship it&nbsp;&amp; tell everyone</p></div>",
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        post = browsed.messages[0]
+        assert post.text == "ship it & tell everyone"
+        assert (post.team_id, post.channel_id) == (_TEAM_ID, _CHANNEL_ID)
+        assert post.chat_id is None
+        assert post.reply_to_id is None, "a root post answers nothing"
+        assert browsed.truncated is False
+
+    async def test_the_order_is_graphs_reply_chain_order_and_the_dates_say_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The surprise this tool has to be honest about. Graph sorts a channel's messages by the
+        last modified date of the *entire reply chain*, so a post from two years ago comes back
+        first because somebody replied to it yesterday. Reordering it would be inventing an order
+        Graph did not give, so the order is preserved and `created_at` is what tells the truth
+        about age — which is exactly what the tool's description tells the caller to read.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1600000000000",
+                            created_at="2024-03-01T08:00:00Z",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1600000000000",
+                                    created_at="2026-02-11T09:00:00Z",
+                                )
+                            ],
+                        ),
+                        _post_payload("1770000000000", created_at="2026-02-10T09:00:00Z"),
+                    ]
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        assert [message.message_id for message in browsed.messages] == [
+            "1600000000000",
+            "1770000000001",
+            "1770000000000",
+        ]
+        first = browsed.messages[0].created_at
+        assert first is not None and first.year == 2024, (
+            "the first message is the oldest post, revived by a reply"
+        )
+
+    async def test_a_reply_carries_a_handle_read_message_can_actually_resolve(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The gap this piece closes. Graph addresses a reply under the post it answers, so the
+        root-post handle shape cannot name one — and a search hit on a reply gets exactly that
+        shape and 404s. Browsing knows each reply's parent, so it can mint the third shape.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                )
+                            ],
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        reply = browsed.messages[1]
+        assert reply.reply_to_id == "1770000000000"
+        assert reply.uri == (
+            f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+            + "/messages/1770000000000/replies/1770000000001"
+        )
+        resolved = message_handle(reply.uri)
+        assert resolved is not None
+        assert (resolved.message_id, resolved.reply_to_id) == (
+            "1770000000001",
+            "1770000000000",
+        )
+        assert resolved.channel_id == _CHANNEL_ID, "the handle round-trips its decoded ids"
+
+    async def test_replies_are_sorted_and_the_newest_of_a_long_thread_are_kept(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph publishes no order for replies, so they are sorted here; and a thread longer than
+        the cap is reported truncated rather than silently shortened."""
+        replies = [
+            _reply_payload(
+                f"177000000{index:04d}",
+                root_id="1770000000000",
+                created_at=f"2026-02-11T10:{index:02d}:00Z",
+            )
+            for index in range(channels.MAX_REPLIES_PER_POST + 3)
+        ]
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={"value": [_post_payload("1770000000000", replies=list(reversed(replies)))]},
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        kept = [message.message_id for message in browsed.messages[1:]]
+        assert kept == [reply["id"] for reply in replies[-channels.MAX_REPLIES_PER_POST :]], (
+            "the newest replies, oldest first"
+        )
+        assert browsed.truncated is True
+
+    async def test_a_thread_graph_itself_paged_is_reported_truncated(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`$expand=replies` has its own cursor per post. Not following it is a deliberate choice
+        — a thread of hundreds is not a tool response — but hiding that it exists is not."""
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                )
+                            ],
+                            more_replies=True,
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        assert len(browsed.messages) == 2
+        assert browsed.truncated is True
+
+    async def test_system_messages_are_dropped_wherever_they_appear(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph offers no `messageType` filter on this collection, so they are filtered here — and
+        they arrive as `unknownFutureValue` without the `Prefer` header, which is why the author
+        and the event detail are the signals. A page can therefore hold fewer posts than asked
+        for, which is not evidence of a quiet channel."""
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _SYSTEM_MESSAGE,
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _SYSTEM_MESSAGE,
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                ),
+                            ],
+                        ),
+                    ]
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        assert [message.message_id for message in browsed.messages] == [
+            "1770000000000",
+            "1770000000001",
+        ]
+        assert all(message.event is None for message in browsed.messages)
+
+    async def test_a_channel_nobody_has_posted_in_is_an_empty_page_not_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_MESSAGES_PATH).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        assert browsed.messages == []
+        assert browsed.truncated is False
+
+
+class TestGraphFailures:
+    async def test_each_listing_surfaces_a_refusal_for_its_own_permission_to_explain(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The three requests are made under three different delegated permissions, and a tenant
+        commonly grants the two basic ones and withholds the broad message permission — so the
+        failure has to reach the tool layer, which is what names the permission."""
+        denied = httpx.Response(
+            403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+        )
+        graph.get("/me/joinedTeams").mock(return_value=denied)
+        graph.get(_CHANNELS_PATH).mock(return_value=denied)
+        graph.get(_MESSAGES_PATH).mock(return_value=denied)
+
+        with pytest.raises(GraphForbidden):
+            _ = await channels.list_teams(client, limit=25)
+        with pytest.raises(GraphForbidden):
+            _ = await channels.list_channels(client, team_id=_TEAM_ID, limit=25)
+        with pytest.raises(GraphForbidden):
+            _ = await channels.browse_channel(
+                client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+            )
+
+    def test_the_three_permissions_are_the_ones_microsoft_documents(self) -> None:
+        """A feature owns the permission its own request needs, and reading a channel's posts is
+        read under the same one `message_search` needs for channel coverage — imported rather than
+        respelled, so the two cannot drift."""
+        assert channels.TEAMS_PERMISSION == "Team.ReadBasic.All"
+        assert channels.CHANNELS_PERMISSION == "Channel.ReadBasic.All"
+        assert channels.POSTS_PERMISSION == "ChannelMessage.Read.All"

--- a/services/office-mcp/tests/features/test_channels.py
+++ b/services/office-mcp/tests/features/test_channels.py
@@ -316,6 +316,38 @@ class TestBrowsingOneChannel:
         assert post.reply_to_id is None, "a root post answers nothing"
         assert browsed.truncated is False
 
+    async def test_one_browse_is_one_graph_request_whatever_the_channel_holds(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The budget, pinned. Graph allows this whole connector about one request a second on a
+        given channel *for the tenant*, so a call that follows `@odata.nextLink` spends a budget
+        that is not its own — and this is the collection where a page walk is most tempting, because
+        system messages are filtered out after Graph has counted them into the page. A walk bounded
+        by items scanned rather than by requests would keep asking for pages until it had `limit`
+        posts; this asks once and lets `truncated` carry the rest.
+        """
+        second_page = graph.get(_MESSAGES_PATH, params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000002")]})
+        )
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_SYSTEM_MESSAGE, _post_payload("1770000000000")],
+                    "@odata.nextLink": f"{GRAPH_V1}{_MESSAGES_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        browsed = await channels.browse_channel(
+            client, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, limit=20
+        )
+
+        assert [message.message_id for message in browsed.messages] == ["1770000000000"]
+        assert browsed.truncated is True, "the page Graph said was not the last one"
+        assert len(graph.calls) == 1, "one browse is one request against the channel"
+        assert not second_page.called, "the collection's cursor is deliberately not followed"
+
     async def test_the_order_is_graphs_reply_chain_order_and_the_dates_say_so(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
@@ -436,11 +468,20 @@ class TestBrowsingOneChannel:
         )
         assert browsed.truncated is True
 
-    async def test_a_thread_graph_itself_paged_is_reported_truncated(
+    async def test_a_thread_graph_itself_paged_is_reported_truncated_and_not_chased(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
-        """`$expand=replies` has its own cursor per post. Not following it is a deliberate choice
-        — a thread of hundreds is not a tool response — but hiding that it exists is not."""
+        """`$expand=replies` has its own cursor per post. Not following it is a deliberate choice —
+        it is a request per post against a channel that allows the whole app one a second, and a
+        thread of hundreds is not a tool response — but hiding that it exists is not.
+
+        The request count is asserted because this is the half of the reply story every description
+        depends on: browsing reaches the newest replies of a post and no further, which is why no
+        surface here may tell a model to browse for an older one.
+        """
+        replies = graph.get(f"{_MESSAGES_PATH}/1770000000000/replies").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
         graph.get(_MESSAGES_PATH).mock(
             return_value=httpx.Response(
                 200,
@@ -468,6 +509,8 @@ class TestBrowsingOneChannel:
 
         assert len(browsed.messages) == 2
         assert browsed.truncated is True
+        assert not replies.called, "a post's own replies cursor is not followed either"
+        assert len(graph.calls) == 1
 
     async def test_system_messages_are_dropped_wherever_they_appear(
         self, client: GraphServiceClient, graph: respx.MockRouter

--- a/services/office-mcp/tests/features/test_chats.py
+++ b/services/office-mcp/tests/features/test_chats.py
@@ -5,10 +5,16 @@ import pytest
 import respx
 from msgraph.graph_service_client import GraphServiceClient
 
-from office_mcp.features import chats
+from office_mcp.features import chats, transcripts
 from office_mcp.graph_client import GraphThrottled
 
-from .conftest import GRAPH_V1, aad_member, chat_payload
+from .conftest import (
+    GRAPH_V1,
+    JOIN_WEB_URL,
+    aad_member,
+    chat_payload,
+    online_meeting_info,
+)
 
 _GUEST_MEMBER = "#microsoft.graph.anonymousGuestConversationMember"
 
@@ -184,6 +190,74 @@ class TestWhatTheCallerIsTold:
         assert description is not None
         assert "may" in description
         assert "not proof" in description
+
+    async def test_a_meeting_chat_carries_the_route_to_its_transcripts(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole of meeting discovery, and the reason there is no second tool for it: a meeting
+        chat is already listed here with its subject and its recency, and `onlineMeetingInfo` is
+        in this collection's default projection — so the handle that reaches the meeting behind it
+        costs no extra request and no extra permission."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:meeting_TjAwMDA@thread.v2",
+                            chat_type="meeting",
+                            topic="Pricing review",
+                            online_meeting_info=online_meeting_info(),
+                        ),
+                        chat_payload("19:release@thread.v2", chat_type="group"),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        meeting_uri = listed.chats[0].meeting_uri
+        assert meeting_uri is not None
+        assert transcripts.meeting_handle(meeting_uri) == transcripts.MeetingHandle(JOIN_WEB_URL)
+        assert listed.chats[1].meeting_uri is None, "a group chat has no meeting behind it"
+
+    async def test_a_meeting_chat_with_no_join_url_offers_no_route_rather_than_a_broken_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The unverified half of the discovery path. `joinWebUrl` is documented on the chat
+        resource and modelled by the SDK, but no live call has proved it is always populated — and
+        it is the only documented route from a chat to its meeting. So a null is reported as a null:
+        no handle, and nothing invented from the chat id to stand in for one."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:meeting_TjAwMDA@thread.v2",
+                            chat_type="meeting",
+                            topic="Pricing review",
+                            online_meeting_info=online_meeting_info(join_web_url=None),
+                        )
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].chat_type == "meeting"
+        assert listed.chats[0].meeting_uri is None
+
+    def test_the_handle_field_says_a_null_is_a_dead_end(self) -> None:
+        """A model reads this description, and the honest reading of a null is "there is no route",
+        not "try something else" — there is nothing else to try."""
+        description = chats.ChatSummary.model_fields["meeting_uri"].description
+
+        assert description is not None
+        assert "no other route" in description
+        assert "list_meeting_transcripts" in description
 
     async def test_an_unknown_chat_type_does_not_fail_the_listing(
         self, client: GraphServiceClient, graph: respx.MockRouter

--- a/services/office-mcp/tests/features/test_chats.py
+++ b/services/office-mcp/tests/features/test_chats.py
@@ -137,11 +137,17 @@ class TestWhatTheCallerIsTold:
             ("Room 3", None),
         ]
 
-    async def test_graphs_silent_member_cap_is_reported(
+    async def test_a_member_list_full_to_graphs_cap_is_flagged_as_possibly_incomplete(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """Graph returns at most 25 members per chat on this endpoint and says nothing about it,
-        so a model summarising "who is in this chat" from the list is wrong without a flag."""
+        so a model summarising "who is in this chat" from the list is wrong without a flag.
+
+        The chat below has *exactly* the cap's worth of members, which is the case the flag may
+        not overclaim on: nothing was dropped from it, and Graph's response is byte-for-byte what
+        a 200-person chat's would be. So the flag is raised — 25-of-25 and 25-of-200 have to be
+        treated alike — and says only that members may be missing.
+        """
         graph.get("/me/chats").mock(
             return_value=httpx.Response(
                 200,
@@ -165,22 +171,37 @@ class TestWhatTheCallerIsTold:
 
         listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
 
-        assert listed.chats[0].members_truncated is True
-        assert listed.chats[1].members_truncated is False
+        crowded = listed.chats[0].members
+        assert crowded is not None and len(crowded) == chats.MEMBERS_PER_CHAT
+        assert listed.chats[0].members_may_be_incomplete is True
+        assert listed.chats[1].members_may_be_incomplete is False
+
+    def test_the_cap_flag_claims_only_what_graph_actually_reveals(self) -> None:
+        """The flag's description is read by the model, so it is part of the contract: a list at
+        the cap may be short of members, and Graph gives nothing that would prove it is."""
+        description = chats.ChatSummary.model_fields["members_may_be_incomplete"].description
+
+        assert description is not None
+        assert "may" in description
+        assert "not proof" in description
 
     async def test_an_unknown_chat_type_does_not_fail_the_listing(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
+        """A `chatType` the SDK's generated enum has no member for deserializes to `None` rather
+        than raising, so the chat arrives typeless and the listing must still name it something.
+        Passing a *valid* type here would exercise nothing.
+        """
         graph.get("/me/chats").mock(
             return_value=httpx.Response(
                 200,
-                json={"value": [chat_payload("19:future@thread.v2", chat_type="meeting")]},
+                json={"value": [chat_payload("19:future@thread.v2", chat_type="sharedChannel")]},
             )
         )
 
         listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
 
-        assert listed.chats[0].chat_type == "meeting"
+        assert listed.chats[0].chat_type == "unknown"
 
 
 class TestTheWindowAndItsHonesty:

--- a/services/office-mcp/tests/features/test_chats.py
+++ b/services/office-mcp/tests/features/test_chats.py
@@ -1,0 +1,249 @@
+"""`list_chats`' feature half: the query Graph is sent, and the traps in what comes back."""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import chats
+from office_mcp.graph_client import GraphThrottled
+
+from .conftest import GRAPH_V1, aad_member, chat_payload
+
+_GUEST_MEMBER = "#microsoft.graph.anonymousGuestConversationMember"
+
+
+class TestTheQueryItSends:
+    async def test_it_asks_graph_for_recency_ordering_and_both_expansions(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The three query parameters this tool's contract rests on.
+
+        Dropping `$orderby` silently returns *some* chats instead of the recent ones, and dropping
+        an expansion silently empties `members` or `last_message_at` — all three failures look
+        like a working tool.
+        """
+        route = graph.get("/me/chats").mock(
+            return_value=httpx.Response(200, json={"value": [chat_payload("19:a@thread.v2")]})
+        )
+
+        _ = await chats.list_recent_chats(client, limit=7, include_member_emails=False)
+
+        params = route.calls.last.request.url.params
+        assert params["$orderby"] == "lastMessagePreview/createdDateTime desc"
+        assert params["$expand"] == "members,lastMessagePreview"
+        assert params["$top"] == "7"
+        assert "$select" not in params, "$select is rejected on this collection"
+
+    async def test_a_limit_above_graphs_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        """The tool's schema bounds `limit` at Graph's own maximum, so a larger value can only
+        arrive from code that bypassed it."""
+        with pytest.raises(AssertionError):
+            _ = await chats.list_recent_chats(
+                client, limit=chats.MAX_CHATS + 1, include_member_emails=False
+            )
+
+
+class TestWhatTheCallerIsTold:
+    async def test_the_sort_key_is_in_the_payload(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The oracle connector sorts by last-message time but returns `lastUpdatedDateTime`, so
+        its list looks unsorted. `last_message_at` is the value the order is by."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload("19:a@thread.v2", last_message_at="2026-02-11T09:15:22.31Z"),
+                        chat_payload("19:b@thread.v2", last_message_at=None),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert [chat.chat_id for chat in listed.chats] == ["19:a@thread.v2", "19:b@thread.v2"]
+        first = listed.chats[0].last_message_at
+        assert first is not None and first.year == 2026
+        assert listed.chats[1].last_message_at is None, (
+            "a chat nobody posted in has no last message"
+        )
+
+    async def test_members_identify_the_chats_that_have_no_topic(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload("19:named@thread.v2", topic="Release planning"),
+                        chat_payload(
+                            "19:unnamed@unq.gbl.spaces",
+                            chat_type="oneOnOne",
+                            topic=None,
+                            members=[aad_member("Ada Lovelace"), aad_member("Alan Turing")],
+                        ),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].members is None, "a named chat needs no roster to be identified"
+        unnamed = listed.chats[1].members
+        assert unnamed is not None
+        assert [member.display_name for member in unnamed] == ["Ada Lovelace", "Alan Turing"]
+        assert [member.email for member in unnamed] == [None, None], "emails are opt-in"
+
+    async def test_emails_are_returned_only_when_asked_for(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:unnamed@unq.gbl.spaces",
+                            topic=None,
+                            members=[
+                                aad_member("Ada Lovelace", email="ada@example.invalid"),
+                                # A meeting room joins as a different member subtype, with no
+                                # email to disambiguate it by.
+                                {
+                                    "@odata.type": _GUEST_MEMBER,
+                                    "id": "member-room",
+                                    "displayName": "Room 3",
+                                },
+                            ],
+                        )
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=True)
+
+        members = listed.chats[0].members
+        assert members is not None
+        assert [(m.display_name, m.email) for m in members] == [
+            ("Ada Lovelace", "ada@example.invalid"),
+            ("Room 3", None),
+        ]
+
+    async def test_graphs_silent_member_cap_is_reported(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph returns at most 25 members per chat on this endpoint and says nothing about it,
+        so a model summarising "who is in this chat" from the list is wrong without a flag."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        chat_payload(
+                            "19:crowded@thread.v2",
+                            topic=None,
+                            members=[
+                                aad_member(f"Person {index}")
+                                for index in range(chats.MEMBERS_PER_CHAT)
+                            ],
+                        ),
+                        chat_payload(
+                            "19:quiet@thread.v2", topic=None, members=[aad_member("Ada Lovelace")]
+                        ),
+                    ]
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].members_truncated is True
+        assert listed.chats[1].members_truncated is False
+
+    async def test_an_unknown_chat_type_does_not_fail_the_listing(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={"value": [chat_payload("19:future@thread.v2", chat_type="meeting")]},
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert listed.chats[0].chat_type == "meeting"
+
+
+class TestTheWindowAndItsHonesty:
+    async def test_a_short_first_page_is_followed_rather_than_believed(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents that `$top` "might not return all chats within a single response" — so
+        a page shorter than `limit` with a next link is a paging artefact, not the end of the
+        collection. Believing it truncates the window for no reason."""
+        # Registered before the unconstrained route below, which would otherwise also match the
+        # second request and hand back page one again.
+        graph.get("/me/chats", params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(200, json={"value": [chat_payload("19:b@thread.v2")]})
+        )
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [chat_payload("19:a@thread.v2")],
+                    "@odata.nextLink": f"{GRAPH_V1}/me/chats?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert [chat.chat_id for chat in listed.chats] == ["19:a@thread.v2", "19:b@thread.v2"]
+        assert listed.truncated is False, "the walk reached the end of the collection"
+
+    async def test_a_full_window_with_more_behind_it_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [chat_payload(f"19:{index}@thread.v2") for index in range(2)],
+                    "@odata.nextLink": f"{GRAPH_V1}/me/chats?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await chats.list_recent_chats(client, limit=2, include_member_emails=False)
+
+        assert len(listed.chats) == 2
+        assert listed.truncated is True
+
+
+class TestGraphFailures:
+    async def test_throttling_carries_graphs_own_retry_after(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`Retry-After: 900` exceeds the SDK retry handler's 180 s ceiling, so it declines to
+        wait and the failure reaches the caller — which is the only case a tool has to explain."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                429,
+                headers={"Retry-After": "900"},
+                json={"error": {"code": "activityLimitReached", "message": "slow down"}},
+            )
+        )
+
+        with pytest.raises(GraphThrottled) as raised:
+            _ = await chats.list_recent_chats(client, limit=25, include_member_emails=False)
+
+        assert raised.value.retry_after_seconds == 900

--- a/services/office-mcp/tests/features/test_identity.py
+++ b/services/office-mcp/tests/features/test_identity.py
@@ -1,0 +1,101 @@
+"""`whoami`'s feature half: what `GET /me` is asked for, and what the caller is told."""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import identity
+from office_mcp.graph_client import GraphForbidden
+
+from .conftest import CALLER_TOKEN
+
+_ME = {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "displayName": "Ada Lovelace",
+    "mail": "ada@example.invalid",
+    "userPrincipalName": "ada@corp.example.invalid",
+    "jobTitle": "Analyst",
+}
+
+
+class TestTheProfileItReturns:
+    async def test_it_asks_graph_only_for_the_properties_it_promises(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`/me`'s default projection is ~20 properties; the tool documents five."""
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        _ = await identity.get_signed_in_user(client)
+
+        selected = route.calls.last.request.url.params["$select"]
+        assert selected.split(",") == ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
+
+    async def test_it_reports_mail_and_upn_separately(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The fixture's `mail` and `userPrincipalName` are on different domains on purpose —
+        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters."""
+        graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        user = await identity.get_signed_in_user(client)
+
+        assert user.mail == "ada@example.invalid"
+        assert user.user_principal_name == "ada@corp.example.invalid"
+        assert user.id == "00000000-0000-4000-8000-000000000001"
+        assert user.display_name == "Ada Lovelace"
+        assert user.job_title == "Analyst"
+
+    async def test_a_guest_account_without_a_mailbox_still_answers(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A guest or unlicensed account has no `mail`. The tool's contract is that
+        `user_principal_name` carries the identity then, so a null must not be an error."""
+        graph.get("/me").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "displayName": "Grace Hopper",
+                    "mail": None,
+                    "userPrincipalName": "grace_example.invalid#EXT#@corp.example.invalid",
+                    "jobTitle": None,
+                },
+            )
+        )
+
+        user = await identity.get_signed_in_user(client)
+
+        assert user.mail is None
+        assert user.user_principal_name == "grace_example.invalid#EXT#@corp.example.invalid"
+
+    async def test_it_calls_as_the_caller(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        _ = await identity.get_signed_in_user(client)
+
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {CALLER_TOKEN}"
+
+
+class TestGraphFailures:
+    async def test_a_refusal_arrives_classified(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The feature wraps its own Graph work in `graph_errors`, so the server layer has a
+        typed failure to map rather than a bare `APIError`."""
+        graph.get("/me").mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "no"}},
+            )
+        )
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await identity.get_signed_in_user(client)
+
+        assert raised.value.status == 403
+        assert raised.value.code == "Authorization_RequestDenied"
+        assert raised.value.request_id == "synthetic-request-id"

--- a/services/office-mcp/tests/features/test_identity.py
+++ b/services/office-mcp/tests/features/test_identity.py
@@ -1,4 +1,4 @@
-"""`whoami`'s feature half: what `GET /me` is asked for, and what the caller is told."""
+"""`get_me`'s feature half: what `GET /me` is asked for, and what the caller is told."""
 
 import httpx
 import pytest
@@ -31,18 +31,23 @@ class TestTheProfileItReturns:
         selected = route.calls.last.request.url.params["$select"]
         assert selected.split(",") == ["id", "displayName", "mail", "userPrincipalName", "jobTitle"]
 
-    async def test_it_reports_mail_and_upn_separately(
+    async def test_it_reports_the_email_and_the_upn_separately(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """The fixture's `mail` and `userPrincipalName` are on different domains on purpose —
-        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters."""
+        that is the live-tenant shape, and collapsing the two is how "my messages" mis-filters.
+
+        Graph's `mail` and `id` are reported as `email` and `user_id`: an address is `email` and a
+        person's Entra id is `user_id` everywhere on this server's surface, and this profile is the
+        one payload a model correlates the rest against.
+        """
         graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
 
         user = await identity.get_signed_in_user(client)
 
-        assert user.mail == "ada@example.invalid"
+        assert user.email == "ada@example.invalid"
         assert user.user_principal_name == "ada@corp.example.invalid"
-        assert user.id == "00000000-0000-4000-8000-000000000001"
+        assert user.user_id == "00000000-0000-4000-8000-000000000001"
         assert user.display_name == "Ada Lovelace"
         assert user.job_title == "Analyst"
 
@@ -66,7 +71,7 @@ class TestTheProfileItReturns:
 
         user = await identity.get_signed_in_user(client)
 
-        assert user.mail is None
+        assert user.email is None
         assert user.user_principal_name == "grace_example.invalid#EXT#@corp.example.invalid"
 
     async def test_it_calls_as_the_caller(

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -5,8 +5,8 @@ authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorati
 carries. Nothing here came from a tenant.
 
 Which strings are handles at all is `message_search`'s question, since search is what mints them:
-`TestTheHandleItMints` in `test_message_search.py` covers the two shapes and everything that is not
-one of them. What is covered here is what a read does with a handle it was given.
+`TestTheHandleItMints` in `test_message_search.py` covers the three shapes and everything that is
+not one of them. What is covered here is what a read does with a handle it was given.
 """
 
 import httpx
@@ -32,8 +32,16 @@ _CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
 _CHAT_PATH = f"/chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
 _CHANNEL_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
 
+_REPLY_ID = "1770000000002"
+_REPLY_PATH = f"{_CHANNEL_PATH}/replies/{_REPLY_ID}"
+
 _CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
 _CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
+# A reply is addressed under the post it answers: the parent's id is `reply_to_id`, and the reply's
+# own id is the message this handle names.
+_REPLY_HANDLE = MessageHandle(
+    message_id=_REPLY_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, reply_to_id=_MESSAGE_ID
+)
 
 
 def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
@@ -60,6 +68,39 @@ class TestTheRequestItMakes:
         _ = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
 
         assert route.called
+
+    async def test_a_reply_handle_reads_it_under_the_post_it_answers(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The only way Graph addresses a channel reply. The reply's own id beside its siblings is
+        a 404, which is the failure a search hit on a reply produces — so the handle names both ids
+        and the request nests them.
+        """
+        route = graph.get(_REPLY_PATH).mock(
+            return_value=httpx.Response(
+                200, json=message_payload(message_id=_REPLY_ID, reply_to_id=_MESSAGE_ID)
+            )
+        )
+
+        message = await message_read.read_message(client, handle=_REPLY_HANDLE)
+
+        assert route.called
+        assert message.message_id == _REPLY_ID
+        assert message.reply_to_id == _MESSAGE_ID
+        assert message.uri == _REPLY_HANDLE.uri, "the handle is echoed as it was given"
+
+    async def test_a_reply_graph_named_no_parent_for_is_still_placed_in_its_thread(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`replyToId` is the message's own property and the handle is only the fallback — but the
+        fallback matters: a reply reported without a parent would read as a root post."""
+        _ = graph.get(_REPLY_PATH).mock(
+            return_value=httpx.Response(200, json=message_payload(message_id=_REPLY_ID))
+        )
+
+        message = await message_read.read_message(client, handle=_REPLY_HANDLE)
+
+        assert message.reply_to_id == _MESSAGE_ID
 
     async def test_it_asks_for_the_message_type_graph_hides_by_default(
         self, client: GraphServiceClient, graph: respx.MockRouter

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -1,0 +1,657 @@
+"""`read_message`' feature half: which handle addresses what, and what a Teams body really holds.
+
+Every payload is synthesised from Microsoft's own documented shapes — the Teams-identity sender, the
+authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorations a Teams body
+carries. Nothing here came from a tenant.
+"""
+
+from typing import cast
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import message_read, message_search
+from office_mcp.features.message_read import MessageHandle
+from office_mcp.features.message_search import SearchCriteria
+from office_mcp.graph_client import GraphForbidden, GraphNotFound
+
+from .conftest import chat_hit, message_payload, search_response
+
+_CHAT_ID = "19:release@thread.v2"
+_MESSAGE_ID = "1770000000000"
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+
+_CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+)
+
+# The path the ids above address once Graph has them. The SDK re-encodes them for the URL, so this
+# is what a percent-decoded handle has to come back out as.
+_CHAT_PATH = f"/chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+
+_CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
+_CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
+
+
+def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
+    _ = graph.get(path).mock(return_value=httpx.Response(200, json=payload))
+
+
+class TestTheHandlesItAccepts:
+    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
+        """The handle is `search_messages`' contract: the ids in it are percent-encoded because a
+        Teams id is full of `:` and `@`, so parsing it means decoding them back."""
+        chat = message_read.message_handle(_CHAT_URI)
+        channel = message_read.message_handle(_CHANNEL_URI)
+
+        assert chat == _CHAT_HANDLE
+        assert channel == _CHANNEL_HANDLE
+
+    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
+        assert message_read.message_handle(_CHAT_URI) is not None
+        assert cast("MessageHandle", message_read.message_handle(_CHAT_URI)).uri == _CHAT_URI
+        assert cast("MessageHandle", message_read.message_handle(_CHANNEL_URI)).uri == _CHANNEL_URI
+
+    def test_an_unencoded_id_still_resolves(self) -> None:
+        """A caller that copied a handle out of a log rather than out of a response has ids that
+        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
+        handle = message_read.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
+
+        assert handle == _CHAT_HANDLE
+
+    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
+        """Graph's permissions for a message read are per surface, so a 403 on a chat read can
+        only be about `Chat.Read` — naming the channel permission alongside it would send an
+        administrator after one that was never missing."""
+        assert _CHAT_HANDLE.permission == "Chat.Read"
+        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # The schemes a polymorphic reader would advertise and this connector cannot serve.
+            "mail:///messages/AAMkAGI2",
+            "calendar:///events/AAMkAGI2",
+            "drive:///items/01ABC",
+            "site:///sites/contoso/pages/1",
+            # Right scheme, wrong shape.
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "teams:///messages/1770000000000",
+            "teams:///chats//messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
+            "teams:///teams/8a9c3c47/messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
+            # A Teams web link, which is what a model reaches for when it has no handle.
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+            "1770000000000",
+            "",
+        ],
+    )
+    def test_it_refuses_everything_else(self, uri: str) -> None:
+        assert message_read.message_handle(uri) is None
+
+
+class TestTheRequestItMakes:
+    async def test_a_chat_handle_reads_the_chat_message_endpoint(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_CHAT_PATH).mock(return_value=httpx.Response(200, json=message_payload()))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert route.called
+
+    async def test_a_channel_handle_reads_the_channel_message_endpoint(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_CHANNEL_PATH).mock(
+            return_value=httpx.Response(200, json=message_payload())
+        )
+
+        _ = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+        assert route.called
+
+    async def test_it_asks_for_the_message_type_graph_hides_by_default(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`messageType` is an evolvable enum: without this header Graph reports
+        `systemEventMessage` as `unknownFutureValue`, which names nothing."""
+        route = graph.get(_CHAT_PATH).mock(return_value=httpx.Response(200, json=message_payload()))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert route.calls.last.request.headers["prefer"] == "include-unknown-enum-members"
+
+    async def test_the_prefer_header_is_not_added_to_every_other_graph_request(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """kiota's `RequestConfiguration.headers` defaults to one `HeadersCollection` shared by
+        every configuration in the process, so a header added to the default leaks into unrelated
+        calls. This is the check that the reader builds its own."""
+        _reads(graph, message_payload())
+        chats = graph.get("/me/chats").mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+        from office_mcp.features import chats as chats_feature
+
+        _ = await chats_feature.list_recent_chats(client, limit=1, include_member_emails=False)
+
+        assert "prefer" not in chats.calls.last.request.headers
+
+
+class TestWhatItReportsAboutTheMessage:
+    async def test_it_answers_with_the_handle_it_was_given(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.uri == _CHAT_URI
+        assert (message.message_id, message.chat_id) == (_MESSAGE_ID, _CHAT_ID)
+        assert (message.team_id, message.channel_id) == (None, None)
+
+    async def test_the_sender_is_the_teams_identity_shape_with_no_email(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A read gives `teamworkUserIdentity`, which has no email property at all — so the field
+        search fills in is null here, and the id is what the two shapes have in common."""
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert message.sender.display_name == "Ada Lovelace"
+        assert message.sender.user_id == "00000000-0000-4000-8000-000000000001"
+        assert message.sender.email is None
+
+    async def test_a_sender_graph_gave_no_name_is_still_identified(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`displayName` is documented Optional and is genuinely absent for federated and external
+        users. A blank name must not read as an anonymous sender."""
+        _reads(
+            graph,
+            message_payload(
+                sender={
+                    "user": {
+                        "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+                        "id": "00000000-0000-4000-8000-000000000002",
+                        "displayName": "",
+                        "userIdentityType": "federatedUser",
+                    }
+                }
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert message.sender.display_name is None, "an empty name is not a name"
+        assert message.sender.user_id == "00000000-0000-4000-8000-000000000002"
+
+    async def test_a_bot_is_named_by_its_application(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                sender={
+                    "application": {
+                        "@odata.type": "#microsoft.graph.teamworkApplicationIdentity",
+                        "id": "0dbc0b2f-e0d6-4a1f-b2f4-8f2b3f3f0e8c",
+                        "displayName": "Release Bot",
+                    }
+                }
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.sender is not None
+        assert (message.sender.display_name, message.sender.user_id) == ("Release Bot", None)
+
+    async def test_edits_and_reactions_are_not_confused_for_each_other(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`lastModifiedDateTime` moves when somebody adds a reaction; `lastEditedDateTime` is the
+        one that means the author changed the text, so it is the one reported."""
+        _reads(
+            graph,
+            message_payload(
+                last_modified_at="2026-02-11T11:00:00Z", last_edited_at="2026-02-11T10:00:00Z"
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.last_edited_at is not None
+        assert message.last_edited_at.isoformat() == "2026-02-11T10:00:00+00:00"
+
+    async def test_an_unedited_message_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.last_edited_at is None
+        assert message.deleted_at is None
+
+    async def test_a_channel_reply_carries_the_post_it_replies_to(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                reply_to_id="1770000000001",
+                web_url="https://teams.microsoft.invalid/l/message/19%3Ageneral/1770000000000",
+            ),
+            _CHANNEL_PATH,
+        )
+
+        message = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+        assert message.reply_to_id == "1770000000001"
+        assert message.web_url is not None
+
+
+class TestTheBodyItNormalises:
+    async def test_plain_text_content_is_left_alone(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload(content="cut the release on Friday", content_type="text"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "cut the release on Friday"
+
+    async def test_teams_html_becomes_readable_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole pipeline over one body: wrapper divs, paragraphs, breaks, a list, formatting
+        tags and HTML entities. Handing any of this to a model verbatim is the quality bug."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '<div><div itemprop="copy-paste-block"><p>Ship <strong>today</strong> '
+                    + "&amp; tell&nbsp;support.</p><p>Blockers:</p><ul><li>build #7</li>"
+                    + "<li>docs</li></ul>done<br/>thanks</div></div>"
+                )
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == (
+            "Ship today & tell support.\nBlockers:\n- build #7\n- docs\ndone\nthanks"
+        )
+
+    async def test_a_mention_reads_as_the_person_it_names(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An `<at id="0">` left in the text would be a key to nothing, and dropping it would read
+        as the author addressing nobody."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="0">Ada Lovelace</at> can you review?</p>',
+                mentions=[
+                    {
+                        "id": 0,
+                        "mentionText": "Ada Lovelace",
+                        "mentioned": {
+                            "user": {
+                                "id": "00000000-0000-4000-8000-000000000001",
+                                "displayName": "Ada Lovelace",
+                                "userIdentityType": "aadUser",
+                            }
+                        },
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "@Ada Lovelace can you review?"
+        assert [(m.text, m.user_id) for m in message.mentions] == [
+            ("Ada Lovelace", "00000000-0000-4000-8000-000000000001")
+        ]
+
+    async def test_a_mention_with_no_text_of_its_own_is_resolved_from_the_mentions_list(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft documents the `<at>` element's `id` as corresponding to `mentions[].id`, which
+        is the authority — the element's own text is sometimes empty."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="3"></at> heads up</p>',
+                mentions=[{"id": 3, "mentionText": "Release planning", "mentioned": {}}],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "@Release planning heads up"
+
+    async def test_a_mention_of_everyone_is_not_reported_as_a_person(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An @everyone arrives as a conversation identity with `user: null`, so a null `user_id`
+        is not a failure to resolve somebody."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p><at id="0">Everyone</at> standup moved</p>',
+                mentions=[
+                    {
+                        "id": 0,
+                        "mentionText": "Everyone",
+                        "mentioned": {
+                            "conversation": {
+                                "id": _CHAT_ID,
+                                "displayName": "Release planning",
+                                "conversationIdentityType": "chat",
+                            }
+                        },
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert [(m.text, m.user_id) for m in message.mentions] == [("Everyone", None)]
+
+    async def test_an_attachment_placeholder_names_what_was_attached(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The body carries only `<attachment id="…">`; the name lives in `attachments[]`, so
+        without resolving one against the other the message reads as if nothing was attached."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p>see this</p><attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "reference",
+                        "contentUrl": "https://contoso.sharepoint.invalid/Shared/plan.xlsx",
+                        "name": "plan.xlsx",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "see this\n[attachment: plan.xlsx]"
+        assert [(a.name, a.content_type) for a in message.attachments] == [
+            ("plan.xlsx", "reference")
+        ]
+        assert message.attachments[0].url is not None
+
+    async def test_an_unnamed_attachment_is_still_marked(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "forwardedMessageReference",
+                        "content": '{"originalMessageId":"1770000000000"}',
+                        "name": None,
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[attachment]"
+        assert message.attachments[0].url is None, (
+            "a forwarded message's `content` is a JSON payload, not a location"
+        )
+
+    async def test_emoji_survive_the_tags_that_carry_them(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`<emoji alt="👀">` holds the character in an attribute, so stripping tags without
+        reading it deletes the emoji from the message."""
+        _reads(
+            graph,
+            message_payload(
+                content='<p>looking <emoji id="1f440_eyes" alt="\U0001f440" title="Eyes"></emoji>'
+                + '<customemoji id="x" alt="teams_party" source="https://x.invalid"></customemoji>'
+                + "</p>"
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "looking \U0001f440teams_party"
+
+    async def test_an_inline_image_is_reported_rather_than_dropped(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '<div><img height="63" src="https://graph.microsoft.com/v1.0/chats/x/'
+                    + 'messages/y/hostedContents/z/$value" width="67"></div>'
+                )
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[image]"
+
+    async def test_an_adaptive_card_is_not_dumped_into_the_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='{"type":"AdaptiveCard","version":"1.4","body":[{"type":"TextBlock"}]}'
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_a_body_with_nothing_in_it_is_null_rather_than_empty(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload(content="<div>   </div>"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text is None
+
+
+class TestTheMessagesThatHaveNoText:
+    async def test_a_deleted_message_is_not_presented_as_content(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Whatever a tombstone's body holds, it is not what the author wrote."""
+        _reads(
+            graph,
+            message_payload(deleted_at="2026-02-12T08:00:00Z", content="<div></div>"),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text is None
+        assert message.deleted_at is not None
+        assert message.deleted_at.isoformat() == "2026-02-12T08:00:00+00:00"
+
+    async def test_a_system_event_says_what_happened_instead_of_the_literal_tag(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The one Graph is most misleading about: `from` is null and the body is the literal
+        `<systemEventMessage/>`. The sentence Teams shows is written by the Teams client and never
+        sent, so `eventDetail`'s type is the only thing that names the event."""
+        _reads(
+            graph,
+            message_payload(
+                sender=None,
+                content="<systemEventMessage/>",
+                message_type="systemEventMessage",
+                event_detail={
+                    "@odata.type": "#microsoft.graph.membersJoinedEventMessageDetail",
+                    "visibleHistoryStartDateTime": "0001-01-01T00:00:00Z",
+                    "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+                },
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event == "members joined"
+        assert message.text is None, "`<systemEventMessage/>` is not text"
+        assert message.sender is None
+
+    @pytest.mark.parametrize(
+        ("odata_type", "expected"),
+        [
+            ("#microsoft.graph.chatRenamedEventMessageDetail", "chat renamed"),
+            ("#microsoft.graph.callEndedEventMessageDetail", "call ended"),
+            ("#microsoft.graph.callTranscriptEventMessageDetail", "call transcript"),
+            ("#microsoft.graph.teamsAppInstalledEventMessageDetail", "teams app installed"),
+            (
+                "#microsoft.graph.conversationMemberRoleUpdatedEventMessageDetail",
+                "conversation member role updated",
+            ),
+            # The subtype Microsoft adds next: reading the type is what covers it, where a table of
+            # the 31 that exist today would answer "unknown".
+            ("#microsoft.graph.somethingNewEventMessageDetail", "something new"),
+        ],
+    )
+    async def test_every_event_type_names_itself(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        odata_type: str,
+        expected: str,
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                sender=None,
+                content="<systemEventMessage/>",
+                message_type="systemEventMessage",
+                event_detail={"@odata.type": odata_type},
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event == expected
+
+    async def test_an_event_graph_did_not_describe_is_still_not_reported_as_a_message(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A `chatEvent` or `typing` message carries no `eventDetail` at all, and without the
+        `Prefer` header its type would arrive as `unknownFutureValue`. Either way it is not
+        something a person wrote."""
+        _reads(
+            graph,
+            message_payload(sender=None, content="", message_type="unknownFutureValue"),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event is not None
+        assert message.text is None
+
+    async def test_an_ordinary_message_has_no_event(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(graph, message_payload())
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.event is None
+
+
+class TestTheFailuresItPassesOn:
+    async def test_a_message_graph_will_not_return_is_a_not_found(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph answers 'deleted', 'never existed' and 'you may not see it' identically; the
+        classification stops here and the tool layer is what refuses to guess between them."""
+        _ = graph.get(_CHAT_PATH).mock(
+            return_value=httpx.Response(
+                404, json={"error": {"code": "NotFound", "message": "Not Found"}}
+            )
+        )
+
+        with pytest.raises(GraphNotFound):
+            _ = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+    async def test_a_refused_permission_is_a_forbidden(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _ = graph.get(_CHANNEL_PATH).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        with pytest.raises(GraphForbidden):
+            _ = await message_read.read_message(client, handle=_CHANNEL_HANDLE)
+
+
+class TestTheRoundTripFromASearchResult:
+    async def test_a_hit_from_search_is_read_by_its_own_handle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The contract between the two tools, end to end at the feature level: whatever
+        `search_messages` puts in `uri`, `read_message` has to resolve without any part of it being
+        reassembled by hand.
+        """
+        _ = graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200, json=search_response([chat_hit(chat_id=_CHAT_ID, message_id=_MESSAGE_ID)])
+            )
+        )
+        route = graph.get(_CHAT_PATH).mock(
+            return_value=httpx.Response(
+                200, json=message_payload(content="<p>cut the release on Friday</p>")
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+        uri = found.messages[0].uri
+        assert uri is not None
+        handle = message_read.message_handle(uri)
+        assert handle is not None, f"search produced a handle read_message rejects: {uri}"
+        message = await message_read.read_message(client, handle=handle)
+
+        assert route.called
+        assert message.uri == uri
+        assert message.text == "cut the release on Friday", (
+            "the point of the round trip: search has no body, and this is where the text comes from"
+        )
+        assert message.sender is not None
+        assert message.sender.display_name == found.messages[0].sender.display_name, (
+            "the same person, whichever tool reported them"
+        )

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -1,11 +1,13 @@
-"""`read_message`' feature half: which handle addresses what, and what a Teams body really holds.
+"""`read_message`' feature half: what a read asks Graph for, and what a Teams body really holds.
 
 Every payload is synthesised from Microsoft's own documented shapes — the Teams-identity sender, the
 authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorations a Teams body
 carries. Nothing here came from a tenant.
-"""
 
-from typing import cast
+Which strings are handles at all is `message_search`'s question, since search is what mints them:
+`TestTheHandleItMints` in `test_message_search.py` covers the two shapes and everything that is not
+one of them. What is covered here is what a read does with a handle it was given.
+"""
 
 import httpx
 import pytest
@@ -13,8 +15,7 @@ import respx
 from msgraph.graph_service_client import GraphServiceClient
 
 from office_mcp.features import message_read, message_search
-from office_mcp.features.message_read import MessageHandle
-from office_mcp.features.message_search import SearchCriteria
+from office_mcp.features.message_search import MessageHandle, SearchCriteria
 from office_mcp.graph_client import GraphForbidden, GraphNotFound
 
 from .conftest import chat_hit, message_payload, search_response
@@ -25,9 +26,6 @@ _TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
 _CHANNEL_ID = "19:general@thread.tacv2"
 
 _CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
-_CHANNEL_URI = (
-    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
-)
 
 # The path the ids above address once Graph has them. The SDK re-encodes them for the URL, so this
 # is what a percent-decoded handle has to come back out as.
@@ -40,61 +38,6 @@ _CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channe
 
 def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
     _ = graph.get(path).mock(return_value=httpx.Response(200, json=payload))
-
-
-class TestTheHandlesItAccepts:
-    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
-        """The handle is `search_messages`' contract: the ids in it are percent-encoded because a
-        Teams id is full of `:` and `@`, so parsing it means decoding them back."""
-        chat = message_read.message_handle(_CHAT_URI)
-        channel = message_read.message_handle(_CHANNEL_URI)
-
-        assert chat == _CHAT_HANDLE
-        assert channel == _CHANNEL_HANDLE
-
-    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
-        assert message_read.message_handle(_CHAT_URI) is not None
-        assert cast("MessageHandle", message_read.message_handle(_CHAT_URI)).uri == _CHAT_URI
-        assert cast("MessageHandle", message_read.message_handle(_CHANNEL_URI)).uri == _CHANNEL_URI
-
-    def test_an_unencoded_id_still_resolves(self) -> None:
-        """A caller that copied a handle out of a log rather than out of a response has ids that
-        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
-        handle = message_read.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
-
-        assert handle == _CHAT_HANDLE
-
-    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
-        """Graph's permissions for a message read are per surface, so a 403 on a chat read can
-        only be about `Chat.Read` — naming the channel permission alongside it would send an
-        administrator after one that was never missing."""
-        assert _CHAT_HANDLE.permission == "Chat.Read"
-        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
-
-    @pytest.mark.parametrize(
-        "uri",
-        [
-            # The schemes a polymorphic reader would advertise and this connector cannot serve.
-            "mail:///messages/AAMkAGI2",
-            "calendar:///events/AAMkAGI2",
-            "drive:///items/01ABC",
-            "site:///sites/contoso/pages/1",
-            # Right scheme, wrong shape.
-            "teams:///chats/19%3Arelease%40thread.v2",
-            "teams:///messages/1770000000000",
-            "teams:///chats//messages/1770000000000",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
-            "teams:///teams/8a9c3c47/messages/1770000000000",
-            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
-            # A Teams web link, which is what a model reaches for when it has no handle.
-            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
-            "1770000000000",
-            "",
-        ],
-    )
-    def test_it_refuses_everything_else(self, uri: str) -> None:
-        assert message_read.message_handle(uri) is None
 
 
 class TestTheRequestItMakes:
@@ -841,7 +784,7 @@ class TestTheRoundTripFromASearchResult:
         )
         uri = found.messages[0].uri
         assert uri is not None
-        handle = message_read.message_handle(uri)
+        handle = message_search.message_handle(uri)
         assert handle is not None, f"search produced a handle read_message rejects: {uri}"
         message = await message_read.read_message(client, handle=handle)
 

--- a/services/office-mcp/tests/features/test_message_read.py
+++ b/services/office-mcp/tests/features/test_message_read.py
@@ -461,20 +461,6 @@ class TestTheBodyItNormalises:
 
         assert message.text == "[image]"
 
-    async def test_an_adaptive_card_is_not_dumped_into_the_answer(
-        self, client: GraphServiceClient, graph: respx.MockRouter
-    ) -> None:
-        _reads(
-            graph,
-            message_payload(
-                content='{"type":"AdaptiveCard","version":"1.4","body":[{"type":"TextBlock"}]}'
-            ),
-        )
-
-        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
-
-        assert message.text == "[card]"
-
     async def test_a_body_with_nothing_in_it_is_null_rather_than_empty(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
@@ -483,6 +469,219 @@ class TestTheBodyItNormalises:
         message = await message_read.read_message(client, handle=_CHAT_HANDLE)
 
         assert message.text is None
+
+
+# One adaptive card, as Microsoft's own example shapes it: the payload lives in the attachment's
+# `content` and the attachment's `contentType` is what names it a card.
+_CARD_PAYLOAD = (
+    '{"type":"AdaptiveCard","version":"1.4",'
+    + '"body":[{"type":"TextBlock","text":"Deploy build #7?"}]}'
+)
+_CARD_ATTACHMENT: dict[str, object] = {
+    "id": "74d20c7f34aa4a7fb74e2b30004247c5",
+    "contentType": "application/vnd.microsoft.card.adaptive",
+    "content": _CARD_PAYLOAD,
+    "name": None,
+}
+
+
+class TestWhatCountsAsACard:
+    """A card is attachment metadata, never the shape of the body text.
+
+    Microsoft marks a card in `attachments[].contentType` —
+    `application/vnd.microsoft.card.adaptive` and its siblings
+    (https://learn.microsoft.com/en-us/graph/api/resources/chatmessageattachment,
+    https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference)
+    — and the card's payload in `attachment.content`. Going by the body text instead means a
+    developer who pastes JSON into Teams has their message reported as a card and its content
+    thrown away, in the one tool that is the only route to a message's text.
+    """
+
+    async def test_a_pasted_json_object_is_a_message_and_comes_back_whole(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The defect this class exists for: brace-and-`"type"` text is what a developer sends all
+        day, and no part of it may be traded for `[card]`."""
+        pasted = '{"type":"service","replicas":3,"image":"office-mcp:1.4.0"}'
+        _reads(graph, message_payload(content=f"<div><p>{pasted}</p></div>"))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == pasted
+        assert message.attachments == [], "nothing was attached, so nothing was a card"
+
+    async def test_json_that_is_only_part_of_a_sentence_keeps_the_sentence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<p>{"type":"TextBlock"} — is this the bit that broke prod?</p>'
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == '{"type":"TextBlock"} — is this the bit that broke prod?'
+
+    async def test_a_card_attachment_reads_as_a_card_where_its_placeholder_sat(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The ordinary shape of a card message: the body carries the `<attachment id="…">`
+        placeholder and the payload is in `attachments[]`. Teams gives a card no `name`, so without
+        reading its `contentType` the card would read as an anonymous `[attachment]`."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    "<p>ready?</p>"
+                    + '<attachment id="74d20c7f34aa4a7fb74e2b30004247c5"></attachment>'
+                ),
+                attachments=[_CARD_ATTACHMENT],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "ready?\n[card]"
+        assert [a.content_type for a in message.attachments] == [
+            "application/vnd.microsoft.card.adaptive"
+        ]
+
+    @pytest.mark.parametrize(
+        ("content_type", "expected"),
+        [
+            ("application/vnd.microsoft.card.adaptive", "[card]"),
+            ("application/vnd.microsoft.card.hero", "[card]"),
+            ("application/vnd.microsoft.card.thumbnail", "[card]"),
+            ("application/vnd.microsoft.card.receipt", "[card]"),
+            ("application/vnd.microsoft.card.signin", "[card]"),
+            ("application/vnd.microsoft.card.codesnippet", "[card]"),
+            ("application/vnd.microsoft.card.announcement", "[card]"),
+            ("application/vnd.microsoft.teams.card.list", "[card]"),
+            ("application/vnd.microsoft.teams.card.o365connector", "[card]"),
+            # The card type Microsoft publishes next: the namespace is the documented shape, so
+            # matching it covers what a table of today's nine values would answer `[attachment]` to.
+            ("application/vnd.microsoft.card.somethingNew", "[card]"),
+            # Not cards. `reference` is a file and `forwardedMessageReference` is a message.
+            ("reference", "[attachment]"),
+            ("forwardedMessageReference", "[attachment]"),
+        ],
+    )
+    async def test_every_card_namespace_teams_documents_names_itself_a_card(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        content_type: str,
+        expected: str,
+    ) -> None:
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {"id": "1727881360458", "contentType": content_type, "name": None},
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == expected
+
+    async def test_a_named_card_is_named_rather_than_generically_marked(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`name` is more use to a reader than the word `card`, so a card that has one keeps it."""
+        _reads(
+            graph,
+            message_payload(
+                content='<attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "application/vnd.microsoft.card.codesnippet",
+                        "name": "deploy.sh",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[attachment: deploy.sh]"
+
+    async def test_a_card_teams_left_in_the_body_is_not_dumped_into_the_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Teams sometimes puts the card's own JSON in `body.content` instead of the placeholder.
+        That body is the attachment's payload repeated, so `[card]` loses nothing — and the
+        attachment is the evidence, which is what makes this safe where a text heuristic was not."""
+        _reads(graph, message_payload(content=_CARD_PAYLOAD, attachments=[_CARD_ATTACHMENT]))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_the_same_payload_formatted_differently_is_still_the_same_card(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The comparison is between parsed payloads, so indentation and key order do not decide
+        whether a model gets a screenful of layout JSON."""
+        _reads(
+            graph,
+            message_payload(
+                content=(
+                    '{\n  "version": "1.4",\n  "type": "AdaptiveCard",\n'
+                    + '  "body": [ { "text": "Deploy build #7?", "type": "TextBlock" } ]\n}'
+                ),
+                attachments=[_CARD_ATTACHMENT],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == "[card]"
+
+    async def test_a_card_attachment_does_not_license_discarding_unrelated_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Both at once, which is the case a conjunction of the two old signals would still lose: a
+        real card attachment *and* a body that is a person's own JSON rather than that card. The
+        text is theirs, so it is returned in full and the card is reported in `attachments`."""
+        pasted = '{"type":"Deployment","replicas":3}'
+        _reads(graph, message_payload(content=f"<p>{pasted}</p>", attachments=[_CARD_ATTACHMENT]))
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == pasted
+        assert [a.content_type for a in message.attachments] == [
+            "application/vnd.microsoft.card.adaptive"
+        ]
+
+    async def test_json_text_with_no_card_attachment_survives_even_beside_a_file(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """An attachment that is not a card is not evidence of one."""
+        pasted = '{"type":"service","port":9544}'
+        _reads(
+            graph,
+            message_payload(
+                content=f'<p>{pasted}</p><attachment id="1727881360458"></attachment>',
+                attachments=[
+                    {
+                        "id": "1727881360458",
+                        "contentType": "reference",
+                        "contentUrl": "https://contoso.sharepoint.invalid/Shared/values.yaml",
+                        "name": "values.yaml",
+                    }
+                ],
+            ),
+        )
+
+        message = await message_read.read_message(client, handle=_CHAT_HANDLE)
+
+        assert message.text == f"{pasted}\n[attachment: values.yaml]"
 
 
 class TestTheMessagesThatHaveNoText:

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -1,0 +1,618 @@
+"""`search_messages`' feature half: the query Graph is sent, and the traps in what comes back.
+
+Every payload is synthesised from Microsoft's own documented shapes — the reduced search
+projection, the Exchange-shaped sender a search hit carries, the authorless system event message.
+Nothing here came from a tenant.
+"""
+
+import json
+from datetime import date
+from typing import cast
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import message_search
+from office_mcp.features.message_search import SearchCriteria
+from office_mcp.graph_client import GraphForbidden
+
+from .conftest import channel_hit, chat_hit, search_response
+
+_MENTIONED = UUID("497b7a2a-9e1a-48d7-80e8-2965d2fc3a81")
+
+
+def _request(route: respx.Route) -> dict[str, object]:
+    """The `searchRequest` the last call put on the wire."""
+    body = cast("dict[str, object]", json.loads(route.calls.last.request.content))
+    requests = cast("list[dict[str, object]]", body["requests"])
+    assert len(requests) == 1, "Graph honours only one searchRequest per call"
+    return requests[0]
+
+
+def _query_string(route: respx.Route) -> str:
+    query = cast("dict[str, object]", _request(route)["query"])
+    return cast("str", query["queryString"])
+
+
+def _unquoted_words(query: str) -> list[str]:
+    """The words of `query` that a KQL parser would read outside any quoted phrase.
+
+    Splitting on `"` and keeping the even-numbered pieces is exactly that, given a query whose
+    quotes are balanced — which every test using this asserts first, because it is the property the
+    quoting exists to hold.
+    """
+    return [
+        word
+        for index, part in enumerate(query.split('"'))
+        if index % 2 == 0
+        for word in part.split()
+    ]
+
+
+class TestTheQueryItSends:
+    async def test_it_asks_only_for_chat_messages_and_pages_by_offset(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph refuses to mix entity types, and its message search pages by `from`/`size`
+        integers rather than by a cursor — which is what lets a stateless tool resume a search."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([chat_hit()]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=25, size=10
+        )
+
+        request = _request(route)
+        assert request["entityTypes"] == ["chatMessage"]
+        assert (request["from"], request["size"]) == (25, 10)
+        assert "sortProperties" not in request, "Graph rejects sorting a chatMessage search"
+
+    async def test_every_criterion_becomes_its_documented_scope_term(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The spellings are Microsoft's, including the inconsistent casing and the fact that
+        `sent` is a comparison rather than a `term:value` pair."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(
+                query="release",
+                sender="ada",
+                recipient="alan",
+                mentions=_MENTIONED,
+                sent_after=date(2026, 1, 1),
+                sent_before=date(2026, 1, 31),
+                has_attachment=True,
+                is_read=False,
+                mentions_me=True,
+            ),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == (
+            "release from:ada to:alan mentions:497b7a2a9e1a48d780e82965d2fc3a81 "
+            + "sent>=2026-01-01 sent<=2026-01-31 hasAttachment:true IsRead:false IsMentioned:true"
+        )
+
+    async def test_the_mentioned_user_id_loses_its_hyphens(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft's `mentions` example is a user id "without '-'" — the one scope term whose
+        value is not the value the caller supplied."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(mentions=_MENTIONED), offset=0, size=25
+        )
+
+        assert _query_string(route) == "mentions:497b7a2a9e1a48d780e82965d2fc3a81"
+
+    async def test_date_bounds_include_the_days_they_name(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`sent>2026-01-01` silently drops everything sent on the 1st, which is never what a
+        caller asking for "since the 1st" meant."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(sent_after=date(2026, 1, 1), sent_before=date(2026, 1, 31)),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == "sent>=2026-01-01 sent<=2026-01-31"
+
+    async def test_a_multi_word_query_reaches_graph_as_words_and_not_as_a_phrase(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The recall this tool would otherwise lose silently. Quoting the whole query — the guard
+        a *filter value* needs — makes it an exact-adjacency phrase, so "cut the release" would
+        match only messages with those three words side by side and drop "the release was cut"
+        entirely, while the parameter promises the words are matched as words. Bare terms are what
+        Graph ANDs, so bare terms are what it is sent.
+        """
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="cut the release"), offset=0, size=25
+        )
+
+        assert _query_string(route) == "cut the release"
+
+    async def test_a_phrase_the_caller_quoted_themselves_stays_a_phrase(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Adjacency is not unavailable, it is just not the default: a caller who wants it asks
+        for it, and the words outside their quotes stay words."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query='friday "release notes"'), offset=0, size=25
+        )
+
+        assert _query_string(route) == 'friday "release notes"'
+
+    @pytest.mark.parametrize(
+        "injection",
+        [
+            "sent>2020-01-01",
+            "from:ceo@example.invalid",
+            "release OR from:ceo",
+            'release" OR IsRead:false OR "',
+            "(release)",
+            "IsMentioned:true",
+            "release NOT IsRead:false",
+            "-release",
+            "rele*",
+            'release" NOT "',
+        ],
+    )
+    async def test_a_caller_cannot_smuggle_kql_through_the_free_text(
+        self, client: GraphServiceClient, graph: respx.MockRouter, injection: str
+    ) -> None:
+        """`query` is words, and the filters a caller may set are exactly the parameters this tool
+        declares. Without this guard, free text reaches Microsoft as Keyword Query Language and can
+        widen the search past every filter the tool applied.
+
+        The guard now works a word at a time rather than over the whole query, so the assertion is
+        about the query string's *structure*: outside the quoted spans there is nothing a KQL parser
+        would read as anything but a keyword. A word with no operator character, no wildcard, no
+        leading `-` and no operator spelling is the only thing left bare, and such a word cannot
+        express a restriction, a negation or a boolean.
+        """
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query=injection), offset=0, size=25
+        )
+
+        sent = _query_string(route)
+        assert sent.count('"') % 2 == 0, f"the quoting is closable from inside: {sent}"
+        for word in _unquoted_words(sent):
+            assert not set(word) & set(':"<>=()*'), f"operator left bare in {sent}: {word}"
+            assert not word.startswith("-"), f"negation left bare in {sent}: {word}"
+            assert word not in {"AND", "OR", "NOT", "NEAR", "ONEAR"}, (
+                f"boolean left bare in {sent}: {word}"
+            )
+
+    async def test_the_words_of_an_injection_attempt_are_still_searched_for(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Neutralising is not dropping: the caller typed those characters, so they are looked for
+        as text. A guard that silently discarded them would answer a different question."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release OR from:ceo"), offset=0, size=25
+        )
+
+        assert _query_string(route) == 'release "OR" "from:ceo"'
+
+    async def test_a_sender_cannot_smuggle_one_either(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client,
+            criteria=SearchCriteria(sender="ada OR IsRead:false"),
+            offset=0,
+            size=25,
+        )
+
+        assert _query_string(route) == 'from:"ada OR IsRead:false"'
+
+    async def test_an_ordinary_value_is_left_as_a_keyword(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Quoting everything would turn every search into a phrase search and lose stemming, so
+        only values that could be read as operators are quoted."""
+        route = graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([]))
+        )
+
+        _ = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release", sender="ada"), offset=0, size=25
+        )
+
+        assert _query_string(route) == "release from:ada"
+
+
+class TestCriteriaThatAskForNothing:
+    def test_an_empty_set_knows_it_is_empty(self) -> None:
+        assert SearchCriteria().is_empty is True
+
+    def test_free_text_with_no_word_in_it_asks_for_nothing(self) -> None:
+        """`is_empty` is measured on the query string, not on which arguments were passed, so a
+        query that leaves nothing to look for is refused by the boundary that refuses no criteria
+        at all — rather than reaching Graph as a search for everything."""
+        assert SearchCriteria(query='" "').is_empty is True
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            SearchCriteria(query="release"),
+            SearchCriteria(sender="ada"),
+            SearchCriteria(recipient="alan"),
+            SearchCriteria(mentions=_MENTIONED),
+            SearchCriteria(sent_after=date(2026, 1, 1)),
+            SearchCriteria(sent_before=date(2026, 1, 31)),
+            SearchCriteria(has_attachment=False),
+            SearchCriteria(is_read=False),
+            SearchCriteria(mentions_me=False),
+        ],
+    )
+    def test_any_single_criterion_is_enough(self, criteria: SearchCriteria) -> None:
+        """`false` is a criterion — "unread messages" and "messages without attachments" are real
+        questions, so only an unset value counts as absent."""
+        assert criteria.is_empty is False
+
+    async def test_searching_for_nothing_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        """The tool refuses it at the boundary, so reaching the feature with it means the
+        boundary was bypassed."""
+        with pytest.raises(AssertionError):
+            _ = await message_search.search_messages(
+                client, criteria=SearchCriteria(), offset=0, size=25
+            )
+
+    async def test_a_size_above_what_graph_documents_is_too(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await message_search.search_messages(
+                client,
+                criteria=SearchCriteria(query="release"),
+                offset=0,
+                size=message_search.MAX_RESULTS + 1,
+            )
+
+
+class TestWhatTheCallerIsTold:
+    async def test_a_chat_hit_carries_a_chat_handle_and_a_channel_hit_a_channel_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The handle is the whole route to the message text, since the search projection has no
+        body — and the ids in it are percent-encoded because a Teams id is full of `:` and `@`."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(chat_id="19:release@thread.v2", message_id="1770000000001"),
+                        channel_hit(
+                            team_id="8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+                            channel_id="19:general@thread.tacv2",
+                            message_id="1770000000002",
+                        ),
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert [message.uri for message in found.messages] == [
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000001",
+            "teams:///teams/8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+            + "/channels/19%3Ageneral%40thread.tacv2/messages/1770000000002",
+        ]
+        # The raw ids are returned alongside, unencoded, for tools that take an id rather than a
+        # handle — a caller must never have to unpick the handle to get one back.
+        assert found.messages[0].chat_id == "19:release@thread.v2"
+        assert (found.messages[1].team_id, found.messages[1].channel_id) == (
+            "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+            "19:general@thread.tacv2",
+        )
+
+    async def test_a_hit_with_neither_identity_is_kept_without_a_handle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph does occasionally return a hit with no chatId and no channelIdentity. Its snippet
+        is still an answer, so it is reported — with a null `uri` saying it cannot be read in
+        full, rather than being dropped or given a handle that would 404."""
+        hit = chat_hit(chat_id=None)
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response([hit]))
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert len(found.messages) == 1
+        assert found.messages[0].uri is None
+        assert found.messages[0].summary is not None
+
+    async def test_the_snippet_and_the_metadata_come_through(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [chat_hit(summary="...cut the <c0>release</c0> on Friday...")]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        message = found.messages[0]
+        assert message.summary == "...cut the <c0>release</c0> on Friday..."
+        assert message.importance == "normal"
+        assert message.created_at is not None and message.created_at.year == 2026
+        assert message.last_modified_at is not None
+
+    async def test_a_search_hits_mailbox_shaped_sender_is_understood(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Teams messages are indexed out of the substrate mailbox, so a hit's `from` is an
+        Exchange `emailAddress` — a shape the Graph SDK has no field for, and one the Teams read
+        APIs never return."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "emailAddress": {
+                                    "name": "Ada Lovelace",
+                                    "address": "ada@example.invalid",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert (sender.display_name, sender.email) == ("Ada Lovelace", "ada@example.invalid")
+        assert sender.user_id is None, "the mailbox shape carries no directory id"
+
+    async def test_a_teams_shaped_sender_is_understood_too(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other branch: `teamworkUserIdentity` has an id and no email at all, and Microsoft
+        documents its display name as optional — a null there is not an anonymous sender."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "user": {
+                                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+                                    "id": "00000000-0000-4000-8000-000000000001",
+                                    "displayName": None,
+                                    "userIdentityType": "aadUser",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert sender.user_id == "00000000-0000-4000-8000-000000000001"
+        assert (sender.display_name, sender.email) == (None, None)
+
+    async def test_a_bot_is_named_by_its_application_identity(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(
+                            sender={
+                                "application": {
+                                    "id": "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+                                    "displayName": "Build Notifier",
+                                }
+                            }
+                        )
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        sender = found.messages[0].sender
+        assert sender.display_name == "Build Notifier"
+        assert sender.user_id is None, "an application id is not a user id"
+
+    async def test_system_event_messages_are_dropped(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A message nobody wrote is not a search result: for "Ada joined the chat" Graph sends a
+        null `from` and a body of the literal `<systemEventMessage/>`, rendering the sentence in
+        the Teams client
+        from `eventDetail` — which the search projection does not even return. Left in, these are
+        results with no author and no text, and a model summarising a page of them reports
+        membership churn as the conversation.
+        """
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(message_id="1770000000001", sender=None),
+                        chat_hit(message_id="1770000000002"),
+                    ]
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert [message.message_id for message in found.messages] == ["1770000000002"]
+
+
+class TestPagingAndItsHonesty:
+    async def test_more_results_available_drives_paging_and_total_is_ignored(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Microsoft documents `total` as the count of results on the page for Teams messages, not
+        the number of matches — so a tool that reports it tells a model there were 25 matches when
+        there may be thousands. Nothing here reads it."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [chat_hit(message_id=f"177000000000{index}") for index in range(3)],
+                    total=3,
+                    more_results_available=True,
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=50, size=25
+        )
+
+        assert found.more_results_available is True
+        assert found.next_offset == 53
+        assert "total" not in message_search.MessageSearchResults.model_fields
+
+    async def test_the_next_offset_counts_graphs_hits_not_the_messages_kept(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The filtering happens on our side of the offset. Advancing by the number of messages
+        returned would re-read the hits that were filtered out, forever."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200,
+                json=search_response(
+                    [
+                        chat_hit(message_id="1770000000001", sender=None),
+                        chat_hit(message_id="1770000000002", sender=None),
+                        chat_hit(message_id="1770000000003"),
+                    ],
+                    more_results_available=True,
+                ),
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert len(found.messages) == 1
+        assert found.next_offset == 3
+
+    async def test_the_last_page_offers_no_next_offset(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                200, json=search_response([chat_hit()], more_results_available=False)
+            )
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="release"), offset=0, size=25
+        )
+
+        assert found.next_offset is None
+
+    async def test_a_search_that_matched_nothing_is_an_empty_page_not_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph answers a no-match search with a container holding no `hits` key at all."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(200, json=search_response(None))
+        )
+
+        found = await message_search.search_messages(
+            client, criteria=SearchCriteria(query="nothing-matches-this"), offset=0, size=25
+        )
+
+        assert found.messages == []
+        assert (found.more_results_available, found.next_offset) == (False, None)
+
+
+class TestGraphFailures:
+    async def test_a_refused_search_surfaces_as_a_permission_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The case the per-chat scan this tool deliberately does not have would have hidden: a
+        tenant that has not granted the search permissions must be told, not worked around."""
+        graph.post("/search/query").mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await message_search.search_messages(
+                client, criteria=SearchCriteria(query="release"), offset=0, size=25
+            )
+
+        assert raised.value.status == 403

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -16,10 +16,23 @@ import respx
 from msgraph.graph_service_client import GraphServiceClient
 
 from office_mcp.features import message_search
-from office_mcp.features.message_search import SearchCriteria
+from office_mcp.features.message_search import MessageHandle, SearchCriteria
 from office_mcp.graph_client import GraphForbidden
 
 from .conftest import channel_hit, chat_hit, search_response
+
+_CHAT_ID = "19:release@thread.v2"
+_MESSAGE_ID = "1770000000000"
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+
+_CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
+_CHANNEL_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
+)
+
+_CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
+_CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
 
 _MENTIONED = UUID("497b7a2a-9e1a-48d7-80e8-2965d2fc3a81")
 
@@ -312,6 +325,65 @@ class TestCriteriaThatAskForNothing:
             )
 
 
+class TestTheHandleItMints:
+    def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
+        """A handle is this module's contract with `read_message`, which is why the shape and its
+        parser live here: the ids in it are percent-encoded because a Teams id is full of `:` and
+        `@`, so reading one back means decoding them."""
+        chat = message_search.message_handle(_CHAT_URI)
+        channel = message_search.message_handle(_CHANNEL_URI)
+
+        assert chat == _CHAT_HANDLE
+        assert channel == _CHANNEL_HANDLE
+
+    def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
+        chat = message_search.message_handle(_CHAT_URI)
+        channel = message_search.message_handle(_CHANNEL_URI)
+
+        assert chat is not None and chat.uri == _CHAT_URI
+        assert channel is not None and channel.uri == _CHANNEL_URI
+
+    def test_an_unencoded_id_still_resolves(self) -> None:
+        """A caller that copied a handle out of a log rather than out of a response has ids that
+        were never encoded; `:` and `@` are unambiguous in a path segment, so those are read too."""
+        handle = message_search.message_handle(f"teams:///chats/{_CHAT_ID}/messages/{_MESSAGE_ID}")
+
+        assert handle == _CHAT_HANDLE
+
+    def test_it_says_which_permission_each_shape_is_read_under(self) -> None:
+        """Graph's permissions for a message read are per surface and the handle is the only
+        thing that knows which surface, so a 403 on a chat read can only be about `Chat.Read` —
+        naming the channel permission alongside it would send an administrator after one that was
+        never missing."""
+        assert _CHAT_HANDLE.permission == "Chat.Read"
+        assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            # The schemes a polymorphic reader would advertise and this connector cannot serve.
+            "mail:///messages/AAMkAGI2",
+            "calendar:///events/AAMkAGI2",
+            "drive:///items/01ABC",
+            "site:///sites/contoso/pages/1",
+            # Right scheme, wrong shape.
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "teams:///messages/1770000000000",
+            "teams:///chats//messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
+            "teams:///teams/8a9c3c47/messages/1770000000000",
+            "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
+            # A Teams web link, which is what a model reaches for when it has no handle.
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+            "1770000000000",
+            "",
+        ],
+    )
+    def test_it_refuses_everything_else(self, uri: str) -> None:
+        assert message_search.message_handle(uri) is None
+
+
 class TestWhatTheCallerIsTold:
     async def test_a_chat_hit_carries_a_chat_handle_and_a_channel_hit_a_channel_one(
         self, client: GraphServiceClient, graph: respx.MockRouter
@@ -343,8 +415,8 @@ class TestWhatTheCallerIsTold:
             "teams:///teams/8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
             + "/channels/19%3Ageneral%40thread.tacv2/messages/1770000000002",
         ]
-        # The raw ids are returned alongside, unencoded, for tools that take an id rather than a
-        # handle — a caller must never have to unpick the handle to get one back.
+        # The raw ids are returned alongside, unencoded, so a hit can be lined up with the
+        # `chat_id` list_chats reports without anyone unpicking the handle to get one back.
         assert found.messages[0].chat_id == "19:release@thread.v2"
         assert (found.messages[1].team_id, found.messages[1].channel_id) == (
             "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
@@ -516,7 +588,7 @@ class TestWhatTheCallerIsTold:
 
 
 class TestPagingAndItsHonesty:
-    async def test_more_results_available_drives_paging_and_total_is_ignored(
+    async def test_truncated_drives_paging_and_total_is_ignored(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """Microsoft documents `total` as the count of results on the page for Teams messages, not
@@ -537,7 +609,7 @@ class TestPagingAndItsHonesty:
             client, criteria=SearchCriteria(query="release"), offset=50, size=25
         )
 
-        assert found.more_results_available is True
+        assert found.truncated is True
         assert found.next_offset == 53
         assert "total" not in message_search.MessageSearchResults.model_fields
 
@@ -595,7 +667,7 @@ class TestPagingAndItsHonesty:
         )
 
         assert found.messages == []
-        assert (found.more_results_available, found.next_offset) == (False, None)
+        assert (found.truncated, found.next_offset) == (False, None)
 
 
 class TestGraphFailures:

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -31,8 +31,17 @@ _CHANNEL_URI = (
     f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
 )
 
+_ROOT_ID = "1760000000000"
+_REPLY_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+    + f"/messages/{_ROOT_ID}/replies/{_MESSAGE_ID}"
+)
+
 _CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
 _CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
+_REPLY_HANDLE = MessageHandle(
+    message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, reply_to_id=_ROOT_ID
+)
 
 _MENTIONED = UUID("497b7a2a-9e1a-48d7-80e8-2965d2fc3a81")
 
@@ -336,6 +345,18 @@ class TestTheHandleItMints:
         assert chat == _CHAT_HANDLE
         assert channel == _CHANNEL_HANDLE
 
+    def test_it_reads_the_reply_shape_that_only_browsing_a_channel_can_mint(self) -> None:
+        """The third shape. Graph addresses a reply in a channel thread under the post it answers,
+        and the search projection carries no `replyToId` — so a search hit on a reply becomes the
+        root-post shape and cannot be read, while `channels.browse_channel` walks a channel post by
+        post and knows each reply's parent. The grammar still lives here, with the other two: two
+        modules that each knew how to write a handle would be free to disagree.
+        """
+        reply = message_search.message_handle(_REPLY_URI)
+
+        assert reply == _REPLY_HANDLE
+        assert reply is not None and reply.uri == _REPLY_URI
+
     def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
         chat = message_search.message_handle(_CHAT_URI)
         channel = message_search.message_handle(_CHANNEL_URI)
@@ -357,6 +378,7 @@ class TestTheHandleItMints:
         never missing."""
         assert _CHAT_HANDLE.permission == "Chat.Read"
         assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+        assert _REPLY_HANDLE.permission == "ChannelMessage.Read.All"
 
     @pytest.mark.parametrize(
         "uri",
@@ -371,7 +393,10 @@ class TestTheHandleItMints:
             "teams:///messages/1770000000000",
             "teams:///chats//messages/1770000000000",
             "teams:///chats/19%3Arelease%40thread.v2/messages/",
+            # A chat has no replies in Graph's addressing — only a channel thread does.
             "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
+            "teams:///teams/8a9c3c47/channels/19%3Ageneral/messages/1770000000000/replies/",
+            "teams:///teams/8a9c3c47/channels/19%3Ageneral/messages//replies/1770000000001",
             "teams:///teams/8a9c3c47/messages/1770000000000",
             "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
             # A Teams web link, which is what a model reaches for when it has no handle.

--- a/services/office-mcp/tests/features/test_message_search.py
+++ b/services/office-mcp/tests/features/test_message_search.py
@@ -357,6 +357,23 @@ class TestTheHandleItMints:
         assert reply == _REPLY_HANDLE
         assert reply is not None and reply.uri == _REPLY_URI
 
+    def test_the_advice_for_a_reply_hit_stops_rather_than_pointing_back_at_browsing(self) -> None:
+        """A hit that is really a channel reply carries the root-post shape, which Graph answers 404
+        to — and the advice for that has to end somewhere. `channels.browse_channel` mints a reply's
+        own handle but reaches only the newest replies of each post on a channel's first page and
+        follows no cursor past them, so "browse the channel instead" is a route for a recent reply
+        and a loop for an older one: browse, not find it, read the same advice, browse again. So the
+        window is named and the terminus is stated here, where the handle that can fail is minted.
+        """
+        described = message_search.MessageHit.model_fields["uri"].description
+        assert described is not None
+
+        assert "browse_channel" in described, "the one tool that can, when the reply is recent"
+        assert "only the newest replies" in described, "and where it stops"
+        assert "no route to its full text" in described
+        assert "browsing again returns the same window" in described
+        assert "stop looking" in described
+
     def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
         chat = message_search.message_handle(_CHAT_URI)
         channel = message_search.message_handle(_CHANNEL_URI)

--- a/services/office-mcp/tests/features/test_recordings.py
+++ b/services/office-mcp/tests/features/test_recordings.py
@@ -48,11 +48,33 @@ def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
     )
 
 
-def _listed(graph: respx.MockRouter, *payloads: object, next_link: bool = False) -> respx.Route:
-    body: dict[str, object] = {"value": list(payloads)}
-    if next_link:
-        body["@odata.nextLink"] = f"{GRAPH_V1}{_RECORDINGS}?$skiptoken=synthetic"
-    return graph.get(_RECORDINGS).mock(return_value=httpx.Response(200, json=body))
+def _listed(graph: respx.MockRouter, *payloads: object) -> respx.Route:
+    return graph.get(_RECORDINGS).mock(
+        return_value=httpx.Response(200, json={"value": list(payloads)})
+    )
+
+
+def _pages(
+    graph: respx.MockRouter, first: list[dict[str, object]], second: list[dict[str, object]]
+) -> respx.Route:
+    """Graph's own paging: a first page carrying `@odata.nextLink`, then the rest.
+
+    Two real pages rather than one page that links to itself, because the walk now follows the
+    cursor to the end of the collection (bounded by `MAX_ARTIFACT_SCAN`) rather than stopping as
+    soon as it has `limit` items — which is the whole of what makes "newest first" true.
+    """
+    return graph.get(_RECORDINGS).mock(
+        side_effect=[
+            httpx.Response(
+                200,
+                json={
+                    "value": first,
+                    "@odata.nextLink": f"{GRAPH_V1}{_RECORDINGS}?$skiptoken=synthetic",
+                },
+            ),
+            httpx.Response(200, json={"value": second}),
+        ]
+    )
 
 
 def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
@@ -415,19 +437,91 @@ class TestScopingToOneOccurrence:
     async def test_a_full_window_with_more_behind_it_says_so(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
+        """More recordings in the window than `limit` holds: the newest of them come back, and
+        `truncated` says the rest are older ones rather than a next page to fetch."""
         _resolved(graph)
-        _listed(
+        _pages(
             graph,
-            recording_payload(recording_id="one"),
-            recording_payload(recording_id="two"),
-            next_link=True,
+            [recording_payload(recording_id="week-1", created_at="2026-02-03T14:00:00Z")],
+            [recording_payload(recording_id="week-2", created_at="2026-02-10T14:00:00Z")],
         )
         _me(graph)
 
-        found = await _listing(client, limit=2)
+        found = await _listing(client, limit=1)
 
         assert found.truncated is True
         assert found.status == "available"
+        assert [item.recording_id for item in found.recordings] == ["week-2"]
+
+    async def test_the_newest_are_returned_and_not_the_first_graph_answered_with(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The recordings lister inherited this from the transcript one and is fixed with it: the
+        collection is ordered before `limit` cuts it, so "the recording of the latest occurrence"
+        is what a small `limit` answers with. Cutting first would have answered `oldest` here.
+        """
+        _resolved(graph, meeting_type="recurring")
+        _listed(
+            graph,
+            recording_payload(recording_id="oldest", created_at="2026-02-03T14:00:00Z"),
+            recording_payload(recording_id="middle", created_at="2026-02-10T14:00:00Z"),
+            recording_payload(recording_id="newest", created_at="2026-02-17T14:00:00Z"),
+        )
+        _me(graph)
+
+        found = await _listing(client, limit=1)
+
+        assert [item.recording_id for item in found.recordings] == ["newest"]
+        assert found.truncated is True
+
+    async def test_the_newest_is_found_even_when_it_is_on_a_later_page(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph, meeting_type="recurring")
+        _pages(
+            graph,
+            [recording_payload(recording_id="oldest", created_at="2026-02-03T14:00:00Z")],
+            [recording_payload(recording_id="newest", created_at="2026-02-17T14:00:00Z")],
+        )
+        _me(graph)
+
+        found = await _listing(client, limit=1)
+
+        assert [item.recording_id for item in found.recordings] == ["newest"]
+
+    async def test_a_scan_that_stopped_short_asserts_no_absence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The self-contradicting answer, in the lister that shares the code it came from:
+        `not_recorded` ("retrying will not help") could be reported alongside `truncated: true`
+        ("there is more"). A collection that was not read to the end settles nothing, so the answer
+        is `scan_incomplete` and no absence is claimed.
+        """
+        ended = datetime.now(UTC) - timedelta(days=30)
+        _resolved(graph, meeting_type="recurring", end=ended.isoformat())
+        _listed(
+            graph,
+            *(
+                recording_payload(
+                    recording_id=f"occurrence-{index}", created_at="2026-02-03T14:00:00Z"
+                )
+                for index in range(transcripts.MAX_ARTIFACT_SCAN + 50)
+            ),
+        )
+        _me(graph)
+
+        found = await _listing(
+            client,
+            started_after=datetime(2026, 3, 1, tzinfo=UTC),
+            started_before=datetime(2026, 3, 2, tzinfo=UTC),
+        )
+
+        assert found.recordings == []
+        assert found.truncated is True
+        assert found.status == "scan_incomplete"
+        assert found.status not in ("not_recorded", "not_ready"), (
+            "a window whose collection was not read to the end settles nothing either way"
+        )
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(
         self, client: GraphServiceClient

--- a/services/office-mcp/tests/features/test_recordings.py
+++ b/services/office-mcp/tests/features/test_recordings.py
@@ -77,6 +77,33 @@ def _pages(
     )
 
 
+# The only meeting shape that outgrows `MAX_ARTIFACT_SCAN`: one occurrence a day, recorded every
+# time, for the better part of a year. Oldest-first, which is an order of Graph's own — it documents
+# no `$orderby` on this collection either — and the one that puts the genuinely newest occurrence
+# past the cap.
+_DAILY_SERIES_START = datetime(2026, 1, 1, 14, 0, tzinfo=UTC)
+_PAST_THE_CAP = transcripts.MAX_ARTIFACT_SCAN + 60
+
+
+def _day(index: int) -> datetime:
+    """When occurrence `index` of the daily series was recorded."""
+    return _DAILY_SERIES_START + timedelta(days=index)
+
+
+def _daily_series(graph: respx.MockRouter, *, total: int = _PAST_THE_CAP) -> respx.Route:
+    """A meeting with more recordings than one call reads, in one page Graph answers with."""
+    return _listed(
+        graph,
+        *(
+            recording_payload(
+                recording_id=f"day-{index}",
+                created_at=_day(index).isoformat().replace("+00:00", "Z"),
+            )
+            for index in range(total)
+        ),
+    )
+
+
 def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
     """A recurring series as Graph holds it: one meeting, one recording collection, three weeks.
 
@@ -522,6 +549,77 @@ class TestScopingToOneOccurrence:
         assert found.status not in ("not_recorded", "not_ready"), (
             "a window whose collection was not read to the end settles nothing either way"
         )
+
+    async def test_narrowing_the_window_cannot_reach_past_the_scan_cap(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The remedy `scan_incomplete` used to give, in the lister that shares the code it came
+        from. The window is applied to the recordings after Graph has answered — Graph documents
+        `contentCorrelationId` as this collection's one filterable property and never a date — so
+        the request goes out bare and a narrower window reads the same recordings. Two windows,
+        one of them bracketing a recording that really exists (`day-250`): the same answer both
+        times, which is why the advice is now to stop rather than to ask again.
+        """
+        _resolved(graph, meeting_type="recurring")
+        listing = _daily_series(graph)
+        _me(graph)
+
+        wide = await _listing(
+            client,
+            started_after=_day(transcripts.MAX_ARTIFACT_SCAN).date(),
+            started_before=_day(_PAST_THE_CAP - 1).date(),
+        )
+        wide_request = listing.calls.last.request.url
+        narrow = await _listing(
+            client, started_after=_day(250).date(), started_before=_day(250).date()
+        )
+        narrow_request = listing.calls.last.request.url
+
+        assert (wide.status, wide.truncated, wide.recordings) == ("scan_incomplete", True, [])
+        assert (narrow.status, narrow.truncated, narrow.recordings) == (wide.status, True, [])
+        assert str(wide_request) == str(narrow_request), "two windows, one request"
+        for asked in (wide_request, narrow_request):
+            assert not {"$filter", "$orderby", "$top"} & set(asked.params), (
+                f"the window is applied here, not by Graph: {asked}"
+            )
+
+    async def test_the_unreadable_answer_tells_a_caller_to_stop_rather_than_to_retry(self) -> None:
+        """The same advice as the transcript lister gives, because it is the same dead end: there
+        is no argument that sends the next call further into the collection."""
+        described = str(recordings.MeetingRecordings.model_fields["status"].description)
+
+        assert "There is nothing to try" in described
+        assert "Stop, and report" in described
+        assert "do not ask again" in described
+        assert "Narrow `started_after`/`started_before` to the occurrence you mean" not in described
+
+    async def test_past_the_cap_the_newest_returned_is_the_newest_of_what_was_read(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """ "Newest first" is exact over the recordings read, and the read stops at the cap: a
+        daily series recorded for most of a year has its newest occurrence past
+        `MAX_ARTIFACT_SCAN`, and no `$orderby` exists to ask Graph for it."""
+        _resolved(graph, meeting_type="recurring")
+        _daily_series(graph)
+        _me(graph)
+
+        found = await _listing(client, limit=3)
+
+        assert found.status == "available"
+        assert found.truncated is True, "the cap was reached, and the answer has to say so"
+        returned = [item.recording_id for item in found.recordings]
+        assert returned == ["day-199", "day-198", "day-197"], "the newest of the ones read"
+        assert f"day-{_PAST_THE_CAP - 1}" not in returned, (
+            "the meeting's genuinely newest recording was never read, which is the whole point"
+        )
+
+    async def test_the_order_is_promised_over_what_was_read_and_not_over_the_meeting(self) -> None:
+        """The sentence the case above makes false if it drifts back."""
+        described = str(recordings.MeetingRecordings.model_fields["recordings"].description)
+
+        assert str(transcripts.MAX_ARTIFACT_SCAN) in described
+        assert "the latest of what was READ" in described
+        assert "The order is over the whole collection" not in described
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(
         self, client: GraphServiceClient

--- a/services/office-mcp/tests/features/test_recordings.py
+++ b/services/office-mcp/tests/features/test_recordings.py
@@ -1,0 +1,455 @@
+"""The meeting-recording listing: what exists, how long it ran, and who may download it.
+
+Every payload is synthesised — no meeting, no recording and no MP4 anywhere near these tests, which
+is easy to hold to because nothing in this module ever fetches recording content.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import recordings, transcripts
+from office_mcp.graph_client import GraphForbidden, GraphNotFound
+
+from .conftest import (
+    GRAPH_V1,
+    JOIN_WEB_URL,
+    ME,
+    MEETING_ID,
+    OTHER_USER_ID,
+    SIGNED_IN_USER_ID,
+    meeting_payload,
+    recording_payload,
+)
+
+_MEETINGS = "/me/onlineMeetings"
+_RECORDINGS = f"/me/onlineMeetings/{MEETING_ID}/recordings"
+_RECORDING_ID = "7e31db25-bc6e-4fd8-96c7-e01264e9b6fc"
+_CONTENT = f"{_RECORDINGS}/{_RECORDING_ID}/content"
+
+
+def _handle() -> transcripts.MeetingHandle:
+    """The same handle the transcript lister takes: one family, one speller, two artifacts."""
+    handle = transcripts.meeting_handle(transcripts.meeting_uri_for(JOIN_WEB_URL) or "")
+    assert handle is not None
+    return handle
+
+
+def _me(graph: respx.MockRouter) -> respx.Route:
+    return graph.get("/me").mock(return_value=httpx.Response(200, json=ME))
+
+
+def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
+    return graph.get(_MEETINGS).mock(
+        return_value=httpx.Response(200, json={"value": [meeting_payload(**meeting)]})  # pyright: ignore[reportArgumentType]
+    )
+
+
+def _listed(graph: respx.MockRouter, *payloads: object, next_link: bool = False) -> respx.Route:
+    body: dict[str, object] = {"value": list(payloads)}
+    if next_link:
+        body["@odata.nextLink"] = f"{GRAPH_V1}{_RECORDINGS}?$skiptoken=synthetic"
+    return graph.get(_RECORDINGS).mock(return_value=httpx.Response(200, json=body))
+
+
+def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
+    """A recurring series as Graph holds it: one meeting, one recording collection, three weeks.
+
+    The same shape the transcript tests use, because it is the same Graph fact — no occurrence id
+    and no per-occurrence addressing exists, so when a recording ran is all that separates them.
+    """
+    _resolved(graph, meeting_type="recurring", end=end)
+    _listed(
+        graph,
+        recording_payload(recording_id="week-1", created_at="2026-02-03T14:02:00Z"),
+        recording_payload(recording_id="week-2", created_at="2026-02-10T14:01:00Z"),
+        recording_payload(recording_id="week-3", created_at="2026-02-17T14:04:00Z"),
+    )
+
+
+async def _listing(
+    client: GraphServiceClient,
+    *,
+    started_after: date | datetime | None = None,
+    started_before: date | datetime | None = None,
+    limit: int = 20,
+) -> recordings.MeetingRecordings:
+    return await recordings.list_meeting_recordings(
+        client,
+        handle=_handle(),
+        started_after=started_after,
+        started_before=started_before,
+        limit=limit,
+    )
+
+
+class TestWhatOneRecordingIsReportedAs:
+    async def test_it_answers_existence_duration_and_reachability(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole question this module exists for: was it recorded, how long, can I get at it.
+
+        The duration is derived — Microsoft publishes no duration, size or media-type property on
+        `callRecording` — and the correlation id is Microsoft's own link to the transcript of the
+        same call, which is the artifact a model can actually read.
+        """
+        _resolved(graph)
+        listing = _listed(graph, recording_payload())
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.status == "available"
+        assert found.meeting_id == MEETING_ID
+        assert found.subject == "Pricing review"
+        assert found.truncated is False
+        assert listing.called
+        recording = found.recordings[0]
+        assert recording.recording_id == _RECORDING_ID
+        assert recording.duration_seconds == pytest.approx(2831.913)
+        assert recording.content_correlation_id == "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3"
+        assert recording.started_at is not None and recording.ended_at is not None
+
+    async def test_nothing_fetches_the_video(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The decision this whole module is built around, asserted rather than merely intended: a
+        recording is an MP4 of a meeting that can run 30 hours, so listing one must never reach for
+        its content — not to size it, not to check it is there, not for anything."""
+        _resolved(graph)
+        _listed(graph, recording_payload())
+        _me(graph)
+        content = graph.get(_CONTENT).mock(return_value=httpx.Response(200, content=b"not an mp4"))
+
+        found = await _listing(client)
+
+        assert found.status == "available"
+        assert not content.called
+
+    def test_a_recording_carries_no_handle_because_nothing_reads_one(self) -> None:
+        """Every readable thing in this connector is addressed by a handle, and a recording is not
+        readable — so minting one would advertise a reader that does not exist and cannot."""
+        assert "uri" not in recordings.RecordingSummary.model_fields
+
+
+class TestTheOrganiserOnlyConstraint:
+    """Microsoft: "getting callRecording content is supported only for the meeting organizer.
+    Meeting participants don't have permission to download meeting recordings" — unless a tenant
+    administrator unblocked them. The metadata is not so restricted, so the two have to be reported
+    separately, and an unreachable recording must never read as a missing one.
+    """
+
+    @pytest.mark.parametrize(
+        ("organizer", "expected"),
+        [
+            (OTHER_USER_ID, "organizer_only"),
+            (SIGNED_IN_USER_ID, "you_are_the_organizer"),
+            (SIGNED_IN_USER_ID.upper(), "you_are_the_organizer"),
+            (None, "unknown"),
+        ],
+        ids=["participant", "organiser", "organiser-in-other-case", "nobody-named"],
+    )
+    async def test_which_side_of_it_the_signed_in_user_is_on(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        organizer: str | None,
+        expected: str,
+    ) -> None:
+        """An Entra object id is a GUID and its casing is not part of its identity, so the
+        comparison is case-insensitive: getting that wrong tells the organiser of a meeting that
+        they may not download their own recording."""
+        _resolved(graph)
+        _listed(graph, recording_payload(organizer_user_id=organizer))
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.recordings[0].content_access == expected
+        assert found.recordings[0].organizer_user_id == organizer
+
+    async def test_a_recording_it_cannot_download_is_still_listed(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The wrong answer this design exists to avoid. For most meetings a participant asks
+        about, the video is out of reach and the recording is real — so the status is `available`,
+        the duration is there, and the organiser is named as the person who has it."""
+        _resolved(graph)
+        _listed(graph, recording_payload(organizer_user_id=OTHER_USER_ID))
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.status == "available", "unreachable content is not a missing recording"
+        assert found.recordings[0].content_access == "organizer_only"
+        assert found.recordings[0].organizer_user_id == OTHER_USER_ID
+        assert found.recordings[0].duration_seconds is not None
+
+    async def test_the_organiser_type_microsofts_own_sample_sends_still_deserializes(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph's list-recordings sample types the organiser
+        `#Microsoft.Teams.GraphSvc.teamworkUserIdentity`, which is not one of the discriminators the
+        SDK knows. An unknown one falls back to the base identity, which still carries the id — if
+        it did not, the whole listing would die on a live payload."""
+        _resolved(graph)
+        _listed(
+            graph,
+            recording_payload(
+                organizer_user_id=SIGNED_IN_USER_ID,
+                organizer_odata_type="#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            ),
+        )
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.recordings[0].content_access == "you_are_the_organizer"
+
+    async def test_the_caller_is_not_looked_up_when_there_is_nothing_to_say_about(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Who the caller is only changes an answer where a recording exists, and "nothing was
+        recorded" is the common answer — so the request that answers it is not spent on that one."""
+        _resolved(graph, end="2026-02-10T15:00:00Z")
+        _listed(graph)
+        me = _me(graph)
+
+        found = await _listing(client)
+
+        assert found.recordings == []
+        assert not me.called
+
+
+class TestTheDurationIsDerivedOrAbsent:
+    @pytest.mark.parametrize(
+        ("created_at", "ended_at"),
+        [
+            (None, "2026-02-10T14:49:53Z"),
+            ("2026-02-10T14:02:41Z", None),
+            ("2026-02-10T14:49:53Z", "2026-02-10T14:02:41Z"),
+        ],
+        ids=["no-start", "no-end", "ends-before-it-began"],
+    )
+    async def test_what_cannot_be_computed_is_null_and_never_invented(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        created_at: str | None,
+        ended_at: str | None,
+    ) -> None:
+        """Microsoft publishes no duration property, so a missing timestamp leaves no second source
+        — and a negative span is not a duration, so it is unknown rather than a negative number of
+        seconds shown to a caller as a length."""
+        _resolved(graph)
+        _listed(graph, recording_payload(created_at=created_at, ended_at=ended_at))
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.recordings[0].duration_seconds is None
+
+    async def test_timestamps_without_an_offset_are_still_subtractable(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The crash the transcript window already paid for, one field along: Graph timestamps in
+        UTC and says so with a `Z`, but a payload without one must not take the call down through a
+        naive-versus-aware subtraction."""
+        _resolved(graph)
+        _listed(
+            graph,
+            recording_payload(created_at="2026-02-10T14:00:00", ended_at="2026-02-10T14:47:11Z"),
+        )
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert found.recordings[0].duration_seconds == pytest.approx(2831.0)
+
+
+class TestTheFourAnswers:
+    async def test_no_matching_meeting_is_a_status_and_costs_no_listing(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph answers the join-URL filter with `200 OK` and an empty `value` rather than a 404,
+        so "no such meeting" is an answer here exactly as it is for transcripts."""
+        graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+        listing = _listed(graph, recording_payload())
+        me = _me(graph)
+
+        found = await _listing(client)
+
+        assert found.status == "meeting_not_found"
+        assert found.meeting_id is None
+        assert found.recordings == []
+        assert not listing.called and not me.called
+
+    async def test_a_meeting_long_over_with_nothing_in_it_was_not_recorded(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph, end=(datetime.now(UTC) - timedelta(days=9)).isoformat())
+        _listed(graph)
+
+        found = await _listing(client)
+
+        assert found.status == "not_recorded"
+        assert found.meeting_id == MEETING_ID, "the meeting resolved; nobody recorded it"
+
+    @pytest.mark.parametrize(
+        "ended",
+        [
+            datetime.now(UTC) - timedelta(minutes=5),
+            datetime.now(UTC) + timedelta(hours=1),
+            None,
+        ],
+        ids=["just-ended", "still-running", "no-end-time"],
+    )
+    async def test_a_meeting_that_just_ended_is_not_ready_rather_than_never_recorded(
+        self, client: GraphServiceClient, graph: respx.MockRouter, ended: datetime | None
+    ) -> None:
+        """The same two empty answers as for transcripts, on the same shared inference: Microsoft
+        publishes no processing status and no availability SLA for a recording either, so the bias
+        is towards the wrong answer that costs a caller one more call."""
+        _resolved(graph, end=ended.isoformat() if ended is not None else None)
+        _listed(graph)
+
+        found = await _listing(client)
+
+        assert found.status == "not_ready"
+
+    async def test_a_long_past_occurrence_of_a_running_series_was_not_recorded(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The promise the shared window keeps: a series' own end time says nothing about an
+        occurrence that ended a month ago, and a caller told to wait for it waits forever."""
+        past = (datetime.now(UTC) - timedelta(days=30)).date()
+        _weekly_series(graph, end=(datetime.now(UTC) + timedelta(days=180)).isoformat())
+
+        found = await _listing(client, started_after=past, started_before=past)
+
+        assert found.recordings == []
+        assert found.status == "not_recorded"
+
+    async def test_a_404_is_still_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The distinction the empty collection exists to be told apart from."""
+        graph.get(_MEETINGS).mock(
+            return_value=httpx.Response(404, json={"error": {"code": "NotFound", "message": "no"}})
+        )
+
+        with pytest.raises(GraphNotFound):
+            _ = await _listing(client)
+
+
+class TestScopingToOneOccurrence:
+    async def test_the_shared_window_picks_one_occurrence_out_of_the_series(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """One meeting, one recording collection, three weeks in it. The window is the transcript
+        lister's own `OccurrenceWindow` — there is no second implementation of it, which is the
+        point: a series bracketed one way for transcripts and another way for recordings would pair
+        the wrong occurrence with the wrong call."""
+        _weekly_series(graph)
+        _me(graph)
+
+        found = await _listing(
+            client,
+            started_after=datetime(2026, 2, 10, tzinfo=UTC),
+            started_before=datetime(2026, 2, 11, tzinfo=UTC),
+        )
+
+        assert found.meeting_type == "recurring"
+        assert [item.recording_id for item in found.recordings] == ["week-2"]
+        assert found.truncated is False
+
+    @pytest.mark.parametrize(
+        ("started_after", "started_before", "expected"),
+        [
+            (date(2026, 2, 10), date(2026, 2, 10), ["week-2"]),
+            (datetime(2026, 2, 10, 14, 0), datetime(2026, 2, 10, 14, 2), ["week-2"]),
+            (datetime(2026, 2, 10, 14, 0, tzinfo=UTC), None, ["week-3", "week-2"]),
+            (None, date(2026, 2, 10), ["week-2", "week-1"]),
+        ],
+        ids=["bare-dates", "no-offset", "open-at-the-top", "open-at-the-bottom"],
+    )
+    async def test_every_window_shape_a_model_writes_is_answered(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        started_after: date | datetime | None,
+        started_before: date | datetime | None,
+        expected: list[str],
+    ) -> None:
+        """The same shapes the transcript lister accepts and on the same UTC assumption, because
+        they are the same parameters on the same window — a model that learned one has learned both.
+        """
+        _weekly_series(graph)
+        _me(graph)
+
+        found = await _listing(client, started_after=started_after, started_before=started_before)
+
+        assert found.status == "available"
+        assert [item.recording_id for item in found.recordings] == expected
+
+    async def test_recordings_come_back_newest_first(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents no `$orderby` on this collection either, so the order it answers in is
+        not a contract and the useful one is applied here."""
+        _resolved(graph)
+        _listed(
+            graph,
+            recording_payload(recording_id="older", created_at="2026-02-03T14:00:00Z"),
+            recording_payload(recording_id="newer", created_at="2026-02-17T14:00:00Z"),
+        )
+        _me(graph)
+
+        found = await _listing(client)
+
+        assert [item.recording_id for item in found.recordings] == ["newer", "older"]
+
+    async def test_a_full_window_with_more_behind_it_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph)
+        _listed(
+            graph,
+            recording_payload(recording_id="one"),
+            recording_payload(recording_id="two"),
+            next_link=True,
+        )
+        _me(graph)
+
+        found = await _listing(client, limit=2)
+
+        assert found.truncated is True
+        assert found.status == "available"
+
+    async def test_a_limit_above_the_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await _listing(client, limit=recordings.MAX_RECORDINGS + 1)
+
+
+class TestWhatGraphRefusalsLookLikeHere:
+    async def test_a_refused_listing_reaches_the_tool_layer_as_a_forbidden(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Recordings need their own admin-consented permission, and a tenant may grant transcript
+        access without it. Nothing is swallowed: the tool layer is what names the permission."""
+        _resolved(graph)
+        graph.get(_RECORDINGS).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await _listing(client)
+
+        assert raised.value.inner_code is None, "an ordinary refusal carries no inner code"

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -353,8 +353,13 @@ class TestTheThreeAbsences:
     def test_the_allowance_is_generous_enough_to_be_the_safe_side(self) -> None:
         """Microsoft publishes no availability SLA, so the only defensible bias is towards telling
         a caller to wait. A tight window would report a still-processing transcript as one that
-        will never exist, which is the one wrong answer a caller cannot detect."""
-        assert timedelta(hours=1) <= transcripts.TRANSCRIPT_DELAY_ALLOWANCE
+        will never exist, which is the one wrong answer a caller cannot detect.
+
+        The allowance is named for artifacts rather than for transcripts because the recordings
+        lister answers its own absence with the same inference (`OccurrenceWindow.settled`) — the
+        assertion is unchanged.
+        """
+        assert timedelta(hours=1) <= transcripts.ARTIFACT_DELAY_ALLOWANCE
 
 
 class TestScopingToOneOccurrence:

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -90,6 +90,37 @@ def _pages(
     )
 
 
+# The only meeting shape that outgrows `MAX_ARTIFACT_SCAN`: one occurrence a day, transcribed every
+# time, for the better part of a year. Written oldest-first because Graph documents no `$orderby`
+# here and answers in an order of its own — this is the order that puts the genuinely newest
+# occurrence past the cap, which is the case both promises below have to be exact about.
+_DAILY_SERIES_START = datetime(2026, 1, 1, 14, 0, tzinfo=UTC)
+_PAST_THE_CAP = transcripts.MAX_ARTIFACT_SCAN + 60
+
+
+def _day(index: int) -> datetime:
+    """When occurrence `index` of the daily series was transcribed."""
+    return _DAILY_SERIES_START + timedelta(days=index)
+
+
+def _daily_series(graph: respx.MockRouter, *, total: int = _PAST_THE_CAP) -> respx.Route:
+    """A meeting with more transcripts than one call reads, in one page Graph answers with."""
+    return graph.get(_TRANSCRIPTS).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [
+                    transcript_payload(
+                        transcript_id=f"day-{index}",
+                        created_at=_day(index).isoformat().replace("+00:00", "Z"),
+                    )
+                    for index in range(total)
+                ]
+            },
+        )
+    )
+
+
 def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
     """A recurring series as Graph holds it: one meeting, one transcript collection, three weeks.
 
@@ -585,6 +616,93 @@ class TestScopingToOneOccurrence:
         assert found.status not in ("not_transcribed", "not_ready"), (
             "a window whose collection was not read to the end settles nothing either way"
         )
+
+    async def test_narrowing_the_window_cannot_reach_past_the_scan_cap(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The remedy `scan_incomplete` used to give, and why it could not work.
+
+        The window is ours: it is applied to the transcripts *after* Graph has answered, because
+        Graph documents no filterable date on this collection. So the request goes out bare and the
+        same first `MAX_ARTIFACT_SCAN` transcripts are read whatever window was asked for — a wide
+        window and a narrow one over the same collection are the same call with the same answer,
+        and "narrow it and ask again" was a loop a model could run forever. Here the narrow window
+        even brackets a transcript that genuinely exists (`day-250`), and it is still never seen.
+        """
+        _resolved(graph, meeting_type="recurring")
+        listing = _daily_series(graph)
+
+        wide = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=_day(transcripts.MAX_ARTIFACT_SCAN).date(),
+            started_before=_day(_PAST_THE_CAP - 1).date(),
+            limit=20,
+        )
+        wide_request = listing.calls.last.request.url
+        narrow = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=_day(250).date(),
+            started_before=_day(250).date(),
+            limit=20,
+        )
+        narrow_request = listing.calls.last.request.url
+
+        assert (wide.status, wide.truncated, wide.transcripts) == ("scan_incomplete", True, [])
+        assert (narrow.status, narrow.truncated, narrow.transcripts) == (wide.status, True, [])
+        assert str(wide_request) == str(narrow_request), "two windows, one request"
+        for asked in (wide_request, narrow_request):
+            assert not {"$filter", "$orderby", "$top"} & set(asked.params), (
+                f"the window is applied here, not by Graph: {asked}"
+            )
+
+    async def test_the_unreadable_answer_tells_a_caller_to_stop_rather_than_to_retry(self) -> None:
+        """The advice a model reads, pinned against the loop it used to be. `scan_incomplete` is
+        the one verdict with no caller action behind it, so what it must say is that there is
+        nothing to try — not an argument to change, which is advice that never terminates."""
+        described = str(transcripts.MeetingTranscripts.model_fields["status"].description)
+
+        assert "There is nothing to try" in described
+        assert "Stop, and report" in described
+        assert "do not ask again" in described
+        assert "Narrow `started_after`/`started_before` to the occurrence you mean" not in described
+
+    async def test_past_the_cap_the_newest_returned_is_the_newest_of_what_was_read(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """ "Newest first" is exact over the transcripts read, and the read stops at the cap.
+
+        A daily series recorded for most of a year has its genuinely newest occurrence past
+        `MAX_ARTIFACT_SCAN`, and Graph offers no `$orderby` to ask for it — so asking for 3 gives
+        the 3 newest of the 200 that were read, not the 3 newest of the meeting. That is the honest
+        answer; the dishonest part was ever calling them "the 3 latest", so the flag that says the
+        read stopped short is asserted here alongside it.
+        """
+        _resolved(graph, meeting_type="recurring")
+        _daily_series(graph)
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=3
+        )
+
+        assert found.status == "available"
+        assert found.truncated is True, "the cap was reached, and the answer has to say so"
+        returned = [item.transcript_id for item in found.transcripts]
+        assert returned == ["day-199", "day-198", "day-197"], "the newest of the ones read"
+        assert f"day-{_PAST_THE_CAP - 1}" not in returned, (
+            "the meeting's genuinely newest transcript was never read, which is the whole point"
+        )
+
+    async def test_the_order_is_promised_over_what_was_read_and_not_over_the_meeting(self) -> None:
+        """The sentence the case above makes false if it drifts back. A model reads this field's
+        description to decide whether the first entry is "the latest transcript of the series", so
+        it has to name the cap and say what the order is over past it."""
+        described = str(transcripts.MeetingTranscripts.model_fields["transcripts"].description)
+
+        assert str(transcripts.MAX_ARTIFACT_SCAN) in described
+        assert "the latest of what was READ" in described
+        assert "The order is over the whole collection" not in described
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(
         self, client: GraphServiceClient

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -5,7 +5,7 @@ nothing here came from a meeting: the speakers are historical figures, the words
 the ids are obviously fake.
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -50,6 +50,11 @@ _ATTRIBUTION_OFF = {
 }
 
 
+# Central European Time, which February is in: the offset a European caller's "15:00" carries, and
+# one hour away from the UTC the same string is read as when it carries no offset at all.
+_CET = timezone(timedelta(hours=1))
+
+
 def _handle() -> transcripts.MeetingHandle:
     handle = transcripts.meeting_handle(transcripts.meeting_uri_for(JOIN_WEB_URL) or "")
     assert handle is not None
@@ -59,6 +64,28 @@ def _handle() -> transcripts.MeetingHandle:
 def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
     return graph.get(_MEETINGS).mock(
         return_value=httpx.Response(200, json={"value": [meeting_payload(**meeting)]})  # pyright: ignore[reportArgumentType]
+    )
+
+
+def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
+    """A recurring series as Graph holds it: one meeting, one transcript collection, three weeks.
+
+    Three occurrences in one collection is the whole reason a window exists — Graph publishes no
+    occurrence id and no per-occurrence addressing — and `end` is the series-wide `endDateTime`,
+    which is the value the verdict must NOT be read off when a window was asked for.
+    """
+    _resolved(graph, meeting_type="recurring", end=end)
+    _ = graph.get(_TRANSCRIPTS).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [
+                    transcript_payload(transcript_id="week-1", created_at="2026-02-03T14:02:00Z"),
+                    transcript_payload(transcript_id="week-2", created_at="2026-02-10T14:01:00Z"),
+                    transcript_payload(transcript_id="week-3", created_at="2026-02-17T14:04:00Z"),
+                ]
+            },
+        )
     )
 
 
@@ -443,6 +470,224 @@ class TestScopingToOneOccurrence:
         )
         assert summary.content_correlation_id == "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3"
         assert summary.started_at is not None and summary.ended_at is not None
+
+
+class TestTheWindowShapesAModelActuallySends:
+    """A window is the only reason `started_after`/`started_before` exist, and a model writes a date
+    the way people write dates. `2026-02-10` and `2026-02-10T14:00:00` both used to reach a
+    comparison between a naive datetime and Graph's aware one and raise `TypeError` at the caller —
+    a crash naming no remedy, for a value the schema had accepted.
+    """
+
+    def test_a_bound_that_named_no_zone_is_resolved_against_utc_and_not_the_host(self) -> None:
+        """Asserted on the resolved instant rather than through a filter, because a machine whose
+        local zone happens to be UTC cannot tell the two readings apart — and the assumption is what
+        the parameter descriptions promise, so it is what has to be pinned."""
+        window = transcripts.OccurrenceWindow.of(
+            datetime(2026, 2, 10, 9, 0), datetime(2026, 2, 10, 17, 0)
+        )
+
+        assert window.started_after == datetime(2026, 2, 10, 9, 0, tzinfo=UTC)
+        assert window.started_before == datetime(2026, 2, 10, 17, 0, tzinfo=UTC)
+
+    def test_a_bare_date_is_a_whole_utc_day_and_not_an_empty_span(self) -> None:
+        """The same date in both bounds is how one occurrence gets bracketed. Resolving both to
+        midnight would make that the empty span between one instant and itself — a window matching
+        nothing, reported as an answer about the day."""
+        window = transcripts.OccurrenceWindow.of(date(2026, 2, 10), date(2026, 2, 10))
+
+        assert window.started_after == datetime(2026, 2, 10, tzinfo=UTC)
+        assert window.started_before is not None
+        assert datetime(2026, 2, 10, 23, 59, 59, tzinfo=UTC) < window.started_before
+        assert window.started_before < datetime(2026, 2, 11, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        ("started_after", "started_before", "expected"),
+        [
+            (date(2026, 2, 10), date(2026, 2, 10), ["week-2"]),
+            (datetime(2026, 2, 10, 14, 0), datetime(2026, 2, 10, 14, 2), ["week-2"]),
+            (datetime(2026, 2, 10), datetime(2026, 2, 11), ["week-2"]),
+            (
+                datetime(2026, 2, 10, 15, 0, tzinfo=_CET),
+                datetime(2026, 2, 10, 16, 0, tzinfo=_CET),
+                ["week-2"],
+            ),
+            (datetime(2026, 2, 10, 14, 0, tzinfo=UTC), None, ["week-3", "week-2"]),
+            (None, date(2026, 2, 10), ["week-2", "week-1"]),
+        ],
+        ids=[
+            "bare-dates",
+            "naive-datetimes",
+            "naive-midnights",
+            "offset-aware",
+            "open-at-the-top",
+            "open-at-the-bottom",
+        ],
+    )
+    async def test_every_shape_bounds_the_series_and_none_of_them_raises(
+        self,
+        client: GraphServiceClient,
+        graph: respx.MockRouter,
+        started_after: date | datetime | None,
+        started_before: date | datetime | None,
+        expected: list[str],
+    ) -> None:
+        """The `_CET` case is the one that has to differ from the naive one: `15:00+01:00` is
+        `14:00Z`, so an offset is honoured rather than dropped, and a bound that carries none is not
+        silently given the host's."""
+        _weekly_series(graph)
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=started_after,
+            started_before=started_before,
+            limit=20,
+        )
+
+        assert found.status == "available"
+        assert [summary.transcript_id for summary in found.transcripts] == expected
+
+    async def test_a_bare_date_keeps_the_last_minute_of_its_day_and_not_the_next_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """What "the whole day" has to mean at the edges, where an off-by-one is invisible: a turn
+        transcribed at 23:59 belongs to the day asked for and one at 00:00 does not."""
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(transcript_id="dawn", created_at="2026-02-10T00:00:01Z"),
+                        transcript_payload(transcript_id="dusk", created_at="2026-02-10T23:59:30Z"),
+                        transcript_payload(
+                            transcript_id="after", created_at="2026-02-11T00:00:30Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=date(2026, 2, 10),
+            started_before=date(2026, 2, 10),
+            limit=20,
+        )
+
+        assert [summary.transcript_id for summary in found.transcripts] == ["dusk", "dawn"]
+
+    async def test_a_graph_timestamp_carrying_no_offset_is_still_comparable(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other side of the same crash. Graph timestamps in UTC and says so with a `Z`, but a
+        window is worth nothing if one payload without one takes the whole call down — so the
+        transcript's own timestamp is resolved on the same assumption as the bounds."""
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(transcript_id="naive", created_at="2026-02-10T14:01:00")
+                    ]
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=date(2026, 2, 10),
+            started_before=date(2026, 2, 10),
+            limit=20,
+        )
+
+        assert [summary.transcript_id for summary in found.transcripts] == ["naive"]
+
+
+class TestTheVerdictIsAboutTheWindowThatWasAskedFor:
+    """`not_ready` and `not_transcribed` are the same empty collection and opposite advice, so which
+    one is given has to follow the window the caller asked about. Reading it off the *meeting* was
+    wrong in exactly the case the window exists for: a series is one meeting, its `endDateTime` is
+    one value for the whole series, and a caller told to wait for an occurrence that ended last
+    month waits forever.
+    """
+
+    @pytest.mark.parametrize(
+        "end",
+        [None, (datetime.now(UTC) + timedelta(days=180)).isoformat()],
+        ids=["no-end-time", "series-runs-for-months"],
+    )
+    async def test_a_long_past_occurrence_of_a_running_series_was_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter, end: str | None
+    ) -> None:
+        past = (datetime.now(UTC) - timedelta(days=30)).date()
+        _weekly_series(graph, end=end)
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=past, started_before=past, limit=20
+        )
+
+        assert found.transcripts == []
+        assert found.status == "not_transcribed", (
+            "the occurrence is a month gone; the series' own end time says nothing about it"
+        )
+
+    async def test_a_window_that_has_only_just_closed_is_still_not_ready(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The allowance has to keep applying to the window itself, or the fix for one wrong answer
+        becomes the other one: a transcript minutes away would be reported as never coming."""
+        _weekly_series(graph, end=None)
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime.now(UTC) - timedelta(hours=1),
+            started_before=datetime.now(UTC) - timedelta(minutes=5),
+            limit=20,
+        )
+
+        assert found.status == "not_ready"
+
+    async def test_a_window_still_open_at_its_far_end_admits_the_answer_is_not_known(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Where it genuinely cannot be told, it still says wait. `started_after` alone leaves the
+        window running up to now, and a series with no end time offers no second piece of evidence —
+        Graph publishes neither a processing status nor an SLA, so the cheap wrong answer wins."""
+        _weekly_series(graph, end=None)
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime.now(UTC) - timedelta(days=30),
+            started_before=None,
+            limit=20,
+        )
+
+        assert found.status == "not_ready"
+
+    async def test_a_meeting_long_over_settles_even_a_window_set_in_the_future(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Either side may settle it. A window a caller put in next week is not an instruction to
+        wait for a meeting that ended nine days ago — nothing more is coming from it."""
+        _resolved(graph, end=(datetime.now(UTC) - timedelta(days=9)).isoformat())
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=(datetime.now(UTC) + timedelta(days=7)).date(),
+            started_before=None,
+            limit=20,
+        )
+
+        assert found.status == "not_transcribed"
 
 
 class TestReadingTheWords:

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -67,6 +67,29 @@ def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
     )
 
 
+def _pages(
+    graph: respx.MockRouter, first: list[dict[str, object]], second: list[dict[str, object]]
+) -> respx.Route:
+    """Graph's own paging: a first page carrying `@odata.nextLink`, then the rest.
+
+    Two real pages rather than one page that links to itself, because the walk now follows the
+    cursor to the end of the collection (bounded by `MAX_ARTIFACT_SCAN`) rather than stopping as
+    soon as it has `limit` items — which is the whole of what makes "newest first" true.
+    """
+    return graph.get(_TRANSCRIPTS).mock(
+        side_effect=[
+            httpx.Response(
+                200,
+                json={
+                    "value": first,
+                    "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=synthetic",
+                },
+            ),
+            httpx.Response(200, json={"value": second}),
+        ]
+    )
+
+
 def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:00:00Z") -> None:
     """A recurring series as Graph holds it: one meeting, one transcript collection, three weeks.
 
@@ -453,25 +476,115 @@ class TestScopingToOneOccurrence:
     async def test_a_full_window_with_more_behind_it_says_so(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
+        """More transcripts in the window than `limit` holds: the newest of them come back, and
+        `truncated` says the rest are older ones rather than a next page to fetch."""
         _resolved(graph)
+        _pages(
+            graph,
+            [transcript_payload(transcript_id="week-1", created_at="2026-02-03T14:00:00Z")],
+            [transcript_payload(transcript_id="week-2", created_at="2026-02-10T14:00:00Z")],
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=1
+        )
+
+        assert found.truncated is True
+        assert found.status == "available"
+        assert [t.transcript_id for t in found.transcripts] == ["week-2"]
+
+    async def test_the_newest_are_returned_and_not_the_first_graph_answered_with(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """ "The latest transcript of this series" is the question this tool exists for, and Graph
+        answers this collection in an order of its own — it documents no `$orderby` at all. So the
+        window is filled from the whole collection and sorted before `limit` cuts it. Cutting first
+        and sorting the remainder returns an arbitrary handful sorted among themselves, which reads
+        exactly like the right answer: here it would have answered `oldest`.
+        """
+        _resolved(graph, meeting_type="recurring")
         graph.get(_TRANSCRIPTS).mock(
             return_value=httpx.Response(
                 200,
                 json={
                     "value": [
-                        transcript_payload(transcript_id=f"week-{index}") for index in range(2)
-                    ],
-                    "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=synthetic",
+                        transcript_payload(
+                            transcript_id="oldest", created_at="2026-02-03T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="middle", created_at="2026-02-10T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="newest", created_at="2026-02-17T14:00:00Z"
+                        ),
+                    ]
                 },
             )
         )
 
         found = await transcripts.list_meeting_transcripts(
-            client, handle=_handle(), started_after=None, started_before=None, limit=2
+            client, handle=_handle(), started_after=None, started_before=None, limit=1
         )
 
+        assert [t.transcript_id for t in found.transcripts] == ["newest"]
         assert found.truncated is True
-        assert found.status == "available"
+
+    async def test_the_newest_is_found_even_when_it_is_on_a_later_page(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The same promise across Graph's own paging: a walk that stopped as soon as it had
+        `limit` items would never have seen the newest one."""
+        _resolved(graph, meeting_type="recurring")
+        _pages(
+            graph,
+            [transcript_payload(transcript_id="oldest", created_at="2026-02-03T14:00:00Z")],
+            [transcript_payload(transcript_id="newest", created_at="2026-02-17T14:00:00Z")],
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=1
+        )
+
+        assert [t.transcript_id for t in found.transcripts] == ["newest"]
+
+    async def test_a_scan_that_stopped_short_asserts_no_absence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The answer that used to contradict itself: `not_transcribed` ("retrying will not help")
+        alongside `truncated: true` ("there is more"). Both cannot be true, and a caller cannot see
+        which one is wrong. A meeting with more transcripts than one call looks through, none of
+        them in the window, is now `scan_incomplete` — which claims nothing about absence.
+        """
+        ended = datetime.now(UTC) - timedelta(days=30)
+        _resolved(graph, meeting_type="recurring", end=ended.isoformat())
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id=f"occurrence-{index}", created_at="2026-02-03T14:00:00Z"
+                        )
+                        for index in range(transcripts.MAX_ARTIFACT_SCAN + 50)
+                    ]
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 3, 1, tzinfo=UTC),
+            started_before=datetime(2026, 3, 2, tzinfo=UTC),
+            limit=20,
+        )
+
+        assert found.transcripts == []
+        assert found.truncated is True
+        assert found.status == "scan_incomplete"
+        assert found.status not in ("not_transcribed", "not_ready"), (
+            "a window whose collection was not read to the end settles nothing either way"
+        )
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(
         self, client: GraphServiceClient

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -89,6 +89,34 @@ def _weekly_series(graph: respx.MockRouter, *, end: str | None = "2026-02-17T15:
     )
 
 
+def _transcript() -> transcripts.TranscriptHandle:
+    """The handle `list_meeting_transcripts` would have minted for the transcript below."""
+    return transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID)
+
+
+def _spoken(graph: respx.MockRouter) -> respx.Route:
+    """The words, answered to every read: `/content` is one stream and each call fetches it all."""
+    return graph.get(_CONTENT).mock(
+        return_value=httpx.Response(200, content=TRANSCRIPT_VTT.encode())
+    )
+
+
+def _spoken_by_nobody(graph: respx.MockRouter) -> respx.Route:
+    """The same endpoint in a tenant with speaker attribution off, which is where it is decided.
+
+    The attributed format is refused and the plain one served, exactly as Graph does it — serving
+    unattributed bytes to the attributed request would say `speaker_attribution` is true, which is
+    the field a caller reads to find out why a speaker filter matched nothing.
+    """
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.headers["accept"] == "text/vtt":
+            return httpx.Response(403, json=_ATTRIBUTION_OFF)
+        return httpx.Response(200, content=TRANSCRIPT_UNATTRIBUTED.encode())
+
+    return graph.get(_CONTENT).mock(side_effect=respond)
+
+
 class TestTheHandleGrammar:
     def test_a_meeting_handle_survives_the_join_url_it_carries(self) -> None:
         """A join URL is full of `:`, `/`, `?`, `&` and `%` and must come back byte-identical:
@@ -817,3 +845,250 @@ class TestReadingTheWords:
                 offset=0,
                 limit=transcripts.MAX_TURNS + 1,
             )
+
+
+class TestNarrowingWhatComesBack:
+    """The filters, over the one transcript that carries every shape the parser survives.
+
+    An hour of meeting is thousands of turns and a model reads it to answer one question, so the
+    narrowing has to happen here rather than in the model's context. What is asserted is the part a
+    caller cannot check for itself: which turns a bound admits, and that the page and its
+    `next_offset` are counted over what survived the filter rather than over the whole transcript.
+    """
+
+    async def test_a_lower_bound_keeps_everything_still_running_at_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Overlap and not containment: the turn that was mid-sentence when the clock struck is the
+        one a caller asking "from here" most wants, and dropping it would silently cut the sentence
+        their question is about."""
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=1.0
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "We should raise the floor price by three per cent.",
+            "Agreed <that> works.",
+            "Nobody was attributed for this one.",
+        ], "the first turn started at -2.5 and was still running at 1.0"
+        assert read.turns[0].start_seconds == -2.5
+
+    async def test_a_lower_bound_drops_what_had_finished_before_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=16.0
+        )
+
+        assert [turn.speaker for turn in read.turns] == ["Grace Hopper", "Ada Lovelace", None]
+        assert read.truncated is False
+
+    async def test_an_upper_bound_keeps_the_turn_that_starts_exactly_on_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Inclusive at both ends, for the same reason: a bound a caller read off a previous answer
+        names a turn that exists, and excluding it would make the two ends disagree."""
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, to_seconds=62.0
+        )
+
+        assert [turn.start_seconds for turn in read.turns] == [-2.5, 16.246, 62.0]
+
+    async def test_both_bounds_together_cut_a_window_out_of_the_middle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=20.0, to_seconds=64.0
+        )
+
+        assert [turn.text for turn in read.turns] == ["Agreed <that> works."]
+
+    async def test_a_speaker_filter_keeps_only_that_speakers_turns(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker="Ada Lovelace"
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "Agreed <that> works.",
+        ]
+        assert read.speaker_attribution is True
+
+    @pytest.mark.parametrize(
+        "speaker",
+        ["ada", "ADA LOVELACE", "lovelace", "Lovelace"],
+        ids=["given", "shouted", "sur", "cased"],
+    )
+    async def test_a_speaker_is_matched_case_insensitively_and_by_part_of_the_name(
+        self, client: GraphServiceClient, graph: respx.MockRouter, speaker: str
+    ) -> None:
+        """A model writes the name it read in a previous answer, or the half of it the caller said.
+        An exact, case-sensitive match would answer "nobody said that" to a question about somebody
+        who spoke — a wrong answer with the shape of a right one."""
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker=speaker
+        )
+
+        assert [turn.speaker for turn in read.turns] == ["Ada Lovelace", "Ada Lovelace"]
+
+    async def test_a_speaker_and_a_window_narrow_together(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """All three at once, which is the question this exists for: what did she say in that
+        stretch. Each filter has to hold, not the last one written."""
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client,
+            handle=_transcript(),
+            offset=0,
+            limit=200,
+            from_seconds=10.0,
+            to_seconds=100.0,
+            speaker="ada",
+        )
+
+        assert [turn.text for turn in read.turns] == ["Agreed <that> works."]
+
+    async def test_a_page_is_cut_from_what_survived_the_filter(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`truncated` counted over the whole transcript would say there is more where the filter
+        already returned everything it matched, and a model would page for turns that cannot come.
+        """
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=2, speaker="ada"
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "Agreed <that> works.",
+        ]
+        assert read.truncated is False, "two matched, two returned; the other turns are not more"
+        assert read.next_offset is None
+
+    async def test_the_next_offset_of_a_filtered_page_continues_the_filtered_sequence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The offset a caller sends back has to index the same sequence it was cut from. Counted
+        over the unfiltered turns it would land in the middle of them: offset 2 of this transcript
+        is Ada's second turn, and offset 2 of what `from_seconds=2.0` matched is the unattributed
+        one."""
+        _spoken(graph)
+        handle = _transcript()
+
+        first = await transcripts.read_transcript(
+            client, handle=handle, offset=0, limit=2, from_seconds=2.0
+        )
+        second = await transcripts.read_transcript(
+            client, handle=handle, offset=first.next_offset or 0, limit=2, from_seconds=2.0
+        )
+
+        assert (first.truncated, first.next_offset) == (True, 2)
+        assert [turn.speaker for turn in first.turns] == ["Grace Hopper", "Ada Lovelace"]
+        assert [turn.text for turn in second.turns] == ["Nobody was attributed for this one."]
+        assert second.truncated is False
+        assert second.next_offset is None
+
+    async def test_a_window_nothing_falls_in_is_no_turns_rather_than_a_refusal(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=7200.0
+        )
+
+        assert read.turns == []
+        assert read.truncated is False
+        assert read.next_offset is None
+
+    async def test_a_speaker_filter_in_a_tenant_with_no_speakers_matches_nothing_and_says_why(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The one empty answer that must not read as "she never spoke". Where the tenant forbids
+        attribution every `speaker` is null, so the filter legitimately matches nothing — and
+        `speaker_attribution` false is the field that explains it. Refusing the call instead would
+        deny a filter the transcript itself supports for time."""
+        _spoken_by_nobody(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker="ada"
+        )
+
+        assert read.turns == []
+        assert read.speaker_attribution is False, "the reason the page is empty"
+        assert read.truncated is False
+
+    async def test_time_still_filters_where_the_speakers_are_gone(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken_by_nobody(graph)
+
+        read = await transcripts.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=30.0
+        )
+
+        assert [turn.start_seconds for turn in read.turns] == [62.0]
+
+    async def test_filters_left_unset_return_the_whole_transcript(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The default is the answer this tool gave before the filters existed, and passing the
+        absent value explicitly is what a model does when it has nothing to narrow by."""
+        _spoken(graph)
+
+        read = await transcripts.read_transcript(
+            client,
+            handle=_transcript(),
+            offset=0,
+            limit=200,
+            from_seconds=None,
+            to_seconds=None,
+            speaker=None,
+        )
+
+        assert [turn.speaker for turn in read.turns] == [
+            "Ada Lovelace",
+            "Grace Hopper",
+            "Ada Lovelace",
+            None,
+        ]
+        assert read.truncated is False
+        assert read.next_offset is None
+
+    async def test_a_window_that_ends_before_it_starts_is_a_programming_error(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """No transcript can satisfy it, so it is a mistake in the caller rather than an empty
+        answer — and the tool layer refuses it before this is ever reached."""
+        content = _spoken(graph)
+
+        with pytest.raises(AssertionError):
+            _ = await transcripts.read_transcript(
+                client,
+                handle=_transcript(),
+                offset=0,
+                limit=200,
+                from_seconds=60.0,
+                to_seconds=30.0,
+            )
+
+        assert not content.called, "an impossible window costs no Graph request"

--- a/services/office-mcp/tests/features/test_transcripts.py
+++ b/services/office-mcp/tests/features/test_transcripts.py
@@ -1,0 +1,574 @@
+"""The meeting-transcript chain: the handles, the filter on the wire, and the words that come back.
+
+Every payload is synthesised. A transcript is the most sensitive thing this connector touches, so
+nothing here came from a meeting: the speakers are historical figures, the words are invented, and
+the ids are obviously fake.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.features import transcripts
+from office_mcp.graph_client import GraphForbidden, GraphNotFound
+
+from .conftest import (
+    GRAPH_V1,
+    JOIN_WEB_URL,
+    MEETING_ID,
+    TRANSCRIPT_UNATTRIBUTED,
+    TRANSCRIPT_VTT,
+    meeting_payload,
+    transcript_payload,
+)
+
+_MEETINGS = "/me/onlineMeetings"
+_TRANSCRIPTS = f"/me/onlineMeetings/{MEETING_ID}/transcripts"
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+_CONTENT = f"{_TRANSCRIPTS}/{_TRANSCRIPT_ID}/content"
+
+_TENANT_SWITCH_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": "Graph API access to transcripts is disabled for this tenant.",
+        "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+    }
+}
+
+_ATTRIBUTION_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": (
+            "Speaker-attributed transcript content is disabled for this tenant. Retry with Accept "
+            + "'application/vnd.microsoft.graph.transcript+text'."
+        ),
+        "innerError": {"code": "SpeakerAttributionNotAllowed"},
+    }
+}
+
+
+def _handle() -> transcripts.MeetingHandle:
+    handle = transcripts.meeting_handle(transcripts.meeting_uri_for(JOIN_WEB_URL) or "")
+    assert handle is not None
+    return handle
+
+
+def _resolved(graph: respx.MockRouter, **meeting: object) -> respx.Route:
+    return graph.get(_MEETINGS).mock(
+        return_value=httpx.Response(200, json={"value": [meeting_payload(**meeting)]})  # pyright: ignore[reportArgumentType]
+    )
+
+
+class TestTheHandleGrammar:
+    def test_a_meeting_handle_survives_the_join_url_it_carries(self) -> None:
+        """A join URL is full of `:`, `/`, `?`, `&` and `%` and must come back byte-identical:
+        Graph matches it against what it stored, character for character."""
+        uri = transcripts.meeting_uri_for(JOIN_WEB_URL)
+        assert uri is not None
+
+        parsed = transcripts.meeting_handle(uri)
+
+        assert parsed is not None
+        assert parsed.join_web_url == JOIN_WEB_URL
+        assert "/" not in uri.removeprefix("teams:///meetings/"), (
+            "the join URL is one path segment; an unencoded slash would make it several"
+        )
+
+    def test_a_transcript_handle_round_trips_both_ids(self) -> None:
+        handle = transcripts.TranscriptHandle("MSo1N2Y5:ZGFjYw==", "MSMjMCMj/0001")
+
+        parsed = transcripts.transcript_handle(handle.uri)
+
+        assert parsed is not None
+        assert (parsed.meeting_id, parsed.transcript_id) == (
+            "MSo1N2Y5:ZGFjYw==",
+            "MSMjMCMj/0001",
+        )
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000",
+            "teams:///meetings/",
+            "teams:///meetings/%20",
+            "teams:///meetings/a/b",
+            f"teams:///transcripts/{MEETING_ID}/{_TRANSCRIPT_ID}",
+            JOIN_WEB_URL,
+            "",
+        ],
+    )
+    def test_what_is_not_a_meeting_handle(self, uri: str) -> None:
+        """A message handle is not a meeting handle and a transcript handle is not one either — the
+        families are separate because the tools and the permissions behind them are."""
+        assert transcripts.meeting_handle(uri) is None
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            transcripts.MeetingHandle(JOIN_WEB_URL).uri,
+            "teams:///transcripts/only-one-id",
+            "teams:///transcripts//a",
+            "teams:///transcripts/a/%20",
+            "teams:///transcripts/a/b/c",
+        ],
+    )
+    def test_what_is_not_a_transcript_handle(self, uri: str) -> None:
+        assert transcripts.transcript_handle(uri) is None
+
+    @pytest.mark.parametrize("join_web_url", [None, "", "   "])
+    def test_no_join_url_means_no_handle_rather_than_an_empty_one(
+        self, join_web_url: str | None
+    ) -> None:
+        """The case the design has to survive: Graph gives a meeting chat no join URL, so there is
+        no route to its transcripts and nothing may pretend otherwise."""
+        assert transcripts.meeting_uri_for(join_web_url) is None
+
+
+class TestTheFilterOnTheWire:
+    """The bug class this piece exists not to repeat: `teams-mcp` sends a raw join URL and gets
+    `200 OK` with an empty `value` — a silent "meeting not found" — for any URL carrying `&` or `#`.
+    """
+
+    async def test_the_join_url_is_percent_encoded_exactly_once(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        url = route.calls.last.request.url
+        # One decode of the wire form must give back exactly the URL Graph stored, inside an OData
+        # literal — that is what "encoded once" means, and it is what Graph compares against.
+        assert url.params["$filter"] == f"JoinWebUrl eq '{JOIN_WEB_URL}'"
+        raw = url.query.decode()
+        assert "%253ameeting" in raw, "an already-escaped `:` has its own `%` escaped"
+        assert "%2540thread" in raw, "and so does an already-escaped `@`"
+        assert "%26anon%3Dtrue" in raw, "an `&` left raw would split the query and truncate it"
+        assert "%2525" not in raw, (
+            "encoding it twice compares `%25` against `%` and matches nothing"
+        )
+        assert raw.count("JoinWebUrl") == 1
+
+    @pytest.mark.parametrize(
+        "join_web_url",
+        [
+            "https://teams.microsoft.invalid/l/meetup-join/19%3ameeting_x%40thread.v2/0#frag",
+            "https://teams.microsoft.invalid/meet/1234567890?p=Ab1%2FCd",
+            "https://teams.microsoft.invalid/l/meetup-join/19:meeting_y@thread.v2/0",
+        ],
+    )
+    async def test_every_shape_of_join_url_reaches_graph_intact(
+        self, client: GraphServiceClient, graph: respx.MockRouter, join_web_url: str
+    ) -> None:
+        """`#` is the worst of these: URL parsers treat it as a fragment and drop everything after
+        it before the request is sent, so a filter built without encoding arrives truncated."""
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await transcripts.list_meeting_transcripts(
+            client,
+            handle=transcripts.MeetingHandle(join_web_url),
+            started_after=None,
+            started_before=None,
+            limit=20,
+        )
+
+        assert route.calls.last.request.url.params["$filter"] == f"JoinWebUrl eq '{join_web_url}'"
+
+    async def test_a_quote_in_the_join_url_is_doubled_and_cannot_close_the_literal(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """OData escapes a quote inside a string literal by doubling it. Percent-encoding it instead
+        would have Graph decode it back to a quote that ends the literal — a 400 at best, and an
+        injected predicate at worst."""
+        route = graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        _ = await transcripts.list_meeting_transcripts(
+            client,
+            handle=transcripts.MeetingHandle("https://x.invalid/a'/b' or JoinWebUrl ne 'z"),
+            started_after=None,
+            started_before=None,
+            limit=20,
+        )
+
+        assert (
+            route.calls.last.request.url.params["$filter"]
+            == "JoinWebUrl eq 'https://x.invalid/a''/b'' or JoinWebUrl ne ''z'"
+        )
+
+
+class TestNoMatchIsNotAnError:
+    async def test_an_empty_collection_is_its_own_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents this filter as answering `200 OK` with an empty `value` when nothing
+        matches — never a 404 — so "no such meeting" is a status and not an exception, and the
+        transcript listing is never even attempted."""
+        graph.get(_MEETINGS).mock(return_value=httpx.Response(200, json={"value": []}))
+        listing = graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(200, json={"value": [transcript_payload()]})
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        assert found.status == "meeting_not_found"
+        assert found.meeting_id is None
+        assert found.transcripts == []
+        assert found.truncated is False
+        assert not listing.called, "there is no meeting to list transcripts of"
+
+    async def test_a_404_is_still_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The distinction the empty collection exists to be told apart from."""
+        graph.get(_MEETINGS).mock(
+            return_value=httpx.Response(404, json={"error": {"code": "NotFound", "message": "no"}})
+        )
+
+        with pytest.raises(GraphNotFound):
+            _ = await transcripts.list_meeting_transcripts(
+                client, handle=_handle(), started_after=None, started_before=None, limit=20
+            )
+
+
+class TestTheThreeAbsences:
+    """Nothing came back — and a model must do three different things about it."""
+
+    async def test_the_tenant_switch_is_a_refusal_and_not_an_empty_answer(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`EnableGraphTranscriptAccess` is off, which no permission and no argument can work
+        around. It has to reach the tool layer as a failure carrying the inner code, because that
+        code is the only thing distinguishing it from an ordinary 403 about a permission."""
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(403, json=_TENANT_SWITCH_OFF))
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await transcripts.list_meeting_transcripts(
+                client, handle=_handle(), started_after=None, started_before=None, limit=20
+            )
+
+        assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+
+    async def test_a_meeting_long_over_with_nothing_in_it_was_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        ended = datetime.now(UTC) - timedelta(days=9)
+        _resolved(graph, end=ended.isoformat())
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        assert found.status == "not_transcribed"
+        assert found.meeting_id == MEETING_ID, "the meeting resolved; it just has no transcript"
+
+    @pytest.mark.parametrize(
+        "ended",
+        [
+            datetime.now(UTC) - timedelta(minutes=5),
+            datetime.now(UTC) + timedelta(hours=1),
+            None,
+        ],
+        ids=["just-ended", "still-running", "no-end-time"],
+    )
+    async def test_a_meeting_that_just_ended_is_not_ready_rather_than_never_transcribed(
+        self, client: GraphServiceClient, graph: respx.MockRouter, ended: datetime | None
+    ) -> None:
+        """The two empty answers are the same bytes from Graph and the opposite advice: wait, or
+        stop. A meeting Graph gave no end time for counts as "wait", because nothing says
+        transcription has finished and one wasted call is cheaper than a wrong answer.
+        """
+        _resolved(graph, end=ended.isoformat() if ended is not None else None)
+        graph.get(_TRANSCRIPTS).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        assert found.status == "not_ready"
+
+    def test_the_allowance_is_generous_enough_to_be_the_safe_side(self) -> None:
+        """Microsoft publishes no availability SLA, so the only defensible bias is towards telling
+        a caller to wait. A tight window would report a still-processing transcript as one that
+        will never exist, which is the one wrong answer a caller cannot detect."""
+        assert timedelta(hours=1) <= transcripts.TRANSCRIPT_DELAY_ALLOWANCE
+
+
+class TestScopingToOneOccurrence:
+    async def test_a_series_is_one_meeting_and_a_window_picks_an_occurrence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A recurring series has one join URL, one meeting id and one transcript collection —
+        Graph publishes no occurrence addressing at all — so the only thing separating occurrences
+        is when transcription began."""
+        _resolved(graph, meeting_type="recurring")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id="week-1", created_at="2026-02-03T14:02:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="week-2", created_at="2026-02-10T14:01:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="week-3", created_at="2026-02-17T14:04:00Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 2, 10, tzinfo=UTC),
+            started_before=datetime(2026, 2, 11, tzinfo=UTC),
+            limit=20,
+        )
+
+        assert found.meeting_type == "recurring"
+        assert [t.transcript_id for t in found.transcripts] == ["week-2"]
+        assert found.truncated is False
+
+    async def test_a_window_with_nothing_in_it_is_not_ready_or_not_transcribed_not_an_error(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph, meeting_type="recurring", end="2026-02-10T15:00:00Z")
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200, json={"value": [transcript_payload(created_at="2026-02-03T14:02:00Z")]}
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client,
+            handle=_handle(),
+            started_after=datetime(2026, 3, 1, tzinfo=UTC),
+            started_before=None,
+            limit=20,
+        )
+
+        assert found.status == "not_transcribed"
+        assert found.transcripts == []
+
+    async def test_transcripts_come_back_newest_first(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents no `$orderby` on this collection, so the order it answers in is not a
+        contract and the useful one is applied here."""
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(
+                            transcript_id="older", created_at="2026-02-03T14:00:00Z"
+                        ),
+                        transcript_payload(
+                            transcript_id="newer", created_at="2026-02-17T14:00:00Z"
+                        ),
+                    ]
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        assert [t.transcript_id for t in found.transcripts] == ["newer", "older"]
+
+    async def test_a_full_window_with_more_behind_it_says_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        transcript_payload(transcript_id=f"week-{index}") for index in range(2)
+                    ],
+                    "@odata.nextLink": f"{GRAPH_V1}{_TRANSCRIPTS}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=2
+        )
+
+        assert found.truncated is True
+        assert found.status == "available"
+
+    async def test_a_limit_above_the_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await transcripts.list_meeting_transcripts(
+                client,
+                handle=_handle(),
+                started_after=None,
+                started_before=None,
+                limit=transcripts.MAX_TRANSCRIPTS + 1,
+            )
+
+    async def test_each_transcript_carries_a_handle_and_the_link_to_its_recording(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _resolved(graph)
+        graph.get(_TRANSCRIPTS).mock(
+            return_value=httpx.Response(200, json={"value": [transcript_payload()]})
+        )
+
+        found = await transcripts.list_meeting_transcripts(
+            client, handle=_handle(), started_after=None, started_before=None, limit=20
+        )
+
+        summary = found.transcripts[0]
+        assert transcripts.transcript_handle(summary.uri) == transcripts.TranscriptHandle(
+            MEETING_ID, _TRANSCRIPT_ID
+        )
+        assert summary.content_correlation_id == "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3"
+        assert summary.started_at is not None and summary.ended_at is not None
+
+
+class TestReadingTheWords:
+    async def test_vtt_becomes_speaker_attributed_timestamped_turns(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole differentiator, and every parsing trap in one transcript: the `WEBVTT` header,
+        a `NOTE` block, cue identifier lines, a voice tag with a class, a cue wrapped over two
+        lines, HTML entities, inline markup, an unattributed cue, an empty one, and the negative
+        offset Microsoft documents for transcription that started mid-conversation."""
+        route = graph.get(_CONTENT).mock(
+            return_value=httpx.Response(
+                200, content=TRANSCRIPT_VTT.encode(), headers={"content-type": "text/vtt"}
+            )
+        )
+
+        read = await transcripts.read_transcript(
+            client,
+            handle=transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert read.speaker_attribution is True
+        assert [(turn.speaker, turn.text) for turn in read.turns] == [
+            ("Ada Lovelace", "Sorry, joining late & muted."),
+            ("Grace Hopper", "We should raise the floor price by three per cent."),
+            ("Ada Lovelace", "Agreed <that> works."),
+            (None, "Nobody was attributed for this one."),
+        ]
+        assert read.turns[0].start_seconds == -2.5, "transcription began mid-conversation"
+        assert (read.turns[1].start_seconds, read.turns[1].end_seconds) == (16.246, 19.9)
+        assert read.turns[3].start_seconds == 3600.0, "an hour in, from the HH:MM:SS form"
+        assert read.truncated is False
+        assert read.next_offset is None
+        assert route.calls.last.request.headers["accept"] == "text/vtt"
+
+    async def test_the_turns_page_without_refusing_a_long_meeting(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_CONTENT).mock(return_value=httpx.Response(200, content=TRANSCRIPT_VTT.encode()))
+        handle = transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID)
+
+        first = await transcripts.read_transcript(client, handle=handle, offset=0, limit=2)
+        second = await transcripts.read_transcript(
+            client, handle=handle, offset=first.next_offset or 0, limit=2
+        )
+
+        assert (first.truncated, first.next_offset) == (True, 2)
+        assert [turn.speaker for turn in first.turns] == ["Ada Lovelace", "Grace Hopper"]
+        assert second.truncated is False
+        assert second.next_offset is None
+        assert [turn.speaker for turn in second.turns] == ["Ada Lovelace", None]
+
+    async def test_a_tenant_that_forbids_speaker_names_degrades_instead_of_failing(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph's own documented remedy: ask again for the unattributed format, which succeeds.
+        `services/teams-mcp` hardcodes `Accept: text/vtt` and so loses the transcript entirely in
+        such a tenant."""
+        attempts: list[str] = []
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            accept = request.headers["accept"]
+            attempts.append(accept)
+            if accept == "text/vtt":
+                return httpx.Response(403, json=_ATTRIBUTION_OFF)
+            return httpx.Response(200, content=TRANSCRIPT_UNATTRIBUTED.encode())
+
+        graph.get(_CONTENT).mock(side_effect=respond)
+
+        read = await transcripts.read_transcript(
+            client,
+            handle=transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert attempts == ["text/vtt", "application/vnd.microsoft.graph.transcript+text"]
+        assert read.speaker_attribution is False
+        assert [turn.speaker for turn in read.turns] == [None, None]
+        assert read.turns[0].text == "We should raise the floor price by three per cent."
+        assert read.turns[0].start_seconds == 16.246, "the timings survive; only the names are gone"
+
+    async def test_the_tenant_switch_is_not_retried_in_another_format(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other 403 on the same endpoint. Microsoft says there is no request-side workaround,
+        so a second request would be a wasted call and the advice for it names an administrator
+        rather than a format — which means the retry must be scoped to the inner code, not to 403.
+        """
+        route = graph.get(_CONTENT).mock(return_value=httpx.Response(403, json=_TENANT_SWITCH_OFF))
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await transcripts.read_transcript(
+                client,
+                handle=transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+                offset=0,
+                limit=200,
+            )
+
+        assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+        assert route.call_count == 1
+
+    async def test_an_empty_transcript_is_no_turns_rather_than_a_blank_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_CONTENT).mock(return_value=httpx.Response(200, content=b"WEBVTT\n\n"))
+
+        read = await transcripts.read_transcript(
+            client,
+            handle=transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert read.turns == []
+        assert read.truncated is False
+
+    async def test_a_limit_above_the_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await transcripts.read_transcript(
+                client,
+                handle=transcripts.TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+                offset=0,
+                limit=transcripts.MAX_TURNS + 1,
+            )

--- a/services/office-mcp/tests/graph_client/test_errors.py
+++ b/services/office-mcp/tests/graph_client/test_errors.py
@@ -121,6 +121,47 @@ async def test_a_throttle_without_a_retry_after_says_so_rather_than_guessing(
     assert retry_sleeps.delays, "the SDK still backs off, it just picks the delay itself"
 
 
+async def test_the_inner_code_is_carried_because_it_is_the_only_thing_that_differs(
+    client: GraphServiceClient, graph: respx.MockRouter
+) -> None:
+    """Two Teams transcript refusals share a status and an outer code and have opposite remedies —
+    one is a tenant switch only a Teams administrator can flip, the other is a format to ask for
+    again — so `innerError.code` is the whole of the difference. It is not one of the SDK's typed
+    inner-error fields, so it arrives in `additional_data` and would be dropped without this.
+    """
+    graph.get("/me").mock(
+        return_value=httpx.Response(
+            403,
+            json={
+                "error": {
+                    "code": "Forbidden",
+                    "message": "Graph API access to transcripts is disabled for this tenant.",
+                    "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+                }
+            },
+        )
+    )
+
+    with pytest.raises(GraphForbidden) as raised, graph_errors():
+        _ = await client.me.get()
+
+    assert raised.value.code == "Forbidden", "the outer code says nothing actionable"
+    assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+
+
+async def test_an_error_without_an_inner_code_reports_none_rather_than_the_outer_one(
+    client: GraphServiceClient, graph: respx.MockRouter
+) -> None:
+    graph.get("/me").mock(
+        return_value=httpx.Response(403, json={"error": {"code": "accessDenied", "message": "no"}})
+    )
+
+    with pytest.raises(GraphForbidden) as raised, graph_errors():
+        _ = await client.me.get()
+
+    assert raised.value.inner_code is None
+
+
 async def test_never_reaching_graph_is_reported_as_upstream_not_as_a_bad_request(
     client: GraphServiceClient, graph: respx.MockRouter
 ) -> None:

--- a/services/office-mcp/tests/graph_client/test_pagination.py
+++ b/services/office-mcp/tests/graph_client/test_pagination.py
@@ -85,7 +85,13 @@ class TestTheCaps:
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """The teams-mcp lesson: a filtered collection can page a long way for nothing, so the
-        cap has to bound what was *looked at*, not what was kept."""
+        cap has to bound what was *looked at*, not what was kept.
+
+        Both of these parameters are used in production, which is why they are here: `matches` by
+        each meeting lister (an occurrence window), and `max_scanned` by the walk underneath them
+        (`features/transcripts.newest_in_window`), which passes a tighter cap than this module's
+        default because a per-meeting collection is a small thing to walk 1000 items of.
+        """
         mock_two_pages(graph)
         first = await client.me.chats.get()
         assert first is not None

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -18,6 +18,7 @@ from office_mcp.graph_client import (
 from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 _PERMISSION = "Chat.Read"
+_CHANNELS = "ChannelMessage.Read.All"
 
 # What azure-identity's `OnBehalfOfCredential.get_token` reports when the delegated permission was
 # never consented to, trimmed of its trace ids.
@@ -172,6 +173,20 @@ class TestTheRefusalThatHappensBeforeGraph:
         assert _PERMISSION in message
         assert "AADSTS" not in message, "no code was invented"
         assert "ValueError" in message
+
+    def test_an_exchange_for_several_permissions_names_them_all(self) -> None:
+        """A tool needing two permissions gets one token or none: Entra redeems the scopes together
+        and refuses them together, saying no more about which one was unconsented than a Graph 403
+        does. Naming one of two would send an administrator to grant a permission that may already
+        be there, and the second attempt fails identically."""
+        with pytest.raises(ToolError) as raised, entra_token_errors(_PERMISSION, _CHANNELS):
+            raise RuntimeError(_UNCONSENTED)
+        message = str(raised.value)
+
+        assert _PERMISSION in message
+        assert _CHANNELS in message
+        assert "grant the delegated permissions" in message, "plural, or it reads as one of them"
+        assert "administrator" in message
 
     def test_a_token_that_arrives_passes_through_untouched(self) -> None:
         with entra_token_errors(_PERMISSION):

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -1,0 +1,117 @@
+"""What a model is told when Graph says no.
+
+These assertions are about *advice*, not wording: each one pins the fact that distinguishes one
+remedy from another, because getting those wrong is what makes a model retry a call that can never
+succeed, or give up on one that would have worked a second later.
+"""
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from office_mcp.graph_client import (
+    GraphFailure,
+    GraphForbidden,
+    GraphNotFound,
+    GraphThrottled,
+    GraphUnavailable,
+)
+from office_mcp.server.errors import graph_tool_errors
+
+_PERMISSION = "Chat.Read"
+
+
+def _message(failure: GraphFailure) -> str:
+    with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION):
+        raise failure
+    return str(raised.value)
+
+
+class TestTheTwoRemediesGraphCannotTellApart:
+    """401 and 403 are both `GraphForbidden`. One is fixed by the user, the other by an admin."""
+
+    def test_a_rejected_token_asks_the_user_to_sign_in_again(self) -> None:
+        message = _message(
+            GraphForbidden("nope", status=401, code="InvalidAuthenticationToken", request_id=None)
+        )
+
+        assert "sign in" in message
+        assert _PERMISSION not in message, "a 401 is not a missing-permission problem"
+
+    def test_a_missing_permission_names_the_permission_and_who_must_grant_it(self) -> None:
+        """The failure Graph is least helpful about: it never says which permission was missing,
+        so the tool has to. Without the name, the remedy is not actionable."""
+        message = _message(
+            GraphForbidden("nope", status=403, code="Authorization_RequestDenied", request_id=None)
+        )
+
+        assert message.count(_PERMISSION) >= 1
+        assert "administrator" in message
+        assert "Retrying will not help" in message
+
+
+class TestRetryAdvice:
+    def test_throttling_passes_graphs_own_delay_through(self) -> None:
+        """Graph's `Retry-After` is the documented fastest way out of throttling; an eager retry
+        makes it last longer, so the number has to survive into the message."""
+        message = _message(
+            GraphThrottled(
+                "slow down",
+                status=429,
+                code="activityLimitReached",
+                request_id=None,
+                retry_after_seconds=42.0,
+            )
+        )
+
+        assert "42 seconds" in message
+
+    def test_throttling_without_a_delay_still_says_not_to_spin(self) -> None:
+        message = _message(
+            GraphThrottled(
+                "slow down", status=429, code=None, request_id=None, retry_after_seconds=None
+            )
+        )
+
+        assert "loop" in message
+        assert "seconds" not in message, "no invented number when Graph gave no advice"
+
+    def test_an_outage_is_worth_exactly_one_retry(self) -> None:
+        message = _message(GraphUnavailable("boom", status=503, code=None, request_id=None))
+
+        assert "Retry once" in message
+
+    def test_a_bad_request_is_not_worth_retrying(self) -> None:
+        message = _message(GraphFailure("bad filter", status=400, code=None, request_id=None))
+
+        assert "retrying it unchanged will fail identically" in message
+
+    def test_a_missing_item_does_not_claim_the_item_does_not_exist(self) -> None:
+        """Graph returns 404 both for "no such thing" and for "none of your business", so a
+        message that asserts absence teaches the model something false."""
+        message = _message(GraphNotFound("gone", status=404, code=None, request_id=None))
+
+        assert "not allowed to know it exists" in message
+
+
+class TestDiagnostics:
+    def test_the_graph_request_id_survives(self) -> None:
+        """It exists only in that one response, and it is the first thing Microsoft support asks
+        for — losing it makes a production failure untraceable afterwards."""
+        message = _message(
+            GraphUnavailable("boom", status=500, code="internalError", request_id="req-42")
+        )
+
+        assert "HTTP 500" in message
+        assert "Graph error code internalError" in message
+        assert "Graph request id req-42" in message
+
+    def test_nothing_is_invented_when_graph_sent_no_evidence(self) -> None:
+        message = _message(GraphUnavailable("unreachable", status=None, code=None, request_id=None))
+
+        assert "None" not in message
+
+    def test_a_success_passes_through_untouched(self) -> None:
+        with graph_tool_errors(_PERMISSION):
+            outcome = "fine"
+
+        assert outcome == "fine"

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -107,6 +107,25 @@ class TestRetryAdvice:
 
         assert "not allowed to know it exists" in message
 
+    def test_a_tool_whose_id_came_from_another_tool_can_say_so_instead(self) -> None:
+        """The default advice — check the id came from a tool response verbatim — is the right
+        first guess when a caller supplied an id, and wrong for a handle another tool just
+        produced: it sends the model to re-check the one thing that cannot be the cause. Only the
+        404 advice is replaceable, because it is the only one whose remedy depends on where the
+        argument came from.
+        """
+        with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION, not_found="Gone."):
+            raise GraphNotFound("gone", status=404, code=None, request_id="req-7")
+
+        assert str(raised.value) == "Gone. (HTTP 404, Graph request id req-7)"
+
+    def test_it_does_not_replace_the_advice_for_any_other_failure(self) -> None:
+        with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION, not_found="Gone."):
+            raise GraphForbidden("nope", status=403, code=None, request_id=None)
+
+        assert "Gone." not in str(raised.value)
+        assert _PERMISSION in str(raised.value)
+
 
 class TestDiagnostics:
     def test_the_graph_request_id_survives(self) -> None:

--- a/services/office-mcp/tests/server/test_errors.py
+++ b/services/office-mcp/tests/server/test_errors.py
@@ -15,13 +15,27 @@ from office_mcp.graph_client import (
     GraphThrottled,
     GraphUnavailable,
 )
-from office_mcp.server.errors import graph_tool_errors
+from office_mcp.server.errors import entra_token_errors, graph_tool_errors
 
 _PERMISSION = "Chat.Read"
+
+# What azure-identity's `OnBehalfOfCredential.get_token` reports when the delegated permission was
+# never consented to, trimmed of its trace ids.
+_UNCONSENTED = (
+    "AADSTS65001: The user or administrator has not consented to use the application with ID "
+    + "'1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'. Send an interactive authorization request for "
+    + "this user and resource."
+)
 
 
 def _message(failure: GraphFailure) -> str:
     with pytest.raises(ToolError) as raised, graph_tool_errors(_PERMISSION):
+        raise failure
+    return str(raised.value)
+
+
+def _token_message(failure: Exception) -> str:
+    with pytest.raises(ToolError) as raised, entra_token_errors(_PERMISSION):
         raise failure
     return str(raised.value)
 
@@ -115,3 +129,52 @@ class TestDiagnostics:
             outcome = "fine"
 
         assert outcome == "fine"
+
+
+class TestTheRefusalThatHappensBeforeGraph:
+    """A permission nobody consented to fails in the On-Behalf-Of exchange, not in Graph.
+
+    Same remedy as the 403 above, reached a step earlier — and the step matters, because this one
+    happens while FastMCP is resolving the tool's token dependency, where the default report is
+    "Failed to resolve dependency 'graph_token'".
+    """
+
+    def test_an_unconsented_permission_names_the_permission_and_the_remedy(self) -> None:
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert message.count(_PERMISSION) >= 1
+        assert "administrator" in message
+        assert "grant the delegated permission" in message
+        assert "sign in" in message, "consent granted after sign-in needs a new token"
+        assert "retrying will not help" in message.lower()
+
+    def test_it_says_the_call_never_happened(self) -> None:
+        """Unlike every Graph failure above, nothing was asked of Microsoft 365 here — a model
+        that believes otherwise reports the read as attempted-and-refused."""
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert "never reached Microsoft Graph" in message
+
+    def test_entras_own_code_survives_for_whoever_has_to_diagnose_it(self) -> None:
+        message = _token_message(RuntimeError(_UNCONSENTED))
+
+        assert "AADSTS65001" in message
+        assert "Send an interactive authorization request" not in message, (
+            "the model cannot act on Entra's prose, and it is not addressed to this connector"
+        )
+
+    def test_a_failure_entra_never_answered_is_still_actionable(self) -> None:
+        """No AADSTS code means the exchange never got as far as Entra — a broken connector, not
+        a refused user. The permission is still named, because it is still what was being asked
+        for, and the exception type is the only evidence there is."""
+        message = _token_message(ValueError("no access token available"))
+
+        assert _PERMISSION in message
+        assert "AADSTS" not in message, "no code was invented"
+        assert "ValueError" in message
+
+    def test_a_token_that_arrives_passes_through_untouched(self) -> None:
+        with entra_token_errors(_PERMISSION):
+            token = "synthetic-obo-graph-token"
+
+        assert token == "synthetic-obo-graph-token"

--- a/services/office-mcp/tests/test_app.py
+++ b/services/office-mcp/tests/test_app.py
@@ -1,7 +1,8 @@
 """The composition root, exercised as a real ASGI app.
 
 Checks that the app starts, its lifespan runs, the process-health routes behave, and that Entra
-auth is actually mounted and enforced. No Microsoft Graph client and no tools yet.
+auth is actually mounted and enforced. The tools it exposes are exercised over the MCP protocol in
+`test_mcp_tools.py`.
 
 Nothing here reaches Entra: constructing the provider performs no I/O, and the assertions below
 only touch metadata this service serves itself plus one unauthenticated request that is rejected
@@ -10,7 +11,7 @@ before any upstream call would happen.
 
 import importlib
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from types import ModuleType
 from typing import Protocol, cast, final, override
 from unittest.mock import MagicMock
@@ -179,10 +180,18 @@ class TestReadyProbesTheConnectionSignInDependsOn:
             return storage
 
         def _auth(
-            entra: EntraConfig, base_url: str, client_storage: AsyncKeyValue
+            entra: EntraConfig,
+            base_url: str,
+            client_storage: AsyncKeyValue,
+            graph_scopes: Sequence[str],
         ) -> AzureProvider:
             provider_was_given.append(client_storage)
-            return build_auth(entra, base_url=base_url, client_storage=client_storage)
+            return build_auth(
+                entra,
+                base_url=base_url,
+                client_storage=client_storage,
+                graph_scopes=graph_scopes,
+            )
 
         monkeypatch.setattr(app_module, "build_oauth_storage", _storage)
         monkeypatch.setattr(app_module, "build_auth", _auth)

--- a/services/office-mcp/tests/test_auth.py
+++ b/services/office-mcp/tests/test_auth.py
@@ -15,6 +15,8 @@ from office_mcp.config import DatabaseConfig, EntraConfig
 
 _DATABASE_URL = "postgresql://user:pass@db:5432/office"
 
+_GRAPH_SCOPES = ("https://graph.microsoft.com/User.Read",)
+
 
 def _entra_config() -> EntraConfig:
     return EntraConfig.model_validate(
@@ -72,6 +74,7 @@ def _build_auth(entra: EntraConfig | None = None) -> AzureProvider:
         entra,
         base_url=_BASE_URL,
         client_storage=build_oauth_storage(entra, _database_config()),
+        graph_scopes=_GRAPH_SCOPES,
     )
 
 
@@ -85,12 +88,26 @@ class TestAuthProvider:
 
     def test_the_server_gates_access_on_its_own_scope_not_a_graph_one(self) -> None:
         """Entra omits OIDC scopes from `scp`, so the provider requires a custom API scope to
-        enforce. Graph permissions are a separate channel, requested by the tools that need
-        them — so nothing Graph-shaped should be gating access to the server itself.
+        enforce. Graph permissions are the separate channel below — a Graph scope among the
+        required ones would be validated on every token and would fail every request, because
+        this API's tokens never carry Graph permissions.
         """
         provider = _build_auth()
 
         assert provider.required_scopes == ["access_as_user"]
+
+    def test_the_graph_permissions_ride_the_authorize_request(self) -> None:
+        """Without this, sign-in never asks for Graph consent, and the On-Behalf-Of exchange each
+        tool performs fails with AADSTS65001 — a failure that happens per tool call, long after
+        the sign-in that would have fixed it, and that no tool can explain to its caller.
+
+        Containment rather than equality: the provider adds `offline_access` to this list itself,
+        which is its business and not something this service should be pinning.
+        """
+        provider = _build_auth()
+
+        assert set(_GRAPH_SCOPES) <= set(provider.additional_authorize_scopes)
+        assert not set(_GRAPH_SCOPES) & set(provider.required_scopes)
 
     def test_it_uses_the_exact_storage_it_was_given(self) -> None:
         """White-box on purpose: passing `client_storage` is the whole difference between a
@@ -103,6 +120,11 @@ class TestAuthProvider:
         """
         storage = build_oauth_storage(_entra_config(), _database_config())
 
-        provider = build_auth(_entra_config(), base_url=_BASE_URL, client_storage=storage)
+        provider = build_auth(
+            _entra_config(),
+            base_url=_BASE_URL,
+            client_storage=storage,
+            graph_scopes=_GRAPH_SCOPES,
+        )
 
         assert provider._client_storage is storage  # pyright: ignore[reportPrivateUsage]

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -55,7 +55,21 @@
    nothing to do with the one a message is read under. Widening it to "any feature may write a
    handle" is what it must never become. `server/` is not subject to this: a tool description names
    the shapes so a model knows what it may pass, and that is prose rather than a second
-implementation.
+   implementation.
+
+10. **No module may address a single meeting recording.** The listing is the whole of the
+    recordings surface, because there are exactly two reasons to reach an individual `callRecording`
+    and both are defects: its `content`, which is an MP4 of a meeting that can run thirty hours and
+    which a model cannot watch, and its `recordingContentUrl`, which is a Graph URL that only this
+    connector's bearer token opens — so handing it to a caller is either useless or a token leak.
+    (Delegated download is organiser-only anyway, so it would also fail for most callers.) "Return
+    metadata and availability, never the bytes" is the whole shape of `features/recordings.py`, and
+    the change that breaks it is a small-looking convenience someone adds later, which is why it is
+    a failing test rather than a paragraph. Enforced on the two SDK names that reach one recording:
+    `by_call_recording_id` and `recording_content_url`. Matched as attribute names through the AST,
+    so a docstring naming Graph's own `recordingContentUrl` property — as `features/recordings.py`
+    does, to say why it is not returned — is prose and not a violation.
+
 Every rule is paired with a guard that fails if the rule has become vacuous — an empty tree to walk,
 a missing file to forbid reaching for, a framework nothing imports any more. None of them is
 conditional: every package these rules are about now exists, so a rule that stops running is a
@@ -99,6 +113,12 @@ _HANDLE_OWNERS: dict[str, frozenset[str]] = {
     "transcripts.py": frozenset({"meetings", "transcripts"}),
 }
 _HANDLE_FAMILY = re.compile(re.escape(_HANDLE_SCHEME) + r"([A-Za-z_]*)")
+
+# The two names in the generated SDK that address one `callRecording` rather than the collection:
+# the item builder (`…recordings.by_call_recording_id(id)`, whose only child worth having is
+# `.content`) and the entity's own content URL. Rule 10 forbids both anywhere under `src/`.
+_RECORDING_ITEM_NAMES = frozenset({"by_call_recording_id", "recording_content_url"})
+_RECORDINGS_MODULE = _FEATURES / "recordings.py"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -270,6 +290,20 @@ def _config_construction_violations(source: pathlib.Path) -> list[str]:
     ]
 
 
+def _attribute_names(source: str) -> set[str]:
+    """Every attribute name `source` reads or calls: `recordings` and `get` in `x.recordings.get()`.
+
+    Attribute names rather than text so that rule 10 constrains code and leaves prose alone: the
+    module it guards has to be able to name the Graph property it deliberately does not return.
+    """
+    return {node.attr for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Attribute)}
+
+
+def _recording_item_violations(source: pathlib.Path) -> list[str]:
+    reached = sorted(_attribute_names(source.read_text()) & _RECORDING_ITEM_NAMES)
+    return [f"{source.relative_to(_SRC)} reaches {name}" for name in reached]
+
+
 def _internal_module_violations(source: pathlib.Path) -> list[str]:
     return [
         f"{source.relative_to(_SRC)}:{line} imports {module}"
@@ -437,6 +471,28 @@ class TestTheDetectionItself:
         """`model_validate` is handed its values; it does not go looking for them."""
         assert not _config_constructions("AppConfig.model_validate({'port': 1})")
 
+    def test_catches_the_violation_the_recording_content_rule_exists_for(self) -> None:
+        """The exact line someone writes when adding a "just check the video is there" convenience,
+        and the property read that would leak a token-bearing Graph URL to a caller."""
+        found = _attribute_names(
+            "async def fetch(client, meeting_id, recording_id):\n"
+            + "    item = client.me.online_meetings.by_online_meeting_id(meeting_id)"
+            + ".recordings.by_call_recording_id(recording_id)\n"
+            + "    return await item.content.get(), item.recording_content_url\n"
+        )
+
+        assert found & _RECORDING_ITEM_NAMES == _RECORDING_ITEM_NAMES
+
+    def test_the_recording_content_rule_leaves_the_collection_and_the_prose_alone(self) -> None:
+        """Listing recordings is the whole point of the module the rule protects, and that module
+        has to be able to explain in words why Graph's `recordingContentUrl` is not passed on."""
+        found = _attribute_names(
+            '"""Not returned: recordingContentUrl needs our own bearer token."""\n'
+            + "page = await client.me.online_meetings.by_online_meeting_id(m).recordings.get()\n"
+        )
+
+        assert not found & _RECORDING_ITEM_NAMES
+
     def test_does_not_fire_on_a_name_that_merely_starts_with_the_prefix(self) -> None:
         assert not _imports_under("from office_mcp.serverless import thing", _SERVER_PREFIX)
         assert not _imports_under("from office_mcp.featureset import thing", _FEATURES_PREFIX)
@@ -584,6 +640,28 @@ class TestEachHandleFamilyHasOneHome:
             + f"not own — each family is minted and parsed in one module ({_HANDLE_OWNERS}), and a "
             + "second speller is free to disagree with it. Build that module's handle type and "
             + "read its `uri` instead."
+        )
+
+
+class TestNoModuleReachesForRecordingBytes:
+    def test_the_recordings_listing_is_actually_there(self) -> None:
+        """Guards the guard: the rule is that the *collection* is the whole surface, so if nothing
+        listed recordings any more it would be forbidding something nothing does."""
+        assert _RECORDINGS_MODULE.is_file(), f"no such file: {_RECORDINGS_MODULE}"
+        assert "recordings" in _attribute_names(_RECORDINGS_MODULE.read_text()), (
+            "features/recordings.py no longer reads the recordings collection"
+        )
+
+    @pytest.mark.parametrize("source", sorted(_SRC.rglob("*.py")), ids=_source_id)
+    def test_no_module_addresses_a_single_recording(self, source: pathlib.Path) -> None:
+        violations = _recording_item_violations(source)
+        assert not violations, (
+            "nothing here may address one meeting recording — the only things behind that door are "
+            + "an MP4 of a meeting up to 30 hours long, which cannot enter a model's context and "
+            + "which delegated callers other than the organiser may not download at all, and a "
+            + "content URL that only this connector's token opens. List the collection and report "
+            + "metadata, duration and access instead:\n  "
+            + "\n  ".join(violations)
         )
 
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -29,6 +29,12 @@
    which permission — ends up spread across the layer whose job is only to expose it, and the
    tool's request then escapes every test that covers the feature.
 
+7. **`features/` must not import FastMCP.** The mirror of rule 1 for the framework rather than for
+   this package: a feature answers with its own types or raises a Graph failure, and turning either
+   into something an MCP client sees — a `ToolError`, a tool annotation, a schema — is `server/`'s
+   job. Without this, "reject a search with no criteria" would sit in the feature as a `ToolError`,
+   and the layer that owns the boundary would no longer own its refusals.
+
 Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
 subpackage; the import-direction check itself runs against every module under `features/`.
 
@@ -51,6 +57,7 @@ _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
 _GRAPH_SDK = "msgraph"
+_MCP_FRAMEWORK = "fastmcp"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -295,6 +302,18 @@ class TestTheDetectionItself:
             _GRAPH_SDK,
         )
 
+    def test_catches_the_violation_the_mcp_framework_rule_exists_for(self) -> None:
+        assert _imports_under(
+            "from fastmcp.exceptions import ToolError\nimport fastmcp\n", _MCP_FRAMEWORK
+        ) == ["fastmcp.exceptions", "fastmcp"]
+
+    def test_the_mcp_framework_rule_leaves_the_protocol_types_alone(self) -> None:
+        """`mcp` is the protocol SDK, a different distribution from the server framework, and a
+        name that merely begins with `fastmcp` is not it either."""
+        assert not _imports_under(
+            "from mcp.types import TextContent\nfrom fastmcpx import thing\n", _MCP_FRAMEWORK
+        )
+
     def test_catches_the_violation_the_config_rule_exists_for(self) -> None:
         assert _imports_under("from office_mcp.config import AppConfig", _CONFIG_MODULE) == [
             "office_mcp.config"
@@ -372,6 +391,25 @@ class TestFeaturesDoNotImportServer:
         assert not violations, (
             "features/ must not import from server/ — the server wires features together, "
             + "not the reverse. Inject the collaborator from create_app() instead:\n  "
+            + "\n  ".join(violations)
+        )
+
+
+class TestFeaturesDoNotImportTheMcpFramework:
+    def test_the_tool_layer_does_import_it(self) -> None:
+        """Guards the guard: the rule is about which layer talks to FastMCP, not about the
+        framework being unused — if `server/` stopped importing it, this rule would be vacuous."""
+        assert _imports_under(
+            (_SERVER / "tools.py").read_text(), _MCP_FRAMEWORK, _package_of(_SERVER / "tools.py")
+        )
+
+    @pytest.mark.parametrize("source", sorted(_FEATURES.rglob("*.py")), ids=_source_id)
+    def test_no_feature_module_imports_the_mcp_framework(self, source: pathlib.Path) -> None:
+        violations = _violations(source, _MCP_FRAMEWORK)
+        assert not violations, (
+            "features/ must not import FastMCP — a feature returns its own types or raises a "
+            + "Graph failure, and turning either into something an MCP client sees belongs to "
+            + "server/. Return the fact (or raise) and let the tool decide what to say:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -35,6 +35,12 @@
    job. Without this, "reject a search with no criteria" would sit in the feature as a `ToolError`,
    and the layer that owns the boundary would no longer own its refusals.
 
+8. **`server/` must not import the Graph SDK's request layer either.** Rule 6 one level down.
+   `msgraph` is the generated client, but a Graph request is *configured* through `kiota_*` — a
+   `RequestConfiguration`, its query parameters, its headers, its middleware options — and all of
+   those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
+   a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
+
 Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
 subpackage; the import-direction check itself runs against every module under `features/`.
 
@@ -57,6 +63,11 @@ _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
 _GRAPH_SDK = "msgraph"
+# The distributions underneath the generated SDK: `kiota_abstractions` is where a
+# `RequestConfiguration`, its headers and its request options live, `kiota_http` is the middleware
+# pipeline and `msgraph_core` is the request adapter. All three are ways to shape a Graph call
+# without importing `msgraph`, which is why rule 8 names them separately from rule 6.
+_GRAPH_REQUEST_LAYER: tuple[str, ...] = ("kiota_abstractions", "kiota_http", "msgraph_core")
 _MCP_FRAMEWORK = "fastmcp"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
@@ -302,6 +313,37 @@ class TestTheDetectionItself:
             _GRAPH_SDK,
         )
 
+    def test_catches_configuring_a_graph_request_without_naming_the_sdk(self) -> None:
+        """The escape hatch rule 6 leaves open: this is a Graph request being shaped, and the word
+        `msgraph` appears nowhere in it."""
+        found = [
+            module
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(
+                "from kiota_abstractions.base_request_configuration import RequestConfiguration\n"
+                + "from kiota_abstractions.headers_collection import HeadersCollection\n"
+                + "import msgraph_core\n",
+                prefix,
+            )
+        ]
+
+        assert found == [
+            "kiota_abstractions.base_request_configuration",
+            "kiota_abstractions.headers_collection",
+            "msgraph_core",
+        ]
+
+    def test_the_request_layer_rule_leaves_unrelated_names_alone(self) -> None:
+        assert not [
+            module
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(
+                "from office_mcp.graph_client import graph_client_for\n"
+                + "from kiotalike.thing import Thing\n",
+                prefix,
+            )
+        ]
+
     def test_catches_the_violation_the_mcp_framework_rule_exists_for(self) -> None:
         assert _imports_under(
             "from fastmcp.exceptions import ToolError\nimport fastmcp\n", _MCP_FRAMEWORK
@@ -464,6 +506,33 @@ class TestTheServerLayerDoesNotSpeakGraph:
             "server/ must not import the Microsoft Graph SDK — a tool declares and exposes; the "
             + "request belongs in a feature module and the transport in graph_client/. Move the "
             + "Graph call into features/ and have the tool call that:\n  "
+            + "\n  ".join(violations)
+        )
+
+    def test_the_layer_that_may_configure_a_request_actually_does(self) -> None:
+        """Guards the guard for the rule below: the request layer is used, in `features/`, which is
+        where it belongs — so forbidding it in `server/` is a boundary rather than a dead letter."""
+        used = [
+            module
+            for source in sorted(_FEATURES.rglob("*.py"))
+            for prefix in _GRAPH_REQUEST_LAYER
+            for module in _imports_under(source.read_text(), prefix, _package_of(source))
+        ]
+
+        assert used, f"nothing under {_FEATURES} configures a Graph request"
+
+    @pytest.mark.parametrize("source", sorted(_SERVER.rglob("*.py")), ids=_source_id)
+    def test_no_server_module_imports_the_graph_request_layer(self, source: pathlib.Path) -> None:
+        violations = [
+            violation
+            for prefix in _GRAPH_REQUEST_LAYER
+            for violation in _violations(source, prefix)
+        ]
+        assert not violations, (
+            "server/ must not import the Graph SDK's request layer — a RequestConfiguration, a "
+            + "header or a request option is part of a Graph call, and a Graph call belongs in "
+            + "features/ however it is spelled. Move it there and have the tool call the "
+            + "feature:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -41,8 +41,10 @@
    those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
    a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
 
-Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
-subpackage; the import-direction check itself runs against every module under `features/`.
+Every rule is paired with a guard that fails if the rule has become vacuous — an empty tree to walk,
+a missing file to forbid reaching for, a framework nothing imports any more. None of them is
+conditional: every package these rules are about now exists, so a rule that stops running is a
+failure and not a skip.
 
 All rules are asserted by walking the AST rather than importing anything, so a violation is
 reported as a failing test with a file and line instead of an ImportError at collection time.
@@ -87,11 +89,6 @@ _CONFIG_CLASSES = frozenset({"AppConfig", "DatabaseConfig", "EntraConfig"})
 # Files allowed to construct one, relative to `_SRC`. Both are the root of a program: `app.py` is
 # the composition root, and `main.py` is the server entrypoint that hands it its `AppConfig`.
 _COMPOSITION_ROOTS = frozenset({"app.py", "main.py"})
-
-
-def _feature_packages() -> set[str]:
-    """The subpackages under `features/`. Empty in this PR — the first ones land later."""
-    return {p.name for p in _FEATURES.iterdir() if p.is_dir() and p.name != "__pycache__"}
 
 
 def _imported_modules(tree: ast.AST, package: str | None = None) -> list[tuple[str, int]]:
@@ -419,13 +416,15 @@ class TestTheDetectionItself:
 
 
 class TestFeaturesDoNotImportServer:
-    @pytest.mark.skipif(not _feature_packages(), reason="feature packages land in later PRs")
     def test_the_feature_tree_is_actually_there(self) -> None:
-        """Guards the guard: a moved/renamed tree must not silently vacate the rule below."""
-        sources = sorted(_FEATURES.rglob("*.py"))
-        assert sources, f"no python sources found under {_FEATURES}"
-        packages = {p.relative_to(_FEATURES).parts[0] for p in sources if p.name != "__init__.py"}
-        assert packages, f"no feature packages found under {_FEATURES}"
+        """Guards the guard: a moved or renamed tree must not silently vacate the rule below.
+
+        The rule is parametrized over `features/`, so an empty tree makes it zero tests that pass
+        by not existing. What has to be there is feature *modules* — `features/` is a grouping and
+        its units are modules, not subpackages (see rule 4) — so that is what is asserted.
+        """
+        modules = [p for p in sorted(_FEATURES.rglob("*.py")) if p.name != "__init__.py"]
+        assert modules, f"no feature modules found under {_FEATURES}"
 
     @pytest.mark.parametrize("source", sorted(_FEATURES.rglob("*.py")), ids=_source_id)
     def test_no_feature_module_imports_from_server(self, source: pathlib.Path) -> None:
@@ -456,7 +455,6 @@ class TestFeaturesDoNotImportTheMcpFramework:
         )
 
 
-@pytest.mark.skipif(not _GRAPH_CLIENT.is_dir(), reason="graph_client/ lands in a later PR")
 class TestGraphClientDoesNotImportFeatures:
     def test_the_client_tree_is_actually_there(self) -> None:
         """Guards the guard, same as above."""
@@ -476,7 +474,6 @@ class TestGraphClientDoesNotImportFeatures:
         )
 
 
-@pytest.mark.skipif(not _GRAPH_CLIENT.is_dir(), reason="graph_client/ lands in a later PR")
 class TestGraphClientDoesNotImportConfig:
     def test_the_settings_module_is_actually_there(self) -> None:
         """Guards the guard: without somewhere to put them, the rule below is unsatisfiable."""

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -41,14 +41,21 @@
    those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
    a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
 
-9. **Only `features/message_search.py` may spell a `teams:///` handle.** A handle is minted by the
-   search that produces it and parsed by the one grammar that lives with it, which is why
-   `message_read` and `channels` take `MessageHandle` from there rather than assembling a URI of
-   their own. Two modules that each knew how to write one would be free to disagree, and the
-   disagreement would look like a message that cannot be read — which is exactly the failure the
-   third (reply) shape exists to fix. `server/` is not subject to this: a tool description names the
-   shapes so a model knows what it may pass, and that is prose rather than a second implementation.
-
+9. **A `teams:///` handle family has exactly one speller.** `features/message_search.py` owns
+   `teams:///chats/…` and `teams:///teams/…`; `features/transcripts.py` owns `teams:///meetings/…`
+   and `teams:///transcripts/…`. Nothing else in `features/` may spell the scheme at all. A
+   handle is minted by the tool that can produce it and parsed by the one grammar that lives with
+   it, which is why `message_read` and `channels` take `MessageHandle` from `message_search` and why
+   `chats` asks `transcripts` for a meeting handle rather than assembling a URI of its own. Two
+   modules that each knew how to write one would be free to disagree, and the disagreement would
+   look like a handle that cannot be read — which is exactly the failure the reply shape exists to
+   fix. The rule was originally "only `message_search`", and it is a *family* rule rather than a
+   module rule because the second family has a different owner for a reason: a meeting is addressed
+   by a join URL that only a chat can supply, and the permission a transcript is read under is
+   nothing to do with the one a message is read under. Widening it to "any feature may write a
+   handle" is what it must never become. `server/` is not subject to this: a tool description names
+   the shapes so a model knows what it may pass, and that is prose rather than a second
+implementation.
 Every rule is paired with a guard that fails if the rule has become vacuous — an empty tree to walk,
 a missing file to forbid reaching for, a framework nothing imports any more. None of them is
 conditional: every package these rules are about now exists, so a rule that stops running is a
@@ -60,6 +67,7 @@ reported as a failing test with a file and line instead of an ImportError at col
 
 import ast
 import pathlib
+import re
 import sys
 
 import pytest
@@ -80,12 +88,17 @@ _GRAPH_SDK = "msgraph"
 _GRAPH_REQUEST_LAYER: tuple[str, ...] = ("kiota_abstractions", "kiota_http", "msgraph_core")
 _MCP_FRAMEWORK = "fastmcp"
 
-# The scheme every message handle this connector mints is written in, and the one feature module
-# allowed to write it. Matched as text rather than through the AST because what rule 9 forbids is a
+# The scheme every handle this connector mints is written in, and which feature module owns which
+# family of them. Matched as text rather than through the AST because what rule 9 forbids is a
 # handle being *spelled* anywhere else — as an f-string, a format template or a concatenation, each
-# of which is a different AST and the same duplication.
+# of which is a different AST and the same duplication. The family is the first path segment after
+# the scheme, which is why the grammars keep their segments distinct.
 _HANDLE_SCHEME = "teams:///"
-_HANDLE_GRAMMAR = _FEATURES / "message_search.py"
+_HANDLE_OWNERS: dict[str, frozenset[str]] = {
+    "message_search.py": frozenset({"chats", "teams"}),
+    "transcripts.py": frozenset({"meetings", "transcripts"}),
+}
+_HANDLE_FAMILY = re.compile(re.escape(_HANDLE_SCHEME) + r"([A-Za-z_]*)")
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -549,25 +562,28 @@ class TestTheServerLayerDoesNotSpeakGraph:
         )
 
 
-class TestTheHandleGrammarHasOneHome:
-    def test_the_module_that_owns_it_actually_writes_one(self) -> None:
-        """Guards the guard: if handles stopped being minted there, the rule below would forbid
-        something nothing does and the grammar would have quietly moved."""
-        assert _HANDLE_SCHEME in _HANDLE_GRAMMAR.read_text(), (
-            f"{_HANDLE_GRAMMAR.name} no longer mints a handle; rule 9 names the wrong module"
+class TestEachHandleFamilyHasOneHome:
+    @pytest.mark.parametrize("owner", sorted(_HANDLE_OWNERS))
+    def test_the_module_that_owns_a_family_actually_writes_it(self, owner: str) -> None:
+        """Guards the guard: if a family stopped being minted where the rule says it is, the rule
+        would forbid something nothing does and the grammar would have quietly moved."""
+        written = set(_HANDLE_FAMILY.findall((_FEATURES / owner).read_text()))
+
+        assert written == _HANDLE_OWNERS[owner], (
+            f"{owner} spells the handle families {sorted(written)}, and rule 9 gives it "
+            + f"{sorted(_HANDLE_OWNERS[owner])}"
         )
 
-    @pytest.mark.parametrize(
-        "source",
-        sorted(path for path in _FEATURES.rglob("*.py") if path != _HANDLE_GRAMMAR),
-        ids=_source_id,
-    )
-    def test_no_other_feature_module_writes_a_handle(self, source: pathlib.Path) -> None:
-        assert _HANDLE_SCHEME not in source.read_text(), (
-            f"only {_HANDLE_GRAMMAR.name} may spell a {_HANDLE_SCHEME} handle — it is minted and "
-            + "parsed there, and a second speller is free to disagree with it. Build a "
-            + "`MessageHandle` and read its `uri` instead:\n  "
-            + str(source.relative_to(_SRC))
+    @pytest.mark.parametrize("source", sorted(_FEATURES.rglob("*.py")), ids=_source_id)
+    def test_no_feature_module_writes_another_families_handle(self, source: pathlib.Path) -> None:
+        owned = _HANDLE_OWNERS.get(source.name, frozenset())
+        trespasses = sorted(set(_HANDLE_FAMILY.findall(source.read_text())) - owned)
+
+        assert not trespasses, (
+            f"{source.relative_to(_SRC)} spells the handle families {trespasses}, which it does "
+            + f"not own — each family is minted and parsed in one module ({_HANDLE_OWNERS}), and a "
+            + "second speller is free to disagree with it. Build that module's handle type and "
+            + "read its `uri` instead."
         )
 
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -13,8 +13,8 @@
    configured — a transport is only allowed to be told.
 
 4. **A package is entered through its `__init__`, never through its modules.** Applies to the
-   packages listed in `_PUBLIC_SURFACE_PACKAGES`. `features/` is not among them: it is a
-   grouping whose `__init__` is documentation.
+   packages listed in `_PUBLIC_SURFACE_PACKAGES`. `features/` is not among them: it is a grouping
+   whose `__init__` is documentation, and whose modules are the units features are composed from.
 
 5. **A config class is only instantiated at the composition root.** `create_app` builds each one
    exactly once and injects it; anything downstream constructing its own re-reads the
@@ -23,10 +23,14 @@
    is unrestricted; only *calling* them is the violation. `main.py` is exempt as a process
    entrypoint: it is the root of its own program and hands `create_app` the config it built.
 
-Rules 2 and 3 apply to `graph_client/`, which lands with the Graph transport — both classes run
-against it from that PR on. Rule 1's "the tree actually has feature packages" guard still skips
-until the first feature package exists; the import-direction check itself runs against whatever
-*is* under `features/` (currently just `__init__.py`, which trivially passes).
+6. **`server/` must not import the Microsoft Graph SDK.** The mirror of rules 2 and 3, from the
+   other side: `msgraph` belongs to `graph_client/` (the transport) and `features/` (the requests).
+   A tool that reaches for the SDK itself is how Graph knowledge — which endpoint, which `$expand`,
+   which permission — ends up spread across the layer whose job is only to expose it, and the
+   tool's request then escapes every test that covers the feature.
+
+Rule 1's "the tree actually has feature packages" guard still skips until a feature grows into a
+subpackage; the import-direction check itself runs against every module under `features/`.
 
 All rules are asserted by walking the AST rather than importing anything, so a violation is
 reported as a failing test with a file and line instead of an ImportError at collection time.
@@ -42,9 +46,11 @@ _SRC = pathlib.Path(__file__).parent.parent / "src" / "office_mcp"
 
 _FEATURES = _SRC / "features"
 _GRAPH_CLIENT = _SRC / "graph_client"
+_SERVER = _SRC / "server"
 _SERVER_PREFIX = "office_mcp.server"
 _FEATURES_PREFIX = "office_mcp.features"
 _CONFIG_MODULE = "office_mcp.config"
+_GRAPH_SDK = "msgraph"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -52,7 +58,10 @@ _CONFIG_MODULE = "office_mcp.config"
 # door. A new package belongs here as soon as its `__init__` exports anything: `server/` earned
 # its place by exporting `ready_response`, `graph_client/` by exporting its transport, and the
 # feature packages join as they land.
-_PUBLIC_SURFACE_PACKAGES: tuple[str, ...] = ("office_mcp.server", "office_mcp.graph_client")
+_PUBLIC_SURFACE_PACKAGES: tuple[str, ...] = (
+    "office_mcp.graph_client",
+    "office_mcp.server",
+)
 
 # The `BaseSettings` classes in config.py, which read the environment when constructed.
 _CONFIG_CLASSES = frozenset({"AppConfig", "DatabaseConfig", "EntraConfig"})
@@ -273,16 +282,28 @@ class TestTheDetectionItself:
             _SERVER_PREFIX,
         )
 
+    def test_catches_the_violation_the_graph_sdk_rule_exists_for(self) -> None:
+        assert _imports_under(
+            "from msgraph.generated.models.chat import Chat\nimport msgraph\n", _GRAPH_SDK
+        ) == ["msgraph.generated.models.chat", "msgraph"]
+
+    def test_the_graph_sdk_rule_leaves_this_services_own_client_alone(self) -> None:
+        """`graph_client` is how `server/` is *supposed* to reach Graph, and `msgraph_core` is a
+        different distribution — neither may be mistaken for the SDK itself."""
+        assert not _imports_under(
+            "from office_mcp.graph_client import graph_client_for\nimport msgraph_core\n",
+            _GRAPH_SDK,
+        )
+
     def test_catches_the_violation_the_config_rule_exists_for(self) -> None:
         assert _imports_under("from office_mcp.config import AppConfig", _CONFIG_MODULE) == [
             "office_mcp.config"
         ]
 
     def test_catches_the_violation_the_internals_rule_exists_for(self) -> None:
-        # `_PUBLIC_SURFACE_PACKAGES` only lists `server` for now, so that's the package under
-        # test here; once the first feature package lands and joins the list, its own modules
-        # serve this same role. The importing directory is `_SRC` — i.e. `app.py`, the
-        # composition root, which is the likeliest place to reach past a front door.
+        # `server` stands in for any listed package here; the rule is about the front door, not
+        # about which package happens to be behind it. The importing directory is `_SRC` — i.e.
+        # `app.py`, the composition root, which is the likeliest place to reach past one.
         assert _internal_imports(
             "from office_mcp.server.readiness import ready_response",
             _SRC,
@@ -388,6 +409,23 @@ class TestGraphClientDoesNotImportConfig:
             "graph_client/ must not import config — it takes its own frozen settings types "
             + "from graph_client/settings.py, which create_app translates the app config into. "
             + "Add the field to those settings and map it in create_app instead:\n  "
+            + "\n  ".join(violations)
+        )
+
+
+class TestTheServerLayerDoesNotSpeakGraph:
+    def test_the_tool_module_is_actually_there(self) -> None:
+        """Guards the guard: with no tools, nothing in `server/` would be tempted to call Graph
+        and the rule below would pass vacuously."""
+        assert (_SERVER / "tools.py").is_file()
+
+    @pytest.mark.parametrize("source", sorted(_SERVER.rglob("*.py")), ids=_source_id)
+    def test_no_server_module_imports_the_graph_sdk(self, source: pathlib.Path) -> None:
+        violations = _violations(source, _GRAPH_SDK)
+        assert not violations, (
+            "server/ must not import the Microsoft Graph SDK — a tool declares and exposes; the "
+            + "request belongs in a feature module and the transport in graph_client/. Move the "
+            + "Graph call into features/ and have the tool call that:\n  "
             + "\n  ".join(violations)
         )
 

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -41,6 +41,14 @@
    those are reachable without ever spelling `msgraph`. A tool that builds one has put the shape of
    a Graph call in the layer whose only job is to expose it, and rule 6 alone would not notice.
 
+9. **Only `features/message_search.py` may spell a `teams:///` handle.** A handle is minted by the
+   search that produces it and parsed by the one grammar that lives with it, which is why
+   `message_read` and `channels` take `MessageHandle` from there rather than assembling a URI of
+   their own. Two modules that each knew how to write one would be free to disagree, and the
+   disagreement would look like a message that cannot be read — which is exactly the failure the
+   third (reply) shape exists to fix. `server/` is not subject to this: a tool description names the
+   shapes so a model knows what it may pass, and that is prose rather than a second implementation.
+
 Every rule is paired with a guard that fails if the rule has become vacuous — an empty tree to walk,
 a missing file to forbid reaching for, a framework nothing imports any more. None of them is
 conditional: every package these rules are about now exists, so a rule that stops running is a
@@ -71,6 +79,13 @@ _GRAPH_SDK = "msgraph"
 # without importing `msgraph`, which is why rule 8 names them separately from rule 6.
 _GRAPH_REQUEST_LAYER: tuple[str, ...] = ("kiota_abstractions", "kiota_http", "msgraph_core")
 _MCP_FRAMEWORK = "fastmcp"
+
+# The scheme every message handle this connector mints is written in, and the one feature module
+# allowed to write it. Matched as text rather than through the AST because what rule 9 forbids is a
+# handle being *spelled* anywhere else — as an f-string, a format template or a concatenation, each
+# of which is a different AST and the same duplication.
+_HANDLE_SCHEME = "teams:///"
+_HANDLE_GRAMMAR = _FEATURES / "message_search.py"
 
 # Packages that publish a surface: outside code imports the package, never a module inside it.
 # Tests are deliberately exempt — they walk `src` only — so the pieces a package composes stay
@@ -531,6 +546,28 @@ class TestTheServerLayerDoesNotSpeakGraph:
             + "features/ however it is spelled. Move it there and have the tool call the "
             + "feature:\n  "
             + "\n  ".join(violations)
+        )
+
+
+class TestTheHandleGrammarHasOneHome:
+    def test_the_module_that_owns_it_actually_writes_one(self) -> None:
+        """Guards the guard: if handles stopped being minted there, the rule below would forbid
+        something nothing does and the grammar would have quietly moved."""
+        assert _HANDLE_SCHEME in _HANDLE_GRAMMAR.read_text(), (
+            f"{_HANDLE_GRAMMAR.name} no longer mints a handle; rule 9 names the wrong module"
+        )
+
+    @pytest.mark.parametrize(
+        "source",
+        sorted(path for path in _FEATURES.rglob("*.py") if path != _HANDLE_GRAMMAR),
+        ids=_source_id,
+    )
+    def test_no_other_feature_module_writes_a_handle(self, source: pathlib.Path) -> None:
+        assert _HANDLE_SCHEME not in source.read_text(), (
+            f"only {_HANDLE_GRAMMAR.name} may spell a {_HANDLE_SCHEME} handle — it is minted and "
+            + "parsed there, and a second speller is free to disagree with it. Build a "
+            + "`MessageHandle` and read its `uri` instead:\n  "
+            + str(source.relative_to(_SRC))
         )
 
 

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -264,9 +264,12 @@ _JOIN_WEB_URL = (
 )
 _MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
 _TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+_RECORDING_ID = "7e31db25-bc6e-4fd8-96c7-e01264e9b6fc"
 _MEETINGS_PATH = "/me/onlineMeetings"
 _TRANSCRIPTS_PATH = f"/me/onlineMeetings/{_MEETING_ID}/transcripts"
+_RECORDINGS_PATH = f"/me/onlineMeetings/{_MEETING_ID}/recordings"
 _CONTENT_PATH = f"{_TRANSCRIPTS_PATH}/{_TRANSCRIPT_ID}/content"
+_RECORDING_CONTENT_PATH = f"{_RECORDINGS_PATH}/{_RECORDING_ID}/content"
 
 _MEETING_CHATS = {
     "value": [
@@ -317,6 +320,35 @@ _TRANSCRIPTS = {
             "createdDateTime": "2026-02-10T14:03:11.204Z",
             "endDateTime": "2026-02-10T14:58:02.117Z",
             "contentCorrelationId": "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+        }
+    ]
+}
+
+# One recording of the same meeting, organised by somebody other than the signed-in user — which is
+# the common case and the one the organiser-only rule bites on. It shares its `contentCorrelationId`
+# with the transcript above, because Microsoft's own link between the two artifacts is that value.
+_RECORDINGS = {
+    "value": [
+        {
+            "id": _RECORDING_ID,
+            "meetingId": _MEETING_ID,
+            "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+            "createdDateTime": "2026-02-10T14:02:41.204Z",
+            "endDateTime": "2026-02-10T14:49:53.117Z",
+            "contentCorrelationId": "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+            "recordingContentUrl": f"{GRAPH_V1}{_RECORDING_CONTENT_PATH}",
+            "meetingOrganizer": {
+                "application": None,
+                "device": None,
+                "user": {
+                    # The type Microsoft's own list-recordings sample sends, which the SDK does not
+                    # know: it has to fall back to the base identity rather than take the call down.
+                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "displayName": None,
+                    "userIdentityType": "aadUser",
+                },
+            },
         }
     ]
 }
@@ -526,6 +558,7 @@ class TestTheToolsThisServerAdvertises:
             "read_message",
             "list_meeting_transcripts",
             "read_transcript",
+            "list_meeting_recordings",
         }
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
@@ -589,6 +622,16 @@ class TestTheToolsThisServerAdvertises:
             "truncated",
             "next_offset",
         }
+        assert set(_properties(tools["list_meeting_recordings"].outputSchema)) == {
+            "status",
+            "meeting_id",
+            "subject",
+            "meeting_type",
+            "started_at",
+            "ended_at",
+            "recordings",
+            "truncated",
+        }
         assert set(_properties(tools["read_message"].outputSchema)) == {
             "uri",
             "message_id",
@@ -633,8 +676,28 @@ class TestTheToolsThisServerAdvertises:
             "search_messages",
             "list_meeting_transcripts",
             "read_transcript",
+            "list_meeting_recordings",
         ):
             assert "truncated" in _properties(tools[name].outputSchema), name
+
+    async def test_the_two_meeting_listers_answer_in_the_same_shape(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Two artifacts of one meeting, asked for by the same handle over the same window, so the
+        answers differ in exactly one field: which artifact is listed. That symmetry is what lets a
+        model that learned one tool use the other without reading it twice — and it is asserted
+        because the alternative (`status` here, `state` there; `subject` here, `topic` there) is
+        what two tools written a week apart drift into.
+        """
+        tools = _named(await mcp_client.list_tools())
+        transcripts_schema = set(_properties(tools["list_meeting_transcripts"].outputSchema))
+        recordings_schema = set(_properties(tools["list_meeting_recordings"].outputSchema))
+
+        assert transcripts_schema - recordings_schema == {"transcripts"}
+        assert recordings_schema - transcripts_schema == {"recordings"}
+        assert set(_properties(tools["list_meeting_transcripts"].inputSchema)) == set(
+            _properties(tools["list_meeting_recordings"].inputSchema)
+        )
 
     async def test_read_message_takes_exactly_one_required_handle(
         self, mcp_client: Client[FastMCPTransport]
@@ -794,6 +857,111 @@ class TestTheToolsThisServerAdvertises:
         assert "window you asked about" in description
         assert "already well past never answers this" in description
         assert "demonstrably passed is never reported this way" in str(status["description"])
+
+    async def test_list_meeting_recordings_takes_the_same_handle_and_window(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["list_meeting_recordings"].inputSchema
+        properties = _properties(schema)
+        limit = _object(properties["limit"])
+
+        assert set(properties) == {"meeting_uri", "started_after", "started_before", "limit"}
+        assert schema.get("required") == ["meeting_uri"]
+        assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
+            "integer",
+            1,
+            50,
+            20,
+        )
+        for bound in ("started_after", "started_before"):
+            assert _optional_types(properties[bound]) == [
+                {"type": "string", "format": "date"},
+                {"type": "string", "format": "date-time"},
+            ]
+
+    async def test_list_meeting_recordings_promises_no_video_and_says_why(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The one thing a model must not hope for. A recording is an MP4 of a meeting that can run
+        30 hours and a model cannot watch video, so no tool here returns or fetches one — and a
+        description that merely omitted to say so would have a model asking for the file, or
+        reporting that it could not get it as if that were a failure.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_recordings"].description
+        assert description is not None
+
+        assert "No video is returned or reachable anywhere in this connector" in description
+        assert "30 hours" in description
+        assert "cannot watch video" in description
+        assert "list_meeting_transcripts" in description, "where a question about content goes"
+        assert "content_correlation_id" in description, "and how to get to the right transcript"
+
+    async def test_list_meeting_recordings_relays_the_organiser_only_rule(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Microsoft's hard constraint, in the words a model has to be able to pass on: delegated
+        download is the organiser's alone unless an administrator unblocked participants. The
+        wording that matters most is the negative one — an unreachable recording is not a missing
+        recording, and reporting it as one is a wrong answer nobody can detect.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_recordings"].description
+        assert description is not None
+        # The whole output schema, `$defs` included: a recording's own fields are described there
+        # rather than inline, and `content_access` has to carry its three meanings where a model
+        # reads the result — not only in the tool's prose.
+        rendered = description + json.dumps(tools["list_meeting_recordings"].outputSchema)
+
+        assert "ORGANISER-ONLY" in description
+        assert "Meeting participants don't have permission to download meeting recordings" in (
+            description
+        )
+        assert "unblocked participants" in description
+        assert "Never report an `organizer_only` recording as a missing one" in description
+        assert "organizer_user_id" in description, "who to ask for it"
+        assert "you_are_the_organizer" in rendered and "organizer_only" in rendered
+        assert "Meeting participants don't have permission" in json.dumps(
+            tools["list_meeting_recordings"].outputSchema
+        ), "the constraint belongs where the result is read, not only in the tool's prose"
+
+    async def test_list_meeting_recordings_names_its_four_answers_and_their_remedies(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The same four-outcome vocabulary the transcript lister established, adapted by one word:
+        `not_recorded` instead of `not_transcribed`. A model that learned when to wait and when to
+        stop for one artifact must not have to learn it again for the other."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_recordings"].description
+        status = _object(_properties(tools["list_meeting_recordings"].outputSchema)["status"])
+        assert description is not None
+        rendered = description + str(status.get("description"))
+
+        for value in ("available", "not_ready", "not_recorded", "meeting_not_found"):
+            assert value in description, value
+        assert "Wait and call again later" in description
+        assert 'NOT "the call was not recorded"' in description
+        assert "Retrying will not help" in description
+        assert "no availability SLA" in rendered, "the inference has to be admitted as one"
+        assert "recurring" in description and "started_after" in description
+        assert "no duration property" in description, "the duration is derived, and says so"
+
+    async def test_list_meeting_recordings_says_it_is_not_behind_the_transcript_switch(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The reason the two artifacts are two tools, said where it changes what a model does: the
+        tenant switch that blocks transcripts — off by default — leaves recordings alone, so a model
+        refused a transcript should still ask whether the meeting was recorded."""
+        tools = _named(await mcp_client.list_tools())
+        recordings_description = tools["list_meeting_recordings"].description
+        transcripts_description = tools["list_meeting_transcripts"].description
+        assert recordings_description is not None and transcripts_description is not None
+
+        assert "NOT behind the tenant-wide Teams switch" in recordings_description
+        assert "OnlineMeetingRecording.Read.All" in recordings_description
+        assert "list_meeting_recordings" in transcripts_description
+        assert "leaves recordings alone" in transcripts_description
 
     async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
         self, mcp_client: Client[FastMCPTransport]
@@ -1152,6 +1320,133 @@ class TestCallingThem:
             ),
             ("https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",),
         ], "the reader needs only transcript access; resolving a join URL is the lister's job"
+
+    async def test_a_model_walks_from_a_meeting_chat_to_whether_the_call_was_recorded(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The question this piece exists to answer, over the real protocol and end to end: was
+        Tuesday's call recorded, how long is it, and can I get at it. Every value is taken from the
+        previous answer exactly as a model would take it — the meeting chat's `meeting_uri` is the
+        same handle the transcript lister takes.
+
+        The recording here is somebody else's, which is the common case: Microsoft permits only the
+        organiser to download a recording, so the answer has to be "there is a 47-minute recording,
+        the organiser has it, and here is the transcript instead" — never "there is no recording".
+        No byte of video is fetched, and the mocked content route proves it.
+        """
+        chats_route = graph.get("/me/chats").mock(
+            return_value=httpx.Response(200, json=_MEETING_CHATS)
+        )
+        meeting = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        listing = graph.get(_RECORDINGS_PATH).mock(
+            return_value=httpx.Response(200, json=_RECORDINGS)
+        )
+        me = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+        video = graph.get(_RECORDING_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=b"synthetic mp4 bytes")
+        )
+
+        listed = _structured(await mcp_client.call_tool("list_chats", {"limit": 5}))
+        found = cast("Sequence[Mapping[str, object]]", listed["chats"])
+        meeting_uri = found[0]["meeting_uri"]
+        available = _structured(
+            await mcp_client.call_tool("list_meeting_recordings", {"meeting_uri": meeting_uri})
+        )
+
+        assert all(route.called for route in (chats_route, meeting, listing, me))
+        assert not video.called, "listing a recording must never fetch it"
+        assert available["status"] == "available"
+        assert available["subject"] == "Pricing review"
+        assert available["truncated"] is False
+        recorded = cast("Sequence[Mapping[str, object]]", available["recordings"])
+        assert len(recorded) == 1
+        assert recorded[0]["duration_seconds"] == pytest.approx(2831.913)
+        assert recorded[0]["content_access"] == "organizer_only"
+        assert recorded[0]["organizer_user_id"] == "00000000-0000-4000-8000-000000000002"
+        assert (
+            recorded[0]["content_correlation_id"]
+            == _TRANSCRIPTS["value"][0]["contentCorrelationId"]
+        ), "the bridge to the readable artifact is Microsoft's own, and both tools report it"
+        assert listing.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            ("https://graph.microsoft.com/Chat.Read",),
+            (
+                "https://graph.microsoft.com/OnlineMeetings.Read",
+                "https://graph.microsoft.com/OnlineMeetingRecording.Read.All",
+                "https://graph.microsoft.com/User.Read",
+            ),
+        ], "resolving the meeting, listing recordings, and finding out who is asking"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_tenant_transcript_switch_does_not_take_the_recording_answer_with_it(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The reason these are two tools rather than one, proved rather than argued. Microsoft's
+        Graph access to transcripts is a tenant switch that is OFF BY DEFAULT and it applies to
+        transcript resources only — so in the commonest tenant the transcript listing 403s while the
+        recording listing answers perfectly well. One tool listing both artifacts would have to fail
+        the whole call here, and a model would be told nothing about a recording that is right
+        there.
+        """
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(return_value=httpx.Response(403, json=_TENANT_SWITCH_OFF))
+        graph.get(_RECORDINGS_PATH).mock(return_value=httpx.Response(200, json=_RECORDINGS))
+        graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+        meeting_uri = f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}"
+
+        refused = await mcp_client.call_tool(
+            "list_meeting_transcripts", {"meeting_uri": meeting_uri}, raise_on_error=False
+        )
+        answered = await mcp_client.call_tool(
+            "list_meeting_recordings", {"meeting_uri": meeting_uri}, raise_on_error=False
+        )
+
+        assert refused.is_error
+        assert "EnableGraphTranscriptAccess" in _error_text(refused)
+        assert not answered.is_error, "the switch Microsoft scopes to transcripts must stop there"
+        body = _structured(answered)
+        assert body["status"] == "available"
+        assert len(cast("Sequence[object]", body["recordings"])) == 1
+
+    @pytest.mark.usefixtures("obo")
+    async def test_nothing_about_a_recording_reaches_a_log_or_a_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A meeting's subject is content — "Northwind acquisition: final terms" says most of what
+        the meeting was about — and this tool returns one for a meeting nobody may even download. So
+        the rule the rest of the surface is held to holds here too, over the whole call: it reaches
+        the caller and no log line and no span attribute anywhere in the process."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        meeting = {"value": [{**_MEETING["value"][0], "subject": secret}]}
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=meeting))
+        graph.get(_RECORDINGS_PATH).mock(return_value=httpx.Response(200, json=_RECORDINGS))
+        graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool(
+            "list_meeting_recordings",
+            {"meeting_uri": f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}"},
+        )
+
+        assert _structured(result)["subject"] == secret, "the subject has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     async def test_the_join_url_reaches_graph_encoded_exactly_once_over_the_real_protocol(
         self,
@@ -1937,6 +2232,8 @@ class TestWhatAModelIsToldWhenGraphRefuses:
             ("list_meeting_transcripts", "meeting_uri", "19:meeting_x@thread.v2"),
             ("read_transcript", "uri", "teams:///meetings/https%3A%2F%2Fx.invalid%2Fa"),
             ("read_transcript", "uri", "teams:///chats/19%3Ax%40thread.v2/messages/1"),
+            ("list_meeting_recordings", "meeting_uri", "teams:///transcripts/a/b"),
+            ("list_meeting_recordings", "meeting_uri", "19:meeting_x@thread.v2"),
         ],
     )
     async def test_each_meeting_tool_refuses_the_other_ones_handle_and_says_where_to_get_its_own(
@@ -1966,6 +2263,7 @@ class TestWhatAModelIsToldWhenGraphRefuses:
                 "teams:///transcripts/{meeting_id}/{transcript_id}",
                 "list_meeting_transcripts",
             ),
+            "list_meeting_recordings": ("teams:///meetings/{join_web_url}", "list_chats"),
         }[tool]
         for fragment in expected:
             assert fragment in message, message

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -1,0 +1,347 @@
+"""The whole loop, over the real MCP protocol: client → tool → OBO token → Microsoft Graph.
+
+This drives the app `create_app` actually builds — same FastMCP server, same Entra auth provider,
+same registered tools, same shared Graph transport — through fastmcp's own in-process client. Only
+the two external systems are stood in for, at exactly the boundary each one owns:
+
+* **Entra's token endpoint.** The signed-in user's token and the On-Behalf-Of exchange are
+  replaced, because the exchange is a network call to login.microsoftonline.com. What is *not*
+  replaced is `EntraOBOToken` itself: the dependency still runs, still finds the app's
+  `AzureProvider`, and the token it produces is the one the tool must put on the wire.
+* **Microsoft Graph**, via respx.
+
+Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
+"""
+
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from typing import cast
+
+import httpx
+import pytest
+import respx
+from azure.core.credentials import AccessToken as GraphAccessToken
+from fastmcp import Client, FastMCP
+from fastmcp.client.client import CallToolResult
+from fastmcp.client.transports import FastMCPTransport
+from fastmcp.server.auth.providers.azure import AzureProvider
+from fastmcp.server.dependencies import AccessToken
+from mcp.types import TextContent, Tool
+from starlette.applications import Starlette
+
+from office_mcp.app import create_app
+from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
+from office_mcp.graph_client import GraphSettings, create_graph_transport
+
+GRAPH_V1 = "https://graph.microsoft.com/v1.0"
+
+# The token the (stubbed) On-Behalf-Of exchange hands back. Asserting on it is what proves the
+# caller's delegated token — and not the connector's own — is what called Graph.
+OBO_TOKEN = "synthetic-obo-graph-token"
+
+_CLIENT_TOKEN = "synthetic-fastmcp-session-token"
+
+_ME = {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "displayName": "Ada Lovelace",
+    "mail": "ada@example.invalid",
+    "userPrincipalName": "ada@corp.example.invalid",
+    "jobTitle": "Analyst",
+}
+
+_CHATS = {
+    "value": [
+        {
+            "id": "19:release@thread.v2",
+            "chatType": "group",
+            "topic": "Release planning",
+            "createdDateTime": "2026-01-04T12:00:00Z",
+            "lastUpdatedDateTime": "2026-02-11T09:15:22.31Z",
+            "members": [
+                {
+                    "@odata.type": "#microsoft.graph.aadUserConversationMember",
+                    "id": "member-ada",
+                    "displayName": "Ada Lovelace",
+                    "email": "ada@example.invalid",
+                }
+            ],
+            "lastMessagePreview": {
+                "id": "1770000000000",
+                "createdDateTime": "2026-02-11T09:15:22.31Z",
+                "body": {"contentType": "text", "content": "synthetic preview"},
+            },
+        }
+    ]
+}
+
+
+class _StubOboCredential:
+    """Stands in for `azure.identity.aio.OnBehalfOfCredential`, which would call Entra.
+
+    Records the scopes it was asked for: those are what the tool declared it needs, and getting
+    them wrong is invisible until a real tenant refuses the exchange.
+    """
+
+    def __init__(self) -> None:
+        self.requested_scopes: list[tuple[str, ...]] = []
+
+    async def get_token(self, *scopes: str) -> GraphAccessToken:
+        self.requested_scopes.append(scopes)
+        return GraphAccessToken(token=OBO_TOKEN, expires_on=0)
+
+
+@pytest.fixture
+def obo(monkeypatch: pytest.MonkeyPatch) -> _StubOboCredential:
+    """Authenticate the in-process caller and stub only the Entra round trip."""
+    credential = _StubOboCredential()
+
+    async def get_obo_credential(
+        _self: AzureProvider, *, user_assertion: str
+    ) -> _StubOboCredential:
+        assert user_assertion == _CLIENT_TOKEN, "the caller's own token is what gets exchanged"
+        return credential
+
+    monkeypatch.setattr(AzureProvider, "get_obo_credential", get_obo_credential)
+    # `EntraOBOToken` reads the caller's token through this function; there is no HTTP request
+    # behind an in-process client, so there is nothing for it to read it from.
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_access_token",
+        lambda: AccessToken(
+            token=_CLIENT_TOKEN,
+            client_id="1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+            scopes=["access_as_user"],
+        ),
+    )
+    return credential
+
+
+@pytest.fixture
+def graph() -> Iterator[respx.MockRouter]:
+    with respx.mock(base_url=GRAPH_V1, assert_all_called=False) as router:
+        yield router
+
+
+def _build_app() -> Starlette:
+    return create_app(
+        config=AppConfig.model_validate({"public_base_url": "https://office-mcp.example"}),
+        # Nothing in these tests reaches Postgres: the engine is lazy and the OAuth state store is
+        # only touched by the HTTP auth path, which an in-process client does not go through.
+        database_config=DatabaseConfig.model_validate(
+            {"url": "postgresql://user:pass@127.0.0.1:1/nope"}
+        ),
+        entra_config=EntraConfig.model_validate(
+            {
+                "tenant_id": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+                "client_id": "1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061",
+                "client_secret": "s3cr3t",
+            }
+        ),
+    )
+
+
+@pytest.fixture
+def app() -> Starlette:
+    return _build_app()
+
+
+def _server_of(app: Starlette) -> FastMCP[None]:
+    """The FastMCP server `create_app` mounted, which is what the MCP protocol talks to."""
+    return cast("FastMCP[None]", app.state.fastmcp_server)
+
+
+@pytest.fixture
+async def mcp_client(app: Starlette) -> AsyncIterator[Client[FastMCPTransport]]:
+    """A real MCP client speaking to that server, lifespan and all."""
+    async with Client(FastMCPTransport(_server_of(app))) as client:
+        yield client
+
+
+def _named(tools: Sequence[Tool]) -> dict[str, Tool]:
+    return {tool.name: tool for tool in tools}
+
+
+def _properties(schema: Mapping[str, object] | None) -> dict[str, object]:
+    """The `properties` of a JSON schema, narrowed off the SDK's `dict[str, Any]`."""
+    assert schema is not None, "expected a schema"
+    properties = schema.get("properties")
+    assert isinstance(properties, dict), f"expected an object schema, got {schema!r}"
+    return cast("dict[str, object]", properties)
+
+
+def _object(value: object) -> dict[str, object]:
+    assert isinstance(value, dict), f"expected an object, got {value!r}"
+    return cast("dict[str, object]", value)
+
+
+def _structured(result: CallToolResult) -> dict[str, object]:
+    data = cast("dict[str, object] | None", result.structured_content)
+    assert data is not None, "the tool returned no structured content"
+    return data
+
+
+class TestTheToolsThisServerAdvertises:
+    async def test_both_tools_are_listed_and_neither_asks_for_a_token(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The Graph token is a dependency, not a parameter: if it ever leaked into the input
+        schema, a model would try to invent one."""
+        tools = _named(await mcp_client.list_tools())
+
+        assert set(tools) == {"whoami", "list_chats"}
+        for tool in tools.values():
+            assert "graph_token" not in _properties(tool.inputSchema)
+
+    async def test_whoami_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
+        tools = _named(await mcp_client.list_tools())
+
+        assert _properties(tools["whoami"].inputSchema) == {}
+        assert tools["whoami"].inputSchema.get("required", []) == []
+
+    async def test_list_chats_bounds_its_limit_where_graph_bounds_it(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Prose ("max 50") is advice; the schema is enforcement — an out-of-range call has to
+        fail loudly rather than be silently clamped to something else."""
+        tools = _named(await mcp_client.list_tools())
+        limit = _object(_properties(tools["list_chats"].inputSchema)["limit"])
+
+        assert limit["type"] == "integer", "not `number`: a fractional page size is meaningless"
+        assert (limit["minimum"], limit["maximum"], limit["default"]) == (1, 50, 25)
+
+    async def test_both_tools_declare_their_result_shape(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The oracle connector returns an unschematised stream of objects whose last element may
+        be pagination metadata. A declared output schema is how `truncated` stops being prose."""
+        tools = _named(await mcp_client.list_tools())
+
+        assert set(_properties(tools["whoami"].outputSchema)) == {
+            "id",
+            "display_name",
+            "mail",
+            "user_principal_name",
+            "job_title",
+        }
+        assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
+
+    async def test_the_tools_are_marked_read_only(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+
+        for tool in tools.values():
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+
+
+class TestCallingThem:
+    async def test_whoami_calls_graph_with_the_exchanged_token(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        result = await mcp_client.call_tool("whoami", {})
+
+        assert _structured(result)["mail"] == "ada@example.invalid"
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [("https://graph.microsoft.com/User.Read",)]
+
+    async def test_list_chats_returns_a_structured_page(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"limit": 5})
+
+        body = _structured(result)
+        assert body["truncated"] is False
+        listed = cast("Sequence[Mapping[str, object]]", body["chats"])
+        assert [chat["chat_id"] for chat in listed] == ["19:release@thread.v2"]
+        assert listed[0]["last_message_at"] == "2026-02-11T09:15:22.310000Z"
+        assert obo.requested_scopes == [("https://graph.microsoft.com/Chat.Read",)]
+
+    async def test_an_out_of_range_limit_is_refused_before_graph_is_called(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"limit": 500}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert not obo.requested_scopes, "no token is exchanged for a call that cannot run"
+
+    async def test_an_argument_this_tool_does_not_have_is_refused(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """A misremembered parameter — `cursor`, say, which this tool deliberately does not have —
+        must fail rather than be ignored, or the model believes it paged when it re-read page one.
+        """
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+
+        result = await mcp_client.call_tool("list_chats", {"cursor": "abc"}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert not obo.requested_scopes
+
+
+class TestTheTransportTheToolsShare:
+    async def test_it_is_closed_when_the_server_shuts_down(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One connection pool serves every tool call, so nothing else in the process would ever
+        notice it being leaked — until a pod's sockets ran out."""
+        built: list[httpx.AsyncClient] = []
+
+        def record(settings: GraphSettings) -> httpx.AsyncClient:
+            transport = create_graph_transport(settings)
+            built.append(transport)
+            return transport
+
+        monkeypatch.setattr("office_mcp.app.create_graph_transport", record)
+
+        async with Client(FastMCPTransport(_server_of(_build_app()))):
+            assert built and not built[0].is_closed
+
+        assert built[0].is_closed
+
+
+class TestWhatAModelIsToldWhenGraphRefuses:
+    async def test_a_missing_permission_names_the_permission(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """End to end, the case the oracle connector handles worst: a 403 that says only that
+        something was forbidden leaves a model with nothing to do but retry."""
+        graph.get("/me/chats").mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}},
+            )
+        )
+
+        result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
+
+        assert result.is_error
+        message = "\n".join(
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        assert "Chat.Read" in message
+        assert "administrator" in message
+        assert "synthetic-request-id" in message
+        assert obo.requested_scopes, "the failure came from Graph, not from the token exchange"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -466,10 +466,15 @@ def _object(value: object) -> dict[str, object]:
     return cast("dict[str, object]", value)
 
 
-def _optional_type(schema: object) -> dict[str, object]:
-    """The non-null branch of an optional parameter's schema, which is where its type lives."""
+def _optional_types(schema: object) -> list[dict[str, object]]:
+    """Every non-null branch of an optional parameter's schema, in the order it declares them."""
     branches = cast("Sequence[object]", _object(schema)["anyOf"])
-    typed = [_object(branch) for branch in branches if _object(branch).get("type") != "null"]
+    return [_object(branch) for branch in branches if _object(branch).get("type") != "null"]
+
+
+def _optional_type(schema: object) -> dict[str, object]:
+    """The one non-null branch of an optional parameter's schema, where it has exactly one."""
+    typed = _optional_types(schema)
     assert len(typed) == 1, f"expected one non-null branch, got {typed!r}"
     return typed[0]
 
@@ -711,16 +716,61 @@ class TestTheToolsThisServerAdvertises:
 
         assert set(properties) == {"meeting_uri", "started_after", "started_before", "limit"}
         assert schema.get("required") == ["meeting_uri"]
-        assert _optional_type(properties["started_after"]) == {
-            "type": "string",
-            "format": "date-time",
-        }
         assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
             "integer",
             1,
             50,
             20,
         )
+
+    @pytest.mark.parametrize("bound", ["started_after", "started_before"], ids=["after", "before"])
+    async def test_each_occurrence_bound_admits_a_bare_date_in_its_own_schema(
+        self, mcp_client: Client[FastMCPTransport], bound: str
+    ) -> None:
+        """A bare `2026-08-11` is what a model writes when scoping a series to one occurrence — the
+        only reason these parameters exist — so the schema has to say a date is legal. A schema
+        offering only `date-time` while the code accepted a date anyway is the disagreement the
+        crash came from: the model was never told which shape was meant."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["list_meeting_transcripts"].inputSchema)
+
+        assert _optional_types(properties[bound]) == [
+            {"type": "string", "format": "date"},
+            {"type": "string", "format": "date-time"},
+        ]
+
+    async def test_the_occurrence_window_states_the_zone_it_resolves_against(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """`09:00` is a different instant in every zone, so a tool that silently picks one has to
+        say which — in the parameter's own description, which is the only place a model reads before
+        writing the value. Both halves are asserted: what an offset-less timestamp means, and what a
+        bare date means at each end of the window."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["list_meeting_transcripts"].inputSchema)
+        after = str(_object(properties["started_after"])["description"])
+        before = str(_object(properties["started_before"])["description"])
+
+        assert "READ AS UTC" in after, "the assumption a naive timestamp is resolved against"
+        assert "whole UTC day" in after and "first instant" in after
+        assert "END of that UTC day" in before, "the same date in both bounds must be that one day"
+        assert "07:00Z" in after, "a worked example beats the word 'timezone'"
+
+    async def test_list_meeting_transcripts_says_the_verdict_is_about_the_window(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The promise the `not_ready` inference has to keep. A recurring series' `endDateTime` can
+        be in the future for years, and a caller told to wait for a transcript of an occurrence that
+        ended last month polls forever — so both the tool and the field say the verdict follows the
+        window that was asked for, not the meeting."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_transcripts"].description
+        status = _object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"])
+        assert description is not None
+
+        assert "window you asked about" in description
+        assert "already well past never answers this" in description
+        assert "demonstrably passed is never reported this way" in str(status["description"])
 
     async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
         self, mcp_client: Client[FastMCPTransport]
@@ -1166,6 +1216,71 @@ class TestCallingThem:
         assert body["status"] == "meeting_not_found"
         assert body["transcripts"] == []
         assert not listing.called
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("started_after", "started_before"),
+        [
+            ("2026-02-10", "2026-02-10"),
+            ("2026-02-10T14:00:00", "2026-02-10T14:30:00"),
+            ("2026-02-10T15:00:00+01:00", "2026-02-10T15:30:00+01:00"),
+            ("2026-02-10T14:00:00Z", None),
+        ],
+        ids=["bare-dates", "no-offset", "offset", "one-sided"],
+    )
+    async def test_the_window_shapes_a_model_writes_are_answered_and_never_raised(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        started_after: str,
+        started_before: str | None,
+    ) -> None:
+        """Over the real protocol, in the shapes a model sends: scoping a recurring series to one
+        occurrence is the only reason these parameters exist, and a model writes `2026-02-10` or
+        `2026-02-10T14:00:00` as readily as an offset-bearing timestamp. Every one of them used to
+        reach a naive-versus-aware comparison and come back as a raw `TypeError` — a failure naming
+        no remedy, for a value the tool's own schema had accepted.
+        """
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(return_value=httpx.Response(200, json=_TRANSCRIPTS))
+
+        result = await mcp_client.call_tool(
+            "list_meeting_transcripts",
+            {
+                "meeting_uri": f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}",
+                "started_after": started_after,
+                "started_before": started_before,
+            },
+        )
+
+        assert not result.is_error, "a window a model plausibly writes must not fail the call"
+        body = _structured(result)
+        assert body["status"] == "available"
+        assert len(cast("Sequence[object]", body["transcripts"])) == 1
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_window_a_model_could_not_have_meant_is_refused_before_any_graph_request(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The other half of "never crash": what is not a date at all is rejected by the schema, so
+        the failure names the parameter and the shape rather than surfacing an exception from inside
+        a comparison — and it costs no Graph request."""
+        meetings = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+
+        result = await mcp_client.call_tool(
+            "list_meeting_transcripts",
+            {
+                "meeting_uri": f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}",
+                "started_after": "last Tuesday",
+            },
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        assert "started_after" in _error_text(result)
+        assert not meetings.called
 
     @pytest.mark.usefixtures("obo")
     async def test_a_channel_post_reaches_the_caller_and_no_log_or_span(

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -38,6 +38,7 @@ from starlette.applications import Starlette
 
 from office_mcp.app import create_app
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
+from office_mcp.features import channels
 from office_mcp.graph_client import GraphSettings, create_graph_transport
 
 GRAPH_V1 = "https://graph.microsoft.com/v1.0"
@@ -587,6 +588,28 @@ class TestTheToolsThisServerAdvertises:
         assert "reply chain" in description
         assert "created_at" in description, "the field that does tell the truth about age"
         assert "search_messages" in description, "where a date-bounded question goes instead"
+
+    async def test_browse_channel_says_what_one_call_costs_and_where_it_stops(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The budget is only a bound if the caller can see it. Microsoft allows this whole
+        connector about one request a second on a given channel across the tenant, so the tool
+        makes exactly one — which means `limit` is the entire window, and a model that expects
+        paging to reach further has to be told it does not, in the description and in the schema
+        rather than only in the code.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["browse_channel"].description
+        limit = _object(_properties(tools["browse_channel"].inputSchema)["limit"])
+        assert description is not None
+
+        assert "exactly one request" in description
+        assert "never pages deeper" in description
+        assert "one request against the channel" in str(limit["description"])
+        assert "browsing again returns the same newest replies" in description, (
+            "the reply window is a dead end, not a first page"
+        )
+        assert "do not browse again for it" in description
 
     async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
         self, mcp_client: Client[FastMCPTransport]
@@ -1244,6 +1267,39 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "not evidence that the message does not exist" in message
         assert "synthetic-request-id" in message, "the id Microsoft support asks for first"
         assert "verbatim" not in message, "the handle did come from a tool response"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_advice_for_an_unreadable_reply_terminates_instead_of_looping(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The one 404 this connector predicts, and the advice that must not be circular. A search
+        hit on a channel reply carries the root-post shape, because Microsoft's index does not say
+        which post the reply hangs under — so it 404s. browse_channel is the only tool that mints a
+        reply's own handle, but it returns the newest replies of each post on a channel's first page
+        and follows neither of Microsoft's cursors past them, since a given channel allows this
+        whole connector about one request a second across the tenant. "Browse the channel instead"
+        is therefore a route for a recent reply and a loop for an older one, so this text has to
+        name the window, say there is no route beyond it, and tell the model what to answer with.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        message = _error_text(result)
+        assert f"newest {channels.MAX_REPLIES_PER_POST} replies" in message, message
+        assert "no route to its full text" in message
+        assert "a second browse returns the same window" in message
+        assert "stop looking" in message
 
     @pytest.mark.usefixtures("obo")
     async def test_a_refused_read_names_only_the_permission_that_surface_needs(

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -353,6 +353,44 @@ _RECORDINGS = {
     ]
 }
 
+# A recurring series as Microsoft holds it: one meeting, one collection, three occurrences — and
+# answered oldest-first, which is an order of Microsoft's own (it documents no `$orderby` on either
+# collection). Written out in that order on purpose: it is what makes "the newest of a series"
+# something a lister has to work for rather than something it gets by accident.
+_SERIES_TRANSCRIPTS: dict[str, object] = {
+    "value": [
+        {
+            "id": f"week-{week}",
+            "meetingId": _MEETING_ID,
+            "createdDateTime": f"2026-02-0{2 + week}T14:00:00Z",
+            "endDateTime": f"2026-02-0{2 + week}T14:50:00Z",
+            "contentCorrelationId": f"bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e{week}",
+        }
+        for week in (1, 2, 3)
+    ]
+}
+
+_SERIES_RECORDINGS: dict[str, object] = {
+    "value": [
+        {
+            "id": f"week-{week}",
+            "meetingId": _MEETING_ID,
+            "createdDateTime": f"2026-02-0{2 + week}T14:00:00Z",
+            "endDateTime": f"2026-02-0{2 + week}T14:50:00Z",
+            "contentCorrelationId": f"bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e{week}",
+            "meetingOrganizer": {
+                "user": {"id": "00000000-0000-4000-8000-000000000002", "displayName": None}
+            },
+        }
+        for week in (1, 2, 3)
+    ]
+}
+
+# The meeting handle `list_chats` mints for the chat above, written out rather than derived: that
+# the handle a model copies from one tool is the argument another takes is the contract between
+# them, and deriving it here would assert only that the test agrees with itself.
+_MEETING_URI = "teams:///meetings/" + quote(_JOIN_WEB_URL, safe="")
+
 _TRANSCRIPT_VTT = """WEBVTT
 
 00:00:16.246 --> 00:00:19.900
@@ -772,25 +810,34 @@ class TestTheToolsThisServerAdvertises:
         for name in ("from_seconds", "to_seconds", "speaker"):
             assert _object(properties[name]).get("description"), f"{name} is undescribed"
 
-    async def test_list_meeting_transcripts_names_the_four_answers_and_their_remedies(
+    async def test_list_meeting_transcripts_names_its_five_answers_and_their_remedies(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
-        """The three absences that must stay distinct, plus "no such meeting". A model can only act
+        """The four absences that must stay distinct, plus "no such meeting". A model can only act
         differently on them if the tool says what each one means, so the words are asserted: the
-        one that means wait must say wait, and must say it is not the one that means stop."""
+        one that means wait must say wait and must say it is not the one that means stop, and the
+        one that means "this was not knowable" must not be reportable as either."""
         tools = _named(await mcp_client.list_tools())
         description = tools["list_meeting_transcripts"].description
         status = _object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"])
         assert description is not None
         rendered = description + str(status.get("description"))
 
-        for value in ("available", "not_ready", "not_transcribed", "meeting_not_found"):
+        for value in (
+            "available",
+            "not_ready",
+            "not_transcribed",
+            "scan_incomplete",
+            "meeting_not_found",
+        ):
             assert value in description, value
         assert "Wait and call again later" in description
         assert 'NOT "there is no transcript"' in description
         assert "Retrying will not help" in description
         assert "no availability SLA" in rendered, "the inference has to be admitted as one"
         assert "recurring" in description and "started_after" in description
+        assert 'Never report it as "there is no transcript"' in description
+        assert "not known" in description, "the fifth answer claims nothing, and has to say so"
 
     async def test_list_meeting_transcripts_takes_a_meeting_handle_and_an_occurrence_window(
         self, mcp_client: Client[FastMCPTransport]
@@ -926,10 +973,10 @@ class TestTheToolsThisServerAdvertises:
             tools["list_meeting_recordings"].outputSchema
         ), "the constraint belongs where the result is read, not only in the tool's prose"
 
-    async def test_list_meeting_recordings_names_its_four_answers_and_their_remedies(
+    async def test_list_meeting_recordings_names_its_five_answers_and_their_remedies(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
-        """The same four-outcome vocabulary the transcript lister established, adapted by one word:
+        """The same five-outcome vocabulary the transcript lister establishes, adapted by one word:
         `not_recorded` instead of `not_transcribed`. A model that learned when to wait and when to
         stop for one artifact must not have to learn it again for the other."""
         tools = _named(await mcp_client.list_tools())
@@ -938,7 +985,13 @@ class TestTheToolsThisServerAdvertises:
         assert description is not None
         rendered = description + str(status.get("description"))
 
-        for value in ("available", "not_ready", "not_recorded", "meeting_not_found"):
+        for value in (
+            "available",
+            "not_ready",
+            "not_recorded",
+            "scan_incomplete",
+            "meeting_not_found",
+        ):
             assert value in description, value
         assert "Wait and call again later" in description
         assert 'NOT "the call was not recorded"' in description
@@ -946,6 +999,30 @@ class TestTheToolsThisServerAdvertises:
         assert "no availability SLA" in rendered, "the inference has to be admitted as one"
         assert "recurring" in description and "started_after" in description
         assert "no duration property" in description, "the duration is derived, and says so"
+        assert 'Never report it as "the call was not recorded"' in description
+        assert "not known" in description, "the fifth answer claims nothing, and has to say so"
+
+    async def test_both_meeting_listers_teach_the_same_status_vocabulary(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Two artifacts, one vocabulary: the three words that are about neither artifact in
+        particular have to be the same words, or a model that learned one tool guesses at the
+        other. Only the settled absence differs, which is the fact that actually differs.
+        """
+        tools = _named(await mcp_client.list_tools())
+        shared = {"available", "not_ready", "scan_incomplete", "meeting_not_found"}
+        statuses = {
+            name: str(_object(_properties(tools[name].outputSchema)["status"]).get("description"))
+            for name in ("list_meeting_transcripts", "list_meeting_recordings")
+        }
+
+        for name, rendered in statuses.items():
+            for value in shared:
+                assert f"`{value}`" in rendered, f"{name} does not name {value}"
+        assert "`not_transcribed`" in statuses["list_meeting_transcripts"]
+        assert "`not_recorded`" in statuses["list_meeting_recordings"]
+        assert "`not_recorded`" not in statuses["list_meeting_transcripts"]
+        assert "`not_transcribed`" not in statuses["list_meeting_recordings"]
 
     async def test_list_meeting_recordings_says_it_is_not_behind_the_transcript_switch(
         self, mcp_client: Client[FastMCPTransport]
@@ -1320,6 +1397,57 @@ class TestCallingThem:
             ),
             ("https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",),
         ], "the reader needs only transcript access; resolving a join URL is the lister's job"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("tool", "path", "collection", "items", "identifier"),
+        [
+            (
+                "list_meeting_transcripts",
+                _TRANSCRIPTS_PATH,
+                "transcripts",
+                _SERIES_TRANSCRIPTS,
+                "transcript_id",
+            ),
+            (
+                "list_meeting_recordings",
+                _RECORDINGS_PATH,
+                "recordings",
+                _SERIES_RECORDINGS,
+                "recording_id",
+            ),
+        ],
+        ids=["transcripts", "recordings"],
+    )
+    async def test_asking_for_the_latest_of_a_series_answers_with_the_latest(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        tool: str,
+        path: str,
+        collection: str,
+        items: dict[str, object],
+        identifier: str,
+    ) -> None:
+        """ "The latest transcript of this series", over the real protocol — the question both
+        listers exist for, and the one they used to get wrong in the same way. Microsoft answers
+        this collection in an order of its own, so a `limit` applied before ordering returns an
+        arbitrary handful sorted among themselves; a model asking for the newest one gets whichever
+        occurrence Microsoft happened to put first, with nothing in the answer to say so.
+        Microsoft's order here puts the oldest first, which is what the old shape would return.
+        """
+        _ = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        _ = graph.get(path).mock(return_value=httpx.Response(200, json=items))
+        _ = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        answer = _structured(
+            await mcp_client.call_tool(tool, {"meeting_uri": _MEETING_URI, "limit": 1})
+        )
+
+        listed = cast("Sequence[Mapping[str, object]]", answer[collection])
+        assert [item[identifier] for item in listed] == ["week-3"], "the newest, not the first"
+        assert answer["status"] == "available"
+        assert answer["truncated"] is True, "the two older occurrences are the 'more' there is"
 
     async def test_a_model_walks_from_a_meeting_chat_to_whether_the_call_was_recorded(
         self,

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -92,6 +92,68 @@ _SEARCH = {
     ]
 }
 
+# The handle the search hit above carries, which is what read_message has to resolve. Written out
+# rather than derived: that a search result's `uri` and a read's argument are the same string is the
+# contract between the two tools, and deriving it here would assert only that the test agrees with
+# itself.
+_MESSAGE_URI = "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000"
+_MESSAGE_PATH = "/chats/19%3Arelease%40thread.v2/messages/1770000000000"
+
+# The same message as `GET /chats/{id}/messages/{id}` returns it: with a body, and with the
+# Teams-shaped sender that carries no email at all.
+_MESSAGE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "etag": "1770000000000",
+    "messageType": "message",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "lastModifiedDateTime": "2026-02-11T09:15:22.31Z",
+    "importance": "normal",
+    "from": {
+        "user": {
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+            "id": "00000000-0000-4000-8000-000000000001",
+            "displayName": "Ada Lovelace",
+            "userIdentityType": "aadUser",
+        }
+    },
+    "body": {
+        "contentType": "html",
+        "content": "<div><p>Let's cut the <strong>release</strong> on Friday&nbsp;&amp; tell "
+        + '<at id="0">Grace Hopper</at>.</p></div>',
+    },
+    "mentions": [
+        {
+            "id": 0,
+            "mentionText": "Grace Hopper",
+            "mentioned": {
+                "user": {
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "displayName": "Grace Hopper",
+                    "userIdentityType": "aadUser",
+                }
+            },
+        }
+    ],
+    "attachments": [],
+}
+
+# A system event message, which Graph sends with no author and no text: the body is the literal
+# `<systemEventMessage/>` and the sentence Teams displays is written by the Teams client.
+_SYSTEM_MESSAGE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "messageType": "systemEventMessage",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "from": None,
+    "body": {"contentType": "html", "content": "<systemEventMessage/>"},
+    "eventDetail": {
+        "@odata.type": "#microsoft.graph.membersJoinedEventMessageDetail",
+        "visibleHistoryStartDateTime": "0001-01-01T00:00:00Z",
+        "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+    },
+}
+
 _CHATS = {
     "value": [
         {
@@ -265,7 +327,7 @@ class TestTheToolsThisServerAdvertises:
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats", "search_messages"}
+        assert set(tools) == {"whoami", "list_chats", "search_messages", "read_message"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
@@ -306,6 +368,50 @@ class TestTheToolsThisServerAdvertises:
             "more_results_available",
             "next_offset",
         }
+        assert set(_properties(tools["read_message"].outputSchema)) == {
+            "uri",
+            "message_id",
+            "chat_id",
+            "team_id",
+            "channel_id",
+            "sender",
+            "text",
+            "event",
+            "created_at",
+            "last_edited_at",
+            "deleted_at",
+            "reply_to_id",
+            "subject",
+            "importance",
+            "web_url",
+            "mentions",
+            "attachments",
+        }
+
+    async def test_read_message_takes_exactly_one_required_handle(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A reader with optional parameters would invite a model to try reading "the last message
+        in this chat", which no handle expresses and this connector cannot serve."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["read_message"].inputSchema
+
+        assert set(_properties(schema)) == {"uri"}
+        assert schema.get("required") == ["uri"]
+
+    async def test_read_message_names_both_handle_shapes_and_no_others(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The description is where a model learns what it may pass. Naming the two shapes is what
+        stops it inventing `mail:///` — and the oracle connector's one polymorphic `read_resource`
+        is exactly the promise this connector does not make."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["read_message"].description
+        assert description is not None
+
+        assert "teams:///chats/{chat_id}/messages/{message_id}" in description
+        assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in description
+        assert "search_messages" in description, "a handle has exactly one source"
 
     async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
         self, mcp_client: Client[FastMCPTransport]
@@ -455,6 +561,89 @@ class TestCallingThem:
                 "https://graph.microsoft.com/ChannelMessage.Read.All",
             )
         ]
+
+    async def test_a_handle_from_a_search_result_reads_the_message_behind_it(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The whole point of the pair, over the real protocol: search returns a handle and no body,
+        and the handle — passed back verbatim, exactly as a model would — resolves into the text.
+        """
+        search = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        read = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_MESSAGE))
+
+        found = _structured(await mcp_client.call_tool("search_messages", {"query": "release"}))
+        hits = cast("Sequence[Mapping[str, object]]", found["messages"])
+        uri = hits[0]["uri"]
+        result = await mcp_client.call_tool("read_message", {"uri": uri})
+
+        assert search.called
+        body = _structured(result)
+        assert body["uri"] == _MESSAGE_URI == uri
+        assert body["text"] == "Let's cut the release on Friday & tell @Grace Hopper."
+        assert body["event"] is None
+        mentions = cast("Sequence[Mapping[str, object]]", body["mentions"])
+        assert [mention["user_id"] for mention in mentions] == [
+            "00000000-0000-4000-8000-000000000002"
+        ]
+        sender = cast("Mapping[str, object]", body["sender"])
+        assert sender["display_name"] == "Ada Lovelace"
+        assert read.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes[-1] == (
+            "https://graph.microsoft.com/Chat.Read",
+            "https://graph.microsoft.com/ChannelMessage.Read.All",
+        ), "the exchange happens before the handle is parsed, so it asks for both surfaces"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_reading_a_system_event_says_what_happened_rather_than_nothing(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """A handle can resolve to a message Graph gives no author and no text for. Answering with
+        an empty message would read as "they said nothing"; the event is what actually happened."""
+        _ = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_SYSTEM_MESSAGE))
+
+        result = await mcp_client.call_tool("read_message", {"uri": _MESSAGE_URI})
+
+        body = _structured(result)
+        assert body["event"] == "members joined"
+        assert body["text"] is None
+        assert body["sender"] is None
+        assert "systemEventMessage" not in json.dumps(body), (
+            "the literal tag Graph puts in the body is not an answer"
+        )
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_message_text_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A message body is as sensitive as the query that found it, and this tool is the one that
+        actually returns message content — so the same rule search is held to holds here, over the
+        whole call and both destinations."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        payload = {**_MESSAGE, "body": {"contentType": "text", "content": secret}}
+        _ = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=payload))
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool("read_message", {"uri": _MESSAGE_URI})
+
+        assert _structured(result)["text"] == secret, "the text has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     @pytest.mark.usefixtures("obo")
     async def test_a_multi_word_query_reaches_graph_as_words_over_the_real_protocol(
@@ -639,6 +828,127 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "AADSTS65001" in message
         assert "resolve dependency" not in message
         assert not route.called, "no token means no Graph request was ever made"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "mail:///messages/AAMkAGI2",
+            "teams:///chats/19%3Arelease%40thread.v2",
+            "https://teams.microsoft.com/l/message/19%3Ageneral/1770000000000",
+        ],
+    )
+    async def test_a_handle_this_connector_cannot_read_shows_the_shapes_it_can(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        uri: str,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The first of three failures a reader has to keep apart, and the only one that is this
+        connector's own fault to explain: the argument is not a handle. Graph is never called, and
+        the remedy is the shape — not "try again"."""
+        route = graph.get(_MESSAGE_PATH).mock(return_value=httpx.Response(200, json=_MESSAGE))
+
+        result = await mcp_client.call_tool("read_message", {"uri": uri}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        message = _error_text(result)
+        assert "teams:///chats/{chat_id}/messages/{message_id}" in message
+        assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in message
+        assert "search_messages" in message
+        assert obo.requested_scopes, "the handle is parsed inside the tool, after the exchange"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_message_graph_will_not_return_is_not_reported_as_never_existing(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The second failure: a well-formed handle Graph answers 404 to. It means deleted, or
+        invisible to this user, or gone — Graph does not say which, so neither may the tool. The
+        default advice for a missing item ("check the id came from a tool response verbatim") is
+        wrong here, because it did.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "could not be read" in message
+        assert "not evidence that the message does not exist" in message
+        assert "synthetic-request-id" in message, "the id Microsoft support asks for first"
+        assert "verbatim" not in message, "the handle did come from a tool response"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_refused_read_names_only_the_permission_that_surface_needs(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The third failure, and the one an administrator acts on. Graph's permissions for a
+        message read are per surface, so a 403 reading a chat can only be about `Chat.Read` —
+        naming the channel permission too would send them after one that was never missing, which
+        is the same defect as naming none.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "Chat.Read" in message
+        assert "administrator" in message
+        assert "ChannelMessage.Read.All" not in message, "this read was in a chat"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_refused_channel_read_names_the_channel_permission_instead(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The other half of the same rule: the tenant that grants `Chat.Read` and withholds the
+        broad channel permission is the common case, and this is the message that gets fixed."""
+        team = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+        _ = graph.get(
+            f"/teams/{team}/channels/19%3Ageneral%40thread.tacv2/messages/1770000000000"
+        ).mock(
+            return_value=httpx.Response(
+                403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message",
+            {
+                "uri": (
+                    f"teams:///teams/{team}/channels/19%3Ageneral%40thread.tacv2"
+                    + "/messages/1770000000000"
+                )
+            },
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "ChannelMessage.Read.All" in message
+        assert "Chat.Read" not in message, "this read was in a channel"
 
     async def test_an_unconsented_search_names_both_permissions_it_asked_for(
         self,

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
 from typing import cast
 from urllib.parse import quote
 
@@ -39,7 +40,7 @@ from starlette.applications import Starlette
 
 from office_mcp.app import create_app
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
-from office_mcp.features import channels
+from office_mcp.features import channels, transcripts
 from office_mcp.graph_client import GraphSettings, create_graph_transport
 
 GRAPH_V1 = "https://graph.microsoft.com/v1.0"
@@ -385,6 +386,37 @@ _SERIES_RECORDINGS: dict[str, object] = {
         for week in (1, 2, 3)
     ]
 }
+
+# The one meeting shape that outgrows what a single call reads: a daily series, transcribed and
+# recorded every time, for the better part of a year. Oldest-first for the same reason the weekly
+# series above is — Microsoft's order is its own — which puts the genuinely newest occurrence past
+# `MAX_ARTIFACT_SCAN`, where neither lister can see it and neither lister may claim it has.
+_PAST_THE_CAP = transcripts.MAX_ARTIFACT_SCAN + 60
+_DAILY_SERIES_START = datetime(2026, 1, 1, 14, 0, tzinfo=UTC)
+
+
+def _day(index: int) -> datetime:
+    """When occurrence `index` of the daily series ran."""
+    return _DAILY_SERIES_START + timedelta(days=index)
+
+
+def _daily_series() -> dict[str, object]:
+    """`_PAST_THE_CAP` artifacts in one page, in the shape both collections share."""
+    return {
+        "value": [
+            {
+                "id": f"day-{index}",
+                "meetingId": _MEETING_ID,
+                "createdDateTime": _day(index).isoformat().replace("+00:00", "Z"),
+                "endDateTime": (_day(index) + timedelta(minutes=50))
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "contentCorrelationId": f"bc842d7a-2f6e-4b18-a1c7-73ef91d5c8{index:03d}",
+            }
+            for index in range(_PAST_THE_CAP)
+        ]
+    }
+
 
 # The meeting handle `list_chats` mints for the chat above, written out rather than derived: that
 # the handle a model copies from one tool is the argument another takes is the contract between
@@ -1024,6 +1056,64 @@ class TestTheToolsThisServerAdvertises:
         assert "`not_recorded`" not in statuses["list_meeting_transcripts"]
         assert "`not_transcribed`" not in statuses["list_meeting_recordings"]
 
+    @pytest.mark.parametrize(
+        "tool",
+        ["list_meeting_transcripts", "list_meeting_recordings"],
+        ids=["transcripts", "recordings"],
+    )
+    async def test_neither_lister_offers_a_remedy_its_mechanism_cannot_keep(
+        self, mcp_client: Client[FastMCPTransport], tool: str
+    ) -> None:
+        """`scan_incomplete` used to end "narrow the window and ask again", which is advice a model
+        can follow forever without progress: the window is applied to the artifacts after Microsoft
+        has answered — Microsoft documents no filterable date on either collection — so a narrower
+        window is the same request over the same artifacts and answers the same way. A dead end
+        stated plainly is a better answer than an actionable-sounding loop, so the remedy is now to
+        stop and report the uncertainty, and the old sentence must not come back.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools[tool].description
+        status = _object(_properties(tools[tool].outputSchema)["status"])
+        assert description is not None
+        rendered = description + str(status.get("description"))
+
+        assert "Stop here." in description, "the answer with nothing to try has to say stop"
+        assert "could not be determined" in description, "the uncertainty IS the answer to report"
+        assert "There is nothing to try" in rendered
+        assert (
+            "narrow `started_after`/`started_before` to the occurrence you mean and ask again"
+            not in rendered.lower()
+        ), "this is the remedy that cannot work, in either place a model reads it"
+
+    @pytest.mark.parametrize(
+        ("tool", "collection"),
+        [
+            ("list_meeting_transcripts", "transcripts"),
+            ("list_meeting_recordings", "recordings"),
+        ],
+        ids=["transcripts", "recordings"],
+    )
+    async def test_neither_lister_promises_the_newest_past_its_scan_cap(
+        self, mcp_client: Client[FastMCPTransport], tool: str, collection: str
+    ) -> None:
+        """ "Newest first" is a property of the artifacts one call READ, not of the meeting: the
+        read stops at `MAX_ARTIFACT_SCAN` and Microsoft publishes no `$orderby` to ask the newest
+        for, so a meeting past that cap can hold a newer artifact than any that came back. Both
+        places a model learns the ordering from — the `limit` it chooses with and the list it reads
+        — have to say so, and "asking for 3 gives the 3 latest" is the sentence that did not.
+        """
+        tools = _named(await mcp_client.list_tools())
+        limit = _object(_properties(tools[tool].inputSchema)["limit"])
+        listed = _object(_properties(tools[tool].outputSchema)[collection])
+        rendered = str(limit.get("description")) + str(listed.get("description"))
+
+        assert str(transcripts.MAX_ARTIFACT_SCAN) in rendered, "the cap is named where it binds"
+        assert "the 3 newest OF THE ONES READ" in str(limit.get("description"))
+        assert "the latest of what was READ" in str(listed.get("description"))
+        assert "so asking for 3 gives the 3 latest" not in rendered, (
+            "the overstatement: past the cap those 3 are the newest of what was read"
+        )
+
     async def test_list_meeting_recordings_says_it_is_not_behind_the_transcript_switch(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
@@ -1448,6 +1538,73 @@ class TestCallingThem:
         assert [item[identifier] for item in listed] == ["week-3"], "the newest, not the first"
         assert answer["status"] == "available"
         assert answer["truncated"] is True, "the two older occurrences are the 'more' there is"
+
+    @pytest.mark.parametrize(
+        ("tool", "path", "collection", "identifier"),
+        [
+            ("list_meeting_transcripts", _TRANSCRIPTS_PATH, "transcripts", "transcript_id"),
+            ("list_meeting_recordings", _RECORDINGS_PATH, "recordings", "recording_id"),
+        ],
+        ids=["transcripts", "recordings"],
+    )
+    async def test_a_meeting_larger_than_one_call_reads_answers_within_what_it_read(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+        tool: str,
+        path: str,
+        collection: str,
+        identifier: str,
+    ) -> None:
+        """The rare meeting both promises have to be exact about, over the real protocol: a series
+        that ran daily for most of a year, so its collection is longer than one call reads.
+
+        Two things are asserted, and they are the two defects this shape found. Asking for the
+        newest returns the newest of the artifacts READ — `day-199` — and never the meeting's
+        actual newest, which sits past the cap where nothing here can see it; `truncated` is the
+        answer's own admission of that. And a window over the part that was not read answers
+        `scan_incomplete` whether it is wide or narrow, because the window is applied to what came
+        back: narrowing it is not a remedy, which is why the tool no longer offers it as one.
+        """
+        _ = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        _ = graph.get(path).mock(return_value=httpx.Response(200, json=_daily_series()))
+        _ = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
+
+        newest = _structured(
+            await mcp_client.call_tool(tool, {"meeting_uri": _MEETING_URI, "limit": 1})
+        )
+        wide = _structured(
+            await mcp_client.call_tool(
+                tool,
+                {
+                    "meeting_uri": _MEETING_URI,
+                    "started_after": _day(transcripts.MAX_ARTIFACT_SCAN).date().isoformat(),
+                    "started_before": _day(_PAST_THE_CAP - 1).date().isoformat(),
+                },
+            )
+        )
+        narrow = _structured(
+            await mcp_client.call_tool(
+                tool,
+                {
+                    "meeting_uri": _MEETING_URI,
+                    "started_after": _day(250).date().isoformat(),
+                    "started_before": _day(250).date().isoformat(),
+                },
+            )
+        )
+
+        listed = cast("Sequence[Mapping[str, object]]", newest[collection])
+        assert len(obo.requested_scopes) == 3, "one delegated exchange per call, all three made"
+        assert [item[identifier] for item in listed] == ["day-199"], "the newest of what was read"
+        assert newest["truncated"] is True, "the read stopped at the cap, and the answer says so"
+        assert wide["status"] == "scan_incomplete"
+        assert (narrow["status"], narrow["truncated"], narrow[collection]) == (
+            wide["status"],
+            wide["truncated"],
+            wide[collection],
+        ), "a narrower window is the same call over the same artifacts, so it is not a remedy"
 
     async def test_a_model_walks_from_a_meeting_chat_to_whether_the_call_was_recorded(
         self,

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -13,6 +13,8 @@ the two external systems are stood in for, at exactly the boundary each one owns
 Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
 """
 
+import json
+import logging
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import cast
 
@@ -27,6 +29,10 @@ from fastmcp.client.transports import FastMCPTransport
 from fastmcp.server.auth.providers.azure import AzureProvider
 from fastmcp.server.dependencies import AccessToken
 from mcp.types import TextContent, Tool
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from starlette.applications import Starlette
 
 from office_mcp.app import create_app
@@ -47,6 +53,43 @@ _ME = {
     "mail": "ada@example.invalid",
     "userPrincipalName": "ada@corp.example.invalid",
     "jobTitle": "Analyst",
+}
+
+_SEARCH_HIT_RESOURCE = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000000000",
+    "chatId": "19:release@thread.v2",
+    "createdDateTime": "2026-02-11T09:15:22.31Z",
+    "lastModifiedDateTime": "2026-02-11T09:15:22.31Z",
+    "importance": "normal",
+    "subject": None,
+    # A search hit's sender is Exchange-shaped, because Teams messages are indexed out of the
+    # substrate mailbox.
+    "from": {"emailAddress": {"name": "Ada Lovelace", "address": "ada@example.invalid"}},
+}
+
+_SEARCH = {
+    "value": [
+        {
+            "searchTerms": [],
+            "hitsContainers": [
+                {
+                    "hits": [
+                        {
+                            "hitId": "1770000000000",
+                            "rank": 1,
+                            "summary": "...cut the <c0>release</c0> on Friday...",
+                            "resource": _SEARCH_HIT_RESOURCE,
+                        }
+                    ],
+                    # Documented as the count on this page for Teams messages, not a match total.
+                    # Present here precisely so a test can prove it is not reported as one.
+                    "total": 1,
+                    "moreResultsAvailable": False,
+                }
+            ],
+        }
+    ]
 }
 
 _CHATS = {
@@ -177,21 +220,52 @@ def _object(value: object) -> dict[str, object]:
     return cast("dict[str, object]", value)
 
 
+def _optional_type(schema: object) -> dict[str, object]:
+    """The non-null branch of an optional parameter's schema, which is where its type lives."""
+    branches = cast("Sequence[object]", _object(schema)["anyOf"])
+    typed = [_object(branch) for branch in branches if _object(branch).get("type") != "null"]
+    assert len(typed) == 1, f"expected one non-null branch, got {typed!r}"
+    return typed[0]
+
+
 def _structured(result: CallToolResult) -> dict[str, object]:
     data = cast("dict[str, object] | None", result.structured_content)
     assert data is not None, "the tool returned no structured content"
     return data
 
 
+def _search_query_string(route: respx.Route) -> str:
+    """The KQL string the last `/search/query` call put on the wire."""
+    body = cast("dict[str, object]", json.loads(route.calls.last.request.content))
+    requests = cast("Sequence[Mapping[str, object]]", body["requests"])
+    assert len(requests) == 1, "Graph honours only one searchRequest per call"
+    query = cast("Mapping[str, object]", requests[0]["query"])
+    return cast("str", query["queryString"])
+
+
+def _error_text(result: CallToolResult) -> str:
+    """Everything the model would read of a failed call."""
+    return "\n".join(block.text for block in result.content if isinstance(block, TextContent))
+
+
+def _record_text(record: logging.LogRecord) -> str:
+    """A log record's whole payload: the formatted message and every field attached to it.
+
+    Structured logging is what makes this necessary — a value passed as an extra never appears in
+    the message but does reach the log sink, so checking `getMessage()` alone would miss it.
+    """
+    return f"{record.getMessage()} {record.__dict__!r}"
+
+
 class TestTheToolsThisServerAdvertises:
-    async def test_both_tools_are_listed_and_neither_asks_for_a_token(
+    async def test_every_tool_is_listed_and_none_asks_for_a_token(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
         """The Graph token is a dependency, not a parameter: if it ever leaked into the input
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats"}
+        assert set(tools) == {"whoami", "list_chats", "search_messages"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
@@ -212,7 +286,7 @@ class TestTheToolsThisServerAdvertises:
         assert limit["type"] == "integer", "not `number`: a fractional page size is meaningless"
         assert (limit["minimum"], limit["maximum"], limit["default"]) == (1, 50, 25)
 
-    async def test_both_tools_declare_their_result_shape(
+    async def test_every_tool_declares_its_result_shape(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
         """The oracle connector returns an unschematised stream of objects whose last element may
@@ -227,6 +301,90 @@ class TestTheToolsThisServerAdvertises:
             "job_title",
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
+        assert set(_properties(tools["search_messages"].outputSchema)) == {
+            "messages",
+            "more_results_available",
+            "next_offset",
+        }
+
+    async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """Not one of the oracle connector's ten schemas uses `anyOf`, so every rule about which
+        parameters may combine lives in prose a model may not read, and an illegal call validates
+        cleanly and silently behaves differently. "At least one criterion" is a real constraint
+        with a JSON Schema spelling, so it is spelled.
+        """
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["search_messages"].inputSchema
+        properties = _properties(schema)
+
+        assert schema.get("required", []) == [], "each criterion is individually optional"
+        alternatives = cast("Sequence[Mapping[str, object]]", schema["anyOf"])
+        required = [cast("Sequence[str]", option["required"]) for option in alternatives]
+        assert [name for (name,) in required] == [
+            "query",
+            "sender",
+            "recipient",
+            "mentions",
+            "sent_after",
+            "sent_before",
+            "has_attachment",
+            "is_read",
+            "mentions_me",
+        ]
+        for (name,) in required:
+            assert name in properties, f"{name} is constrained but is not a parameter"
+
+    async def test_search_messages_types_the_parameters_graph_is_fussy_about(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A mentioned user must be an id — Microsoft matches that scope term on the id alone, so a
+        display name silently matches nothing — and the dates are whole days, not timestamps."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["search_messages"].inputSchema)
+
+        assert _optional_type(properties["mentions"]) == {"type": "string", "format": "uuid"}
+        assert _optional_type(properties["sent_after"]) == {"type": "string", "format": "date"}
+        assert _optional_type(properties["sent_before"]) == {"type": "string", "format": "date"}
+
+    async def test_the_query_parameter_describes_the_matching_it_actually_does(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The description is the only place a model learns what `query` does, so it has to match
+        what the query builder does. It promised "matched as words" while the whole query was being
+        sent as one quoted phrase, which is a recall loss a caller cannot see: the tool answers with
+        fewer messages than exist and nothing says so. Both halves are pinned here — that the words
+        are ANDed, and that adjacency is available by quoting.
+        """
+        tools = _named(await mcp_client.list_tools())
+        query = _object(_properties(tools["search_messages"].inputSchema)["query"])
+        description = cast("str", query["description"])
+
+        assert "Every word must appear" in description
+        assert "any order" in description
+        assert "not matched as a phrase unless you quote them" in description
+        assert '"release notes"' in description, "the phrase syntax needs an example to be usable"
+
+    async def test_search_messages_bounds_its_page_where_microsoft_documents_it(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["search_messages"].inputSchema)
+        size = _object(properties["size"])
+        offset = _object(properties["offset"])
+
+        assert (size["type"], size["minimum"], size["maximum"], size["default"]) == (
+            "integer",
+            1,
+            50,
+            25,
+        )
+        assert (offset["type"], offset["minimum"], offset["default"]) == ("integer", 0, 0)
+        assert "maximum" not in offset, (
+            "Microsoft documents no offset ceiling for message search; inventing one would refuse "
+            + "a page Graph would have served"
+        )
 
     async def test_the_tools_are_marked_read_only(
         self, mcp_client: Client[FastMCPTransport]
@@ -269,6 +427,104 @@ class TestCallingThem:
         assert [chat["chat_id"] for chat in listed] == ["19:release@thread.v2"]
         assert listed[0]["last_message_at"] == "2026-02-11T09:15:22.310000Z"
         assert obo.requested_scopes == [("https://graph.microsoft.com/Chat.Read",)]
+
+    async def test_search_messages_returns_hits_with_handles_and_no_invented_total(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The flagship call, end to end: one POST to Microsoft's search index, hits carrying a
+        handle a reader can resolve, and both search permissions on the exchanged token."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        result = await mcp_client.call_tool("search_messages", {"query": "release"})
+
+        body = _structured(result)
+        assert body["more_results_available"] is False
+        assert body["next_offset"] is None
+        assert "total" not in body, "Graph's `total` is a page count for Teams, not a match count"
+        found = cast("Sequence[Mapping[str, object]]", body["messages"])
+        assert [message["uri"] for message in found] == [
+            "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000"
+        ]
+        assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            (
+                "https://graph.microsoft.com/Chat.Read",
+                "https://graph.microsoft.com/ChannelMessage.Read.All",
+            )
+        ]
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_multi_word_query_reaches_graph_as_words_over_the_real_protocol(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """End to end, the recall bug: a two-word question has to arrive at Microsoft's index as
+        two terms it will AND, not as one quoted phrase that only matches them side by side."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        _ = await mcp_client.call_tool("search_messages", {"query": "cut the release"})
+
+        assert _search_query_string(route) == "cut the release"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_search_with_no_criteria_is_refused_and_says_what_to_add(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """FastMCP validates arguments against the signature, not against the advertised schema, so
+        the `anyOf` alone would not stop this — and Graph would answer it with an arbitrary slice of
+        everything the user can read, which looks exactly like a result set."""
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+
+        result = await mcp_client.call_tool("search_messages", {"size": 5}, raise_on_error=False)
+
+        assert result.is_error
+        assert not route.called
+        assert "query" in _error_text(result) and "sent_after" in _error_text(result)
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_search_text_reaches_graph_and_nothing_else(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """What a user searched their own messages for is as sensitive as the messages: it names
+        people, deals and diagnoses. `services/teams-mcp` had to go back and strip query terms out
+        of its spans and logs, so this connector never puts them there — and this test is what says
+        so, over the whole call, not over one function.
+
+        Both destinations are checked. The log capture covers everything this process emits during
+        the call, ours and FastMCP's own. The span exporter is attached to whatever tracer provider
+        is in play: no span is created on this path today, so that half is a ratchet — the day one
+        is added carrying the query, it fails here.
+        """
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        secret = "acquisition-of-northwind-traders"
+        caplog.set_level(logging.DEBUG)
+
+        _ = await mcp_client.call_tool(
+            "search_messages", {"query": secret, "sender": "ada@example.invalid"}
+        )
+
+        assert secret in route.calls.last.request.content.decode(), (
+            "the query has to have reached Graph, or this test proves nothing"
+        )
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     async def test_an_out_of_range_limit_is_refused_before_graph_is_called(
         self,
@@ -343,9 +599,7 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
 
         assert result.is_error
-        message = "\n".join(
-            block.text for block in result.content if isinstance(block, TextContent)
-        )
+        message = _error_text(result)
         assert "Chat.Read" in message
         assert "administrator" in message
         assert "synthetic-request-id" in message
@@ -385,3 +639,41 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "AADSTS65001" in message
         assert "resolve dependency" not in message
         assert not route.called, "no token means no Graph request was ever made"
+
+    async def test_an_unconsented_search_names_both_permissions_it_asked_for(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The tenant that grants `Chat.Read` and withholds `ChannelMessage.Read.All`.
+
+        Entra redeems a two-scope exchange as a whole and refuses it as a whole, naming no more than
+        the application: which of the two was missing is not in AADSTS65001 any more than it is in a
+        Graph 403. So the refusal has to name both, exactly as the 403 path does — an administrator
+        handed one name may grant the one that was never missing and see the identical failure.
+
+        This is also the assertion that says the wording here is *ours*: the exchange happens inside
+        FastMCP's dependency resolution, so without the wrapper the model reads "Failed to resolve
+        dependency 'graph_token' for search_messages" and can act on none of it.
+        """
+        route = graph.post("/search/query").mock(return_value=httpx.Response(200, json=_SEARCH))
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "search_messages", {"query": "release"}, raise_on_error=False
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "Chat.Read" in message, message
+        assert "ChannelMessage.Read.All" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no search was ever made"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -18,6 +18,7 @@ import logging
 import re
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import cast
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -253,6 +254,90 @@ _REPLY: dict[str, object] = {
     "mentions": [],
 }
 
+# The meeting side, end to end. The join URL is shaped like the ones Graph stores — already-escaped
+# `%3a`/`%40`, a `?context=` query, an `&` parameter — because that shape is what the `$filter` has
+# to survive. Nothing here is a real meeting: the words are invented and the speakers are long dead.
+_JOIN_WEB_URL = (
+    "https://teams.microsoft.invalid/l/meetup-join/"
+    + "19%3ameeting_TjAwMDAwMDAwMDAwMA%40thread.v2/0"
+    + "?context=%7b%22Tid%22%3a%228a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81%22%7d&anon=true"
+)
+_MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+_MEETINGS_PATH = "/me/onlineMeetings"
+_TRANSCRIPTS_PATH = f"/me/onlineMeetings/{_MEETING_ID}/transcripts"
+_CONTENT_PATH = f"{_TRANSCRIPTS_PATH}/{_TRANSCRIPT_ID}/content"
+
+_MEETING_CHATS = {
+    "value": [
+        {
+            "id": "19:meeting_TjAwMDAwMDAwMDAwMA@thread.v2",
+            "chatType": "meeting",
+            "topic": "Pricing review",
+            "createdDateTime": "2026-02-10T13:55:00Z",
+            "lastUpdatedDateTime": "2026-02-10T15:01:00Z",
+            "onlineMeetingInfo": {
+                "calendarEventId": "AAMkAGSYNTHETIC",
+                "joinWebUrl": _JOIN_WEB_URL,
+                "organizer": {
+                    "user": {
+                        "id": "00000000-0000-4000-8000-000000000002",
+                        "displayName": "Grace Hopper",
+                    }
+                },
+            },
+            "lastMessagePreview": {
+                "id": "1770000000001",
+                "createdDateTime": "2026-02-10T15:01:00Z",
+                "body": {"contentType": "text", "content": "synthetic preview"},
+            },
+        }
+    ]
+}
+
+_MEETING = {
+    "value": [
+        {
+            "id": _MEETING_ID,
+            "subject": "Pricing review",
+            "meetingType": "scheduled",
+            "joinWebUrl": _JOIN_WEB_URL,
+            "startDateTime": "2026-02-10T14:00:00Z",
+            "endDateTime": "2026-02-10T15:00:00Z",
+        }
+    ]
+}
+
+_TRANSCRIPTS = {
+    "value": [
+        {
+            "id": _TRANSCRIPT_ID,
+            "meetingId": _MEETING_ID,
+            "callId": "af630fe0-04d3-4559-8cf9-91fe45e36296",
+            "createdDateTime": "2026-02-10T14:03:11.204Z",
+            "endDateTime": "2026-02-10T14:58:02.117Z",
+            "contentCorrelationId": "bc842d7a-2f6e-4b18-a1c7-73ef91d5c8e3",
+        }
+    ]
+}
+
+_TRANSCRIPT_VTT = """WEBVTT
+
+00:00:16.246 --> 00:00:19.900
+<v Grace Hopper>We should raise the floor price by three per cent.</v>
+
+00:01:02.000 --> 00:01:04.500
+<v Ada Lovelace>Agreed, that works.</v>
+"""
+
+_TENANT_SWITCH_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": "Graph API access to transcripts is disabled for this tenant.",
+        "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+    }
+}
+
 _CHATS = {
     "value": [
         {
@@ -434,6 +519,8 @@ class TestTheToolsThisServerAdvertises:
             "browse_channel",
             "search_messages",
             "read_message",
+            "list_meeting_transcripts",
+            "read_transcript",
         }
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
@@ -475,6 +562,25 @@ class TestTheToolsThisServerAdvertises:
         assert set(_properties(tools["browse_channel"].outputSchema)) == {"messages", "truncated"}
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
+            "truncated",
+            "next_offset",
+        }
+        assert set(_properties(tools["list_meeting_transcripts"].outputSchema)) == {
+            "status",
+            "meeting_id",
+            "subject",
+            "meeting_type",
+            "started_at",
+            "ended_at",
+            "transcripts",
+            "truncated",
+        }
+        assert set(_properties(tools["read_transcript"].outputSchema)) == {
+            "uri",
+            "meeting_id",
+            "transcript_id",
+            "speaker_attribution",
+            "turns",
             "truncated",
             "next_offset",
         }
@@ -520,6 +626,8 @@ class TestTheToolsThisServerAdvertises:
             "list_channels",
             "browse_channel",
             "search_messages",
+            "list_meeting_transcripts",
+            "read_transcript",
         ):
             assert "truncated" in _properties(tools[name].outputSchema), name
 
@@ -554,6 +662,65 @@ class TestTheToolsThisServerAdvertises:
         )
         assert "search_messages" in description
         assert "browse_channel" in description, "the reply shape has exactly one source"
+
+    async def test_read_transcript_takes_a_handle_and_a_window_and_names_its_one_shape(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A second reader, deliberately: a transcript is read under a different permission from a
+        message, and a token is exchanged per tool — so one polymorphic reader would have to redeem
+        transcript access to read a chat message. Its handle shape is therefore its own, and the
+        description has to name it and say which tool mints it."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["read_transcript"].inputSchema
+        description = tools["read_transcript"].description
+        assert description is not None
+
+        assert set(_properties(schema)) == {"uri", "offset", "limit"}
+        assert schema.get("required") == ["uri"]
+        assert "teams:///transcripts/{meeting_id}/{transcript_id}" in description
+        assert "list_meeting_transcripts" in description
+        assert "read_message" in description, "the two readers must not be confusable"
+
+    async def test_list_meeting_transcripts_names_the_four_answers_and_their_remedies(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The three absences that must stay distinct, plus "no such meeting". A model can only act
+        differently on them if the tool says what each one means, so the words are asserted: the
+        one that means wait must say wait, and must say it is not the one that means stop."""
+        tools = _named(await mcp_client.list_tools())
+        description = tools["list_meeting_transcripts"].description
+        status = _object(_properties(tools["list_meeting_transcripts"].outputSchema)["status"])
+        assert description is not None
+        rendered = description + str(status.get("description"))
+
+        for value in ("available", "not_ready", "not_transcribed", "meeting_not_found"):
+            assert value in description, value
+        assert "Wait and call again later" in description
+        assert 'NOT "there is no transcript"' in description
+        assert "Retrying will not help" in description
+        assert "no availability SLA" in rendered, "the inference has to be admitted as one"
+        assert "recurring" in description and "started_after" in description
+
+    async def test_list_meeting_transcripts_takes_a_meeting_handle_and_an_occurrence_window(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["list_meeting_transcripts"].inputSchema
+        properties = _properties(schema)
+        limit = _object(properties["limit"])
+
+        assert set(properties) == {"meeting_uri", "started_after", "started_before", "limit"}
+        assert schema.get("required") == ["meeting_uri"]
+        assert _optional_type(properties["started_after"]) == {
+            "type": "string",
+            "format": "date-time",
+        }
+        assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
+            "integer",
+            1,
+            50,
+            20,
+        )
 
     async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
         self, mcp_client: Client[FastMCPTransport]
@@ -850,6 +1017,155 @@ class TestCallingThem:
                 "https://graph.microsoft.com/ChannelMessage.Read.All",
             ),
         ], "each tool exchanges a token for the permissions its own request needs"
+
+    async def test_a_model_walks_from_a_meeting_chat_to_what_was_said_in_the_meeting(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The flagship path of this piece, over the real protocol, with every value taken from the
+        previous answer exactly as a model would take it: which meetings are there (list_chats,
+        because a meeting chat *is* the index), what transcripts does this one have, and then the
+        words — speaker-attributed and timestamped, not a link to a file.
+
+        The oracle connector reaches a transcript only through an opaque URI it got from a calendar
+        read; this walk needs no calendar permission at all, and it ends in text.
+        """
+        chats_route = graph.get("/me/chats").mock(
+            return_value=httpx.Response(200, json=_MEETING_CHATS)
+        )
+        meeting = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        listing = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(200, json=_TRANSCRIPTS)
+        )
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                200, content=_TRANSCRIPT_VTT.encode(), headers={"content-type": "text/vtt"}
+            )
+        )
+
+        listed = _structured(await mcp_client.call_tool("list_chats", {"limit": 5}))
+        found = cast("Sequence[Mapping[str, object]]", listed["chats"])
+        meeting_uri = found[0]["meeting_uri"]
+        available = _structured(
+            await mcp_client.call_tool("list_meeting_transcripts", {"meeting_uri": meeting_uri})
+        )
+        listed_transcripts = cast("Sequence[Mapping[str, object]]", available["transcripts"])
+        read = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": listed_transcripts[0]["uri"]})
+        )
+
+        assert all(route.called for route in (chats_route, meeting, listing, content))
+        assert found[0]["chat_type"] == "meeting"
+        assert available["status"] == "available"
+        assert available["subject"] == "Pricing review"
+        assert available["meeting_id"] == _MEETING_ID
+        assert read["speaker_attribution"] is True
+        turns = cast("Sequence[Mapping[str, object]]", read["turns"])
+        assert [(turn["speaker"], turn["start_seconds"]) for turn in turns] == [
+            ("Grace Hopper", 16.246),
+            ("Ada Lovelace", 62.0),
+        ]
+        assert turns[0]["text"] == "We should raise the floor price by three per cent."
+        assert read["truncated"] is False
+        assert content.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert content.calls.last.request.headers["accept"] == "text/vtt"
+        assert obo.requested_scopes == [
+            ("https://graph.microsoft.com/Chat.Read",),
+            (
+                "https://graph.microsoft.com/OnlineMeetings.Read",
+                "https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",
+            ),
+            ("https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",),
+        ], "the reader needs only transcript access; resolving a join URL is the lister's job"
+
+    async def test_the_join_url_reaches_graph_encoded_exactly_once_over_the_real_protocol(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """End to end, the bug class: `services/teams-mcp` sends a raw join URL and Microsoft
+        answers `200 OK` with an empty result — a silent "meeting not found" — for any URL carrying
+        `&` or `#`. The handle carries the URL through the protocol unchanged, and the `$filter`
+        Graph receives has to decode back to exactly what Microsoft stored."""
+        graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_MEETING_CHATS))
+        route = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(return_value=httpx.Response(200, json=_TRANSCRIPTS))
+
+        listed = _structured(await mcp_client.call_tool("list_chats", {}))
+        found = cast("Sequence[Mapping[str, object]]", listed["chats"])
+        _ = await mcp_client.call_tool(
+            "list_meeting_transcripts", {"meeting_uri": found[0]["meeting_uri"]}
+        )
+
+        url = route.calls.last.request.url
+        assert url.params["$filter"] == f"JoinWebUrl eq '{_JOIN_WEB_URL}'"
+        raw = url.query.decode()
+        assert "%253ameeting" in raw and "%2540thread" in raw and "%26anon%3Dtrue" in raw
+        assert "%2525" not in raw
+        assert obo.requested_scopes
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_transcript_text_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A transcript is the most sensitive content this connector touches — a verbatim record of
+        what people said in a room — so the rule search and read are held to is tightest here: the
+        words reach the caller and no log line and no span attribute anywhere in the process."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        vtt = f"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Ada Lovelace>{secret}</v>\n"
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(return_value=httpx.Response(200, json=_TRANSCRIPTS))
+        _ = graph.get(_CONTENT_PATH).mock(return_value=httpx.Response(200, content=vtt.encode()))
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
+        )
+
+        turns = cast("Sequence[Mapping[str, object]]", _structured(result)["turns"])
+        assert turns[0]["text"] == secret, "the transcript has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_meeting_no_join_url_matches_is_a_status_and_not_an_error(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """Microsoft answers this filter with `200 OK` and an empty `value` rather than a 404, so
+        "no match" must not arrive as a failure — and must not be reported as the meeting having
+        been deleted either."""
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json={"value": []}))
+        listing = graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(200, json=_TRANSCRIPTS)
+        )
+
+        result = await mcp_client.call_tool(
+            "list_meeting_transcripts",
+            {"meeting_uri": f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}"},
+        )
+
+        assert not result.is_error
+        body = _structured(result)
+        assert body["status"] == "meeting_not_found"
+        assert body["transcripts"] == []
+        assert not listing.called
 
     @pytest.mark.usefixtures("obo")
     async def test_a_channel_post_reaches_the_caller_and_no_log_or_span(
@@ -1360,6 +1676,126 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         message = _error_text(result)
         assert "ChannelMessage.Read.All" in message
         assert "Chat.Read" not in message, "this read was in a channel"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        "tool", ["list_meeting_transcripts", "read_transcript"], ids=["listing", "reading"]
+    )
+    async def test_the_tenant_transcript_switch_sends_the_caller_to_a_teams_administrator(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        tool: str,
+    ) -> None:
+        """The failure this connector has already paid for once, in `teams-mcp`. Microsoft Graph
+        access to transcripts is a tenant switch that is off by default, and while it is off every
+        transcript call returns 403 with no request-side workaround. Read as an ordinary 403 it
+        would send an administrator to grant a permission that was never missing, and read as a
+        consent problem it would send the user round the sign-in loop — so the remedy has to name
+        the Teams admin centre, name the cmdlet, and rule both of those out.
+        """
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(
+            return_value=httpx.Response(
+                403, headers={"request-id": "synthetic-request-id"}, json=_TENANT_SWITCH_OFF
+            )
+        )
+        graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                403, headers={"request-id": "synthetic-request-id"}, json=_TENANT_SWITCH_OFF
+            )
+        )
+        arguments = {
+            "list_meeting_transcripts": {
+                "meeting_uri": f"teams:///meetings/{quote(_JOIN_WEB_URL, safe='')}"
+            },
+            "read_transcript": {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
+        }[tool]
+
+        result = await mcp_client.call_tool(tool, arguments, raise_on_error=False)
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "Teams administrator" in message
+        assert "EnableGraphTranscriptAccess" in message
+        assert "not a consent problem" in message.replace("NOT a consent", "not a consent")
+        assert "sign in again will not change it" in message
+        assert "OnlineMeetingTranscript.Read.All" not in message, (
+            "naming the permission sends an administrator after one that was never missing"
+        )
+        assert "synthetic-request-id" in message
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("tool", "argument", "uri"),
+        [
+            ("list_meeting_transcripts", "meeting_uri", "teams:///transcripts/a/b"),
+            ("list_meeting_transcripts", "meeting_uri", "19:meeting_x@thread.v2"),
+            ("read_transcript", "uri", "teams:///meetings/https%3A%2F%2Fx.invalid%2Fa"),
+            ("read_transcript", "uri", "teams:///chats/19%3Ax%40thread.v2/messages/1"),
+        ],
+    )
+    async def test_each_meeting_tool_refuses_the_other_ones_handle_and_says_where_to_get_its_own(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        tool: str,
+        argument: str,
+        uri: str,
+    ) -> None:
+        """Four handle families now exist and a model will mix them up. Each refusal has to name the
+        one shape this tool reads and the one tool that mints it — "invalid handle" would leave a
+        model guessing, and guessing between families is exactly what produces a loop."""
+        meetings = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
+
+        result = await mcp_client.call_tool(tool, {argument: uri}, raise_on_error=False)
+
+        assert result.is_error
+        assert not meetings.called and not content.called, "a bad handle costs no Graph request"
+        message = _error_text(result)
+        expected = {
+            "list_meeting_transcripts": ("teams:///meetings/{join_web_url}", "list_chats"),
+            "read_transcript": (
+                "teams:///transcripts/{meeting_id}/{transcript_id}",
+                "list_meeting_transcripts",
+            ),
+        }[tool]
+        for fragment in expected:
+            assert fragment in message, message
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_transcript_graph_will_not_return_blames_the_meeting_window_not_the_handle(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """A 404 on a well-formed transcript handle is almost always age: Microsoft stops serving a
+        meeting's artifacts once the meeting expires. The message-reader's advice would be wrong
+        here in both directions — a transcript is not deleted by a user, and browsing a channel is
+        not a route to one."""
+        graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "expires" in message
+        assert "list_meeting_transcripts" in message
+        assert "browse_channel" not in message
+        assert "synthetic-request-id" in message
 
     async def test_an_unconsented_search_names_both_permissions_it_asked_for(
         self,

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -680,11 +680,34 @@ class TestTheToolsThisServerAdvertises:
         description = tools["read_transcript"].description
         assert description is not None
 
-        assert set(_properties(schema)) == {"uri", "offset", "limit"}
+        assert set(_properties(schema)) == {
+            "uri",
+            "offset",
+            "limit",
+            "from_seconds",
+            "to_seconds",
+            "speaker",
+        }
         assert schema.get("required") == ["uri"]
         assert "teams:///transcripts/{meeting_id}/{transcript_id}" in description
         assert "list_meeting_transcripts" in description
         assert "read_message" in description, "the two readers must not be confusable"
+
+    async def test_read_transcript_narrows_by_seconds_and_by_speaker_in_its_own_schema(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The turns are already timestamped and attributed in the answer, so the filters are named
+        in the same units the answer reports: seconds from the meeting's start, and the speaker as
+        the transcript spells them. A model narrows only what it can see, and every one of these is
+        optional — the unfiltered read stays the default."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["read_transcript"].inputSchema)
+
+        for bound in ("from_seconds", "to_seconds"):
+            assert _optional_type(properties[bound])["type"] == "number", bound
+        assert _optional_type(properties["speaker"])["type"] == "string"
+        for name in ("from_seconds", "to_seconds", "speaker"):
+            assert _object(properties[name]).get("description"), f"{name} is undescribed"
 
     async def test_list_meeting_transcripts_names_the_four_answers_and_their_remedies(
         self, mcp_client: Client[FastMCPTransport]
@@ -1281,6 +1304,72 @@ class TestCallingThem:
         assert result.is_error
         assert "started_after" in _error_text(result)
         assert not meetings.called
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_transcript_is_read_narrowed_to_a_speaker_and_to_a_stretch_of_the_meeting(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """Over the real protocol, in the two shapes a model reaches for: "what did she say" and
+        "what was said after that point". An hour of meeting is thousands of turns and a model that
+        can only ask for all of them spends its context on the transcript instead of the answer.
+        """
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
+        uri = f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"
+
+        by_speaker = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": uri, "speaker": "grace"})
+        )
+        by_time = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": uri, "from_seconds": 20})
+        )
+
+        assert [
+            turn["speaker"] for turn in cast("Sequence[Mapping[str, object]]", by_speaker["turns"])
+        ] == ["Grace Hopper"]
+        assert by_speaker["speaker_attribution"] is True
+        assert by_speaker["truncated"] is False, "one turn matched and one turn came back"
+        turns = cast("Sequence[Mapping[str, object]]", by_time["turns"])
+        assert [turn["start_seconds"] for turn in turns] == [62.0]
+        assert content.call_count == 2, "paging and filtering are over the parsed turns, not Graph"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("filters", "named"),
+        [
+            ({"from_seconds": 60, "to_seconds": 30}, "from_seconds"),
+            ({"speaker": ""}, "speaker"),
+            ({"speaker": "   "}, "speaker"),
+        ],
+        ids=["inverted-window", "empty-speaker", "blank-speaker"],
+    )
+    async def test_a_filter_no_transcript_could_satisfy_is_refused_before_any_graph_request(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        filters: Mapping[str, object],
+        named: str,
+    ) -> None:
+        """A window that ends before it starts, and a speaker that names nobody, both match nothing
+        by construction — answering them with an empty page would read as "she said nothing in the
+        meeting", which is a wrong answer nobody can detect. The refusal names the parameter, and it
+        costs no Graph request."""
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}", **filters},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        assert named in _error_text(result), _error_text(result)
+        assert not content.called
 
     @pytest.mark.usefixtures("obo")
     async def test_a_channel_post_reaches_the_caller_and_no_log_or_span(

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 import respx
 from azure.core.credentials import AccessToken as GraphAccessToken
+from azure.core.exceptions import ClientAuthenticationError
 from fastmcp import Client, FastMCP
 from fastmcp.client.client import CallToolResult
 from fastmcp.client.transports import FastMCPTransport
@@ -78,14 +79,18 @@ class _StubOboCredential:
     """Stands in for `azure.identity.aio.OnBehalfOfCredential`, which would call Entra.
 
     Records the scopes it was asked for: those are what the tool declared it needs, and getting
-    them wrong is invisible until a real tenant refuses the exchange.
+    them wrong is invisible until a real tenant refuses the exchange. Set `refusal` to be that
+    tenant — an exchange Entra declines is the failure that happens before Graph.
     """
 
     def __init__(self) -> None:
         self.requested_scopes: list[tuple[str, ...]] = []
+        self.refusal: Exception | None = None
 
     async def get_token(self, *scopes: str) -> GraphAccessToken:
         self.requested_scopes.append(scopes)
+        if self.refusal is not None:
+            raise self.refusal
         return GraphAccessToken(token=OBO_TOKEN, expires_on=0)
 
 
@@ -345,3 +350,38 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "administrator" in message
         assert "synthetic-request-id" in message
         assert obo.requested_scopes, "the failure came from Graph, not from the token exchange"
+
+    async def test_a_permission_nobody_consented_to_names_it_too(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The same missing permission, one step earlier: Entra refuses the On-Behalf-Of exchange
+        (AADSTS65001) and Graph is never called.
+
+        This runs inside FastMCP's dependency resolution rather than inside the tool body, so it
+        bypasses the tool's own error handling entirely — the report a model gets by default is
+        "Failed to resolve dependency 'graph_token' for list_chats", which names neither the
+        permission nor anyone who could grant it. Whatever else changes, this end of the wire has
+        to stay as actionable as the 403 above.
+        """
+        route = graph.get("/me/chats").mock(return_value=httpx.Response(200, json=_CHATS))
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool("list_chats", {}, raise_on_error=False)
+
+        assert result.is_error
+        message = "\n".join(
+            block.text for block in result.content if isinstance(block, TextContent)
+        )
+        assert "Chat.Read" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no Graph request was ever made"

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -15,6 +15,7 @@ Every payload is synthesised: fake ids, `.invalid` domains, public-domain names.
 
 import json
 import logging
+import re
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import cast
 
@@ -327,15 +328,15 @@ class TestTheToolsThisServerAdvertises:
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"whoami", "list_chats", "search_messages", "read_message"}
+        assert set(tools) == {"get_me", "list_chats", "search_messages", "read_message"}
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
-    async def test_whoami_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
+    async def test_get_me_takes_no_arguments(self, mcp_client: Client[FastMCPTransport]) -> None:
         tools = _named(await mcp_client.list_tools())
 
-        assert _properties(tools["whoami"].inputSchema) == {}
-        assert tools["whoami"].inputSchema.get("required", []) == []
+        assert _properties(tools["get_me"].inputSchema) == {}
+        assert tools["get_me"].inputSchema.get("required", []) == []
 
     async def test_list_chats_bounds_its_limit_where_graph_bounds_it(
         self, mcp_client: Client[FastMCPTransport]
@@ -355,17 +356,17 @@ class TestTheToolsThisServerAdvertises:
         be pagination metadata. A declared output schema is how `truncated` stops being prose."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(_properties(tools["whoami"].outputSchema)) == {
-            "id",
+        assert set(_properties(tools["get_me"].outputSchema)) == {
+            "user_id",
             "display_name",
-            "mail",
+            "email",
             "user_principal_name",
             "job_title",
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
-            "more_results_available",
+            "truncated",
             "next_offset",
         }
         assert set(_properties(tools["read_message"].outputSchema)) == {
@@ -387,6 +388,25 @@ class TestTheToolsThisServerAdvertises:
             "mentions",
             "attachments",
         }
+
+    async def test_the_whole_surface_speaks_one_language(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """These tools arrived one at a time and are read all at once, by a model choosing between
+        them. So the conventions are asserted rather than merely written down: a name is verb_noun
+        (`whoami` was the one exception and is now `get_me`), a result field is snake_case, and a
+        tool whose answer is a list says "there is more" with the one word `truncated` — two words
+        for that would be two things for a model to learn, and a reason for it to guess.
+        """
+        tools = _named(await mcp_client.list_tools())
+
+        for name in tools:
+            assert re.fullmatch(r"[a-z]+(_[a-z]+)+", name), f"{name} is not verb_noun"
+        for tool in tools.values():
+            for field in _properties(tool.outputSchema):
+                assert re.fullmatch(r"[a-z][a-z0-9]*(_[a-z0-9]+)*", field), f"{field} is not snake"
+        for name in ("list_chats", "search_messages"):
+            assert "truncated" in _properties(tools[name].outputSchema), name
 
     async def test_read_message_takes_exactly_one_required_handle(
         self, mcp_client: Client[FastMCPTransport]
@@ -503,7 +523,7 @@ class TestTheToolsThisServerAdvertises:
 
 
 class TestCallingThem:
-    async def test_whoami_calls_graph_with_the_exchanged_token(
+    async def test_get_me_calls_graph_with_the_exchanged_token(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
@@ -511,9 +531,9 @@ class TestCallingThem:
     ) -> None:
         route = graph.get("/me").mock(return_value=httpx.Response(200, json=_ME))
 
-        result = await mcp_client.call_tool("whoami", {})
+        result = await mcp_client.call_tool("get_me", {})
 
-        assert _structured(result)["mail"] == "ada@example.invalid"
+        assert _structured(result)["email"] == "ada@example.invalid"
         assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
         assert obo.requested_scopes == [("https://graph.microsoft.com/User.Read",)]
 
@@ -547,7 +567,7 @@ class TestCallingThem:
         result = await mcp_client.call_tool("search_messages", {"query": "release"})
 
         body = _structured(result)
-        assert body["more_results_available"] is False
+        assert body["truncated"] is False
         assert body["next_offset"] is None
         assert "total" not in body, "Graph's `total` is a page count for Teams, not a match count"
         found = cast("Sequence[Mapping[str, object]]", body["messages"])

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -155,6 +155,103 @@ _SYSTEM_MESSAGE = {
     },
 }
 
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+_CHANNELS_PATH = f"/teams/{_TEAM_ID}/channels"
+_CHANNEL_MESSAGES_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages"
+
+# Only the five properties `GET /me/joinedTeams` populates; every other property of a team comes
+# back null on that endpoint, asked for or not.
+_TEAMS = {
+    "value": [
+        {
+            "id": _TEAM_ID,
+            "displayName": "Engineering",
+            "description": "Ships the product",
+            "isArchived": False,
+            "tenantId": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+        }
+    ]
+}
+
+_CHANNELS = {
+    "value": [
+        {
+            "id": _CHANNEL_ID,
+            "displayName": "General",
+            "description": "Everything and nothing",
+            "createdDateTime": "2026-01-04T12:00:00Z",
+            "membershipType": "standard",
+        }
+    ]
+}
+
+_ROOT_POST_ID = "1770000000000"
+_REPLY_ID = "1770000000002"
+
+# One channel post with one reply, as `?$top=…&$expand=replies` returns it.
+_CHANNEL_POSTS = {
+    "value": [
+        {
+            "@odata.type": "#microsoft.graph.chatMessage",
+            "id": _ROOT_POST_ID,
+            "messageType": "message",
+            "createdDateTime": "2026-02-11T09:15:22.31Z",
+            "from": {
+                "user": {
+                    "id": "00000000-0000-4000-8000-000000000001",
+                    "displayName": "Ada Lovelace",
+                    "userIdentityType": "aadUser",
+                }
+            },
+            "body": {"contentType": "html", "content": "<div><p>Release plan for Friday</p></div>"},
+            "replies": [
+                {
+                    "@odata.type": "#microsoft.graph.chatMessage",
+                    "id": _REPLY_ID,
+                    "messageType": "message",
+                    "createdDateTime": "2026-02-11T10:02:00Z",
+                    "replyToId": _ROOT_POST_ID,
+                    "from": {
+                        "user": {
+                            "id": "00000000-0000-4000-8000-000000000002",
+                            "displayName": "Grace Hopper",
+                            "userIdentityType": "aadUser",
+                        }
+                    },
+                    "body": {"contentType": "text", "content": "agreed, Friday works"},
+                }
+            ],
+        }
+    ]
+}
+
+# The handle the reply above carries, and the path Graph serves it from. A reply is addressed under
+# the post it answers — no other shape reaches it — which is the whole point of the third shape.
+_REPLY_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+    + f"/messages/{_ROOT_POST_ID}/replies/{_REPLY_ID}"
+)
+_REPLY_PATH = f"{_CHANNEL_MESSAGES_PATH}/{_ROOT_POST_ID}/replies/{_REPLY_ID}"
+
+_REPLY: dict[str, object] = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": _REPLY_ID,
+    "messageType": "message",
+    "createdDateTime": "2026-02-11T10:02:00Z",
+    "replyToId": _ROOT_POST_ID,
+    "from": {
+        "user": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "displayName": "Grace Hopper",
+            "userIdentityType": "aadUser",
+        }
+    },
+    "body": {"contentType": "text", "content": "agreed, Friday works"},
+    "attachments": [],
+    "mentions": [],
+}
+
 _CHATS = {
     "value": [
         {
@@ -328,7 +425,15 @@ class TestTheToolsThisServerAdvertises:
         schema, a model would try to invent one."""
         tools = _named(await mcp_client.list_tools())
 
-        assert set(tools) == {"get_me", "list_chats", "search_messages", "read_message"}
+        assert set(tools) == {
+            "get_me",
+            "list_chats",
+            "list_teams",
+            "list_channels",
+            "browse_channel",
+            "search_messages",
+            "read_message",
+        }
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
 
@@ -364,6 +469,9 @@ class TestTheToolsThisServerAdvertises:
             "job_title",
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats", "truncated"}
+        assert set(_properties(tools["list_teams"].outputSchema)) == {"teams", "truncated"}
+        assert set(_properties(tools["list_channels"].outputSchema)) == {"channels", "truncated"}
+        assert set(_properties(tools["browse_channel"].outputSchema)) == {"messages", "truncated"}
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
             "truncated",
@@ -405,7 +513,13 @@ class TestTheToolsThisServerAdvertises:
         for tool in tools.values():
             for field in _properties(tool.outputSchema):
                 assert re.fullmatch(r"[a-z][a-z0-9]*(_[a-z0-9]+)*", field), f"{field} is not snake"
-        for name in ("list_chats", "search_messages"):
+        for name in (
+            "list_chats",
+            "list_teams",
+            "list_channels",
+            "browse_channel",
+            "search_messages",
+        ):
             assert "truncated" in _properties(tools[name].outputSchema), name
 
     async def test_read_message_takes_exactly_one_required_handle(
@@ -419,19 +533,60 @@ class TestTheToolsThisServerAdvertises:
         assert set(_properties(schema)) == {"uri"}
         assert schema.get("required") == ["uri"]
 
-    async def test_read_message_names_both_handle_shapes_and_no_others(
+    async def test_read_message_names_every_handle_shape_and_no_others(
         self, mcp_client: Client[FastMCPTransport]
     ) -> None:
-        """The description is where a model learns what it may pass. Naming the two shapes is what
+        """The description is where a model learns what it may pass. Naming the shapes is what
         stops it inventing `mail:///` — and the oracle connector's one polymorphic `read_resource`
-        is exactly the promise this connector does not make."""
+        is exactly the promise this connector does not make. The reply shape is named with the tool
+        that mints it, because it is the one no search result carries.
+        """
         tools = _named(await mcp_client.list_tools())
         description = tools["read_message"].description
         assert description is not None
 
         assert "teams:///chats/{chat_id}/messages/{message_id}" in description
         assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in description
-        assert "search_messages" in description, "a handle has exactly one source"
+        assert (
+            "teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}"
+            in description
+        )
+        assert "search_messages" in description
+        assert "browse_channel" in description, "the reply shape has exactly one source"
+
+    async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A channel id alone addresses nothing — Graph's only path to a channel's messages goes
+        through its team — and 20/50 are Graph's own default and maximum for the collection."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["browse_channel"].inputSchema
+        limit = _object(_properties(schema)["limit"])
+
+        assert set(_properties(schema)) == {"team_id", "channel_id", "limit"}
+        assert schema.get("required") == ["team_id", "channel_id"]
+        assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
+            "integer",
+            1,
+            50,
+            20,
+        )
+
+    async def test_browse_channel_says_what_the_order_actually_is(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The one thing a model cannot find out for itself. Graph orders this collection by the
+        last modified date of the whole reply chain, so the first post is the most recently *active*
+        thread and may be years old — a tool that let "newest first" be assumed would have the
+        model reporting an old post as today's news.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["browse_channel"].description
+        assert description is not None
+
+        assert "reply chain" in description
+        assert "created_at" in description, "the field that does tell the truth about age"
+        assert "search_messages" in description, "where a date-bounded question goes instead"
 
     async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
         self, mcp_client: Client[FastMCPTransport]
@@ -615,6 +770,100 @@ class TestCallingThem:
             "https://graph.microsoft.com/Chat.Read",
             "https://graph.microsoft.com/ChannelMessage.Read.All",
         ), "the exchange happens before the handle is parsed, so it asks for both surfaces"
+
+    async def test_a_model_walks_from_its_teams_to_a_reply_it_can_read(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The channel side end to end, over the real protocol, with every id taken from the
+        previous answer exactly as a model would take it: which teams am I in, what channels are in
+        this team, what was posted in this channel — and then the reply's own handle, resolved.
+
+        That last step is the gap this piece closes. Graph addresses a reply under the post it
+        answers, so before browsing existed no tool could produce a handle for one: a search hit on
+        a reply carries the root-post shape and Graph answers it 404. Here the browse mints the
+        reply's handle and read_message resolves it, which is the whole contract between the two.
+        """
+        teams = graph.get("/me/joinedTeams").mock(return_value=httpx.Response(200, json=_TEAMS))
+        listing = graph.get(_CHANNELS_PATH).mock(return_value=httpx.Response(200, json=_CHANNELS))
+        posts = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json=_CHANNEL_POSTS)
+        )
+        read = graph.get(_REPLY_PATH).mock(return_value=httpx.Response(200, json=_REPLY))
+
+        listed = _structured(await mcp_client.call_tool("list_teams", {}))
+        found = cast("Sequence[Mapping[str, object]]", listed["teams"])
+        team_id = found[0]["team_id"]
+        channels = _structured(await mcp_client.call_tool("list_channels", {"team_id": team_id}))
+        in_team = cast("Sequence[Mapping[str, object]]", channels["channels"])
+        channel_id = in_team[0]["channel_id"]
+        browsed = _structured(
+            await mcp_client.call_tool(
+                "browse_channel", {"team_id": team_id, "channel_id": channel_id}
+            )
+        )
+        messages = cast("Sequence[Mapping[str, object]]", browsed["messages"])
+        result = _structured(
+            await mcp_client.call_tool("read_message", {"uri": messages[1]["uri"]})
+        )
+
+        assert (team_id, channel_id) == (_TEAM_ID, _CHANNEL_ID)
+        assert all(route.called for route in (teams, listing, posts, read))
+        assert [message["message_id"] for message in messages] == [_ROOT_POST_ID, _REPLY_ID]
+        assert messages[0]["text"] == "Release plan for Friday", "browsing returns the whole post"
+        assert messages[1]["reply_to_id"] == _ROOT_POST_ID
+        assert messages[1]["uri"] == _REPLY_URI
+        assert result["text"] == "agreed, Friday works"
+        assert result["uri"] == _REPLY_URI
+        assert read.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            ("https://graph.microsoft.com/Team.ReadBasic.All",),
+            ("https://graph.microsoft.com/Channel.ReadBasic.All",),
+            ("https://graph.microsoft.com/ChannelMessage.Read.All",),
+            (
+                "https://graph.microsoft.com/Chat.Read",
+                "https://graph.microsoft.com/ChannelMessage.Read.All",
+            ),
+        ], "each tool exchanges a token for the permissions its own request needs"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_channel_post_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A channel post is message content like any other, and this tool returns a page of it at
+        once — so the rule search and read are held to holds here too, over the whole call."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        post = {
+            **_CHANNEL_POSTS["value"][0],
+            "body": {"contentType": "text", "content": secret},
+            "replies": [],
+        }
+        _ = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [post]})
+        )
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool(
+            "browse_channel", {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID}
+        )
+
+        messages = cast("Sequence[Mapping[str, object]]", _structured(result)["messages"])
+        assert messages[0]["text"] == secret, "the post has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
 
     @pytest.mark.usefixtures("obo")
     async def test_reading_a_system_event_says_what_happened_rather_than_nothing(
@@ -813,6 +1062,92 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "administrator" in message
         assert "synthetic-request-id" in message
         assert obo.requested_scopes, "the failure came from Graph, not from the token exchange"
+
+    @pytest.mark.parametrize(
+        ("tool", "arguments", "path", "permission", "not_named"),
+        [
+            ("list_teams", {}, "/me/joinedTeams", "Team.ReadBasic.All", "Channel.ReadBasic.All"),
+            (
+                "list_channels",
+                {"team_id": _TEAM_ID},
+                _CHANNELS_PATH,
+                "Channel.ReadBasic.All",
+                "Team.ReadBasic.All",
+            ),
+            (
+                "browse_channel",
+                {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID},
+                _CHANNEL_MESSAGES_PATH,
+                "ChannelMessage.Read.All",
+                "Channel.ReadBasic.All",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("obo")
+    async def test_each_channel_tool_names_only_the_permission_its_own_request_needs(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        tool: str,
+        arguments: dict[str, str],
+        path: str,
+        permission: str,
+        not_named: str,
+    ) -> None:
+        """Three requests, three delegated permissions, and a tenant that grants the two basic ones
+        while withholding the broad message permission is the common case — so naming the wrong one
+        sends an administrator after a permission that was never missing, which is as useless as
+        naming none. Graph's 403 says only that something was forbidden.
+        """
+        _ = graph.get(path).mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(tool, arguments, raise_on_error=False)
+
+        assert result.is_error
+        message = _error_text(result)
+        assert permission in message
+        assert not_named not in message
+        assert "administrator" in message
+        assert "synthetic-request-id" in message
+
+    async def test_an_unconsented_channel_browse_names_the_message_permission(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The same missing permission one step earlier, on the tool most likely to hit it:
+        `ChannelMessage.Read.All` is the broad scope an administrator has to consent to, and Entra
+        refuses the exchange before Graph is reached at all."""
+        route = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json=_CHANNEL_POSTS)
+        )
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "browse_channel",
+            {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "ChannelMessage.Read.All" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no Graph request was ever made"
 
     async def test_a_permission_nobody_consented_to_names_it_too(
         self,

--- a/services/office-mcp/uv.lock
+++ b/services/office-mcp/uv.lock
@@ -659,6 +659,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
 ]
 
+[package.optional-dependencies]
+azure = [
+    { name = "fastmcp-slim", extra = ["azure"] },
+]
+
 [[package]]
 name = "fastmcp-slim"
 version = "3.4.5"
@@ -677,6 +682,10 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-identity" },
+    { name = "pyjwt" },
+]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
@@ -1768,7 +1777,7 @@ source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
     { name = "cryptography" },
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["azure"] },
     { name = "httpx", extra = ["http2"] },
     { name = "msgraph-sdk" },
     { name = "opentelemetry-api" },
@@ -1801,7 +1810,7 @@ dev = [
 requires-dist = [
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "cryptography", specifier = "==49.0.0" },
-    { name = "fastmcp", specifier = "==3.4.5" },
+    { name = "fastmcp", extras = ["azure"], specifier = "==3.4.5" },
     { name = "httpx", extras = ["http2"], specifier = "==0.28.1" },
     { name = "msgraph-sdk", specifier = "==1.61.0" },
     { name = "opentelemetry-api", specifier = "==1.44.0" },


### PR DESCRIPTION
Two commits fix two defects in the two meeting listers, and correct two statements that a model
reads. Commit `e8be42e2` makes the two fixes. Commit `e4955b25` corrects the two statements.
Together they touch 12 files, with 1123 insertions and 109 deletions.

## The two fixes

The transcript lister and the recordings lister repeated the same two statements: the
`collect_pages` call and the `sorted` call. Those two statements now live in one function,
`features/transcripts.newest_in_window`, and both listers call it.

`began_at` is private again as `_began_at`. `recordings` imports the shared function instead of a
sort key.

### A — the sort ran after the cut

`collect_pages(..., limit=limit)` stopped the read at `limit` items in Graph server order.
`sorted(..., reverse=True)` then ran over those items only. A model that asked for the 3 newest
recordings got 3 arbitrary ones, sorted among themselves. Nothing in the answer said so.

`list_meeting_transcripts` had the same defect. `newest_in_window` keeps every artifact that the
occurrence window holds. It sorts that result. It cuts the result to `limit` last.

**What one call costs now.** Before the fix each lister called
`collect_pages(first_page, client, limit=limit, matches=window.holds)`, so the read stopped at
`limit` matched artifacts. `newest_in_window` passes `limit=MAX_ARTIFACT_SCAN` and
`max_scanned=MAX_ARTIFACT_SCAN` (`features/transcripts.py:768`). Every call therefore reads the
meeting's artifact collection, up to 200 artifacts, in as many pages as Graph chooses. The common
case costs more, and a sort requires that cost. Microsoft documents no `$orderby` on either
collection, so a tool cannot name the newest artifact before it reads the collection.

`MAX_ARTIFACT_SCAN = 200` caps that cost. Items are what `collect_pages` can cap. 200 is four times
50, and 50 is the largest `limit` that either tool accepts (`MAX_TRANSCRIPTS`, `MAX_RECORDINGS`).

**Where the cap lives.** `MAX_ARTIFACT_SCAN` is in `features/transcripts.py`.
`features/recordings.py` imports it, and `server/tools.py` interpolates
`transcripts.MAX_ARTIFACT_SCAN` into the recordings descriptions as well. One home is deliberate:
the cap is one promise about two artifacts, and two constants would drift apart.
`graph_client/pagination.py` names `features/transcripts.MAX_ARTIFACT_SCAN` as the tighter cap of
its second way to bound a read. `features/__init__.py` records the newest-first walk among what
`recordings` borrows from `transcripts`. `tests/test_layering.py` passes at the head with that
import in place.

The cap number is also in the words a model reads. Those places are both `limit` descriptions, both
list fields, both `truncated` fields, both `status` descriptions and both tool descriptions.

### B — one answer could report `not_transcribed` together with `truncated: true`

"A retry will not help" and "there is more" cannot both be true, and a caller cannot see which one
is wrong. The defect needed a meeting with more artifacts than the cap.

A tool can report an absence only from a collection that it read to the end. A read that
`MAX_ARTIFACT_SCAN` stopped therefore reports no absence. It reports **`scan_incomplete`**, in both
tools. `_absence(scan_stopped_short=collected.truncated, settled=...)` takes
the flag and the verdict from one value. Each lister reports `available` when the window holds
artifacts, so `truncated: true` can accompany only `available` or `scan_incomplete`.

`scan_incomplete` is a fifth value of the existing `status` field. It is not a new field, not a new
parameter and not a new tool.

**What an older consumer sees.** `status` is a plain `str` on both models (`transcripts.py:465`,
`recordings.py:188`). The fifth value is therefore not a schema-visible enum change. A consumer that
branches on the four old values falls through silently, so such a consumer needs a default branch
for the new word. Both tool descriptions name all five values.

## Two statements that a model reads, corrected in the second commit

Both listers apply the occurrence window on the client side, and the two Microsoft references are
the reason. `calltranscript-get` and `callrecording-get` both document `$select` as the optional
query parameter, and neither one names `$orderby`. Each reference shows one `$filter` example, and
each of those filters on `contentCorrelationId` (`calltranscript-get` Example 11,
`callrecording-get` Example 5). The request therefore goes out bare, and the read takes up to
`MAX_ARTIFACT_SCAN` artifacts in Graph's own order. A feature test per lister asserts that the
request URL carries no `$filter`, no `$orderby` and no `$top`.

### C — `scan_incomplete` offered a remedy that the mechanism cannot keep

The first commit told the caller to narrow `started_after`/`started_before` and to ask again. Each
lister applies the window to the artifacts after Graph answers. A narrower window therefore sends
the same request, reads the same artifacts and returns the same status.
`test_narrowing_the_window_cannot_reach_past_the_scan_cap` asserts one identical request URL for a
wide window and a narrow one.

The status now states that nothing can help. It tells the caller to stop and to report that the
answer is not determined. `test_the_unreadable_answer_tells_a_caller_to_stop_rather_than_to_retry`
asserts that the `status` description holds "There is nothing to try", "Stop, and report" and "do
not ask again". It also asserts that the old remedy sentence is gone.

### D — "newest first" was a promise about the collection

Past the cap, "newest first" describes the artifacts that the call read. Every place that makes the
promise now names which of the two it means, and each place names `truncated` as the flag for the
difference. The cap itself is unchanged: with no `$orderby`, a larger cap reads more artifacts and
still cannot promise the newest.

`truncated` has two causes now, and the descriptions separate them.

- The window holds more artifacts than `limit`. The entries are the newest of the window, and the
  caller can raise `limit` to 50.
- The meeting holds more artifacts than one call reads, which is `MAX_ARTIFACT_SCAN`. The order then
  covers the artifacts that the call read, so the first entry can be older than the meeting's newest
  artifact. No argument to the tool reads further, because each lister applies the window after
  Graph answers.

Which cause happened is not always visible. Both `truncated` descriptions tell a model to call the
first entry the most recent of what was read. Fewer entries than the caller asked for, together with
`truncated: true`, is always the second cause.

## What the branch verified

- **The journey tests, in-process over the real MCP protocol** (`fastmcp.Client` against the server
  that `create_app` builds, and Graph through respx). Each one passes every id and handle from one
  answer into the next call. `test_a_model_walks_from_its_teams_to_a_reply_it_can_read` runs
  `list_teams → list_channels → browse_channel → read_message` on a reply handle that
  `browse_channel` mints. `test_a_model_walks_from_a_meeting_chat_to_what_was_said_in_the_meeting`
  runs `list_chats → list_meeting_transcripts → read_transcript`.
  `test_a_model_walks_from_a_meeting_chat_to_whether_the_call_was_recorded` runs
  `list_chats → list_meeting_recordings`.
  `test_a_handle_from_a_search_result_reads_the_message_behind_it` runs
  `search_messages → read_message`.
- **A protocol-level test for fix A** over both listers
  (`test_asking_for_the_latest_of_a_series_answers_with_the_latest`, parametrized over `transcripts`
  and `recordings`). The mocked collection answers a three-occurrence series oldest first, the call
  passes `limit: 1`, and the test asserts one entry `week-3`, `status: available` and
  `truncated: true`.
- **The first commit added tests for fix A**. The fix-A test runs over both listers. Six more tests
  are feature-level, three per lister. One test is
  `test_both_meeting_listers_teach_the_same_status_vocabulary`. The commit also replaced the two
  "four answers" description tests with "five answers" tests.
- **The shared vocabulary test** asserts four shared words:
  `{\"available\", \"not_ready\", \"scan_incomplete\", \"meeting_not_found\"}`. It reads them from the
  `status` field description of each output schema. It also asserts that `list_meeting_transcripts`
  names `not_transcribed`, that `list_meeting_recordings` names `not_recorded`, and that neither
  tool names the other word.
- **The second commit added tests for fixes C and D.** Three protocol-level functions run parametrized over both
  listers: `test_neither_lister_offers_a_remedy_its_mechanism_cannot_keep`,
  `test_neither_lister_promises_the_newest_past_its_scan_cap` and
  `test_a_meeting_larger_than_one_call_reads_answers_within_what_it_read`.
  Eight feature-level tests are also added, four per lister.
- **What the largest of those tests builds.** `_daily_series` builds `MAX_ARTIFACT_SCAN + 60`
  artifacts, which is 260. `limit: 1` answers `day-199`, and `truncated` is true. A wide window and a
  narrow window over the part that the call did not read both answer `scan_incomplete`. Both answers
  carry the same `truncated` value and the same empty list.
- **All CI gates on this branch pass.** This includes pytest, ruff check, ruff format --check, and
  basedpyright. `tests/test_layering.py` passes at the head.
- **The real process**, at the default port 9544 (`config.py` has `port: int = Field(default=9544,
  …)` and `.env.example` has `PORT=9544`). `/health` 200, `/probe` 200, and `/metrics` 200 in the
  Prometheus format. `/.well-known/oauth-authorization-server` and
  `/.well-known/oauth-protected-resource/mcp` both answer 200 and agree: `issuer` is
  `http://localhost:9544/`, `authorization_servers` holds that same value, and both documents name
  the `access_as_user` scope. An unauthenticated `POST /mcp` answers `401` with
  `WWW-Authenticate: Bearer resource_metadata=\"http://localhost:9544/.well-known/oauth-protected-resource/mcp\"`.
- **The readiness probe, both ways.** With Postgres reachable on port 9001, `/ready` answers 200 and
  `{\"status\":\"healthy\",\"checks\":{\"database\":true}}`. With an unreachable database port, `/ready`
  answers 503 and `{\"status\":\"unhealthy\",\"checks\":{\"database\":false}}`. `/health` still answers 200,
  and the service logs `ready.database_unreachable` as a structured event at warning level. It does
  not crash.

## Drift found, and how the branch resolved it

| Suspect | Finding |
| --- | --- |
| `collect_pages`'s `matches` / `max_scanned` have no production caller | **The suspicion holds for `max_scanned` only.** On the base branch `matches` had two callers and `max_scanned` had none. At the head each one has exactly one caller: `newest_in_window` passes both (`features/transcripts.py:768`). The meeting read passes its own tighter cap instead of `MAX_SCANNED_ITEMS = 1000`. A new docstring in `tests/graph_client/test_pagination.py` records that both parameters are used in production. The branch deleted nothing. |
| Item budget (teams/channels) against request budget (browse_channel) | **`graph_client/pagination.py` now records three ways to bound a read, in one place**, and the README points at that module. An inventory walks until it has `limit` items. A meeting's artifacts are walked to a tighter scan cap, because this code filters them and also sorts them. A channel's messages get no paged read, at one request per second per app per tenant. |
| The outcome vocabulary across two tools | **The fifth word is identical in both tools**, and only the settled absence differs (`not_transcribed` against `not_recorded`). `test_both_meeting_listers_teach_the_same_status_vocabulary` asserts the four shared words, and it asserts that neither tool names the other tool's absence word. |
| Ten descriptions, one voice | **One description was incomplete.** `get_me` now names where its `user_id` matches: `search_messages` matches `mentions` on it, and a recording reports `organizer_user_id`. It also names `email` as the value that matches a chat member from `list_chats`, because that list carries no ids. |
| Layering: no rule skipped or weakened | **`tests/test_layering.py` is unchanged by this branch.** All tests pass at the head. |
| The README | **Three passages were stale, and the branch corrected all three.** The module list named neither `transcripts` nor `recordings`. The status paragraph said four statuses, and it split the two absences on the meeting's end time. It says five now, the end of the window splits them, and the meeting is the fallback. The paragraph about bounded reads gave one way to bound a read, and it gives three now. |

## Deployability

- The CI job runs `helm dependency update` and then `helm template .` with
  `--values ci-values.yaml` where that file exists, and it exists for this chart. The job pins helm
  v3.19.0 (`azure/setup-helm` v4.3.1 with `version: v3.19.0`). This session could not repeat the
  render, because helm is not on its PATH.
- `scripts/render-values-schema.sh` **generates** `values.schema.json` from the base chart's schema
  and `values.additional.schema.json`, and nobody edits it by hand. This session could not run that
  script either, because it needs helm. The branch changed no chart value and no schema file: the
  one chart change is comment text in `values.yaml`.
- The branch adds **no configuration**. `config.py` and `.env.example` are not in the diff. Every
  Graph permission is a code constant, and there are eight distinct permission strings across
  `features/`.
- **What `values.yaml` records.** Eight delegated permissions. Two of them need admin consent
  independently of each other: `OnlineMeetingTranscript.Read.All` and
  `OnlineMeetingRecording.Read.All`. The last item is the tenant-wide Teams setting for Graph
  access to meeting transcripts, which is off by default. Until a Teams administrator turns that
  setting on, `list_meeting_transcripts` answers 403 with that remedy, and every other tool answers
  as before.

## Not changed, on purpose

- **`MAX_SCANNED_ITEMS = 1000`** stays the default in `graph_client/pagination.py` for the
  inventories. Nothing filters them, so the items kept are the work done, and that cap never binds.
- **`$top` on the two artifact collections.** Neither Microsoft reference documents it, and the two
  requests go out without it. A feature test per lister pins that.

## For the owner (the branch did not build these)

- **No cursor on the two meeting listers.** They take `meeting_uri`, `started_after`,
  `started_before` and `limit`. A caller cannot reach the artifacts past `MAX_ARTIFACT_SCAN`, and a
  narrower window does not help, because each lister applies the window after Graph answers. A
  cursor is the feature that would remove that limit.
- **No metric on the cap.** `scan_incomplete` needs a meeting with more artifacts than the cap, so
  it is hard to observe in production. A metric on the cap is the cheap way to see it. The branch
  added none, and `metrics.py` is not in the diff.
