### PR TITLE
feat(office-mcp): list the channels of one team

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,12 +2,12 @@
 
 An MCP server for Microsoft 365 via Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes five MCP
+Users sign in with their own Microsoft account and the server acts as them. It exposes six MCP
 tools so far — `get_me`, the signed-in user's own profile; `list_chats`, their Microsoft Teams chats
-most recently active first; `list_teams`, the teams they are a member of; `search_messages`,
-full-text search across every Teams message they can see; and `read_message`, one of those messages
-in full — each one a file of its own, and more land in later PRs, stacked on top of this one, one
-tool per PR.
+most recently active first; `list_teams`, the teams they are a member of; `list_channels`, the
+channels of one of those teams; `search_messages`, full-text search across every Teams message they
+can see; and `read_message`, one of those messages in full — each one a file of its own, and more
+land in later PRs, stacked on top of this one, one tool per PR.
 
 ## Layout
 
@@ -78,6 +78,7 @@ Tools redeem permissions per call via On-Behalf-Of. No permission = no consent =
 | `User.Read` | Delegated | No | `get_me` |
 | `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` |
 | `Team.ReadBasic.All` | Delegated | No | `list_teams` |
+| `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
 | `ChannelMessage.Read.All` | Delegated | Usually | `search_messages`, `read_message` (channels) |
 
 Multiple tools naming the same permission is normal. It is not duplication to remove. Each tool
@@ -101,6 +102,12 @@ misspelling is on both sides.
 but Microsoft docs say searches never return more than GET would. All channel GET needs
 `ChannelMessage.Read.All`. Without it, searches silently cover chats only. Asking at sign-in makes
 tenants that withhold it fail visibly at consent, not serve incomplete results.
+
+The channel inventory is two permissions, and they are separate scopes on purpose:
+`Channel.ReadBasic.All` lists a team's channels, `ChannelMessage.Read.All` reads what was posted in
+one. Each is the least-privileged permission Microsoft documents for its collection. A tenant
+refusing the message permission still lists teams and channels, and each tool's 403 names only the
+permission its own request needed.
 
 **State:** Tokens revalidated per request. FastMCP's default store is an encrypted file tree. It
 resets on restart. It breaks at replicas: each replica writes its own file, invisible to the

--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,12 +2,10 @@
 
 An MCP server for Microsoft 365 via Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes six MCP
-tools so far — `get_me`, the signed-in user's own profile; `list_chats`, their Microsoft Teams chats
-most recently active first; `list_teams`, the teams they are a member of; `list_channels`, the
-channels of one of those teams; `search_messages`, full-text search across every Teams message they
-can see; and `read_message`, one of those messages in full — each one a file of its own, and more
-land in later PRs, stacked on top of this one, one tool per PR.
+Users sign in with their own Microsoft account; the server acts as them. Six MCP tools are available:
+`get_me` (profile), `list_chats` (chats by recency), `list_teams` (teams the user is in), `list_channels`
+(channels in one team), `search_messages` (full-text search), and `read_message` (one message in full).
+Each tool is one file; more land in later PRs, one tool per PR.
 
 ## Layout
 

--- a/services/office-mcp/src/office_mcp/shared/seam.py
+++ b/services/office-mcp/src/office_mcp/shared/seam.py
@@ -53,7 +53,13 @@ _GRAPH_SCOPE_PREFIX = "https://graph.microsoft.com/"
 READ_ONLY: dict[str, bool] = {"readOnlyHint": True, "openWorldHint": True}
 
 REQUESTABLE_PERMISSIONS: frozenset[str] = frozenset(
-    {"User.Read", "Chat.Read", "Team.ReadBasic.All", "ChannelMessage.Read.All"}
+    {
+        "User.Read",
+        "Chat.Read",
+        "Team.ReadBasic.All",
+        "Channel.ReadBasic.All",
+        "ChannelMessage.Read.All",
+    }
 )
 
 

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -16,7 +16,14 @@ import httpx
 from fastmcp import FastMCP
 
 from office_mcp.shared.seam import graph_scope
-from office_mcp.tools import get_me, list_chats, list_teams, read_message, search_messages
+from office_mcp.tools import (
+    get_me,
+    list_channels,
+    list_chats,
+    list_teams,
+    read_message,
+    search_messages,
+)
 
 __all__ = ["GRAPH_SCOPES", "register_tools"]
 
@@ -35,6 +42,7 @@ _TOOL_MODULES: tuple[ToolModule, ...] = (
     get_me,
     list_chats,
     list_teams,
+    list_channels,
     search_messages,
     read_message,
 )

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -7,7 +7,7 @@ TRAP: Derive `GRAPH_SCOPES` from modules, never hand-write it. `create_app` pass
 to the auth provider at startup. A missing permission causes sign-in to fail with AADSTS65001.
 Deriving here guarantees every tool has consent.
 
-Order is stable (via `dict.fromkeys`, not `set`)."""
+Order is stable (via `dict.fromkeys`, not `set`). This keeps token keys the same across restarts."""
 
 from typing import Protocol
 

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -1,14 +1,13 @@
-"""The registry: every tool module and their shared permissions.
+"""The registry of all tools and their permissions.
 
-A tool is one file. It publishes `GRAPH_PERMISSIONS` (tuple) and `register` (function). Adding a
-tool: one file plus one line here.
+Each tool is one file that publishes `GRAPH_PERMISSIONS` and `register`. Add a tool: one file
+plus one line here.
 
-TRAP: `GRAPH_SCOPES` must be derived from modules, never hand-written. At startup, `create_app`
-passes all permissions to the auth provider. A forgotten permission means sign-in fails with
-AADSTS65001. Deriving it here guarantees every registered tool has consent.
+TRAP: Derive `GRAPH_SCOPES` from modules, never hand-write it. `create_app` passes all permissions
+to the auth provider at startup. A missing permission causes sign-in to fail with AADSTS65001.
+Deriving here guarantees every tool has consent.
 
-Order is stable (via `dict.fromkeys`, not `set`) so token keys don't change on each restart.
-"""
+Order is stable (via `dict.fromkeys`, not `set`)."""
 
 from typing import Protocol
 
@@ -29,8 +28,7 @@ __all__ = ["GRAPH_SCOPES", "register_tools"]
 
 
 class ToolModule(Protocol):
-    """Contract a tool file must satisfy. Checked structurally: missing `GRAPH_PERMISSIONS` or
-    `register` is a type error, not a runtime surprise."""
+    """Contract a tool must satisfy. Type-checked structurally at import."""
 
     GRAPH_PERMISSIONS: tuple[str, ...]
 

--- a/services/office-mcp/src/office_mcp/tools/list_channels.py
+++ b/services/office-mcp/src/office_mcp/tools/list_channels.py
@@ -1,7 +1,8 @@
 """`list_channels` — channels of one team the signed-in user can access.
 
-`list_teams` names a team; this names a channel inside it. Channel names are unique only inside
-their own team — every team has a `General` — so channel identification needs both ids.
+`list_teams` names a team; this names a channel inside it. A channel id alone identifies nothing
+in Graph. Channel names are unique only inside their own team — every team has a `General`.
+Channel identification needs both ids.
 
 **`$select` is a requirement: the connector must exclude the expensive `email` property.** Graph \
 documents email as "an expensive operation that results in slow performance". Without `$select`, \
@@ -42,7 +43,8 @@ _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 # Window size and limit cap. Graph accepts no `$top` here; this bounds requests per call.
 MAX_CHANNELS = 200
 
-# Excludes `email` (expensive) and `isArchived` (archived channels are in preview).
+# Excludes `email` (expensive). Excludes `isArchived`: archived channels are a Teams preview
+# feature. Excludes `layoutType`: Graph documents it as always null on this collection.
 _CHANNEL_FIELDS = ("id", "displayName", "description", "createdDateTime", "membershipType")
 
 type _ChannelsQuery = ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters
@@ -121,7 +123,8 @@ async def list_channels(client: GraphServiceClient, *, team_id: str, limit: int)
 
 def _channel(channel: Channel) -> ChannelSummary:
     assert channel.id is not None, "Graph returned a channel with no id"
-    # Unknown membership types deserialize to None rather than raising (Graph SDK behavior).
+    # `ChannelMembershipType` subclasses `str`; each member equals its own wire value. Unknown
+    # membership types deserialize to None rather than raising (Graph SDK behavior).
     return ChannelSummary(
         channel_id=channel.id,
         display_name=channel.display_name,
@@ -132,8 +135,11 @@ def _channel(channel: Channel) -> ChannelSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Register this tool. The tool owns the request, window, answer shape, fields, permission, \
-and description. Token exchange and error wording stay in `shared/seam.py`."""
+    """Register this tool with the shared Graph transport.
+
+    The tool borrows `transport` per call and does not own it. `create_app` closes it on
+    shutdown.
+    """
 
     @mcp.tool(
         name=TOOL_NAME,

--- a/services/office-mcp/src/office_mcp/tools/list_channels.py
+++ b/services/office-mcp/src/office_mcp/tools/list_channels.py
@@ -1,0 +1,199 @@
+"""`list_channels` — the channels of one team the signed-in user can see.
+
+The middle step of the channel path: `list_teams` names a team and this names a channel inside it.
+The pair is always needed, because a channel name is unique only inside its own team — every team
+has a `General` — and a channel id alone addresses nothing in Graph, which is why the handle
+`read_message` takes for a channel message carries both.
+
+**`$select` here is a requirement rather than an optimisation.** Graph documents populating a
+channel's `email` as "an expensive operation that results in slow performance"
+(https://learn.microsoft.com/en-us/graph/api/channel-list), and selecting around it is the only way
+not to pay for it. The same reference gives this collection `$select` and `$filter` and nothing
+else — no `$top`, which `services/teams-mcp` shipped and had to take back out — so the window is
+applied while walking the pages Graph chose, exactly as `list_teams` does.
+
+The collection is already access-trimmed: "Teams members can't see private or shared channels that
+they aren't members of in the response for this API". That is why an absent channel is not evidence
+that the team has no such channel, and why the description says so rather than leaving a model to
+conclude it.
+
+What this file does not own is the token and the refusal wording (`shared/seam.py`, so this tool's
+403 sounds like every other tool's). Everything else — the name, the description, the permission,
+the fields asked for, the window, the answer shape and the request — is here.
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.channel import Channel
+from msgraph.generated.teams.item.channels.channels_request_builder import ChannelsRequestBuilder
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import collect_pages, graph_client_for, graph_errors
+from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
+
+TOOL_NAME = "list_channels"
+
+# The delegated Graph permission this tool's one request needs — the cheap "basic" scope over a
+# channel's identity, which is all this collection returns. Reading what was *posted* in a channel
+# is the broad `ChannelMessage.Read.All`, which the tools that read messages declare; a tenant
+# commonly grants this one and withholds that one, which is why the two are named separately.
+GRAPH_PERMISSIONS: tuple[str, ...] = ("Channel.ReadBasic.All",)
+
+# Built once at import: a call inside a parameter default rebuilds the descriptor on every
+# registration and is a lint error in both of this repo's checkers.
+_TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
+
+# How many channels one call returns, and the ceiling on `limit`. Graph takes no `$top` on this
+# collection either, so this window is this connector's own and so is its bound: it caps the number
+# of Graph requests one call can make while walking the pages.
+MAX_CHANNELS = 200
+
+# What a channel listing asks for, which is everything Graph populates that identifies a channel.
+# `email` is excluded deliberately (see the module docstring), and so is `isArchived`: Graph
+# documents `layoutType` as coming back null on this collection and archived channels are a Teams
+# preview concept, so neither is claimed here.
+_CHANNEL_FIELDS = ("id", "displayName", "description", "createdDateTime", "membershipType")
+
+type _ChannelsQuery = ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters
+
+_DESCRIPTION = f"""\
+List the channels of one Microsoft Teams team, identified by the `team_id` list_teams returned: \
+each channel's id, name, description, membership type and creation date.
+
+Call this to see what channels a team has, and to put a name to the `channel_id` search_messages \
+reports on a channel message — a channel id alone addresses nothing. Channel names are unique only \
+inside their own team (every team has a `General`), which is why the pair is always needed. No \
+message content is returned here.
+
+The list is already trimmed to what the signed-in user may see: Microsoft omits private and shared \
+channels they are not a member of, so an absent channel is not evidence that the team has no such \
+channel. `membership_type` says which kind each one is — `standard`, `private` or `shared`.
+
+There is no pagination and no ordering, for the same reason as list_teams: Microsoft accepts no \
+page size on this collection either. As many channels as `limit` means the team may have more; \
+fewer than `limit` is all of them this user can see. Widen `limit` (up to {MAX_CHANNELS}).\
+"""
+
+
+class ChannelSummary(BaseModel):
+    channel_id: str = Field(
+        description=(
+            "The channel's Graph id, e.g. `19:...@thread.tacv2`. It is the id search_messages "
+            + "reports as `channel_id` on a channel message, and it addresses a channel only "
+            + "together with its `team_id`. Opaque — copy it rather than constructing one from a "
+            + "name."
+        )
+    )
+    display_name: str | None = Field(
+        description=(
+            "The channel's name as Teams shows it, e.g. `General`. Every team has a `General` "
+            + "channel, so a name is only unique within its own team."
+        )
+    )
+    description: str | None = Field(
+        description="What the channel is for, as its owners wrote it. Often null."
+    )
+    membership_type: str | None = Field(
+        description=(
+            "`standard` for a channel every team member is in, `private` for one with its own "
+            + "member list, or `shared` for one shared with other teams. Null when Microsoft Graph "
+            + "reported a type this connector predates. Private and shared channels the signed-in "
+            + "user is not a member of are not in this list at all."
+        )
+    )
+    created_at: datetime | None = Field(
+        description="When the channel was created — useful to tell apart similarly named channels."
+    )
+
+
+class ChannelList(BaseModel):
+    channels: list[ChannelSummary] = Field(
+        description=(
+            "The channels of this team that the signed-in user can see. As many as `limit` means "
+            + "there may be more; fewer than `limit` is all of them the user can see. There is no "
+            + f"cursor: raise `limit` (up to {MAX_CHANNELS}). Microsoft Graph applies no order to "
+            + "this collection either."
+        )
+    )
+
+
+async def list_channels(client: GraphServiceClient, *, team_id: str, limit: int) -> ChannelList:
+    """The channels of `team_id` the signed-in user can see, up to `limit`."""
+    assert 1 <= limit <= MAX_CHANNELS, f"limit must be within 1..{MAX_CHANNELS}, got {limit}"
+
+    configuration = RequestConfiguration[_ChannelsQuery](
+        query_parameters=ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters(
+            select=list(_CHANNEL_FIELDS)
+        )
+    )
+    with graph_errors():
+        first_page = await client.teams.by_team_id(team_id).channels.get(
+            request_configuration=configuration
+        )
+        assert first_page is not None, "Graph answered a channel listing with no collection"
+        collected = await collect_pages(first_page, client, limit=limit)
+
+    return ChannelList(channels=[_channel(channel) for channel in collected.items])
+
+
+def _channel(channel: Channel) -> ChannelSummary:
+    assert channel.id is not None, "Graph returned a channel with no id"
+    # `ChannelMembershipType` subclasses `str`, so the member is its own wire value ("standard");
+    # a value the generated enum has no member for deserializes to None rather than raising.
+    return ChannelSummary(
+        channel_id=channel.id,
+        display_name=channel.display_name,
+        description=channel.description,
+        membership_type=channel.membership_type,
+        created_at=channel.created_date_time,
+    )
+
+
+def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this tool against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
+    borrows it per call and never owns it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(
+        name=TOOL_NAME,
+        title="List a Team's Channels",
+        description=_DESCRIPTION,
+        annotations=READ_ONLY,
+    )
+    async def list_a_teams_channels(
+        team_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The team whose channels to list, exactly as list_teams reported its "
+                    + "`team_id`. Opaque — a team's name is not one, and one cannot be "
+                    + "constructed."
+                ),
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=MAX_CHANNELS,
+                description=(
+                    "How many channels to return. Default 50, maximum "
+                    + f"{MAX_CHANNELS} — as with list_teams, Microsoft Graph applies no "
+                    + "page size here and this is the window applied while paging."
+                ),
+            ),
+        ] = 50,
+        graph_token: str = _TOKEN,
+    ) -> ChannelList:
+        with graph_tool_errors(*GRAPH_PERMISSIONS):
+            return await list_channels(
+                graph_client_for(transport, graph_token), team_id=team_id, limit=limit
+            )

--- a/services/office-mcp/src/office_mcp/tools/list_channels.py
+++ b/services/office-mcp/src/office_mcp/tools/list_channels.py
@@ -1,26 +1,19 @@
-"""`list_channels` — the channels of one team the signed-in user can see.
+"""`list_channels` — channels of one team the signed-in user can access.
 
-The middle step of the channel path: `list_teams` names a team and this names a channel inside it.
-The pair is always needed, because a channel name is unique only inside its own team — every team
-has a `General` — and a channel id alone addresses nothing in Graph, which is why the handle
-`read_message` takes for a channel message carries both.
+`list_teams` names a team; this names a channel inside it. Channel names are unique only inside
+their own team — every team has a `General` — so channel identification needs both ids.
 
-**`$select` here is a requirement rather than an optimisation.** Graph documents populating a
-channel's `email` as "an expensive operation that results in slow performance"
-(https://learn.microsoft.com/en-us/graph/api/channel-list), and selecting around it is the only way
-not to pay for it. The same reference gives this collection `$select` and `$filter` and nothing
-else — no `$top`, which `services/teams-mcp` shipped and had to take back out — so the window is
-applied while walking the pages Graph chose, exactly as `list_teams` does.
+**`$select` is a requirement: the connector must exclude the expensive `email` property.** Graph \
+documents email as "an expensive operation that results in slow performance". Without `$select`, \
+every channel listing pays that cost. The collection accepts no `$top` (Graph returns 400); \
+the window is this connector's own, applied while walking pages.
 
-The collection is already access-trimmed: "Teams members can't see private or shared channels that
-they aren't members of in the response for this API". That is why an absent channel is not evidence
-that the team has no such channel, and why the description says so rather than leaving a model to
-conclude it.
+Graph filters membership-based channels: private and shared channels the user is not a member of \
+do not appear. An absent channel does not mean the team lacks it — only that the user cannot \
+access it.
 
-What this file does not own is the token and the refusal wording (`shared/seam.py`, so this tool's
-403 sounds like every other tool's). Everything else — the name, the description, the permission,
-the fields asked for, the window, the answer shape and the request — is here.
-"""
+Token exchange and error wording belong to `shared/seam.py`; the tool owns the request, window,
+answer shape, fields, permission, and description."""
 
 from datetime import datetime
 from typing import Annotated
@@ -38,61 +31,48 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_channels"
 
-# The delegated Graph permission this tool's one request needs — the cheap "basic" scope over a
-# channel's identity, which is all this collection returns. Reading what was *posted* in a channel
-# is the broad `ChannelMessage.Read.All`, which the tools that read messages declare; a tenant
-# commonly grants this one and withholds that one, which is why the two are named separately.
+# The cheap "basic" scope for channel identity. Reading messages needs `ChannelMessage.Read.All`;
+# a tenant often grants this one and withholds the broad one, so the two are named separately.
 GRAPH_PERMISSIONS: tuple[str, ...] = ("Channel.ReadBasic.All",)
 
-# Built once at import: a call inside a parameter default rebuilds the descriptor on every
-# registration and is a lint error in both of this repo's checkers.
+# Built at import, not in the parameter default: rebuilding the descriptor on every registration
+# is a lint error.
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
-# How many channels one call returns, and the ceiling on `limit`. Graph takes no `$top` on this
-# collection either, so this window is this connector's own and so is its bound: it caps the number
-# of Graph requests one call can make while walking the pages.
+# Window size and limit cap. Graph accepts no `$top` here; this bounds requests per call.
 MAX_CHANNELS = 200
 
-# What a channel listing asks for, which is everything Graph populates that identifies a channel.
-# `email` is excluded deliberately (see the module docstring), and so is `isArchived`: Graph
-# documents `layoutType` as coming back null on this collection and archived channels are a Teams
-# preview concept, so neither is claimed here.
+# Excludes `email` (expensive) and `isArchived` (archived channels are in preview).
 _CHANNEL_FIELDS = ("id", "displayName", "description", "createdDateTime", "membershipType")
 
 type _ChannelsQuery = ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParameters
 
 _DESCRIPTION = f"""\
-List the channels of one Microsoft Teams team, identified by the `team_id` list_teams returned: \
-each channel's id, name, description, membership type and creation date.
+List channels of a Microsoft Teams team. Pass the `team_id` from list_teams.
 
-Call this to see what channels a team has, and to put a name to the `channel_id` search_messages \
-reports on a channel message — a channel id alone addresses nothing. Channel names are unique only \
-inside their own team (every team has a `General`), which is why the pair is always needed. No \
-message content is returned here.
+Each channel's id, name, description, membership type, and creation date are returned. \
+Channel names are unique only inside their own team (every team has a `General`), so use both \
+ids to address a channel. `membership_type` is `standard`, `private`, or `shared`.
 
-The list is already trimmed to what the signed-in user may see: Microsoft omits private and shared \
-channels they are not a member of, so an absent channel is not evidence that the team has no such \
-channel. `membership_type` says which kind each one is — `standard`, `private` or `shared`.
+The list shows only channels the signed-in user can access. An absent channel means the user \
+cannot access it, not that the team lacks it.
 
-There is no pagination and no ordering, for the same reason as list_teams: Microsoft accepts no \
-page size on this collection either. As many channels as `limit` means the team may have more; \
-fewer than `limit` is all of them this user can see. Widen `limit` (up to {MAX_CHANNELS}).\
+Microsoft Graph applies no page size to this collection. As many channels as `limit` means more \
+may exist; fewer than `limit` is all of them the user can see. Raise `limit` (up to \
+{MAX_CHANNELS}).\
 """
 
 
 class ChannelSummary(BaseModel):
     channel_id: str = Field(
         description=(
-            "The channel's Graph id, e.g. `19:...@thread.tacv2`. It is the id search_messages "
-            + "reports as `channel_id` on a channel message, and it addresses a channel only "
-            + "together with its `team_id`. Opaque — copy it rather than constructing one from a "
-            + "name."
+            "The channel's Graph id, e.g. `19:...@thread.tacv2`. Use it with `team_id` to "
+            + "address a channel. Opaque — copy it from responses rather than constructing it."
         )
     )
     display_name: str | None = Field(
         description=(
-            "The channel's name as Teams shows it, e.g. `General`. Every team has a `General` "
-            + "channel, so a name is only unique within its own team."
+            "The channel name, e.g. `General`. Names are unique only inside their own team."
         )
     )
     description: str | None = Field(
@@ -100,10 +80,9 @@ class ChannelSummary(BaseModel):
     )
     membership_type: str | None = Field(
         description=(
-            "`standard` for a channel every team member is in, `private` for one with its own "
-            + "member list, or `shared` for one shared with other teams. Null when Microsoft Graph "
-            + "reported a type this connector predates. Private and shared channels the signed-in "
-            + "user is not a member of are not in this list at all."
+            "`standard` for all team members, `private` for a member-list channel, or `shared` "
+            + "for a channel shared with other teams. Null if the type predates this code. "
+            + "Channels the user is not a member of do not appear."
         )
     )
     created_at: datetime | None = Field(
@@ -114,10 +93,9 @@ class ChannelSummary(BaseModel):
 class ChannelList(BaseModel):
     channels: list[ChannelSummary] = Field(
         description=(
-            "The channels of this team that the signed-in user can see. As many as `limit` means "
-            + "there may be more; fewer than `limit` is all of them the user can see. There is no "
-            + f"cursor: raise `limit` (up to {MAX_CHANNELS}). Microsoft Graph applies no order to "
-            + "this collection either."
+            "Channels the user can access. As many as `limit` means more may exist; fewer is all "
+            + "of them. No cursor; raise `limit` (up to "
+            + f"{MAX_CHANNELS}). Microsoft Graph does not order this collection."
         )
     )
 
@@ -143,8 +121,7 @@ async def list_channels(client: GraphServiceClient, *, team_id: str, limit: int)
 
 def _channel(channel: Channel) -> ChannelSummary:
     assert channel.id is not None, "Graph returned a channel with no id"
-    # `ChannelMembershipType` subclasses `str`, so the member is its own wire value ("standard");
-    # a value the generated enum has no member for deserializes to None rather than raising.
+    # Unknown membership types deserialize to None rather than raising (Graph SDK behavior).
     return ChannelSummary(
         channel_id=channel.id,
         display_name=channel.display_name,
@@ -155,11 +132,8 @@ def _channel(channel: Channel) -> ChannelSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport.
-
-    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
-    borrows it per call and never owns it. `create_app` closes it on shutdown.
-    """
+    """Register this tool. The tool owns the request, window, answer shape, fields, permission, \
+and description. Token exchange and error wording stay in `shared/seam.py`."""
 
     @mcp.tool(
         name=TOOL_NAME,
@@ -173,9 +147,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The team whose channels to list, exactly as list_teams reported its "
-                    + "`team_id`. Opaque — a team's name is not one, and one cannot be "
-                    + "constructed."
+                    "The team whose channels to list, exactly as list_teams reported it. "
+                    + "Opaque — copy it rather than constructing it. A team name is not one; "
+                    + "names can repeat within a tenant, but team_ids do not."
                 ),
             ),
         ],
@@ -186,8 +160,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 le=MAX_CHANNELS,
                 description=(
                     "How many channels to return. Default 50, maximum "
-                    + f"{MAX_CHANNELS} — as with list_teams, Microsoft Graph applies no "
-                    + "page size here and this is the window applied while paging."
+                    + f"{MAX_CHANNELS}. Microsoft Graph applies no page size; this is the "
+                    + "window applied while paging."
                 ),
             ),
         ] = 50,

--- a/services/office-mcp/src/office_mcp/tools/list_teams.py
+++ b/services/office-mcp/src/office_mcp/tools/list_teams.py
@@ -38,16 +38,18 @@ List the Microsoft Teams teams you are a member of, with each team's id, name, d
 and archived flag.
 
 This is the channel side of Teams. To read a channel message, first use this tool to find the \
-team. The `team_id` is the same id search_messages reports on channel messages. The `limit` is \
-a window over Microsoft's order; shorter than `limit` means end of list.\
+team, then list_channels to find the channel. The `team_id` is what list_channels takes, and the \
+same id search_messages reports on channel messages. The `limit` is a window over Microsoft's \
+order; shorter than `limit` means end of list.\
 """
 
 
 class TeamSummary(BaseModel):
     team_id: str = Field(
         description=(
-            "The team's Graph id. This is the same id search_messages reports on channel "
-            + "messages. Opaque—copy it verbatim, never build one from a name."
+            "The team's Graph id. This is what list_channels takes, and the same id "
+            + "search_messages reports on channel messages. Opaque—copy it verbatim, never "
+            + "build one from a name."
         )
     )
     display_name: str | None = Field(

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -143,6 +143,8 @@ _SYSTEM_MESSAGE = {
 }
 
 _TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+_CHANNELS_PATH = f"/teams/{_TEAM_ID}/channels"
 
 # Only the five properties `GET /me/joinedTeams` populates; every other property of a team comes
 # back null on that endpoint, asked for or not.
@@ -154,6 +156,18 @@ _TEAMS = {
             "description": "Ships the product",
             "isArchived": False,
             "tenantId": "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81",
+        }
+    ]
+}
+
+_CHANNELS = {
+    "value": [
+        {
+            "id": _CHANNEL_ID,
+            "displayName": "General",
+            "description": "Everything and nothing",
+            "createdDateTime": "2026-01-04T12:00:00Z",
+            "membershipType": "standard",
         }
     ]
 }
@@ -390,6 +404,7 @@ class TestTheToolsThisServerAdvertises:
             "get_me",
             "list_chats",
             "list_teams",
+            "list_channels",
             "search_messages",
             "read_message",
         }
@@ -428,6 +443,7 @@ class TestTheToolsThisServerAdvertises:
         }
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats"}
         assert set(_properties(tools["list_teams"].outputSchema)) == {"teams"}
+        assert set(_properties(tools["list_channels"].outputSchema)) == {"channels"}
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
             "next_offset",
@@ -733,6 +749,42 @@ class TestCallingThem:
         assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
         assert obo.requested_scopes == [("https://graph.microsoft.com/Team.ReadBasic.All",)]
 
+    async def test_a_model_walks_from_its_teams_to_the_channels_of_one_of_them(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The channel path as far as it goes today, over the real protocol, with the id taken from
+        the previous answer exactly as a model would take it: which teams am I in, then what
+        channels are in this team.
+
+        Two things only an end-to-end call shows. The `team_id` this server hands out is the one it
+        accepts back, in that spelling, through the MCP schema and out again — an inventory whose
+        ids no other tool takes is an inventory nothing can be done with. And the token is redeemed
+        per tool, so a tenant that grants the team scope and withholds the channel one is refused at
+        the second step rather than the first; a tool that quietly asked for the registry's union
+        would take that distinction away without any schema changing.
+        """
+        teams = graph.get("/me/joinedTeams").mock(return_value=httpx.Response(200, json=_TEAMS))
+        listing = graph.get(_CHANNELS_PATH).mock(return_value=httpx.Response(200, json=_CHANNELS))
+
+        listed = _structured(await mcp_client.call_tool("list_teams", {}))
+        found = cast("Sequence[Mapping[str, object]]", listed["teams"])
+        team_id = found[0]["team_id"]
+        channels = _structured(await mcp_client.call_tool("list_channels", {"team_id": team_id}))
+        in_team = cast("Sequence[Mapping[str, object]]", channels["channels"])
+
+        assert (team_id, in_team[0]["channel_id"]) == (_TEAM_ID, _CHANNEL_ID)
+        assert in_team[0]["display_name"] == "General"
+        assert in_team[0]["membership_type"] == "standard"
+        assert all(route.called for route in (teams, listing))
+        assert listing.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert obo.requested_scopes == [
+            ("https://graph.microsoft.com/Team.ReadBasic.All",),
+            ("https://graph.microsoft.com/Channel.ReadBasic.All",),
+        ], "each tool exchanges a token for the permissions its own request needs"
+
     @pytest.mark.usefixtures("obo")
     async def test_a_collection_microsoft_never_ends_is_refused_in_eleven_requests(
         self,
@@ -1003,6 +1055,52 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "administrator" in message
         assert "synthetic-request-id" in message
         assert obo.requested_scopes
+
+    @pytest.mark.parametrize(
+        ("tool", "arguments", "path", "permission", "not_named"),
+        [
+            ("list_teams", {}, "/me/joinedTeams", "Team.ReadBasic.All", "Channel.ReadBasic.All"),
+            (
+                "list_channels",
+                {"team_id": _TEAM_ID},
+                _CHANNELS_PATH,
+                "Channel.ReadBasic.All",
+                "Team.ReadBasic.All",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("obo")
+    async def test_each_channel_tool_names_only_the_permission_its_own_request_needs(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        tool: str,
+        arguments: dict[str, str],
+        path: str,
+        permission: str,
+        not_named: str,
+    ) -> None:
+        """Two requests, two delegated permissions, and the whole reason the channel inventory is
+        not one scope: a tenant can grant either without the other, so naming the wrong one sends an
+        administrator after a permission that was never missing, which is as useless as naming none.
+        Graph's 403 says only that something was forbidden.
+        """
+        _ = graph.get(path).mock(
+            return_value=httpx.Response(
+                403,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(tool, arguments, raise_on_error=False)
+
+        assert result.is_error
+        message = _error_text(result)
+        assert permission in message
+        assert not_named not in message
+        assert "administrator" in message
+        assert "synthetic-request-id" in message
 
     @pytest.mark.usefixtures("obo")
     async def test_a_refused_search_names_both_permissions_it_was_made_under(

--- a/services/office-mcp/tests/tools/test_list_channels.py
+++ b/services/office-mcp/tests/tools/test_list_channels.py
@@ -1,0 +1,184 @@
+"""`list_channels`: what the query asks for, what it declines, and the pages it follows.
+
+Two of the assertions here are about parameters. `$select` is a requirement rather than an
+optimisation — Graph documents populating a channel's `email` as an expensive operation — and `$top`
+is one Graph answers with a 400, which `services/teams-mcp` shipped and had to take back out.
+
+Every payload is synthesised from Microsoft's documented shapes.
+"""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphForbidden
+from office_mcp.tools import list_channels as lister
+
+from .conftest import GRAPH_V1
+
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+_CHANNELS_PATH = f"/teams/{_TEAM_ID}/channels"
+
+
+def _channel_payload(
+    channel_id: str,
+    *,
+    display_name: str = "General",
+    membership_type: str = "standard",
+) -> dict[str, object]:
+    return {
+        "id": channel_id,
+        "displayName": display_name,
+        "description": "Synthetic channel",
+        "createdDateTime": "2026-01-04T12:00:00Z",
+        "membershipType": membership_type,
+    }
+
+
+class TestTheQueryItSends:
+    async def test_listing_channels_selects_around_the_expensive_property(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph documents populating a channel's `email` as an expensive operation, and `$select`
+        is the only way to decline it. `$top` is unsupported here too."""
+        route = graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [_channel_payload(_CHANNEL_ID)]})
+        )
+
+        _ = await lister.list_channels(client, team_id=_TEAM_ID, limit=10)
+
+        params = route.calls.last.request.url.params
+        assert params["$select"] == "id,displayName,description,createdDateTime,membershipType"
+        assert "email" not in params["$select"]
+        assert "$top" not in params, "$top is rejected on this collection"
+
+    @pytest.mark.parametrize("limit", [0, lister.MAX_CHANNELS + 1])
+    async def test_a_limit_outside_the_window_is_a_programming_error(
+        self, client: GraphServiceClient, limit: int
+    ) -> None:
+        """The tool's schema bounds `limit`, so a value outside it can only arrive from code that
+        bypassed it."""
+        with pytest.raises(AssertionError):
+            _ = await lister.list_channels(client, team_id=_TEAM_ID, limit=limit)
+
+
+class TestTheInventoryItReports:
+    async def test_the_channel_pages_are_followed_rather_than_read_once(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """This collection takes no `$top`, so Graph chooses the page size and a second page is
+        normal. teams-mcp read only the first one until it was fixed ("page teams/channels
+        lists"), which silently hid channels from the listing.
+        """
+        graph.get(_CHANNELS_PATH, params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(
+                200, json={"value": [_channel_payload("19:second@thread.tacv2")]}
+            )
+        )
+        graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_channel_payload(_CHANNEL_ID)],
+                    "@odata.nextLink": f"{GRAPH_V1}{_CHANNELS_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        listed = await lister.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+        assert [channel.channel_id for channel in listed.channels] == [
+            _CHANNEL_ID,
+            "19:second@thread.tacv2",
+        ]
+        assert len(listed.channels) < 25, "the walk reached the end of the collection"
+
+    async def test_an_empty_page_in_the_middle_does_not_end_the_collection(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The load-bearing case for the other half of what this answer promises: fewer channels
+        than `limit` is every channel of this team the user can see.
+
+        Graph answers the odd page with nothing in it and an `@odata.nextLink` still set, and the
+        SDK's own page walker reads an empty page as the end of a collection. Believing it here
+        would not merely drop a channel — it would turn a window with more behind it into "this
+        team has one channel", a claim about the user's own team that nothing checked. The
+        sentence in the description is therefore only true while every page is followed, and this
+        is the test that says so for this collection rather than for paging in general.
+        """
+        graph.get(_CHANNELS_PATH, params={"$skiptoken": "third"}).mock(
+            return_value=httpx.Response(
+                200, json={"value": [_channel_payload("19:third@thread.tacv2")]}
+            )
+        )
+        graph.get(_CHANNELS_PATH, params={"$skiptoken": "second"}).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [],
+                    "@odata.nextLink": f"{GRAPH_V1}{_CHANNELS_PATH}?$skiptoken=third",
+                },
+            )
+        )
+        graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_channel_payload(_CHANNEL_ID)],
+                    "@odata.nextLink": f"{GRAPH_V1}{_CHANNELS_PATH}?$skiptoken=second",
+                },
+            )
+        )
+
+        listed = await lister.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+        assert [channel.channel_id for channel in listed.channels] == [
+            _CHANNEL_ID,
+            "19:third@thread.tacv2",
+        ]
+
+    async def test_a_channels_membership_type_comes_through_and_an_unknown_one_does_not_fail(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A `membershipType` the SDK's generated enum has no member for deserializes to None
+        rather than raising, so the channel must still be listed."""
+        graph.get(_CHANNELS_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _channel_payload(_CHANNEL_ID, membership_type="private"),
+                        _channel_payload("19:future@thread.tacv2", membership_type="hypothetical"),
+                    ]
+                },
+            )
+        )
+
+        listed = await lister.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+        assert [channel.membership_type for channel in listed.channels] == ["private", None]
+        created = listed.channels[0].created_at
+        assert created is not None and created.year == 2026
+
+
+class TestGraphFailures:
+    async def test_a_refusal_arrives_classified_for_the_tool_to_explain(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """This request is made under its own delegated permission — a tenant commonly grants the
+        two basic ones and withholds the broad message permission — so the failure has to reach the
+        tool layer, which is what names the permission."""
+        denied = httpx.Response(
+            403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+        )
+        graph.get(_CHANNELS_PATH).mock(return_value=denied)
+
+        with pytest.raises(GraphForbidden):
+            _ = await lister.list_channels(client, team_id=_TEAM_ID, limit=25)
+
+    def test_the_permission_is_the_one_microsoft_documents(self) -> None:
+        """A tool owns the permission its own request needs, and listing channels is the cheap
+        "basic" scope — reading what was posted in one is the broader `ChannelMessage.Read.All`."""
+        assert lister.GRAPH_PERMISSIONS == ("Channel.ReadBasic.All",)


### PR DESCRIPTION
# `list_channels` — the channels of one team the signed-in user can see

`list_teams` names a team and stops there. This is the tool that gets inside one: given a
`team_id`, the channels in it — id, name, description, membership type, creation date. No message
content, and no new machinery. It is the second half of the channel inventory, and the first tool
on this connector to take an id another tool minted.

## What it answers, and why the pair is the unit

A channel id addresses nothing on its own. Every team has a `General`, so a channel *name* is
unique only inside its team, and Graph's own path for a channel message is
`/teams/{team_id}/channels/{channel_id}/messages/{id}` — team first, always. That is why this tool
takes a `team_id` rather than offering to find a channel by name, and why the answer's field
descriptions say the id addresses a channel only together with its team's. `read_message` already
takes a handle carrying both; this is where a model gets them from something other than a search
hit.

The other thing it answers is the naming question `list_teams` answers one level up.
`search_messages` reports a bare `channel_id` on every channel hit. Until now nothing could turn
that into "the release channel in Engineering". Now something can.

## Decisions worth knowing

**`$select` is a requirement here, not an optimisation.** Microsoft documents populating a
channel's `email` as "an expensive operation that results in slow performance", and there is no
switch for it other than selecting around it. So the field list is load-bearing and the test asserts
it against the query that actually goes on the wire — an unnoticed missing `$select` is a listing
that got slower for nobody's benefit, and nothing else would report it.

**No `$top` on `/teams/{id}/channels` either — documented unsupported.** The same reference gives
this collection `$select` and `$filter` and nothing else. `services/teams-mcp` shipped a `$top` here
and had to take it back out, so sending one buys a 400 rather than a narrower answer. `limit` is
therefore a window this connector applies while walking the pages Graph chose, exactly as
`list_teams` does, and `MAX_CHANNELS` bounds how many Graph requests one call may spend rather than
anything Graph would refuse.

**"Fewer than `limit` is all of them" is proved by test, not carried across.** That sentence is the
whole completeness signal on this surface — no flag, no cursor — and it is only true while the walk
follows Microsoft's paging to the end. Graph answers the odd page with nothing in it and an
`@odata.nextLink` still set, and the SDK's own walker reads that as the end of the collection.
Believing it would not merely drop a channel; it would turn a window with more behind it into "this
team has one channel", a claim about the user's own team that nothing checked. The test that says so
for *this* collection is what makes the sentence shippable. It was checked by breaking the walk: with
an empty page treated as the end, that test is the only one in the file that fails.

**The answer says what it cannot see.** Graph trims this collection to the caller — private and
shared channels they are not a member of are simply absent, not marked absent. So the description
says an absent channel is not evidence the team has no such channel, rather than leaving a model to
conclude it, and `membership_type` names which kind each visible channel is. A `membershipType` this
connector predates deserializes to `None` rather than raising, and a channel whose kind we cannot
name is still a channel that has to be listed.

**Two permissions for the channel inventory, on purpose.** `Channel.ReadBasic.All` is Microsoft's
least-privileged delegated scope over a channel's identity, which is all this collection returns,
and it needs no administrator. Reading what was *posted* in a channel is the broad
`ChannelMessage.Read.All` that most tenants gate behind admin consent. Keeping them separate is what
a tenant actually uses: refusing the broad one still leaves the inventory readable, and each tool's
403 names only the permission its own request needed rather than sending an administrator after one
that was never missing. That is asserted end to end, per tool, and not merely written in the README.

## What it adds to `shared/`

Nothing — and that is the decision, not an omission.

The tempting candidates are both non-vocabulary. The page-size ceiling is one: `list_channels` picks
the same number `list_teams` picked, over a different Graph collection, and two tools agreeing about
a number is not agreement about a *meaning*. Either is free to change it tomorrow without the other
being wrong, so a shared constant would create a coupling the domain does not have. The other is the
prose about paging a `$top`-less collection, which reads nearly the same in both files — and prose
that two tools share is prose that has stopped being about the tool it is on. Rule 4 exists for
exactly this, and the honest answer here is that this tool leans on `shared/seam.py` for its token
and its refusal wording, on `graph_client/` for the transport and the walk, and on nothing else.

Vocabulary is what two tools must not be free to disagree about — the `teams:///` grammar, the shape
of a message, who the signed-in user is. A window size and a paragraph are neither.

## Layering

No rule becomes newly assertable at this level. The one rule still absent (rule 7, no module
addresses a single meeting recording) needs a recordings listing to be the surface it protects, and
its anti-vacuity guard would still fail here; it arrives with the tool that lists them, exactly as
`tests/test_layering.py` says it will. Every rule that *is* asserted keeps working unchanged: this
tool imports `shared/seam.py`, `graph_client/` and FastMCP and nothing else of the package, names no
sibling, spells no handle, and enters every package through its `__init__`.

What does get exercised for the first time is rule 4's reason for existing rather than rule 4
itself. `list_teams` and `list_channels` are the first pair of tools where one's answer is the
other's argument, and they still share no code, no constant and no sentence — the connection between
them is a `team_id` on the wire and two paragraphs that each argue their own side of it.

## Fallout, deliberately included

`list_teams` shipped a description saying "No tool here takes a team id as an argument". It was true
when it was written and this PR makes it false, so it is corrected here, in its own commit. A
description is live protocol surface: a stale sentence does not send a model somewhere that fails
loudly, it talks the model out of a call that would have worked. No name, argument, field or
permission of `list_teams` changes — prose only.

