### PR TITLE
feat(office-mcp): walk one channel’s posts and their newest replies

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,10 +2,13 @@
 
 An MCP server for Microsoft 365 via Microsoft Graph API.
 
-Users sign in with their own Microsoft account; the server acts as them. Six MCP tools are available:
-`get_me` (profile), `list_chats` (chats by recency), `list_teams` (teams the user is in), `list_channels`
-(channels in one team), `search_messages` (full-text search), and `read_message` (one message in full).
-Each tool is one file; more land in later PRs, one tool per PR.
+Users sign in with their own Microsoft account and the server acts as them. It exposes seven MCP
+tools so far — `get_me`, the signed-in user's own profile; `list_chats`, their Microsoft Teams chats
+most recently active first; `list_teams`, the teams they are a member of; `list_channels`, the
+channels of one of those teams; `browse_channel`, what was posted in one of those channels;
+`search_messages`, full-text search across every Teams message they can see; and `read_message`,
+one of those messages in full — each one a file of its own, and more land in later PRs, stacked on
+top of this one, one tool per PR.
 
 ## Layout
 
@@ -77,7 +80,7 @@ Tools redeem permissions per call via On-Behalf-Of. No permission = no consent =
 | `Chat.Read` | Delegated | No | `list_chats`, `search_messages`, `read_message` |
 | `Team.ReadBasic.All` | Delegated | No | `list_teams` |
 | `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
-| `ChannelMessage.Read.All` | Delegated | Usually | `search_messages`, `read_message` (channels) |
+| `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
 
 Multiple tools naming the same permission is normal. It is not duplication to remove. Each tool
 declares its own tuple because that tuple words its own 403 and AADSTS65001 messages.
@@ -96,10 +99,23 @@ administrator handed two names may grant the one that was never missing. Search 
 surface beforehand, so it names both. `shared/seam.py` lists both in `REQUESTABLE_PERMISSIONS`:
 misspelling is on both sides.
 
-`ChannelMessage.Read.All` requested deliberately. `Chat.Read` alone lets Graph *accept* searches
-but Microsoft docs say searches never return more than GET would. All channel GET needs
-`ChannelMessage.Read.All`. Without it, searches silently cover chats only. Asking at sign-in makes
-tenants that withhold it fail visibly at consent, not serve incomplete results.
+`ChannelMessage.Read.All` is the broad one, and it is requested deliberately. `Chat.Read` alone is
+enough for Graph to *accept* a `chatMessage` search, but Microsoft documents that a search never
+returns more than the equivalent GET would, and every channel-message GET in v1.0 requires
+`ChannelMessage.Read.All` — so without it a search silently covers chats only and reports nothing
+missing. Asking for it at sign-in makes a tenant that withholds it fail visibly at consent rather
+than serve half an answer per query. It is also what `browse_channel` spends on its one request, and
+what `read_message` needs for a channel message. It is the first permission here that needs an
+administrator, and the first row where one tool needs
+two: neither Graph's 403 nor Entra's AADSTS65001 says which of the two was missing, so
+`search_messages` names both in every refusal — handed one name, an administrator may grant the
+permission that was never missing and watch the identical failure. A search has no choice about
+that, because a search happens before anything knows which surface a hit will be on; a *read* does,
+which is why its 403 names one. `shared/seam.py` writes the same names out once more, by hand, as
+`REQUESTABLE_PERMISSIONS`: every other check compares the tool files against a list derived from
+those same files, so a misspelling is on both sides of the comparison and holds — and Entra rejects
+an authorize request carrying a scope it does not know, which fails every sign-in for every user.
+Adding a name there is the deliberate act this table records.
 
 The channel inventory is two permissions, and they are separate scopes on purpose:
 `Channel.ReadBasic.All` lists a team's channels, `ChannelMessage.Read.All` reads what was posted in
@@ -116,24 +132,38 @@ with key from client secret. Rotating the secret requires each user to re-login 
 
 `graph_client/` wraps the official msgraph-sdk (no token acquisition; FastMCP provides token).
 
-- **One transport, many callers:** `create_graph_transport` builds the `httpx.AsyncClient` once.
-  `graph_client_for(transport, token)` wraps it per call. Per-call clients leak TLS and pools.
-
-- **Throttling built-in:** SDK retries 429/503/504 three times. Timeouts return `GraphThrottled`.
-
-- **Four error types:** `GraphThrottled` (429), `GraphForbidden` (401/403), `GraphNotFound` (404),
-  `GraphUnavailable` (5xx/unreachable). Wrap Graph work with `with graph_errors():`.
-
-- **Paging:** Follows `@odata.nextLink` via `collect_pages` (item/scan caps). Search uses offsets.
-
-- **TRAP: Empty pages with `@odata.nextLink` mean keep going.** SDK's `PageIterator` treats empty
-  pages as end-of-collection. A collection like `[1 item+link]`, `[empty+link]`, `[3 more]`
-  becomes one item. List tools here claim "end" only by returning short of `limit`.
-  `collect_pages` follows empties (bounded by `MAX_EMPTY_PAGES`, not scan budget) or raises
-  `GraphPagingUnending`—short answers mean the limit applied.
-
-- **TRAP:** SDK bearer provider doesn't validate allowed hosts. Redirects to non-Graph URLs send
-  delegated credentials. Restrict to `graph.microsoft.com`.
+- **One transport, many callers.** `create_graph_transport(settings)` builds the `httpx.AsyncClient`
+  — connection pool plus the SDK's middleware pipeline — once, and `graph_client_for(transport,
+  token)` wraps it per call. The token is the only thing that varies; a client per call would mean
+  a TLS handshake per call and a leaked pool.
+- **Throttling is the SDK's, deliberately.** Its retry middleware already waits out `Retry-After`
+  on 429/503/504 (on `asyncio.sleep`, not a blocking one) three times, which is exactly Graph's
+  documented contract. Nothing here re-implements it and there is no rate limiter. What is added is
+  the *typed* outcome: when the retries are outlasted, callers get `GraphThrottled` carrying
+  `retry_after_seconds`, not a status code to re-interpret.
+- **Errors are four categories**, because those are the four remedies: `GraphThrottled` (429),
+  `GraphForbidden` (401/403), `GraphNotFound` (404) and `GraphUnavailable` (5xx, or never reached).
+  Wrap Graph work in `with graph_errors():`. Anything else stays the base `GraphFailure`.
+- **Paging follows `@odata.nextLink`** via `collect_pages`, replaying the URL verbatim, with an item
+  cap, a *scan* cap — the teams-mcp lesson that a filtered collection can walk a long way for very
+  few kept items — a bound on how many pages of nothing it will follow in a row, and a `capped` flag
+  so a partial answer never looks complete. A channel's messages are the exception and are not
+  walked at all: Graph allows about one request a second on a given channel for the whole app across
+  the tenant, so `browse_channel` makes exactly one and `$top` is its window. Search is not paged
+  this way either: `POST /search/query` takes stateless `from`/`size` offsets, so a search tool
+  resumes by re-issuing rather than by carrying a cursor.
+- **An empty page carrying a next link means keep going, and the walk is ours because of it.** The
+  SDK's `PageIterator.enumerate` returns `False` for a page whose `value` is empty and its `iterate`
+  reads that as the end of the collection — so a collection Graph answers `[1 item + nextLink]`,
+  `[nothing + nextLink]`, `[3 more]` came back as one item. Every list-shaped tool here says "that
+  is all of it" by coming back short of `limit`, so believing an empty page does not merely lose
+  items: it turns a window with more behind it into a claim that there is not. `collect_pages` walks
+  through them, bounds a *run* of them (`MAX_EMPTY_PAGES`, and it is not pooled with the scan cap:
+  an empty page spends no scan budget, so a shared budget is no bound on empty pages at all), and
+  raises `GraphPagingUnending` rather than answering short — because a short answer means a cap.
+- **The caller's token goes to `graph.microsoft.com` and nowhere else.** The SDK's bearer provider
+  does not check its own allowed-hosts validator, so a redirect or an off-Graph `nextLink` would
+  otherwise be handed a user's delegated credential.
 
 ## Run locally
 

--- a/services/office-mcp/src/office_mcp/graph_client/pagination.py
+++ b/services/office-mcp/src/office_mcp/graph_client/pagination.py
@@ -15,6 +15,13 @@ empty pages: if it carries nextLink, keep going.
 Empty run bound: Following empty pages needs its own bound separate from item cap. `MAX_EMPTY_PAGES`
 is that bound, counted per run on its own—never pooled with item budget.
 
+A channel's messages are deliberately not walked here at all, and they are the collection the scan
+cap was written against — which is worth saying in the same breath. Filtering them after the fact
+is exactly the shape that cap exists for, but the throttling limit above is per *app* per tenant on
+a given channel, so even a capped walk spends a budget that belongs to every other user of this
+connector. `browse_channel` therefore makes one request, uses `$top` as its window, and never comes
+here; the cap is for collections whose cost is the caller's own.
+
 Search paging not handled: POST /search/query uses from/size offsets, not cursors.
 """
 

--- a/services/office-mcp/src/office_mcp/shared/__init__.py
+++ b/services/office-mcp/src/office_mcp/shared/__init__.py
@@ -2,7 +2,7 @@
 
 Every tool in `tools/` is a file of its own — its name, its description, its Graph permissions, its
 arguments, its answer shape, its Graph request and its own error wording all in one place, so that
-adding the third tool is adding one file and reading the second is reading one file. That is the
+adding the eighth tool is adding one file and reading the seventh is reading one file. That is the
 whole point, and it has exactly one cost: two files are free to disagree. This package is the list
 of things they must not.
 
@@ -11,12 +11,17 @@ difference between the copies would be a bug a caller could see:
 
 * `handles.py` — the `teams:///` grammar. A handle minted by one tool and read by another is only
   readable while there is one definition of it; two spellers would not look like a disagreement,
-  they would look like a handle one tool produced and another answers 404 to.
-* `messages.py` — what a Teams message is. A message a search found and the same message read by
-  handle are the same type, normalised by the same function, or the two tools answer differently
+  they would look like a handle one tool produced and another answers 404 to. The reply shape is
+  the clearest case: only `browse_channel` can mint one and only `read_message` resolves it, and
+  neither of them spells it.
+* `messages.py` — what a Teams message is. A message browsed in a channel and the same message read
+  by handle are the same type, normalised by the same function, or the two tools answer differently
   about the same message. The sender is where Graph's projections visibly differ — a search hit
   carries a mailbox-shaped `emailAddress` and every Teams read a `teamworkUserIdentity` with no
   email at all — and the Teams HTML a body arrives as is what nothing above here should ever see.
+  It also holds `MAX_REPLIES_PER_POST`, the window on a channel thread: `browse_channel` applies
+  it, and `search_messages` and `read_message` both have to describe it to explain why a reply a
+  search found may have no handle that reads.
 * `identity.py` — who the signed-in user is. `get_me` reports it; it is also the fact every other
   answer on this connector is correlated against, so a second tool asking it with a `GET /me` of
   its own would be a second answer to one question.

--- a/services/office-mcp/src/office_mcp/shared/handles.py
+++ b/services/office-mcp/src/office_mcp/shared/handles.py
@@ -5,23 +5,22 @@ shape must exist. Two modules spelling `teams:///meetings/…` would silently di
 lives here, not in tool files. This is the only module that spells or parses these URIs (enforced
 by tests/test_layering.py).
 
-## The three shapes, and why they are three
+## The four shapes, and why they are four
 
-Two of them are Graph's ways of addressing a Teams message
+Three of them are Graph's three ways to address a Teams message
 (https://learn.microsoft.com/en-us/graph/api/chatmessage-get):
 
     teams:///chats/{chatId}/messages/{messageId}
     teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}
+    teams:///teams/{teamId}/channels/{channelId}/messages/{rootId}/replies/{replyId}
 
-Graph has a third — a reply in a channel thread is addressed *under* the post it answers,
-`…/messages/{rootId}/replies/{replyId}` — and it is deliberately not written yet. The search
-projection carries no `replyToId`, so nothing this connector has can tell a reply from a root post;
-a shape no tool can mint is a shape nothing has checked the spelling of, and it belongs with the
-tool that walks a channel post by post and therefore knows each reply's parent. Which is also why a
-channel hit that is really a reply gets the root-post shape above: it is the only true thing a
-search can say about where that message lives.
+The third is the one a search cannot mint. Graph addresses a reply in a channel thread *under* its
+parent post, and the search projection carries no `replyToId` — so a channel hit that is really a
+reply becomes the second shape, which Graph answers 404 to. `browse_channel` walks a channel post
+by post and therefore knows each reply's parent, which is why it is what mints this shape and why
+the shape lives here rather than there.
 
-The third shape: `teams:///meetings/{joinWebUrl}`. A meeting is addressed by join URL because that
+The fourth shape: `teams:///meetings/{joinWebUrl}`. A meeting is addressed by join URL because that
 is the only route Microsoft Graph gives a delegated caller from chat to meeting. The chat
 collection's default projection carries `onlineMeetingInfo.joinWebUrl` and Graph's onlineMeetings
 lookup matches it byte-for-byte. Nothing else—no chat id, topic, or date—turns into one.
@@ -69,6 +68,7 @@ class MessageHandle:
     chat_id: str | None = None
     team_id: str | None = None
     channel_id: str | None = None
+    reply_to_id: str | None = None
 
     @property
     def permission(self) -> str:
@@ -84,6 +84,11 @@ class MessageHandle:
             "a handle addresses either a chat or a team channel"
         )
         channel = f"teams:///teams/{_segment(self.team_id)}/channels/{_segment(self.channel_id)}"
+        if self.reply_to_id is not None:
+            return (
+                f"{channel}/messages/{_segment(self.reply_to_id)}"
+                + f"/replies/{_segment(self.message_id)}"
+            )
         return f"{channel}/messages/{_segment(self.message_id)}"
 
 
@@ -102,11 +107,14 @@ class MeetingHandle:
 # above percent-encode each one.
 _CHAT_HANDLE = re.compile(r"\Ateams:///chats/([^/]+)/messages/([^/]+)\Z")
 _CHANNEL_HANDLE = re.compile(r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)\Z")
+_REPLY_HANDLE = re.compile(
+    r"\Ateams:///teams/([^/]+)/channels/([^/]+)/messages/([^/]+)/replies/([^/]+)\Z"
+)
 _MEETING_HANDLE = re.compile(r"\Ateams:///meetings/([^/]+)\Z")
 
 
 def message_handle(uri: str) -> MessageHandle | None:
-    """`uri` as a message handle, or None if it is not one this connector can address.
+    """`uri` as a message handle, or None if it is not one this connector can read.
 
     None rather than an exception carrying advice: what to tell a caller about a malformed handle
     is the tool boundary's business, and each reader's advice names its own shapes and its own
@@ -116,6 +124,17 @@ def message_handle(uri: str) -> MessageHandle | None:
     if chat is not None:
         chat_id, message_id = (unquote(part) for part in chat.groups())
         return _message_handle(MessageHandle(message_id=message_id, chat_id=chat_id))
+    reply = _REPLY_HANDLE.match(uri)
+    if reply is not None:
+        team_id, channel_id, root_id, message_id = (unquote(part) for part in reply.groups())
+        return _message_handle(
+            MessageHandle(
+                message_id=message_id,
+                team_id=team_id,
+                channel_id=channel_id,
+                reply_to_id=root_id,
+            )
+        )
     channel = _CHANNEL_HANDLE.match(uri)
     if channel is not None:
         team_id, channel_id, message_id = (unquote(part) for part in channel.groups())
@@ -143,7 +162,13 @@ def meeting_uri_for(join_web_url: str | None) -> str | None:
 
 def _message_handle(handle: MessageHandle) -> MessageHandle | None:
     """The handle, unless a segment decoded to nothing — `%20` is not an id."""
-    ids = (handle.message_id, handle.chat_id, handle.team_id, handle.channel_id)
+    ids = (
+        handle.message_id,
+        handle.chat_id,
+        handle.team_id,
+        handle.channel_id,
+        handle.reply_to_id,
+    )
     if any(value is not None and not value.strip() for value in ids):
         return None
     return handle

--- a/services/office-mcp/src/office_mcp/shared/messages.py
+++ b/services/office-mcp/src/office_mcp/shared/messages.py
@@ -1,11 +1,11 @@
 """What a Teams message is: the shape it is answered in, and the HTML it is unwound from.
 
-Two tools answer with a message or part of one — a search hit and a single read — and Graph hands
-each of them a different projection of the same thing. A message therefore has to mean the same
-thing whichever tool produced it, and that is a property of there being one definition rather than
-of two agreeing: a message a search found and the same message read by handle are the same type,
-normalised by the same function, with the same sender shape and the same test for "did a person
-write this".
+Three tools answer with a message or part of one — a search hit, a channel post and its replies, a
+single read — and Graph hands each of them a different projection of the same thing. A message
+therefore has to mean the same thing whichever tool produced it, and that is a property of there
+being one definition rather than of three agreeing: a post browsed in a channel and a message read
+by handle are the same type, normalised by the same function, with the same sender shape and the
+same test for "did a person write this".
 
 What the normalisation has to survive, all of it documented and none of it optional:
 
@@ -28,8 +28,9 @@ What the normalisation has to survive, all of it documented and none of it optio
   client and Graph never sends it (https://learn.microsoft.com/en-us/graph/system-messages). A
   search drops these and a read that lands on one has to say what the event *was*, from
   `eventDetail` — two behaviours over one question, which is why `event_of` is the one place that
-  answers it rather than each tool having its own opinion about what counts as a message somebody
-  wrote.
+  answers it. A channel listing filters by the same call: Graph offers no server-side `messageType`
+  filter on that collection, so the filtering is client-side, and it has to ask the same question a
+  read does or the two tools disagree about what a message is.
 * **Deleted and edited messages exist.** `deletedDateTime` and `lastEditedDateTime` are read-only
   properties of `chatMessage`; a tombstone must not be presented as live content.
 * **`mentions[]` and `attachments[]` are the key to the body.** The body carries `<at id="0">` and
@@ -37,6 +38,10 @@ What the normalisation has to survive, all of it documented and none of it optio
   resolved. A *card* is one of those attachments and nothing else: Graph marks it by the
   attachment's `contentType`, so that — never the shape of the body text — is what says a message
   is a card here.
+
+One number lives here for the same reason the shape does: `MAX_REPLIES_PER_POST`, how far back into
+a channel thread a reply is reachable at all. One tool applies it and two others *describe* it —
+which is exactly the shape of a fact that must not be spelled twice.
 """
 
 import html
@@ -54,6 +59,30 @@ from msgraph.generated.models.chat_message_type import ChatMessageType
 from pydantic import BaseModel, Field
 
 from office_mcp.shared.handles import MessageHandle
+
+# How many of a post's replies a channel browse returns, and so how far back a reply is reachable in
+# this connector at all. Shared vocabulary rather than the browser's own, because two tools that
+# never apply it have to *describe* it: a search hit that is really a channel reply carries a handle
+# Graph answers 404 to, and the reader's explanation of that 404 names this window as the only place
+# a reply's own handle can be minted from. A second spelling of the number is a refusal telling a
+# caller to look somewhere the browser does not reach.
+#
+# `$expand=replies` brings back up to 200 replies per post, and 50 posts of 200 replies is a
+# response no caller has a budget for — so the newest of each thread are kept, and a thread that
+# came back full to this window is one that may have older replies, exactly as a full page is
+# elsewhere here.
+#
+# This window is the end of the line rather than a first page. Graph puts its own cursor on a post
+# whose expanded replies were themselves paged, and following it is a request per post against a
+# channel that allows the whole app one a second — the same reason a channel's own pages are not
+# walked. That cursor needs no separate reporting: Graph expands up to 200 replies before it pages
+# them, so a thread it paged has far more than this window holds and the window comes back full. So
+# a reply older than this window has no route to its full text here: a search can find it and report
+# Microsoft's snippet, but Graph addresses a reply under the post it answers and the search index
+# does not name that post, so such a hit cannot be read. Browsing again returns the same newest
+# replies, which is why every surface that mentions this says so rather than sending a caller back
+# round.
+MAX_REPLIES_PER_POST = 10
 
 
 class MessageSender(BaseModel):
@@ -280,7 +309,9 @@ def message_of(message: ChatMessage, *, handle: MessageHandle) -> TeamsMessage:
         created_at=message.created_date_time,
         last_edited_at=message.last_edited_date_time,
         deleted_at=message.deleted_date_time,
-        reply_to_id=message.reply_to_id,
+        # The handle is the fallback rather than the source: it names a parent only for a reply,
+        # while Graph sets `replyToId` on every message in a channel thread.
+        reply_to_id=message.reply_to_id or handle.reply_to_id,
         subject=message.subject,
         # `ChatMessageImportance` subclasses `str`, so the member is its own wire value.
         importance=message.importance,

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -16,6 +16,7 @@ from fastmcp import FastMCP
 
 from office_mcp.shared.seam import graph_scope
 from office_mcp.tools import (
+    browse_channel,
     get_me,
     list_channels,
     list_chats,
@@ -41,6 +42,7 @@ _TOOL_MODULES: tuple[ToolModule, ...] = (
     list_chats,
     list_teams,
     list_channels,
+    browse_channel,
     search_messages,
     read_message,
 )

--- a/services/office-mcp/src/office_mcp/tools/browse_channel.py
+++ b/services/office-mcp/src/office_mcp/tools/browse_channel.py
@@ -6,15 +6,18 @@ across every chat and channel, not one. `read_message` reads a message by handle
 Four design decisions:
 
 **Order is thread activity, not post date.** Graph sorts by reply-chain last modified, so a
-two-year-old post moves to the first page when someone replies to it. This order is preserved.
-Read `created_at` to know when a post was written, not its position here.
+two-year-old post moves to the first page when someone replies to it. This order is kept, not
+corrected — re-sorting would invent an order Graph never gave. Read `created_at` to know when a
+post was written, not its position here. The same order rules out paging by date: a walk could
+never tell when it had gone back far enough.
 
 **One request only.** Graph rate-limits channel reads to one request per second for this app
 across the tenant. This tool makes one request: `$top` is the window, the single page Graph
 answers with is the result.
 
 **No date filter.** This collection accepts only `$top` and `$expand=replies`, no `$filter`.
-Use `search_messages` with `sent_after`/`sent_before` to search by date.
+Graph documents no `$orderby` for it either. Use `search_messages` with
+`sent_after`/`sent_before` to search by date.
 
 **Cannot tell if a page is the whole channel.** System messages are dropped after Graph counts them,
 so a short page is not proof the channel is empty. Graph's `@odata.nextLink` on the page says if
@@ -56,7 +59,8 @@ TOOL_NAME = "browse_channel"
 # Several tools declare one permission; deduplication is the registry's job.
 GRAPH_PERMISSIONS: tuple[str, ...] = (CHANNEL_PERMISSION,)
 
-# Built at import time. A parameter default call rebuilds the descriptor on every registration.
+# Built at import time. A parameter default call rebuilds the descriptor on every registration,
+# which trips a lint error in both of this repo's checkers.
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
 # Graph's documented ceiling on `$top` for a channel's messages — the whole of one request.
@@ -182,7 +186,8 @@ async def browse_channel(
         )
         assert page is not None, "Graph answered a channel message listing with no collection"
 
-    # The window is this tool's promise, not Graph's, so apply it rather than trust it.
+    # `$top` is `limit`, so Graph should never send back more than that — but the window is
+    # this tool's promise, not Graph's, so apply it rather than trust it.
     posts = [message for message in (page.value or []) if _is_a_post(message)]
     kept = posts[:limit]
 

--- a/services/office-mcp/src/office_mcp/tools/browse_channel.py
+++ b/services/office-mcp/src/office_mcp/tools/browse_channel.py
@@ -1,50 +1,30 @@
-"""`browse_channel` — one Teams channel's posts, each followed by the replies to it.
+"""`browse_channel` — one Teams channel's posts with their newest replies.
 
-The one thing the other message tools cannot do: walk a single channel. `search_messages` finds
-messages by keyword across every chat and channel at once and cannot be scoped to one of them;
-`read_message` reads a message somebody already has a handle for. This is the tool for "what is
-going on in this channel".
+Walk one channel — the only message tool that can. `search_messages` finds messages by keyword
+across every chat and channel, not one. `read_message` reads a message by handle.
 
-Four things make it what it is, and each of them is a decision rather than a detail.
+Four design decisions:
 
-**The order is thread activity, not post recency.** Graph sorts this collection "by the last
-modified date of the entire reply chain, including both the root channel message and its replies"
-(https://learn.microsoft.com/en-us/graph/api/channel-list-messages), so a two-year-old post returns
-to the first page the moment somebody replies to it. That order is preserved rather than corrected —
-reordering it would be inventing an order Graph did not give — and `created_at` is what tells the
-truth about age. It also makes "stop paging once a page is older than X" an unsound stop condition:
-a walk down this collection could not know when it had gone back far enough, which is one of the two
-reasons there is no walk.
+**Order is thread activity, not post date.** Graph sorts by reply-chain last modified, so a
+two-year-old post moves to the first page when someone replies to it. This order is preserved.
+Read `created_at` to know when a post was written, not its position here.
 
-**There is no sweep, and that is the other reason.** Graph caps reads at "one request per second per
-app per tenant … on a given channel" (https://learn.microsoft.com/en-us/graph/throttling-limits),
-and that budget is per *app* — so walking every channel of a team degrades every other user in the
-tenant, and following `@odata.nextLink` down one channel spends the tenant's whole budget for that
-channel on one caller. This tool therefore issues exactly one request: `$top` is the window and the
-single page Graph answers with is the answer. A caller who needs a wider window raises `limit`;
-searching across channels is `search_messages`'s job.
+**One request only.** Graph rate-limits channel reads to one request per second for this app
+across the tenant. This tool makes one request: `$top` is the window, the single page Graph
+answers with is the result.
 
-**It cannot be date-bounded at all.** `$top` and `$expand=replies` are the only parameters this
-collection takes — "The other OData query parameters aren't currently supported" — so there is no
-`$filter` and no `$orderby`, and no date parameter is offered rather than one being faked.
-`search_messages` puts a date into the search index instead, for the price of the one request it was
-making anyway.
+**No date filter.** This collection accepts only `$top` and `$expand=replies`, no `$filter`.
+Use `search_messages` with `sent_after`/`sent_before` to search by date.
 
-**That one page is the one place here where "was that everything?" is not derivable.** Everywhere
-else a page short of `limit` is the end of the collection, because the walk underneath followed
-Graph's paging to it; here nothing is followed, and system messages are dropped out of the page
-after Graph counted them into it, so a short answer says nothing either way. What does say something
-is Graph's own `@odata.nextLink` on that page — an accurate read, and the only one available — so it
-is reported, opt-in, as `ChannelPosts` explains.
+**Cannot tell if a page is the whole channel.** System messages are dropped after Graph counts them,
+so a short page is not proof the channel is empty. Graph's `@odata.nextLink` on the page says if
+more exists — reported via `include_window_completeness`.
 
-What this file does not own is the handle grammar (`shared/handles.py`, so that the reply handle
-this mints is the one `read_message` resolves — and this is the only tool that can mint it, because
-Graph addresses a reply under the post it answers and a search projection carries no `replyToId`),
-the message shape and its Teams-HTML normaliser, which also holds the reply window
-(`shared/messages.py`, so that a post browsed here and a message read by handle are the same thing
-rather than two that agree, and so that `read_message`'s 404 advice names the same number this
-window is), and the token and refusal wording (`shared/seam.py`). Everything else — the name, the
-description, the permission, the arguments, the answer shape and the request — is here.
+This file owns the name, description, permission, arguments, answer shape and request. The handle
+grammar lives in `shared/handles.py` (so the reply handle this tool mints is what `read_message`
+resolves and this is the only tool that can mint it). The message shape and Teams HTML normaliser
+live in `shared/messages.py` (so a post browsed and a message read are the same type). Token and
+error text live in `shared/seam.py`.
 """
 
 from datetime import UTC, datetime
@@ -72,125 +52,85 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "browse_channel"
 
-# The one delegated permission this tool's one request needs: the broad message permission, which is
-# also what buys `search_messages` its channel coverage. It is imported rather than respelled —
-# which surface a Teams message is read under is handle vocabulary, and a second spelling of
-# `ChannelMessage.Read.All` is a second thing to keep true. Several tools declaring one permission
-# is what the registry's deduplication is for, and none of them may leave it out.
+# Import CHANNEL_PERMISSION to avoid misspelling — handle vocabulary owns surface permissions.
+# Several tools declare one permission; deduplication is the registry's job.
 GRAPH_PERMISSIONS: tuple[str, ...] = (CHANNEL_PERMISSION,)
 
-# Built once at import: a call inside a parameter default rebuilds the descriptor on every
-# registration and is a lint error in both of this repo's checkers.
+# Built at import time. A parameter default call rebuilds the descriptor on every registration.
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
-# Graph's documented ceiling on `$top` for a channel's messages, and so the widest window one call
-# can answer with: the call is one request and `$top` is the whole of it.
+# Graph's documented ceiling on `$top` for a channel's messages — the whole of one request.
 MAX_POSTS = 50
 
 type _MessagesQuery = MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters
 
 _DESCRIPTION = f"""\
-Read what was posted in one Microsoft Teams channel: its posts with their full text, each followed \
-by the replies to it. Takes the `team_id` and `channel_id` list_teams and list_channels returned.
+Read a Teams channel's posts with their replies. Take `team_id` and `channel_id` from list_teams \
+and list_channels.
 
-This is the one thing the other message tools cannot do — walk a single channel in order. \
-search_messages finds messages by keyword across every chat and channel at once but cannot be \
-scoped to one channel, and read_message reads a single message you already have a handle for. \
-Reach for this when the question is "what is going on in this channel" rather than "where was this \
-mentioned". Do not call it for channel after channel: Microsoft rate-limits reads of a given \
-channel to about one request a second for this whole connector across the tenant, so a sweep is \
-slow for you and harmful to everyone else on it — search_messages covers every channel in one \
-request. This call spends exactly one request of that budget: it reads the single page Microsoft \
-answers with and never pages deeper, so `limit` is the whole window and widening `limit` — not \
-calling again — is how to see more.
+This is the only message tool that walks one channel. `search_messages` finds messages by keyword \
+across channels and chats (not scoped to one). `read_message` reads a single message by handle. \
+Use this when you need to know "what is in this channel".
 
-**The order is not what it looks like.** Microsoft sorts this collection by the last modified time \
-of the entire reply chain, so a two-year-old post returns to the front the moment somebody replies \
-to it. The first message here is the most recently *active* thread, not the most recent post. Read \
-`created_at` before saying when anything was written, never the position in this list, and do not \
-report the top of the list as "the latest news in the channel".
+**Do not sweep channels.** Microsoft rate-limits a given channel to about one request per second \
+for this app across the tenant. This tool makes one request: `$top` is the window. To see more, \
+raise `limit` rather than calling again. `search_messages` covers all channels in one request.
 
-It cannot be date-filtered, and this is Microsoft's limit rather than a missing parameter: this \
-collection accepts no filter and no sort at all. To bound by date use search_messages with \
-`sent_after`/`sent_before`, which the search index applies and which covers channels. For the same \
-reason, paging deeper is not a way to reach older posts — there is no cursor, and a wider `limit` \
-(up to {MAX_POSTS}, Microsoft's own maximum) or a search is the only way to see more.
+**The order is thread activity, not post date.** Microsoft sorts by the last-modified time of the \
+entire reply chain. A two-year-old post moves to the first page when someone replies to it. Read \
+`created_at` to know when a post was written — not its position here or the top of the list.
 
-**Never report this as the whole of a channel unless you asked and were told.** A page holding \
-fewer than `limit` posts is not evidence that the channel has no more — Microsoft counts the \
-system messages into that page before they are dropped here — so, unlike every other list here, \
-what comes back cannot tell you whether it was everything. Microsoft's page does say, and \
-`include_window_completeness` is how to have it reported: `more_posts_in_channel` is Microsoft's \
-own "there is more of this channel", which no `limit` here reaches — the older posts of a busy \
-channel are reached by searching, not by asking again — and `posts_cut_to_limit` is the separate \
-case of this window closing over posts Microsoft did send, which a wider `limit` does fix. Both \
-are null unless you set it.
+**Cannot filter by date.** This collection accepts only `$top` and `$expand=replies`. Use \
+`search_messages` with `sent_after`/`sent_before` for date bounds.
 
-Replies come with their posts: up to {MAX_REPLIES_PER_POST} of the newest per post, \
-oldest first, each carrying the post it answers in `reply_to_id`. A post carrying that many \
-replies may have older ones, and those are out of reach rather than one call \
-away — Microsoft's cursor into a thread is a request per post against the same one-a-second \
-budget, so it is not followed and browsing again returns the same newest replies. Every message is \
-complete — the same fields, and the same plain text normalised out of Teams' HTML, that \
-read_message returns — so a message here needs no second call to read it. Its `uri` is a handle \
-for quoting or re-reading it, and for a reply it is the only handle that exists: Microsoft \
-addresses a reply under its parent post, which a search result cannot express. That is also the \
-limit of what this tool can rescue: when a search hit is a reply older than the window above, \
-there is no route to its full text anywhere in this connector — report the search snippet, say so, \
-and do not browse again for it.
+**Cannot tell if a page is the whole channel.** Microsoft drops system messages after counting \
+them, so a short page is not proof the channel is empty. Set `include_window_completeness` to see \
+Microsoft's cursor on the page (`more_posts_in_channel`) — the only accurate answer.
 
-System messages are dropped — somebody joining, a call ending, a channel being renamed — because \
-Microsoft gives them no author and no text. That is why a page can hold fewer posts than `limit`, \
-and it is not evidence that the channel is quiet.\
+Replies come with posts: up to {MAX_REPLIES_PER_POST} newest per post, oldest first. Each reply \
+carries `reply_to_id` with its parent. Older replies on a post are unreachable — browsing again \
+returns the same newest ones. Every message is complete (same shape and text as `read_message` \
+returns). A reply's `uri` is its only handle, because Microsoft addresses it under its parent — \
+search cannot express this. When a search hit is a reply older than this window, there is no \
+route to its full text anywhere in this connector — report the search snippet and stop looking.
+
+System messages (joins, call ends, renames) are dropped — Microsoft gives them no author or text. \
+That is why pages may be shorter than `limit` and is not evidence the channel is quiet.\
 """
 
 
 class ChannelPosts(BaseModel):
     messages: list[TeamsMessage] = Field(
         description=(
-            "The channel's posts and their replies, in thread order: each root post is followed by "
-            + "the replies to it, oldest first, and a reply carries the post it answers in "
-            + "`reply_to_id`. Every message is complete — the same shape and the same normalised "
-            + "text read_message answers with — so nothing here needs a second read.\n"
-            + "This is one window on the channel and never the whole of it, whatever comes back. "
-            + f"Up to `limit` posts are returned (raise it, up to {MAX_POSTS}) and up to "
-            + f"{MAX_REPLIES_PER_POST} of the newest replies per post, so a post carrying that "
-            + "many replies may have older ones — and those are a dead end rather than a next "
-            + "page, because browsing again returns the same newest ones. FEWER posts than "
-            + "`limit` is NOT evidence that the channel holds no more: Microsoft counts system "
-            + "messages into the page it answers with and they are dropped from this list, and "
-            + "the same is true of a thread's replies. Whether the channel does hold more is the "
-            + "one thing here you cannot read off this list, and Microsoft's own answer to it is "
-            + "reported when you ask: set `include_window_completeness` for "
-            + "`more_posts_in_channel`. There is no cursor and paging deeper is not a route to "
-            + "older posts: Microsoft orders this collection by reply-chain activity rather than "
-            + "by date, so reaching back in time is search_messages with `sent_before`."
+            "Posts and their replies, in thread order. Each root post is followed by its replies, "
+            + "oldest first. Replies carry `reply_to_id` with their parent post. Each message is "
+            + "complete — same shape and text as `read_message` returns — no second read needed.\n"
+            + "Up to `limit` posts returned (raise it, up to "
+            + f"{MAX_POSTS}). Up to {MAX_REPLIES_PER_POST} newest replies per post (older ones "
+            + "unreachable, browsing returns the same newest). Fewer posts than `limit` is NOT "
+            + "proof the channel holds no more — Microsoft drops system messages after counting "
+            + "them. Set `include_window_completeness` for `more_posts_in_channel` (the only way "
+            + "to know if more exists). Microsoft orders by reply-chain last modified, not date; "
+            + "use `search_messages` with `sent_before` to reach back in time."
         )
     )
     more_posts_in_channel: bool | None = Field(
         description=(
-            "Whether Microsoft said this channel holds posts beyond the page it answered with — "
-            + "its `@odata.nextLink` on that page, reported as it came — or null when "
-            + "`include_window_completeness` was not set, which is the default.\n"
-            + "True means there ARE more posts and this window is not the channel. It is not a "
-            + "cursor and there is nothing here to page with: this tool spends one request against "
-            + "a channel Microsoft rate-limits to about one a second for the whole connector, so "
-            + "the remedy is a wider `limit` for a little more, and search_messages with "
-            + "`sent_before` to reach back in time. False means Microsoft offered no continuation "
-            + f"of the collection, so — subject to `limit` and to {MAX_REPLIES_PER_POST} replies a "
-            + "post — this window was the whole channel. This is the only thing that says either "
-            + "way: a short list does NOT mean the channel ran out."
+            "Microsoft's cursor on the page (`@odata.nextLink`), or null if "
+            + "`include_window_completeness` was not set (the default). True: more posts "
+            + "exist beyond this page; a wider `limit` gets a little more, `search_messages` "
+            + "with `sent_before` reaches older posts. False: this window was the whole "
+            + "channel (subject to `limit` and reply limits). Null means this field was not "
+            + "requested. A short page alone does NOT mean the channel ran out."
         )
     )
     posts_cut_to_limit: bool | None = Field(
         description=(
-            "Whether Microsoft's page held more posts than `limit` and this answer was cut to it, "
-            + "or null when `include_window_completeness` was not set. A different fact from "
-            + f"`more_posts_in_channel` with a different remedy: raise `limit` (up to {MAX_POSTS}) "
-            + "and the cut posts are in the next answer, where more of the channel is not "
-            + "reachable at all. Normally false whatever the channel holds — `$top` is set to "
-            + "`limit`, so Microsoft answers with no more than that — and reported rather than "
-            + "assumed because the window is this tool's promise rather than Microsoft's."
+            "Whether Microsoft's page held more posts than `limit` and this answer was cut "
+            + "to it, or null if `include_window_completeness` was not set. Different from "
+            + f"`more_posts_in_channel`: raise `limit` (up to {MAX_POSTS}) to get the cut "
+            + "posts; they are in the next answer. Normally false because `$top` is set to "
+            + "`limit`. Reported, not assumed, because the window is this tool's promise."
         )
     )
 
@@ -203,36 +143,29 @@ async def browse_channel(
     limit: int,
     include_window_completeness: bool,
 ) -> ChannelPosts:
-    """Up to `limit` posts from one channel's first page, each with the newest of its replies.
+    """Return up to `limit` posts from a channel's first page, each with its newest replies.
 
-    One Graph request against the channel, always. Graph's per-channel budget is a single request a
-    second for the whole app in the tenant, so neither cursor Graph offers here is followed: not the
-    collection's `@odata.nextLink` and not a post's own `replies@odata.nextLink`. `$top` is the
-    window and `$expand=replies` makes a thread part of that one request rather than a round trip
-    per post; a caller who needs more raises `limit` (up to `MAX_POSTS`, Graph's own ceiling)
-    instead of the tool spending the tenant's budget on their behalf.
+    One Graph request, always. Graph rate-limits a given channel to one request per second for this
+    app across the tenant. Neither cursor is followed: not `@odata.nextLink` on the collection or
+    `replies@odata.nextLink` on a post. `$top=limit` is the window; `$expand=replies` brings
+    threads into one request instead of one per post. A caller who needs more raises `limit`
+    instead of this tool spending the tenant's budget.
 
-    The system messages — somebody joining, a call ending, a channel being renamed — are dropped,
-    and Graph offers no `$filter` to drop them at the source, so they are filtered out of the page
-    Graph counted them into: a page can hold fewer posts than `limit` without the channel having run
-    out of them. That is what makes this the one tool here whose answer cannot say whether it was
-    everything, and the reason `include_window_completeness` exists at all. Elsewhere a short
-    answer is the end of the collection — `collect_pages` followed Graph's paging to it — so "there
-    is more" is derivable and is not reported; here nothing was followed and a short answer says
-    nothing.
+    System messages (joins, call ends, renames) are dropped. Graph has no `$filter` to drop them
+    at the source, so they are filtered out of the page Graph counted them into. This means a page
+    can be shorter than `limit` without the channel being empty. This is the one tool whose answer
+    cannot say if it is everything — that is why `include_window_completeness` exists. Elsewhere
+    a short answer means the end of the collection (paging reached it); here nothing was followed,
+    so a short answer says nothing.
 
-    Two facts are reported for it, separately, because their remedies are opposite ones and one
-    boolean over both is the ambiguous "there is more" flag no answer here carries — it would mean
-    "raise `limit`" or "nothing will help" with no way to tell which. `more_posts_in_channel` is
-    Graph's own `@odata.nextLink` on the page, read as it came: the channel holds more, and nothing
-    here reaches it — a wider `limit` buys a little more of the same page and `search_messages` is
-    the route back in time. `posts_cut_to_limit` is this function's own window closing over posts
-    Graph did send, which a wider `limit` does fix. Both are null unless asked for: a field that is
-    null for almost every answer is one a model need not reason about, and only a caller whose
-    question turns on it pays that price.
+    Two facts are reported separately because their remedies differ and one boolean over both would
+    be ambiguous. `more_posts_in_channel`: Graph's `@odata.nextLink` as-is. The channel holds more,
+    and nothing here reaches it — raise `limit` for more of the same page, `search_messages` for
+    older posts. `posts_cut_to_limit`: this function's window closing over posts Graph did send;
+    raise `limit` to get them. Both are null unless asked for.
 
-    The reply window is deliberately not a third fact here. A thread's older replies are out of
-    reach whether or not Graph paged them, so nothing acts on it — see `_replies`.
+    Reply window is deliberately not a third fact. Older replies on a post are unreachable either
+    way, so nothing acts on it — see `_replies` function.
     """
     assert 1 <= limit <= MAX_POSTS, f"limit must be within 1..{MAX_POSTS}, got {limit}"
 
@@ -249,8 +182,7 @@ async def browse_channel(
         )
         assert page is not None, "Graph answered a channel message listing with no collection"
 
-    # `$top` is `limit`, so Graph returning more posts than were asked for should not happen — but
-    # the window is this tool's promise rather than Graph's, so it is applied rather than trusted.
+    # The window is this tool's promise, not Graph's, so apply it rather than trust it.
     posts = [message for message in (page.value or []) if _is_a_post(message)]
     kept = posts[:limit]
 
@@ -283,16 +215,15 @@ def _is_a_post(message: ChatMessage) -> bool:
 
 
 def _replies(post: ChatMessage) -> list[ChatMessage]:
-    """The newest `MAX_REPLIES_PER_POST` replies to `post`, oldest first.
+    """Newest `MAX_REPLIES_PER_POST` replies to `post`, oldest first.
 
-    Sorted here because Graph publishes no order for replies — the reply collection documents
-    `$top` and nothing else — so the order they arrive in is not a contract to preserve. The newest
-    are the ones kept: a thread's recent turns are what a question about it is usually about.
-
-    Whether older ones were left behind is not reported, because a full window says it: Graph
-    expands up to 200 replies per post, so a thread it paged had more than 200 of them and the
-    window returned is full either way. That leaves the same reading as everywhere else here — this
-    many replies means there may be more, fewer means that was the thread.
+    Sorted here because Graph does not order replies — the reply collection documents `$top`
+    only, so the arrival order is not a contract to preserve. Keep the newest: a thread's recent
+    turns are usually what a question needs. Whether older replies were left behind is not
+    reported, because a full window already says it: Graph expands up to 200 replies per post, so
+    a thread it paged had more than 200 and the window is full either way. That leaves the same
+    reading as everywhere here: this many replies means there may be more, fewer means that was
+    the thread.
     """
     replies = sorted((reply for reply in post.replies or [] if _is_a_post(reply)), key=_sent_at)
     return replies[-MAX_REPLIES_PER_POST:]
@@ -327,8 +258,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The team the channel belongs to, exactly as list_teams reported its "
-                    + "`team_id`. A channel id alone does not address a channel."
+                    "The team the channel is in, exactly as `list_teams` reported. A channel id "
+                    + "alone does not address a channel."
                 ),
             ),
         ],
@@ -337,9 +268,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The channel to read, exactly as list_channels reported its `channel_id` (or "
-                    + "as search_messages reported `channel_id` on a channel message). Opaque — a "
-                    + "channel's name is not one."
+                    "The channel to read, exactly as `list_channels` or `search_messages` reported "
+                    + "it. Opaque — copy it, do not build it from a channel name."
                 ),
             ),
         ],
@@ -349,11 +279,12 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=MAX_POSTS,
                 description=(
-                    "How many posts to return, each with its replies. Default 20 and maximum "
-                    + f"{MAX_POSTS} — both Microsoft Graph's own, for this collection. "
-                    + "One call is one request against the channel and this is the whole of its "
-                    + "window: widen it to see more rather than calling again. System messages are "
-                    + "dropped after Graph counts them, so a page can hold fewer posts than this."
+                    "How many posts to return, each with its replies. Default 20, maximum "
+                    + f"{MAX_POSTS} (both Graph's own for this collection). One call is one "
+                    + "request against the channel and is the whole of its window: raise "
+                    + "`limit` to see more rather than calling again. Microsoft drops system "
+                    + "messages after counting them, so a page can hold fewer posts than "
+                    + "`limit`."
                 ),
             ),
         ] = 20,
@@ -361,15 +292,14 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             bool,
             Field(
                 description=(
-                    "Report whether this window was the whole channel, as `more_posts_in_channel` "
-                    + "and `posts_cut_to_limit` in the answer. Off by default; set it when the "
-                    + "answer turns on completeness, because this is the one tool here where a "
-                    + "short answer tells you nothing — it reads a single page, and Microsoft "
-                    + "counts system messages into that page before they are dropped. "
-                    + "`more_posts_in_channel` is Microsoft's own cursor on that page: the channel "
-                    + "holds more, and nothing here pages to it. `posts_cut_to_limit` is the "
-                    + "separate, ordinary case of more posts on the page than `limit`, which a "
-                    + "wider `limit` fixes. Both are null when this is not set."
+                    "Report whether this window was the whole channel as `more_posts_in_channel` "
+                    + "and `posts_cut_to_limit`. Off by default. Set it when the answer turns on "
+                    + "completeness — this is the one tool where a short page tells you nothing. "
+                    + "Microsoft counts system messages into the page before they are dropped. "
+                    + "`more_posts_in_channel` is Microsoft's cursor: the channel holds more and "
+                    + "nothing here reaches it. `posts_cut_to_limit` is the ordinary case of "
+                    + "more posts on the page than `limit`, fixed by raising `limit`. Both "
+                    + "are null when not requested."
                 )
             ),
         ] = False,

--- a/services/office-mcp/src/office_mcp/tools/browse_channel.py
+++ b/services/office-mcp/src/office_mcp/tools/browse_channel.py
@@ -1,0 +1,385 @@
+"""`browse_channel` — one Teams channel's posts, each followed by the replies to it.
+
+The one thing the other message tools cannot do: walk a single channel. `search_messages` finds
+messages by keyword across every chat and channel at once and cannot be scoped to one of them;
+`read_message` reads a message somebody already has a handle for. This is the tool for "what is
+going on in this channel".
+
+Four things make it what it is, and each of them is a decision rather than a detail.
+
+**The order is thread activity, not post recency.** Graph sorts this collection "by the last
+modified date of the entire reply chain, including both the root channel message and its replies"
+(https://learn.microsoft.com/en-us/graph/api/channel-list-messages), so a two-year-old post returns
+to the first page the moment somebody replies to it. That order is preserved rather than corrected —
+reordering it would be inventing an order Graph did not give — and `created_at` is what tells the
+truth about age. It also makes "stop paging once a page is older than X" an unsound stop condition:
+a walk down this collection could not know when it had gone back far enough, which is one of the two
+reasons there is no walk.
+
+**There is no sweep, and that is the other reason.** Graph caps reads at "one request per second per
+app per tenant … on a given channel" (https://learn.microsoft.com/en-us/graph/throttling-limits),
+and that budget is per *app* — so walking every channel of a team degrades every other user in the
+tenant, and following `@odata.nextLink` down one channel spends the tenant's whole budget for that
+channel on one caller. This tool therefore issues exactly one request: `$top` is the window and the
+single page Graph answers with is the answer. A caller who needs a wider window raises `limit`;
+searching across channels is `search_messages`'s job.
+
+**It cannot be date-bounded at all.** `$top` and `$expand=replies` are the only parameters this
+collection takes — "The other OData query parameters aren't currently supported" — so there is no
+`$filter` and no `$orderby`, and no date parameter is offered rather than one being faked.
+`search_messages` puts a date into the search index instead, for the price of the one request it was
+making anyway.
+
+**That one page is the one place here where "was that everything?" is not derivable.** Everywhere
+else a page short of `limit` is the end of the collection, because the walk underneath followed
+Graph's paging to it; here nothing is followed, and system messages are dropped out of the page
+after Graph counted them into it, so a short answer says nothing either way. What does say something
+is Graph's own `@odata.nextLink` on that page — an accurate read, and the only one available — so it
+is reported, opt-in, as `ChannelPosts` explains.
+
+What this file does not own is the handle grammar (`shared/handles.py`, so that the reply handle
+this mints is the one `read_message` resolves — and this is the only tool that can mint it, because
+Graph addresses a reply under the post it answers and a search projection carries no `replyToId`),
+the message shape and its Teams-HTML normaliser, which also holds the reply window
+(`shared/messages.py`, so that a post browsed here and a message read by handle are the same thing
+rather than two that agree, and so that `read_message`'s 404 advice names the same number this
+window is), and the token and refusal wording (`shared/seam.py`). Everything else — the name, the
+description, the permission, the arguments, the answer shape and the request — is here.
+"""
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from msgraph.generated.models.chat_message import ChatMessage
+from msgraph.generated.teams.item.channels.item.messages.messages_request_builder import (
+    MessagesRequestBuilder,
+)
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import graph_client_for, graph_errors
+from office_mcp.shared.handles import CHANNEL_PERMISSION, MessageHandle
+from office_mcp.shared.messages import (
+    MAX_REPLIES_PER_POST,
+    TeamsMessage,
+    event_of,
+    message_of,
+)
+from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
+
+TOOL_NAME = "browse_channel"
+
+# The one delegated permission this tool's one request needs: the broad message permission, which is
+# also what buys `search_messages` its channel coverage. It is imported rather than respelled —
+# which surface a Teams message is read under is handle vocabulary, and a second spelling of
+# `ChannelMessage.Read.All` is a second thing to keep true. Several tools declaring one permission
+# is what the registry's deduplication is for, and none of them may leave it out.
+GRAPH_PERMISSIONS: tuple[str, ...] = (CHANNEL_PERMISSION,)
+
+# Built once at import: a call inside a parameter default rebuilds the descriptor on every
+# registration and is a lint error in both of this repo's checkers.
+_TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
+
+# Graph's documented ceiling on `$top` for a channel's messages, and so the widest window one call
+# can answer with: the call is one request and `$top` is the whole of it.
+MAX_POSTS = 50
+
+type _MessagesQuery = MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters
+
+_DESCRIPTION = f"""\
+Read what was posted in one Microsoft Teams channel: its posts with their full text, each followed \
+by the replies to it. Takes the `team_id` and `channel_id` list_teams and list_channels returned.
+
+This is the one thing the other message tools cannot do — walk a single channel in order. \
+search_messages finds messages by keyword across every chat and channel at once but cannot be \
+scoped to one channel, and read_message reads a single message you already have a handle for. \
+Reach for this when the question is "what is going on in this channel" rather than "where was this \
+mentioned". Do not call it for channel after channel: Microsoft rate-limits reads of a given \
+channel to about one request a second for this whole connector across the tenant, so a sweep is \
+slow for you and harmful to everyone else on it — search_messages covers every channel in one \
+request. This call spends exactly one request of that budget: it reads the single page Microsoft \
+answers with and never pages deeper, so `limit` is the whole window and widening `limit` — not \
+calling again — is how to see more.
+
+**The order is not what it looks like.** Microsoft sorts this collection by the last modified time \
+of the entire reply chain, so a two-year-old post returns to the front the moment somebody replies \
+to it. The first message here is the most recently *active* thread, not the most recent post. Read \
+`created_at` before saying when anything was written, never the position in this list, and do not \
+report the top of the list as "the latest news in the channel".
+
+It cannot be date-filtered, and this is Microsoft's limit rather than a missing parameter: this \
+collection accepts no filter and no sort at all. To bound by date use search_messages with \
+`sent_after`/`sent_before`, which the search index applies and which covers channels. For the same \
+reason, paging deeper is not a way to reach older posts — there is no cursor, and a wider `limit` \
+(up to {MAX_POSTS}, Microsoft's own maximum) or a search is the only way to see more.
+
+**Never report this as the whole of a channel unless you asked and were told.** A page holding \
+fewer than `limit` posts is not evidence that the channel has no more — Microsoft counts the \
+system messages into that page before they are dropped here — so, unlike every other list here, \
+what comes back cannot tell you whether it was everything. Microsoft's page does say, and \
+`include_window_completeness` is how to have it reported: `more_posts_in_channel` is Microsoft's \
+own "there is more of this channel", which no `limit` here reaches — the older posts of a busy \
+channel are reached by searching, not by asking again — and `posts_cut_to_limit` is the separate \
+case of this window closing over posts Microsoft did send, which a wider `limit` does fix. Both \
+are null unless you set it.
+
+Replies come with their posts: up to {MAX_REPLIES_PER_POST} of the newest per post, \
+oldest first, each carrying the post it answers in `reply_to_id`. A post carrying that many \
+replies may have older ones, and those are out of reach rather than one call \
+away — Microsoft's cursor into a thread is a request per post against the same one-a-second \
+budget, so it is not followed and browsing again returns the same newest replies. Every message is \
+complete — the same fields, and the same plain text normalised out of Teams' HTML, that \
+read_message returns — so a message here needs no second call to read it. Its `uri` is a handle \
+for quoting or re-reading it, and for a reply it is the only handle that exists: Microsoft \
+addresses a reply under its parent post, which a search result cannot express. That is also the \
+limit of what this tool can rescue: when a search hit is a reply older than the window above, \
+there is no route to its full text anywhere in this connector — report the search snippet, say so, \
+and do not browse again for it.
+
+System messages are dropped — somebody joining, a call ending, a channel being renamed — because \
+Microsoft gives them no author and no text. That is why a page can hold fewer posts than `limit`, \
+and it is not evidence that the channel is quiet.\
+"""
+
+
+class ChannelPosts(BaseModel):
+    messages: list[TeamsMessage] = Field(
+        description=(
+            "The channel's posts and their replies, in thread order: each root post is followed by "
+            + "the replies to it, oldest first, and a reply carries the post it answers in "
+            + "`reply_to_id`. Every message is complete — the same shape and the same normalised "
+            + "text read_message answers with — so nothing here needs a second read.\n"
+            + "This is one window on the channel and never the whole of it, whatever comes back. "
+            + f"Up to `limit` posts are returned (raise it, up to {MAX_POSTS}) and up to "
+            + f"{MAX_REPLIES_PER_POST} of the newest replies per post, so a post carrying that "
+            + "many replies may have older ones — and those are a dead end rather than a next "
+            + "page, because browsing again returns the same newest ones. FEWER posts than "
+            + "`limit` is NOT evidence that the channel holds no more: Microsoft counts system "
+            + "messages into the page it answers with and they are dropped from this list, and "
+            + "the same is true of a thread's replies. Whether the channel does hold more is the "
+            + "one thing here you cannot read off this list, and Microsoft's own answer to it is "
+            + "reported when you ask: set `include_window_completeness` for "
+            + "`more_posts_in_channel`. There is no cursor and paging deeper is not a route to "
+            + "older posts: Microsoft orders this collection by reply-chain activity rather than "
+            + "by date, so reaching back in time is search_messages with `sent_before`."
+        )
+    )
+    more_posts_in_channel: bool | None = Field(
+        description=(
+            "Whether Microsoft said this channel holds posts beyond the page it answered with — "
+            + "its `@odata.nextLink` on that page, reported as it came — or null when "
+            + "`include_window_completeness` was not set, which is the default.\n"
+            + "True means there ARE more posts and this window is not the channel. It is not a "
+            + "cursor and there is nothing here to page with: this tool spends one request against "
+            + "a channel Microsoft rate-limits to about one a second for the whole connector, so "
+            + "the remedy is a wider `limit` for a little more, and search_messages with "
+            + "`sent_before` to reach back in time. False means Microsoft offered no continuation "
+            + f"of the collection, so — subject to `limit` and to {MAX_REPLIES_PER_POST} replies a "
+            + "post — this window was the whole channel. This is the only thing that says either "
+            + "way: a short list does NOT mean the channel ran out."
+        )
+    )
+    posts_cut_to_limit: bool | None = Field(
+        description=(
+            "Whether Microsoft's page held more posts than `limit` and this answer was cut to it, "
+            + "or null when `include_window_completeness` was not set. A different fact from "
+            + f"`more_posts_in_channel` with a different remedy: raise `limit` (up to {MAX_POSTS}) "
+            + "and the cut posts are in the next answer, where more of the channel is not "
+            + "reachable at all. Normally false whatever the channel holds — `$top` is set to "
+            + "`limit`, so Microsoft answers with no more than that — and reported rather than "
+            + "assumed because the window is this tool's promise rather than Microsoft's."
+        )
+    )
+
+
+async def browse_channel(
+    client: GraphServiceClient,
+    *,
+    team_id: str,
+    channel_id: str,
+    limit: int,
+    include_window_completeness: bool,
+) -> ChannelPosts:
+    """Up to `limit` posts from one channel's first page, each with the newest of its replies.
+
+    One Graph request against the channel, always. Graph's per-channel budget is a single request a
+    second for the whole app in the tenant, so neither cursor Graph offers here is followed: not the
+    collection's `@odata.nextLink` and not a post's own `replies@odata.nextLink`. `$top` is the
+    window and `$expand=replies` makes a thread part of that one request rather than a round trip
+    per post; a caller who needs more raises `limit` (up to `MAX_POSTS`, Graph's own ceiling)
+    instead of the tool spending the tenant's budget on their behalf.
+
+    The system messages — somebody joining, a call ending, a channel being renamed — are dropped,
+    and Graph offers no `$filter` to drop them at the source, so they are filtered out of the page
+    Graph counted them into: a page can hold fewer posts than `limit` without the channel having run
+    out of them. That is what makes this the one tool here whose answer cannot say whether it was
+    everything, and the reason `include_window_completeness` exists at all. Elsewhere a short
+    answer is the end of the collection — `collect_pages` followed Graph's paging to it — so "there
+    is more" is derivable and is not reported; here nothing was followed and a short answer says
+    nothing.
+
+    Two facts are reported for it, separately, because their remedies are opposite ones and one
+    boolean over both is the ambiguous "there is more" flag no answer here carries — it would mean
+    "raise `limit`" or "nothing will help" with no way to tell which. `more_posts_in_channel` is
+    Graph's own `@odata.nextLink` on the page, read as it came: the channel holds more, and nothing
+    here reaches it — a wider `limit` buys a little more of the same page and `search_messages` is
+    the route back in time. `posts_cut_to_limit` is this function's own window closing over posts
+    Graph did send, which a wider `limit` does fix. Both are null unless asked for: a field that is
+    null for almost every answer is one a model need not reason about, and only a caller whose
+    question turns on it pays that price.
+
+    The reply window is deliberately not a third fact here. A thread's older replies are out of
+    reach whether or not Graph paged them, so nothing acts on it — see `_replies`.
+    """
+    assert 1 <= limit <= MAX_POSTS, f"limit must be within 1..{MAX_POSTS}, got {limit}"
+
+    configuration = RequestConfiguration[_MessagesQuery](
+        query_parameters=MessagesRequestBuilder.MessagesRequestBuilderGetQueryParameters(
+            expand=["replies"], top=limit
+        )
+    )
+    with graph_errors():
+        page = await (
+            client.teams.by_team_id(team_id)
+            .channels.by_channel_id(channel_id)
+            .messages.get(request_configuration=configuration)
+        )
+        assert page is not None, "Graph answered a channel message listing with no collection"
+
+    # `$top` is `limit`, so Graph returning more posts than were asked for should not happen — but
+    # the window is this tool's promise rather than Graph's, so it is applied rather than trusted.
+    posts = [message for message in (page.value or []) if _is_a_post(message)]
+    kept = posts[:limit]
+
+    messages: list[TeamsMessage] = []
+    for post in kept:
+        assert post.id is not None, "Graph returned a channel message with no id"
+        messages.append(
+            message_of(post, handle=MessageHandle(post.id, team_id=team_id, channel_id=channel_id))
+        )
+        messages.extend(
+            message_of(
+                reply,
+                handle=MessageHandle(
+                    _reply_id(reply), team_id=team_id, channel_id=channel_id, reply_to_id=post.id
+                ),
+            )
+            for reply in _replies(post)
+        )
+
+    return ChannelPosts(
+        messages=messages,
+        more_posts_in_channel=bool(page.odata_next_link) if include_window_completeness else None,
+        posts_cut_to_limit=len(kept) < len(posts) if include_window_completeness else None,
+    )
+
+
+def _is_a_post(message: ChatMessage) -> bool:
+    """Whether a person wrote this, rather than Teams recording that something happened."""
+    return event_of(message) is None
+
+
+def _replies(post: ChatMessage) -> list[ChatMessage]:
+    """The newest `MAX_REPLIES_PER_POST` replies to `post`, oldest first.
+
+    Sorted here because Graph publishes no order for replies — the reply collection documents
+    `$top` and nothing else — so the order they arrive in is not a contract to preserve. The newest
+    are the ones kept: a thread's recent turns are what a question about it is usually about.
+
+    Whether older ones were left behind is not reported, because a full window says it: Graph
+    expands up to 200 replies per post, so a thread it paged had more than 200 of them and the
+    window returned is full either way. That leaves the same reading as everywhere else here — this
+    many replies means there may be more, fewer means that was the thread.
+    """
+    replies = sorted((reply for reply in post.replies or [] if _is_a_post(reply)), key=_sent_at)
+    return replies[-MAX_REPLIES_PER_POST:]
+
+
+def _sent_at(message: ChatMessage) -> datetime:
+    """When a message was sent, or the beginning of time for one Graph gave no timestamp."""
+    return message.created_date_time or datetime.min.replace(tzinfo=UTC)
+
+
+def _reply_id(reply: ChatMessage) -> str:
+    assert reply.id is not None, "Graph returned a channel reply with no id"
+    return reply.id
+
+
+def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this tool against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
+    borrows it per call and never owns it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(
+        name=TOOL_NAME,
+        title="Browse a Teams Channel",
+        description=_DESCRIPTION,
+        annotations=READ_ONLY,
+    )
+    async def browse_a_channel(
+        team_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The team the channel belongs to, exactly as list_teams reported its "
+                    + "`team_id`. A channel id alone does not address a channel."
+                ),
+            ),
+        ],
+        channel_id: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The channel to read, exactly as list_channels reported its `channel_id` (or "
+                    + "as search_messages reported `channel_id` on a channel message). Opaque — a "
+                    + "channel's name is not one."
+                ),
+            ),
+        ],
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=MAX_POSTS,
+                description=(
+                    "How many posts to return, each with its replies. Default 20 and maximum "
+                    + f"{MAX_POSTS} — both Microsoft Graph's own, for this collection. "
+                    + "One call is one request against the channel and this is the whole of its "
+                    + "window: widen it to see more rather than calling again. System messages are "
+                    + "dropped after Graph counts them, so a page can hold fewer posts than this."
+                ),
+            ),
+        ] = 20,
+        include_window_completeness: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Report whether this window was the whole channel, as `more_posts_in_channel` "
+                    + "and `posts_cut_to_limit` in the answer. Off by default; set it when the "
+                    + "answer turns on completeness, because this is the one tool here where a "
+                    + "short answer tells you nothing — it reads a single page, and Microsoft "
+                    + "counts system messages into that page before they are dropped. "
+                    + "`more_posts_in_channel` is Microsoft's own cursor on that page: the channel "
+                    + "holds more, and nothing here pages to it. `posts_cut_to_limit` is the "
+                    + "separate, ordinary case of more posts on the page than `limit`, which a "
+                    + "wider `limit` fixes. Both are null when this is not set."
+                )
+            ),
+        ] = False,
+        graph_token: str = _TOKEN,
+    ) -> ChannelPosts:
+        with graph_tool_errors(*GRAPH_PERMISSIONS):
+            return await browse_channel(
+                graph_client_for(transport, graph_token),
+                team_id=team_id,
+                channel_id=channel_id,
+                limit=limit,
+                include_window_completeness=include_window_completeness,
+            )

--- a/services/office-mcp/src/office_mcp/tools/list_channels.py
+++ b/services/office-mcp/src/office_mcp/tools/list_channels.py
@@ -32,8 +32,10 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_channels"
 
-# The cheap "basic" scope for channel identity. Reading messages needs `ChannelMessage.Read.All`;
-# a tenant often grants this one and withholds the broad one, so the two are named separately.
+# The delegated Graph permission this tool's one request needs — the cheap "basic" scope over a
+# channel's identity, which is all this collection returns. Reading what was *posted* in a channel
+# is the broad `ChannelMessage.Read.All` and is `browse_channel`'s to declare; a tenant commonly
+# grants this one and withholds that one, which is why the two are named separately.
 GRAPH_PERMISSIONS: tuple[str, ...] = ("Channel.ReadBasic.All",)
 
 # Built at import, not in the parameter default: rebuilding the descriptor on every registration
@@ -52,9 +54,10 @@ type _ChannelsQuery = ChannelsRequestBuilder.ChannelsRequestBuilderGetQueryParam
 _DESCRIPTION = f"""\
 List channels of a Microsoft Teams team. Pass the `team_id` from list_teams.
 
-Each channel's id, name, description, membership type, and creation date are returned. \
-Channel names are unique only inside their own team (every team has a `General`), so use both \
-ids to address a channel. `membership_type` is `standard`, `private`, or `shared`.
+Call this to find the channel to browse, then pass `team_id` and `channel_id` together to \
+browse_channel — a channel id alone addresses nothing. Channel names are unique only inside their \
+own team (every team has a `General`), which is why the pair is always needed. No message content \
+is returned here.
 
 The list shows only channels the signed-in user can access. An absent channel means the user \
 cannot access it, not that the team lacks it.
@@ -68,8 +71,9 @@ may exist; fewer than `limit` is all of them the user can see. Raise `limit` (up
 class ChannelSummary(BaseModel):
     channel_id: str = Field(
         description=(
-            "The channel's Graph id, e.g. `19:...@thread.tacv2`. Use it with `team_id` to "
-            + "address a channel. Opaque — copy it from responses rather than constructing it."
+            "The channel's Graph id, e.g. `19:...@thread.tacv2`. Pass it with its `team_id` to "
+            + "browse_channel; it is also the id search_messages reports as `channel_id` on a "
+            + "channel message. Opaque — copy it rather than constructing one from a name."
         )
     )
     display_name: str | None = Field(

--- a/services/office-mcp/src/office_mcp/tools/read_message.py
+++ b/services/office-mcp/src/office_mcp/tools/read_message.py
@@ -31,6 +31,9 @@ from msgraph.generated.models.chat_message import ChatMessage
 from msgraph.generated.teams.item.channels.item.messages.item.chat_message_item_request_builder import (  # noqa: E501
     ChatMessageItemRequestBuilder as ChannelMessageRequestBuilder,
 )
+from msgraph.generated.teams.item.channels.item.messages.item.replies.item.chat_message_item_request_builder import (  # noqa: E501
+    ChatMessageItemRequestBuilder as ChannelReplyRequestBuilder,
+)
 from msgraph.graph_service_client import GraphServiceClient
 from pydantic import Field
 
@@ -56,15 +59,22 @@ _DESCRIPTION = """\
 Read one Microsoft Teams message in full, from the `uri` handle search_messages produces: the \
 whole text, sender, @-mentions, attachments, and edit/delete status.
 
-This is the other half of search_messages. Graph's search index has no message body, so a search \
-result carries only Microsoft's `summary` snippet. Read the message here to get the full text. \
-Never present a snippet as the message.
+This is the other half of search_messages, and the only route to the text of a message a search \
+found. Microsoft's search index answers with a reduced view of a message that contains no body at \
+all, so a search result carries only Microsoft's `summary` snippet. Read the message here whenever \
+the answer depends on what somebody actually said rather than on the fact that a matching message \
+exists — and never present a snippet as the message. A message browse_channel returned needs no \
+read: that tool answers with the whole message already.
 
-`uri` takes a handle this connector produced, exactly one of these shapes:
+`uri` takes a handle this connector produced, in one of exactly three shapes:
   teams:///chats/{chat_id}/messages/{message_id}
   teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}
-Nothing else is readable. This connector does not address mail, calendar events, files or sites. \
-Pass the `uri` from a tool result verbatim — do not assemble one.
+  teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}
+Nothing else is readable here. No handle of this connector's names mail, a calendar event, a file \
+or a SharePoint page, and nothing turns a person's name or a chat topic into one — pass the `uri` \
+from a tool result verbatim. The third shape above is the one only browse_channel emits: Microsoft \
+addresses a reply in a channel thread under the post it answers, and a search result does not say \
+which post that is.
 
 `text` is plain text normalised from Teams HTML: mentions read as `@Name`, list items as `- `, \
 attachments as `[attachment: name]`, inline images as `[image]`, cards as `[card]`. The `mentions` \
@@ -78,15 +88,16 @@ happened. Do not invent the wording.\
 """
 
 _BAD_HANDLE = (
-    "read_message takes a `uri` handle search_messages produced. This is not one. A readable "
-    + "handle has one of exactly two shapes:\n"
+    "read_message takes a `uri` handle that search_messages or browse_channel produced, and this "
+    + "is not one. A readable handle has one of exactly three shapes:\n"
     + "  teams:///chats/{chat_id}/messages/{message_id}\n"
     + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}\n"
-    + "with ids percent-encoded, e.g. "
-    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. "
-    + "Copy the `uri` from a tool result — do not assemble one. "
-    + "This reader serves Teams messages only: "
-    + "no mail, files or sites. Retrying this value will fail identically."
+    + "  teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}\n"
+    + "with the ids percent-encoded, e.g. "
+    + "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000. Copy the `uri` of a tool "
+    + "result rather than assembling one. This reader serves Teams messages only: no mail, files "
+    + "or sites are addressable in this connector at all. Retrying this value will fail "
+    + "identically."
 )
 
 _UNREADABLE = (
@@ -104,6 +115,7 @@ type _ChatMessageQuery = ChatMessageRequestBuilder.ChatMessageItemRequestBuilder
 type _ChannelMessageQuery = (
     ChannelMessageRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
 )
+type _ChannelReplyQuery = ChannelReplyRequestBuilder.ChatMessageItemRequestBuilderGetQueryParameters
 
 
 async def read_message(client: GraphServiceClient, *, handle: MessageHandle) -> TeamsMessage:
@@ -128,6 +140,15 @@ async def _get(client: GraphServiceClient, handle: MessageHandle) -> ChatMessage
     messages = (
         client.teams.by_team_id(handle.team_id).channels.by_channel_id(handle.channel_id).messages
     )
+    if handle.reply_to_id is not None:
+        # A reply is addressed under the post it replies to, never beside it — the reply id alone
+        # is a 404. `by_chat_message_id1` is the generated name for the second message id in that
+        # path, the first being the parent post's.
+        return await (
+            messages.by_chat_message_id(handle.reply_to_id)
+            .replies.by_chat_message_id1(handle.message_id)
+            .get(request_configuration=RequestConfiguration[_ChannelReplyQuery](headers=_headers()))
+        )
     return await messages.by_chat_message_id(handle.message_id).get(
         request_configuration=RequestConfiguration[_ChannelMessageQuery](headers=_headers())
     )

--- a/services/office-mcp/src/office_mcp/tools/read_message.py
+++ b/services/office-mcp/src/office_mcp/tools/read_message.py
@@ -44,7 +44,7 @@ from office_mcp.shared.handles import (
     MessageHandle,
     message_handle,
 )
-from office_mcp.shared.messages import TeamsMessage, message_of
+from office_mcp.shared.messages import MAX_REPLIES_PER_POST, TeamsMessage, message_of
 from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "read_message"
@@ -101,11 +101,22 @@ _BAD_HANDLE = (
 )
 
 _UNREADABLE = (
-    "Microsoft 365 would not return this message. The handle is well formed, so this is not a "
-    + "bad argument. This is not evidence that the message does not exist: Graph answers "
-    + "deleted, never existed, and invisible-to-user identically and does not say which. "
-    + "Report that the message could not be read. Retrying will not help. Report the search "
-    + "snippet with sender and date, say full text could not be retrieved, and stop looking."
+    "Microsoft 365 would not return this message. The handle is well formed, so this is not a bad "
+    + "argument — and it is not evidence that the message does not exist: Graph answers 'deleted', "
+    + "'never existed' and 'the signed-in user may not see it' with the same 404, and does not say "
+    + "which of them it meant. Report that the message could not be read, never that it was never "
+    + "written. Retrying will not help and this connector has no other route to the text. One "
+    + "well-formed handle always fails this way: a reply in a channel thread is addressed under "
+    + "the post it answers, and a search result does not identify that post — so a search hit that "
+    + "is a reply cannot be read from its own handle. browse_channel is the only tool that emits a "
+    + "reply's own handle, and it reaches the newest "
+    + f"{MAX_REPLIES_PER_POST} replies of each post on the channel's first page and no "
+    + "further: it follows neither Microsoft's cursor into an older part of a thread nor the one "
+    + "into older posts, because a given channel allows this whole connector about one request a "
+    + "second across the tenant. So browse that channel once; if the reply is not in what comes "
+    + "back there is no route to its full text, and a second browse returns the same window. "
+    + "Report the search snippet with its sender and date, say the full text could not be "
+    + "retrieved, and stop looking."
 )
 
 # Without this header, Graph answers systemEventMessage as unknownFutureValue.

--- a/services/office-mcp/src/office_mcp/tools/search_messages.py
+++ b/services/office-mcp/src/office_mcp/tools/search_messages.py
@@ -49,7 +49,7 @@ from pydantic import BaseModel, Field
 
 from office_mcp.graph_client import graph_client_for, graph_errors
 from office_mcp.shared.handles import CHANNEL_PERMISSION, CHAT_PERMISSION, MessageHandle
-from office_mcp.shared.messages import MessageSender, sender_of
+from office_mcp.shared.messages import MAX_REPLIES_PER_POST, MessageSender, sender_of
 from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "search_messages"
@@ -65,9 +65,12 @@ _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 MAX_RESULTS = 50
 
 _DESCRIPTION = f"""\
-Search Microsoft Teams messages the signed-in user can see in chats and channels by keywords, \
-sender, mentions, date, attachments, and read state. Messages from any participant match. Call \
-get_me to learn who the user is. This is the only search tool here.
+Search the Microsoft Teams messages the signed-in user can see — every one-to-one chat, group \
+chat, meeting chat and channel they belong to — by keywords, sender, mentions, date, attachments \
+and read state. Messages from ANY participant match, not only the user's own; call get_me if you \
+need to know who the user is. It is the only tool here that searches: it finds messages anywhere, \
+read_message reads one of them in full, and browse_channel is what walks a single channel when the \
+question is about that channel rather than about a keyword.
 
 A result is metadata plus a snippet, by necessity. Graph's search index has no message body, so \
 `summary` — Microsoft's excerpt, truncated with `...` — is the only text here. Every hit carries \
@@ -105,7 +108,17 @@ class MessageHit(BaseModel):
             + "`teams:///teams/{teamId}/channels/{channelId}/messages/{messageId}` with ids "
             + "percent-encoded. Pass it verbatim to read_message. Search has no message body, so "
             + "this is the only route to full text, attachments and mentions. Null when Graph "
-            + "returned a hit with neither chat nor channel identity."
+            + "returned a hit with neither chat nor channel identity. "
+            + "One handle here can fail to read: Microsoft "
+            + "addresses a reply in a channel thread under its parent post and its search index "
+            + "does not say which post that is, so a hit that is a reply gets the root-post form "
+            + "above and read_message may answer that it could not be read. browse_channel is the "
+            + "only tool that emits a reply's own handle, and it reaches only the newest "
+            + f"{MAX_REPLIES_PER_POST} replies of each post on the channel's first page, following "
+            + "no cursor further back. If "
+            + "the reply is not in that window there is no route to its full text and browsing "
+            + "again returns the same window: report this `summary` with the sender and date "
+            + "here, say the full text could not be retrieved, and stop looking."
         )
     )
     message_id: str = Field(

--- a/services/office-mcp/tests/shared/test_handles.py
+++ b/services/office-mcp/tests/shared/test_handles.py
@@ -28,18 +28,28 @@ _CHANNEL_URI = (
     f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
 )
 
+_ROOT_ID = "1760000000000"
+_REPLY_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+    + f"/messages/{_ROOT_ID}/replies/{_MESSAGE_ID}"
+)
+
 _CHAT_HANDLE = handles.MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
 _CHANNEL_HANDLE = handles.MessageHandle(
     message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID
 )
+_REPLY_HANDLE = handles.MessageHandle(
+    message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, reply_to_id=_ROOT_ID
+)
 
 
 class TestTheMessageHandleGrammar:
-    """The two shapes a Teams message is addressed by, and everything that is not one of them.
+    """The three shapes a Teams message is addressed by, and everything that is not one of them.
 
-    `search_messages` mints both. That is exactly why the grammar is not its file's — a handle one
-    tool minted and another answers 404 to does not look like a disagreement — so it is tested here,
-    once, rather than beside whichever tool happens to write it.
+    `search_messages` mints two of these and `browse_channel` the third; `read_message` reads all
+    three back. That is exactly why the grammar is neither tool's — a handle one minted and another
+    answers 404 to does not look like a disagreement — so it is tested here, once, rather than
+    beside whichever tool happens to write it.
     """
 
     def test_it_reads_the_two_shapes_search_emits_and_decodes_their_ids(self) -> None:
@@ -50,6 +60,18 @@ class TestTheMessageHandleGrammar:
 
         assert chat == _CHAT_HANDLE
         assert channel == _CHANNEL_HANDLE
+
+    def test_it_reads_the_reply_shape_that_only_browsing_a_channel_can_mint(self) -> None:
+        """The third shape. Graph addresses a reply in a channel thread under the post it answers,
+        and the search projection carries no `replyToId` — so a search hit on a reply becomes the
+        root-post shape and cannot be read, while `browse_channel` walks a channel post by post and
+        knows each reply's parent. The grammar still lives here, with the other two: two modules
+        that each knew how to write a handle would be free to disagree.
+        """
+        reply = handles.message_handle(_REPLY_URI)
+
+        assert reply == _REPLY_HANDLE
+        assert reply is not None and reply.uri == _REPLY_URI
 
     def test_a_handle_survives_the_round_trip_it_came_from(self) -> None:
         chat = handles.message_handle(_CHAT_URI)
@@ -72,6 +94,7 @@ class TestTheMessageHandleGrammar:
         never missing."""
         assert _CHAT_HANDLE.permission == "Chat.Read"
         assert _CHANNEL_HANDLE.permission == "ChannelMessage.Read.All"
+        assert _REPLY_HANDLE.permission == "ChannelMessage.Read.All"
 
     @pytest.mark.parametrize(
         "uri",
@@ -86,11 +109,10 @@ class TestTheMessageHandleGrammar:
             "teams:///messages/1770000000000",
             "teams:///chats//messages/1770000000000",
             "teams:///chats/19%3Arelease%40thread.v2/messages/",
-            # A chat has no replies in Graph's addressing, and the reply shape a channel thread does
-            # have is not written yet — a search cannot tell a reply from a root post, so nothing
-            # here may answer as if it could.
+            # A chat has no replies in Graph's addressing — only a channel thread does.
             "teams:///chats/19%3Arelease%40thread.v2/messages/1770000000000/replies/1770000000001",
-            "teams:///teams/8a9c3c47/channels/19%3Ageneral/messages/1770000000000/replies/17700001",
+            "teams:///teams/8a9c3c47/channels/19%3Ageneral/messages/1770000000000/replies/",
+            "teams:///teams/8a9c3c47/channels/19%3Ageneral/messages//replies/1770000000001",
             "teams:///teams/8a9c3c47/messages/1770000000000",
             "teams:///chats/19%3Arelease%40thread.v2/messages/%20",
             # A Teams web link, which is what a model reaches for when it has no handle.

--- a/services/office-mcp/tests/test_layering.py
+++ b/services/office-mcp/tests/test_layering.py
@@ -65,8 +65,8 @@ two numbered rules that held those halves apart went with them.
    `teams:///chats/…` would be free to disagree, and the disagreement would not look like a
    disagreement — it would look like a handle one tool produced and another answers 404 to. The
    owner is named once for every family rather than per family, which is strictly stronger than
-   letting each grammar live with the tool that mints it: two tools mint between them the three
-   shapes below and neither file spells one, so there is nothing for a second speller to be.
+   letting each grammar live with the tool that mints it: three tools mint between them the four
+   shapes below and no tool file spells one, so there is nothing for a second speller to be.
 
    *Spells or parses* is about what a literal is **used for**, not about how it is spaced. Prose is
    most of what the scheme is written in here and all of it is legitimate: a tool description shows

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -145,6 +145,7 @@ _SYSTEM_MESSAGE = {
 _TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
 _CHANNEL_ID = "19:general@thread.tacv2"
 _CHANNELS_PATH = f"/teams/{_TEAM_ID}/channels"
+_CHANNEL_MESSAGES_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages"
 
 # Only the five properties `GET /me/joinedTeams` populates; every other property of a team comes
 # back null on that endpoint, asked for or not.
@@ -170,6 +171,72 @@ _CHANNELS = {
             "membershipType": "standard",
         }
     ]
+}
+
+_ROOT_POST_ID = "1770000000000"
+_REPLY_ID = "1770000000002"
+
+# One channel post with one reply, as `?$top=…&$expand=replies` returns it.
+_CHANNEL_POSTS = {
+    "value": [
+        {
+            "@odata.type": "#microsoft.graph.chatMessage",
+            "id": _ROOT_POST_ID,
+            "messageType": "message",
+            "createdDateTime": "2026-02-11T09:15:22.31Z",
+            "from": {
+                "user": {
+                    "id": "00000000-0000-4000-8000-000000000001",
+                    "displayName": "Ada Lovelace",
+                    "userIdentityType": "aadUser",
+                }
+            },
+            "body": {"contentType": "html", "content": "<div><p>Release plan for Friday</p></div>"},
+            "replies": [
+                {
+                    "@odata.type": "#microsoft.graph.chatMessage",
+                    "id": _REPLY_ID,
+                    "messageType": "message",
+                    "createdDateTime": "2026-02-11T10:02:00Z",
+                    "replyToId": _ROOT_POST_ID,
+                    "from": {
+                        "user": {
+                            "id": "00000000-0000-4000-8000-000000000002",
+                            "displayName": "Grace Hopper",
+                            "userIdentityType": "aadUser",
+                        }
+                    },
+                    "body": {"contentType": "text", "content": "agreed, Friday works"},
+                }
+            ],
+        }
+    ]
+}
+
+# The handle the reply above carries, and the path Graph serves it from. A reply is addressed under
+# the post it answers — no other shape reaches it — which is the whole point of the third shape.
+_REPLY_URI = (
+    f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+    + f"/messages/{_ROOT_POST_ID}/replies/{_REPLY_ID}"
+)
+_REPLY_PATH = f"{_CHANNEL_MESSAGES_PATH}/{_ROOT_POST_ID}/replies/{_REPLY_ID}"
+
+_REPLY: dict[str, object] = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": _REPLY_ID,
+    "messageType": "message",
+    "createdDateTime": "2026-02-11T10:02:00Z",
+    "replyToId": _ROOT_POST_ID,
+    "from": {
+        "user": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "displayName": "Grace Hopper",
+            "userIdentityType": "aadUser",
+        }
+    },
+    "body": {"contentType": "text", "content": "agreed, Friday works"},
+    "attachments": [],
+    "mentions": [],
 }
 
 _CHATS = {
@@ -341,7 +408,7 @@ def _optional_type(schema: object) -> dict[str, object]:
 # The tools that answer with a Teams message, and so with a sender. They are the reason
 # `shared/messages.py` exists, and the reason the sender shape is asserted over the live schemas
 # rather than over the model class: what a model reads is the schema.
-_MESSAGE_TOOLS: tuple[str, ...] = ("read_message", "search_messages")
+_MESSAGE_TOOLS: tuple[str, ...] = ("read_message", "browse_channel", "search_messages")
 
 
 def _items(schema: object) -> dict[str, object]:
@@ -352,9 +419,10 @@ def _items(schema: object) -> dict[str, object]:
 def _sender_schema(schema: Mapping[str, object] | None) -> dict[str, object]:
     """The sender object inside a tool's answer, wherever that answer puts a message.
 
-    `read_message` answers with one message and carries `sender` at the top; `search_messages`
-    answers with a list and carries it per element. Both reach the same `MessageSender`, which is
-    the point — this is what makes "does the guidance reach this tool" one question rather than two.
+    `read_message` answers with one message and carries `sender` at the top; `browse_channel` and
+    `search_messages` answer with a list and carry it per element. All of them reach the same
+    `MessageSender`, which is the point — this is what makes "does the guidance reach this tool"
+    one question rather than three.
     """
     properties = _properties(schema)
     message = properties if "sender" in properties else _properties(_items(properties["messages"]))
@@ -405,6 +473,7 @@ class TestTheToolsThisServerAdvertises:
             "list_chats",
             "list_teams",
             "list_channels",
+            "browse_channel",
             "search_messages",
             "read_message",
         }
@@ -444,6 +513,11 @@ class TestTheToolsThisServerAdvertises:
         assert set(_properties(tools["list_chats"].outputSchema)) == {"chats"}
         assert set(_properties(tools["list_teams"].outputSchema)) == {"teams"}
         assert set(_properties(tools["list_channels"].outputSchema)) == {"channels"}
+        assert set(_properties(tools["browse_channel"].outputSchema)) == {
+            "messages",
+            "more_posts_in_channel",
+            "posts_cut_to_limit",
+        }
         assert set(_properties(tools["search_messages"].outputSchema)) == {
             "messages",
             "next_offset",
@@ -474,14 +548,21 @@ class TestTheToolsThisServerAdvertises:
         """Tool names are verb_noun, fields are snake_case, no truncated flag.
 
         The last of those was written down before there was a list-shaped tool to break it. There
-        are two now, and between them they are the reason the convention was worth asserting early:
-        a window filled to `limit` says there may be more and a short one says there is not,
+        are several now, and between them they are the reason the convention was worth asserting
+        early: a window filled to `limit` says there may be more and a short one says there is not,
         `next_offset` says it outright where paging exists, and `truncated` on top of either means
         "raise `limit`" or "nothing will help" with no way to tell which. `list_chats` says it by
         the length of its window, which is only honest because its walk follows Microsoft's paging
         to the end of the collection; `search_messages` cannot say it that way at all, because
         Microsoft reports a page count rather than a match total for Teams messages — so it says it
         with `next_offset` and that field is asserted to be there.
+
+        Where a completeness fact is NOT derivable from the answer it survives as an opt-in field,
+        which is asserted too: the flag that asks for it defaults to off, so no ordinary answer
+        carries the caveat, and each tool that has one carries one field per fact rather than one
+        boolean over several. `browse_channel` is the tool that needs it — it reads a single page
+        and drops system messages out of it after Microsoft counted them in, so its length says
+        neither thing.
         """
         tools = _named(await mcp_client.list_tools())
 
@@ -494,6 +575,9 @@ class TestTheToolsThisServerAdvertises:
             assert "truncated" not in _properties(tool.outputSchema), name
         for name in ("search_messages",):
             assert "next_offset" in _properties(tools[name].outputSchema), name
+        for name, flag in (("browse_channel", "include_window_completeness"),):
+            asked_for = _object(_properties(tools[name].inputSchema)[flag])
+            assert asked_for["default"] is False, f"{name} would report completeness unasked"
 
     async def test_search_messages_makes_its_criteria_optional_but_not_all_of_them(
         self, mcp_client: Client[FastMCPTransport]
@@ -586,18 +670,19 @@ class TestTheToolsThisServerAdvertises:
         that stops a model reading a null as a fact about the person: a search hit carries an
         Exchange-style `emailAddress` while a Teams read answers with a `teamworkUserIdentity`
         that has no email property at all, so which fields are filled in says which shape Graph
-        used rather than saying the sender has no name or no address. `read_message` is where that
-        matters, because its senders normally arrive with `email` null.
+        used rather than saying the sender has no name or no address. `read_message` and
+        `browse_channel` are where that matters, because they are the two whose senders normally
+        arrive with `email` null.
 
         `search_messages` is deliberately not in that list: it overrides at field level, so its
-        own words are what a model reads there. The per-field descriptions are shared by both
-        either way, and that is asserted too — a difference between them would be one tool
+        own words are what a model reads there. The per-field descriptions are shared by all
+        three either way, and that is asserted too — a difference between them would be one tool
         explaining `user_id` differently from the next.
         """
         tools = _named(await mcp_client.list_tools())
         taught = {name: _sender_schema(tools[name].outputSchema) for name in _MESSAGE_TOOLS}
 
-        for name in ("read_message",):
+        for name in ("read_message", "browse_channel"):
             written = taught[name]["description"]
             assert isinstance(written, str)
             # A docstring reaches the schema with its own line breaks; what is pinned is the
@@ -630,7 +715,8 @@ class TestTheToolsThisServerAdvertises:
     ) -> None:
         """The description is where a model learns what it may pass. Naming the shapes is what
         stops it inventing `mail:///` — and the oracle connector's one polymorphic `read_resource`
-        is exactly the promise this connector does not make.
+        is exactly the promise this connector does not make. The reply shape is named with the tool
+        that mints it, because it is the one no search result carries.
         """
         tools = _named(await mcp_client.list_tools())
         description = tools["read_message"].description
@@ -638,7 +724,73 @@ class TestTheToolsThisServerAdvertises:
 
         assert "teams:///chats/{chat_id}/messages/{message_id}" in description
         assert "teams:///teams/{team_id}/channels/{channel_id}/messages/{message_id}" in description
-        assert "search_messages" in description, "the shapes have exactly one source"
+        assert (
+            "teams:///teams/{team_id}/channels/{channel_id}/messages/{root_id}/replies/{reply_id}"
+            in description
+        )
+        assert "search_messages" in description
+        assert "browse_channel" in description, "the reply shape has exactly one source"
+
+    async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A channel id alone addresses nothing — Graph's only path to a channel's messages goes
+        through its team — and 20/50 are Graph's own default and maximum for the collection."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["browse_channel"].inputSchema
+        limit = _object(_properties(schema)["limit"])
+
+        assert set(_properties(schema)) == {
+            "team_id",
+            "channel_id",
+            "limit",
+            "include_window_completeness",
+        }
+        assert schema.get("required") == ["team_id", "channel_id"]
+        assert (limit["type"], limit["minimum"], limit["maximum"], limit["default"]) == (
+            "integer",
+            1,
+            50,
+            20,
+        )
+
+    async def test_browse_channel_says_what_the_order_actually_is(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The one thing a model cannot find out for itself. Graph orders this collection by the
+        last modified date of the whole reply chain, so the first post is the most recently *active*
+        thread and may be years old — a tool that let "newest first" be assumed would have the
+        model reporting an old post as today's news.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["browse_channel"].description
+        assert description is not None
+
+        assert "reply chain" in description
+        assert "created_at" in description, "the field that does tell the truth about age"
+        assert "search_messages" in description, "where a date-bounded question goes instead"
+
+    async def test_browse_channel_says_what_one_call_costs_and_where_it_stops(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The budget is only a bound if the caller can see it. Microsoft allows this whole
+        connector about one request a second on a given channel across the tenant, so the tool
+        makes exactly one — which means `limit` is the entire window, and a model that expects
+        paging to reach further has to be told it does not, in the description and in the schema
+        rather than only in the code.
+        """
+        tools = _named(await mcp_client.list_tools())
+        description = tools["browse_channel"].description
+        limit = _object(_properties(tools["browse_channel"].inputSchema)["limit"])
+        assert description is not None
+
+        assert "exactly one request" in description
+        assert "never pages deeper" in description
+        assert "one request against the channel" in str(limit["description"])
+        assert "browsing again returns the same newest replies" in description, (
+            "the reply window is a dead end, not a first page"
+        )
+        assert "do not browse again for it" in description
 
     async def test_no_description_names_a_tool_this_server_does_not_advertise(
         self, mcp_client: Client[FastMCPTransport]
@@ -749,41 +901,119 @@ class TestCallingThem:
         assert route.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
         assert obo.requested_scopes == [("https://graph.microsoft.com/Team.ReadBasic.All",)]
 
-    async def test_a_model_walks_from_its_teams_to_the_channels_of_one_of_them(
+    async def test_a_model_walks_from_its_teams_to_a_reply_it_can_read(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
         obo: _StubOboCredential,
     ) -> None:
-        """The channel path as far as it goes today, over the real protocol, with the id taken from
-        the previous answer exactly as a model would take it: which teams am I in, then what
-        channels are in this team.
+        """The channel side end to end, over the real protocol, with every id taken from the
+        previous answer exactly as a model would take it: which teams am I in, what channels are in
+        this team, what was posted in this channel — and then the reply's own handle, resolved.
 
-        Two things only an end-to-end call shows. The `team_id` this server hands out is the one it
-        accepts back, in that spelling, through the MCP schema and out again — an inventory whose
-        ids no other tool takes is an inventory nothing can be done with. And the token is redeemed
-        per tool, so a tenant that grants the team scope and withholds the channel one is refused at
-        the second step rather than the first; a tool that quietly asked for the registry's union
-        would take that distinction away without any schema changing.
+        That last step is the gap this piece closes. Graph addresses a reply under the post it
+        answers, so before browsing existed no tool could produce a handle for one: a search hit on
+        a reply carries the root-post shape and Graph answers it 404. Here the browse mints the
+        reply's handle and read_message resolves it, which is the whole contract between the two.
+
+        The token is redeemed per tool, so a tenant that grants the two basic channel scopes and
+        withholds the broad message one is refused at the third step rather than the first; a tool
+        that quietly asked for the registry's union would take that distinction away without any
+        schema changing.
         """
         teams = graph.get("/me/joinedTeams").mock(return_value=httpx.Response(200, json=_TEAMS))
         listing = graph.get(_CHANNELS_PATH).mock(return_value=httpx.Response(200, json=_CHANNELS))
+        posts = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json=_CHANNEL_POSTS)
+        )
+        read = graph.get(_REPLY_PATH).mock(return_value=httpx.Response(200, json=_REPLY))
 
         listed = _structured(await mcp_client.call_tool("list_teams", {}))
         found = cast("Sequence[Mapping[str, object]]", listed["teams"])
         team_id = found[0]["team_id"]
         channels = _structured(await mcp_client.call_tool("list_channels", {"team_id": team_id}))
         in_team = cast("Sequence[Mapping[str, object]]", channels["channels"])
+        channel_id = in_team[0]["channel_id"]
+        browsed = _structured(
+            await mcp_client.call_tool(
+                "browse_channel", {"team_id": team_id, "channel_id": channel_id}
+            )
+        )
+        messages = cast("Sequence[Mapping[str, object]]", browsed["messages"])
+        result = _structured(
+            await mcp_client.call_tool("read_message", {"uri": messages[1]["uri"]})
+        )
 
-        assert (team_id, in_team[0]["channel_id"]) == (_TEAM_ID, _CHANNEL_ID)
+        assert (team_id, channel_id) == (_TEAM_ID, _CHANNEL_ID)
         assert in_team[0]["display_name"] == "General"
         assert in_team[0]["membership_type"] == "standard"
-        assert all(route.called for route in (teams, listing))
-        assert listing.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert all(route.called for route in (teams, listing, posts, read))
+        assert [message["message_id"] for message in messages] == [_ROOT_POST_ID, _REPLY_ID]
+        assert messages[0]["text"] == "Release plan for Friday", "browsing returns the whole post"
+        assert messages[1]["reply_to_id"] == _ROOT_POST_ID
+        assert messages[1]["uri"] == _REPLY_URI
+        assert result["text"] == "agreed, Friday works"
+        assert result["uri"] == _REPLY_URI
+        assert read.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
         assert obo.requested_scopes == [
             ("https://graph.microsoft.com/Team.ReadBasic.All",),
             ("https://graph.microsoft.com/Channel.ReadBasic.All",),
+            ("https://graph.microsoft.com/ChannelMessage.Read.All",),
+            (
+                "https://graph.microsoft.com/Chat.Read",
+                "https://graph.microsoft.com/ChannelMessage.Read.All",
+            ),
         ], "each tool exchanges a token for the permissions its own request needs"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_same_channel_page_answers_differently_with_and_without_microsofts_cursor(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The signal this tool cannot infer, over the real protocol. Without it these two answers
+        are byte-identical: one page of posts WITH an `@odata.nextLink` and the same page without
+        one, so a caller could not tell "that was the whole channel" from "Microsoft says there is
+        more".
+
+        It is the one list here where that is not derivable. Everywhere else the walk underneath
+        followed Microsoft's paging to the end of the collection, so a short answer IS the end; this
+        tool makes one request against a channel Microsoft rate-limits to about one a second for the
+        whole connector, and drops system messages out of the page after Microsoft counted them into
+        it. So the cursor is read and reported when asked for — and, asked for, it is accurate.
+        """
+        posts = {"value": [{**_CHANNEL_POSTS["value"][0], "replies": []}]}
+        with_more = {
+            **posts,
+            "@odata.nextLink": f"{GRAPH_V1}{_CHANNEL_MESSAGES_PATH}?$skiptoken=synthetic",
+        }
+        route = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json=with_more)
+        )
+        ids = {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID}
+
+        unasked = _structured(await mcp_client.call_tool("browse_channel", ids))
+        told = _structured(
+            await mcp_client.call_tool(
+                "browse_channel", {**ids, "include_window_completeness": True}
+            )
+        )
+        route.mock(return_value=httpx.Response(200, json=posts))
+        whole = _structured(
+            await mcp_client.call_tool(
+                "browse_channel", {**ids, "include_window_completeness": True}
+            )
+        )
+
+        assert unasked["more_posts_in_channel"] is None, "null unless a caller asks"
+        assert unasked["posts_cut_to_limit"] is None
+        assert told["more_posts_in_channel"] is True, "Microsoft's own cursor, read as it came"
+        assert whole["more_posts_in_channel"] is False, "the same page, its cursor taken off"
+        assert told["posts_cut_to_limit"] is False, "the window closed over nothing Microsoft sent"
+        assert told["messages"] == unasked["messages"] == whole["messages"], (
+            "asking about completeness changes what is reported and never what was read"
+        )
+        assert route.call_count == 3, "one request per call, and the cursor still never followed"
 
     @pytest.mark.usefixtures("obo")
     async def test_a_collection_microsoft_never_ends_is_refused_in_eleven_requests(
@@ -918,6 +1148,43 @@ class TestCallingThem:
         result = await mcp_client.call_tool("read_message", {"uri": _MESSAGE_URI})
 
         assert _structured(result)["text"] == secret, "the text has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_channel_post_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A channel post is message content like any other, and this tool returns a page of it at
+        once — so the rule search and read are held to holds here too, over the whole call."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        post = {
+            **_CHANNEL_POSTS["value"][0],
+            "body": {"contentType": "text", "content": secret},
+            "replies": [],
+        }
+        _ = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [post]})
+        )
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool(
+            "browse_channel", {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID}
+        )
+
+        messages = cast("Sequence[Mapping[str, object]]", _structured(result)["messages"])
+        assert messages[0]["text"] == secret, "the post has to have been returned"
         for record in caplog.records:
             assert secret not in _record_text(record), f"logged by {record.name}"
         for span in exporter.get_finished_spans():
@@ -1067,6 +1334,13 @@ class TestWhatAModelIsToldWhenGraphRefuses:
                 "Channel.ReadBasic.All",
                 "Team.ReadBasic.All",
             ),
+            (
+                "browse_channel",
+                {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID},
+                _CHANNEL_MESSAGES_PATH,
+                "ChannelMessage.Read.All",
+                "Channel.ReadBasic.All",
+            ),
         ],
     )
     @pytest.mark.usefixtures("obo")
@@ -1080,10 +1354,10 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         permission: str,
         not_named: str,
     ) -> None:
-        """Two requests, two delegated permissions, and the whole reason the channel inventory is
-        not one scope: a tenant can grant either without the other, so naming the wrong one sends an
-        administrator after a permission that was never missing, which is as useless as naming none.
-        Graph's 403 says only that something was forbidden.
+        """Three requests, three delegated permissions, and a tenant that grants the two basic ones
+        while withholding the broad message permission is the common case — so naming the wrong one
+        sends an administrator after a permission that was never missing, which is as useless as
+        naming none. Graph's 403 says only that something was forbidden.
         """
         _ = graph.get(path).mock(
             return_value=httpx.Response(
@@ -1101,6 +1375,39 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert not_named not in message
         assert "administrator" in message
         assert "synthetic-request-id" in message
+
+    async def test_an_unconsented_channel_browse_names_the_message_permission(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        obo: _StubOboCredential,
+    ) -> None:
+        """The same missing permission one step earlier, on the tool most likely to hit it:
+        `ChannelMessage.Read.All` is the broad scope an administrator has to consent to, and Entra
+        refuses the exchange before Graph is reached at all."""
+        route = graph.get(_CHANNEL_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json=_CHANNEL_POSTS)
+        )
+        obo.refusal = ClientAuthenticationError(
+            message=(
+                "AADSTS65001: The user or administrator has not consented to use the application "
+                + "with ID '1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5061'."
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "browse_channel",
+            {"team_id": _TEAM_ID, "channel_id": _CHANNEL_ID},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        message = _error_text(result)
+        assert "ChannelMessage.Read.All" in message, message
+        assert "administrator" in message
+        assert "AADSTS65001" in message
+        assert "resolve dependency" not in message
+        assert not route.called, "no token means no Graph request was ever made"
 
     @pytest.mark.usefixtures("obo")
     async def test_a_refused_search_names_both_permissions_it_was_made_under(

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -785,13 +785,15 @@ class TestTheToolsThisServerAdvertises:
         limit = _object(_properties(tools["browse_channel"].inputSchema)["limit"])
         assert description is not None
 
-        assert "exactly one request" in description
-        assert "never pages deeper" in description
+        assert "makes one request" in description
+        assert "raise `limit` rather than calling again" in description, (
+            "where it stops: the window widens, it never pages deeper"
+        )
         assert "one request against the channel" in str(limit["description"])
-        assert "browsing again returns the same newest replies" in description, (
+        assert "browsing again returns the same newest" in description, (
             "the reply window is a dead end, not a first page"
         )
-        assert "do not browse again for it" in description
+        assert "stop looking" in description
 
     async def test_no_description_names_a_tool_this_server_does_not_advertise(
         self, mcp_client: Client[FastMCPTransport]

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -29,6 +29,7 @@ from starlette.applications import Starlette
 from office_mcp.app import create_app
 from office_mcp.config import AppConfig, DatabaseConfig, EntraConfig
 from office_mcp.graph_client import GraphSettings, create_graph_transport
+from office_mcp.shared.messages import MAX_REPLIES_PER_POST
 
 GRAPH_V1 = "https://graph.microsoft.com/v1.0"
 
@@ -1542,6 +1543,39 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "not evidence that the message does not exist" in message
         assert "synthetic-request-id" in message, "the id Microsoft support asks for first"
         assert "verbatim" not in message, "the handle did come from a tool response"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_advice_for_an_unreadable_reply_terminates_instead_of_looping(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """The one 404 this connector predicts, and the advice that must not be circular. A search
+        hit on a channel reply carries the root-post shape, because Microsoft's index does not say
+        which post the reply hangs under — so it 404s. browse_channel is the only tool that mints a
+        reply's own handle, but it returns the newest replies of each post on a channel's first page
+        and follows neither of Microsoft's cursors past them, since a given channel allows this
+        whole connector about one request a second across the tenant. "Browse the channel instead"
+        is therefore a route for a recent reply and a loop for an older one, so this text has to
+        name the window, say there is no route beyond it, and tell the model what to answer with.
+        """
+        _ = graph.get(_MESSAGE_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_message", {"uri": _MESSAGE_URI}, raise_on_error=False
+        )
+
+        message = _error_text(result)
+        assert f"newest {MAX_REPLIES_PER_POST} replies" in message, message
+        assert "no route to its full text" in message
+        assert "a second browse returns the same window" in message
+        assert "stop looking" in message
 
     @pytest.mark.usefixtures("obo")
     async def test_a_refused_read_names_only_the_permission_that_surface_needs(

--- a/services/office-mcp/tests/tools/test_browse_channel.py
+++ b/services/office-mcp/tests/tools/test_browse_channel.py
@@ -1,0 +1,622 @@
+"""`browse_channel`: the one request it spends, the order it must not correct, and the traps.
+
+Two of the assertions here are about parameters that are *not* sent — Graph accepts no `$orderby`
+and no `$filter` on a channel's messages, which is why no date argument is offered — and two are
+about cursors that are read rather than followed, because a given channel allows this whole
+connector about one request a second across the tenant. The fourth trap is the ordering of the
+collection, which is by reply-chain activity: the one Graph documents and the one nobody expects.
+
+Every payload is synthesised from Microsoft's documented shapes: the ids are obviously fake, the
+domains are `.invalid`, and the names are from the public domain.
+"""
+
+from collections.abc import Mapping, Sequence
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphForbidden
+from office_mcp.shared.handles import message_handle
+from office_mcp.shared.messages import MAX_REPLIES_PER_POST
+from office_mcp.tools import browse_channel as browser
+
+from .conftest import GRAPH_V1
+
+_TEAM_ID = "8a9c3c47-0f9e-4a24-9b1e-2f0d5c6b7a81"
+_CHANNEL_ID = "19:general@thread.tacv2"
+_MESSAGES_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages"
+
+# The sender shape every Teams *read* API answers with: a `teamworkUserIdentity`, which has an id,
+# an optional display name and no email property at all.
+_TEAMS_SENDER: dict[str, object] = {
+    "user": {
+        "@odata.type": "#microsoft.graph.teamworkUserIdentity",
+        "id": "00000000-0000-4000-8000-000000000001",
+        "displayName": "Ada Lovelace",
+        "userIdentityType": "aadUser",
+    }
+}
+
+
+def _message_payload(
+    *,
+    message_id: str,
+    content: str,
+    content_type: str = "html",
+) -> dict[str, object]:
+    """One full `chatMessage`, as a channel's message collection returns it.
+
+    Unlike a search hit this carries a `body` — which is why browsing needs no follow-up read — and
+    the Teams-shaped sender rather than the mailbox-shaped one.
+    """
+    return {
+        "@odata.type": "#microsoft.graph.chatMessage",
+        "id": message_id,
+        "etag": message_id,
+        "messageType": "message",
+        "createdDateTime": "2026-02-11T09:15:22.31Z",
+        "lastModifiedDateTime": "2026-02-11T09:15:22.31Z",
+        "lastEditedDateTime": None,
+        "deletedDateTime": None,
+        "subject": None,
+        "importance": "normal",
+        "locale": "en-us",
+        "webUrl": None,
+        "replyToId": None,
+        "from": dict(_TEAMS_SENDER),
+        "body": {"contentType": content_type, "content": content},
+        "mentions": [],
+        "attachments": [],
+        "reactions": [],
+        "eventDetail": None,
+    }
+
+
+def _post_payload(
+    message_id: str,
+    *,
+    content: str = "<div><p>a synthetic post</p></div>",
+    created_at: str = "2026-02-11T09:15:22.31Z",
+    replies: Sequence[Mapping[str, object]] = (),
+    more_replies: bool = False,
+) -> dict[str, object]:
+    """One channel root post as `?$expand=replies` returns it."""
+    payload = _message_payload(message_id=message_id, content=content)
+    payload["createdDateTime"] = created_at
+    payload["replies"] = [dict(reply) for reply in replies]
+    if more_replies:
+        payload["replies@odata.nextLink"] = f"{GRAPH_V1}{_MESSAGES_PATH}/{message_id}/replies"
+    return payload
+
+
+def _reply_payload(
+    message_id: str, *, root_id: str, created_at: str, content: str = "a synthetic reply"
+) -> dict[str, object]:
+    payload = _message_payload(message_id=message_id, content=content, content_type="text")
+    payload["createdDateTime"] = created_at
+    payload["replyToId"] = root_id
+    return payload
+
+
+_SYSTEM_MESSAGE: dict[str, object] = {
+    "@odata.type": "#microsoft.graph.chatMessage",
+    "id": "1770000009999",
+    # Without the `Prefer` header Graph reports this type as `unknownFutureValue`, which is what
+    # makes the authorless `from` and the populated `eventDetail` the signals worth filtering on.
+    "messageType": "unknownFutureValue",
+    "createdDateTime": "2026-02-11T10:00:00Z",
+    "from": None,
+    "body": {"contentType": "html", "content": "<systemEventMessage/>"},
+    "eventDetail": {
+        "@odata.type": "#microsoft.graph.membersAddedEventMessageDetail",
+        "members": [{"id": "00000000-0000-4000-8000-000000000002"}],
+    },
+    "replies": [],
+}
+
+
+class TestTheQueryItSends:
+    async def test_browsing_a_channel_asks_for_replies_and_a_page_size(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`$top` and `$expand` are the only two parameters this collection takes — and the
+        expansion is what makes a thread one request instead of one per post, which matters where
+        Graph allows the whole app one request a second per channel."""
+        route = graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000000")]})
+        )
+
+        _ = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=7,
+            include_window_completeness=False,
+        )
+
+        params = route.calls.last.request.url.params
+        assert params["$top"] == "7"
+        assert params["$expand"] == "replies"
+        assert "$orderby" not in params, "no ordering is supported here"
+        assert "$filter" not in params, "no filter is supported here, which is why no date is taken"
+
+    async def test_a_page_of_posts_above_graphs_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await browser.browse_channel(
+                client,
+                team_id=_TEAM_ID,
+                channel_id=_CHANNEL_ID,
+                limit=browser.MAX_POSTS + 1,
+                include_window_completeness=False,
+            )
+
+
+class TestBrowsingOneChannel:
+    async def test_a_post_arrives_whole_rather_than_as_a_snippet(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The point of the tool: a channel listing carries every field a single read does, so the
+        text is normalised here and no follow-up read is needed."""
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            content="<div><p>ship it&nbsp;&amp; tell everyone</p></div>",
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        post = browsed.messages[0]
+        assert post.text == "ship it & tell everyone"
+        assert (post.team_id, post.channel_id) == (_TEAM_ID, _CHANNEL_ID)
+        assert post.chat_id is None
+        assert post.reply_to_id is None, "a root post answers nothing"
+
+    async def test_one_browse_is_one_graph_request_whatever_the_channel_holds(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The budget, pinned. Graph allows this whole connector about one request a second on a
+        given channel *for the tenant*, so a call that follows `@odata.nextLink` spends a budget
+        that is not its own — and this is the collection where a page walk is most tempting, because
+        system messages are filtered out after Graph has counted them into the page. A walk bounded
+        by items scanned rather than by requests would keep asking for pages until it had `limit`
+        posts; this asks once, and the cursor is read rather than followed.
+        """
+        second_page = graph.get(_MESSAGES_PATH, params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000002")]})
+        )
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_SYSTEM_MESSAGE, _post_payload("1770000000000")],
+                    "@odata.nextLink": f"{GRAPH_V1}{_MESSAGES_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        assert [message.message_id for message in browsed.messages] == ["1770000000000"]
+        assert len(graph.calls) == 1, "one browse is one request against the channel"
+        assert not second_page.called, "the collection's cursor is deliberately not followed"
+
+    async def test_the_order_is_graphs_reply_chain_order_and_the_dates_say_so(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The surprise this tool has to be honest about. Graph sorts a channel's messages by the
+        last modified date of the *entire reply chain*, so a post from two years ago comes back
+        first because somebody replied to it yesterday. Reordering it would be inventing an order
+        Graph did not give, so the order is preserved and `created_at` is what tells the truth
+        about age — which is exactly what the tool's description tells the caller to read.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1600000000000",
+                            created_at="2024-03-01T08:00:00Z",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1600000000000",
+                                    created_at="2026-02-11T09:00:00Z",
+                                )
+                            ],
+                        ),
+                        _post_payload("1770000000000", created_at="2026-02-10T09:00:00Z"),
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        assert [message.message_id for message in browsed.messages] == [
+            "1600000000000",
+            "1770000000001",
+            "1770000000000",
+        ]
+        first = browsed.messages[0].created_at
+        assert first is not None and first.year == 2024, (
+            "the first message is the oldest post, revived by a reply"
+        )
+
+    async def test_a_reply_carries_a_handle_read_message_can_actually_resolve(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The gap this piece closes. Graph addresses a reply under the post it answers, so the
+        root-post handle shape cannot name one — and a search hit on a reply gets exactly that
+        shape and 404s. Browsing knows each reply's parent, so it can mint the third shape.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                )
+                            ],
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        reply = browsed.messages[1]
+        assert reply.reply_to_id == "1770000000000"
+        assert reply.uri == (
+            f"teams:///teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2"
+            + "/messages/1770000000000/replies/1770000000001"
+        )
+        resolved = message_handle(reply.uri)
+        assert resolved is not None
+        assert (resolved.message_id, resolved.reply_to_id) == (
+            "1770000000001",
+            "1770000000000",
+        )
+        assert resolved.channel_id == _CHANNEL_ID, "the handle round-trips its decoded ids"
+
+    async def test_replies_are_sorted_and_the_newest_of_a_long_thread_are_kept(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph publishes no order for replies, so they are sorted here, and a thread longer than
+        the window comes back full to it — which is the only thing said about a thread's older
+        replies now, and all that can be said: they are out of reach either way."""
+        replies = [
+            _reply_payload(
+                f"177000000{index:04d}",
+                root_id="1770000000000",
+                created_at=f"2026-02-11T10:{index:02d}:00Z",
+            )
+            for index in range(MAX_REPLIES_PER_POST + 3)
+        ]
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={"value": [_post_payload("1770000000000", replies=list(reversed(replies)))]},
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        kept = [message.message_id for message in browsed.messages[1:]]
+        assert kept == [reply["id"] for reply in replies[-MAX_REPLIES_PER_POST:]], (
+            "the newest replies, oldest first"
+        )
+        assert len(kept) == MAX_REPLIES_PER_POST, (
+            "a thread filled to the window is how a caller sees that it may have older replies"
+        )
+
+    async def test_a_thread_graph_itself_paged_is_not_chased(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`$expand=replies` has its own cursor per post, and not following it is a deliberate
+        choice: it is a request per post against a channel that allows the whole app one a second,
+        and a thread of hundreds is not a tool response.
+
+        The cursor needs no reporting of its own — Graph expands up to 200 replies before it pages
+        them, so a thread it paged has far more than this window holds and the window comes back
+        full either way. The request count is what matters and is asserted, because this is the half
+        of the reply story every description depends on: browsing reaches the newest replies of a
+        post and no further, which is why no surface here may tell a model to browse for an older
+        one.
+        """
+        replies = graph.get(f"{_MESSAGES_PATH}/1770000000000/replies").mock(
+            return_value=httpx.Response(200, json={"value": []})
+        )
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                )
+                            ],
+                            more_replies=True,
+                        )
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        assert len(browsed.messages) == 2
+        assert not replies.called, "a post's own replies cursor is not followed either"
+        assert len(graph.calls) == 1
+
+    async def test_system_messages_are_dropped_wherever_they_appear(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph offers no `messageType` filter on this collection, so they are filtered here — and
+        they arrive as `unknownFutureValue` without the `Prefer` header, which is why the author
+        and the event detail are the signals. A page can therefore hold fewer posts than asked
+        for, which is not evidence of a quiet channel."""
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _SYSTEM_MESSAGE,
+                        _post_payload(
+                            "1770000000000",
+                            replies=[
+                                _SYSTEM_MESSAGE,
+                                _reply_payload(
+                                    "1770000000001",
+                                    root_id="1770000000000",
+                                    created_at="2026-02-11T10:00:00Z",
+                                ),
+                            ],
+                        ),
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        assert [message.message_id for message in browsed.messages] == [
+            "1770000000000",
+            "1770000000001",
+        ]
+        assert all(message.event is None for message in browsed.messages)
+
+    async def test_microsofts_own_cursor_is_what_says_the_channel_holds_more(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The completeness signal this tool cannot do without, and the one it can read accurately.
+
+        Every other list here answers whether it was everything by its own length, because the
+        walk underneath it followed Graph's paging to the end of the collection. This tool follows
+        nothing — one request is the whole budget — and system messages are dropped out of the page
+        after
+        Graph counted them into it, so its length says neither thing. Graph's `@odata.nextLink` on
+        that page does, so it is reported: read, never followed.
+        """
+        second_page = graph.get(_MESSAGES_PATH, params={"$skiptoken": "synthetic"}).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000002")]})
+        )
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_post_payload("1770000000000")],
+                    "@odata.nextLink": f"{GRAPH_V1}{_MESSAGES_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=True,
+        )
+
+        assert browsed.more_posts_in_channel is True
+        assert browsed.posts_cut_to_limit is False, "the window closed over nothing Graph sent"
+        assert len(browsed.messages) == 1, "a short answer, and Graph said there is more"
+        assert len(graph.calls) == 1 and not second_page.called, "the cursor is read, not followed"
+
+    async def test_the_same_page_without_a_cursor_says_that_was_the_channel(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other half, and the reason the field is worth its place: without it these two
+        answers are byte-identical, so a caller cannot tell "that was the whole channel" from
+        "Microsoft says there is more". This is the page above with its cursor taken off, and
+        nothing else changed.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(200, json={"value": [_post_payload("1770000000000")]})
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=True,
+        )
+
+        assert browsed.more_posts_in_channel is False
+        assert browsed.posts_cut_to_limit is False
+
+    async def test_a_page_holding_more_posts_than_the_window_is_the_other_fact(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Two causes, two fields, because the remedies are opposite. Raising `limit` returns the
+        posts this window closed over; nothing here returns the posts behind Microsoft's cursor. One
+        boolean over both is the ambiguous flag no answer here carries, so a page Graph over-served
+        without advertising more must report the second and not the first.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [
+                        _post_payload("1770000000000"),
+                        _post_payload("1770000000001"),
+                        _post_payload("1770000000002"),
+                    ]
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=2,
+            include_window_completeness=True,
+        )
+
+        assert [message.message_id for message in browsed.messages] == [
+            "1770000000000",
+            "1770000000001",
+        ]
+        assert browsed.posts_cut_to_limit is True, "raise `limit` and the third post comes back"
+        assert browsed.more_posts_in_channel is False, "Microsoft offered no continuation"
+
+    async def test_neither_fact_is_reported_unless_it_was_asked_for(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Opt-in because a field that is null for almost every answer is one a model need not
+        reason about, so only the caller whose question turns on completeness pays for it. The
+        default answer is the messages and nothing else.
+        """
+        graph.get(_MESSAGES_PATH).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "value": [_post_payload("1770000000000")],
+                    "@odata.nextLink": f"{GRAPH_V1}{_MESSAGES_PATH}?$skiptoken=synthetic",
+                },
+            )
+        )
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=1,
+            include_window_completeness=False,
+        )
+
+        assert browsed.more_posts_in_channel is None
+        assert browsed.posts_cut_to_limit is None
+        assert len(browsed.messages) == 1, "the answer itself is unchanged either way"
+
+    async def test_a_channel_nobody_has_posted_in_is_an_empty_page_not_a_failure(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_MESSAGES_PATH).mock(return_value=httpx.Response(200, json={"value": []}))
+
+        browsed = await browser.browse_channel(
+            client,
+            team_id=_TEAM_ID,
+            channel_id=_CHANNEL_ID,
+            limit=20,
+            include_window_completeness=False,
+        )
+
+        assert browsed.messages == []
+
+
+class TestGraphFailures:
+    async def test_a_refusal_arrives_classified_for_the_tool_to_explain(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """This request is made under the broad message permission, which a tenant commonly
+        withholds while granting the two basic listing ones — so the failure has to reach the tool
+        layer, which is what names the permission."""
+        denied = httpx.Response(
+            403, json={"error": {"code": "Authorization_RequestDenied", "message": "denied"}}
+        )
+        graph.get(_MESSAGES_PATH).mock(return_value=denied)
+
+        with pytest.raises(GraphForbidden):
+            _ = await browser.browse_channel(
+                client,
+                team_id=_TEAM_ID,
+                channel_id=_CHANNEL_ID,
+                limit=20,
+                include_window_completeness=False,
+            )
+
+    def test_the_permission_is_the_one_microsoft_documents(self) -> None:
+        """Reading a channel's posts is read under the same permission `search_messages` needs for
+        channel coverage — taken from the handle grammar rather than respelled, so the two cannot
+        drift."""
+        assert browser.GRAPH_PERMISSIONS == ("ChannelMessage.Read.All",)

--- a/services/office-mcp/tests/tools/test_list_channels.py
+++ b/services/office-mcp/tests/tools/test_list_channels.py
@@ -180,5 +180,5 @@ class TestGraphFailures:
 
     def test_the_permission_is_the_one_microsoft_documents(self) -> None:
         """A tool owns the permission its own request needs, and listing channels is the cheap
-        "basic" scope — reading what was posted in one is the broader `ChannelMessage.Read.All`."""
+        "basic" scope — reading what was posted in one is browse_channel's broader permission."""
         assert lister.GRAPH_PERMISSIONS == ("Channel.ReadBasic.All",)

--- a/services/office-mcp/tests/tools/test_read_message.py
+++ b/services/office-mcp/tests/tools/test_read_message.py
@@ -5,7 +5,7 @@ authorless `<systemEventMessage/>`, the `<at>`/`<emoji>`/`<attachment>` decorati
 carries. Nothing here came from a tenant.
 
 Which strings are handles at all is `shared/handles.py`'s question, not this tool's:
-`TestTheMessageHandleGrammar` in `tests/shared/test_handles.py` covers the two shapes and
+`TestTheMessageHandleGrammar` in `tests/shared/test_handles.py` covers the three shapes and
 everything that is not one of them. What is covered here is what a read does with a handle it was
 given.
 """
@@ -35,8 +35,16 @@ _CHAT_URI = f"teams:///chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
 _CHAT_PATH = f"/chats/19%3Arelease%40thread.v2/messages/{_MESSAGE_ID}"
 _CHANNEL_PATH = f"/teams/{_TEAM_ID}/channels/19%3Ageneral%40thread.tacv2/messages/{_MESSAGE_ID}"
 
+_REPLY_ID = "1770000000002"
+_REPLY_PATH = f"{_CHANNEL_PATH}/replies/{_REPLY_ID}"
+
 _CHAT_HANDLE = MessageHandle(message_id=_MESSAGE_ID, chat_id=_CHAT_ID)
 _CHANNEL_HANDLE = MessageHandle(message_id=_MESSAGE_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID)
+# A reply is addressed under the post it answers: the parent's id is `reply_to_id`, and the reply's
+# own id is the message this handle names.
+_REPLY_HANDLE = MessageHandle(
+    message_id=_REPLY_ID, team_id=_TEAM_ID, channel_id=_CHANNEL_ID, reply_to_id=_MESSAGE_ID
+)
 
 
 def _reads(graph: respx.MockRouter, payload: dict[str, object], path: str = _CHAT_PATH) -> None:
@@ -63,6 +71,39 @@ class TestTheRequestItMakes:
         _ = await read_message.read_message(client, handle=_CHANNEL_HANDLE)
 
         assert route.called
+
+    async def test_a_reply_handle_reads_it_under_the_post_it_answers(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The only way Graph addresses a channel reply. The reply's own id beside its siblings is
+        a 404, which is the failure a search hit on a reply produces — so the handle names both ids
+        and the request nests them.
+        """
+        route = graph.get(_REPLY_PATH).mock(
+            return_value=httpx.Response(
+                200, json=message_payload(message_id=_REPLY_ID, reply_to_id=_MESSAGE_ID)
+            )
+        )
+
+        message = await read_message.read_message(client, handle=_REPLY_HANDLE)
+
+        assert route.called
+        assert message.message_id == _REPLY_ID
+        assert message.reply_to_id == _MESSAGE_ID
+        assert message.uri == _REPLY_HANDLE.uri, "the handle is echoed as it was given"
+
+    async def test_a_reply_graph_named_no_parent_for_is_still_placed_in_its_thread(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """`replyToId` is the message's own property and the handle is only the fallback — but the
+        fallback matters: a reply reported without a parent would read as a root post."""
+        _ = graph.get(_REPLY_PATH).mock(
+            return_value=httpx.Response(200, json=message_payload(message_id=_REPLY_ID))
+        )
+
+        message = await read_message.read_message(client, handle=_REPLY_HANDLE)
+
+        assert message.reply_to_id == _MESSAGE_ID
 
     async def test_it_makes_one_request_and_narrows_it_with_nothing(
         self, client: GraphServiceClient, graph: respx.MockRouter

--- a/services/office-mcp/tests/tools/test_search_messages.py
+++ b/services/office-mcp/tests/tools/test_search_messages.py
@@ -5,7 +5,7 @@ projection, the Exchange-shaped sender a search hit carries, the authorless syst
 Nothing here came from a tenant.
 
 Which strings are handles at all is `shared/handles.py`'s question, not this tool's:
-`TestTheMessageHandleGrammar` in `tests/shared/test_handles.py` covers the two shapes and
+`TestTheMessageHandleGrammar` in `tests/shared/test_handles.py` covers the three shapes and
 everything that is not one of them. What is covered here is which of them a hit carries.
 """
 
@@ -20,6 +20,7 @@ import respx
 from msgraph.graph_service_client import GraphServiceClient
 
 from office_mcp.graph_client import GraphForbidden
+from office_mcp.shared.messages import MAX_REPLIES_PER_POST
 from office_mcp.tools import search_messages
 from office_mcp.tools.search_messages import SearchCriteria
 
@@ -394,14 +395,33 @@ class TestTheHandleItMints:
 
         assert "or infer from its absence" in described
 
+    def test_the_advice_for_a_reply_hit_stops_rather_than_pointing_back_at_browsing(self) -> None:
+        """A hit that is really a channel reply carries the root-post shape, which Graph answers 404
+        to — and the advice for that has to end somewhere. `browse_channel` mints a reply's own
+        handle but reaches only the newest replies of each post on a channel's first page and
+        follows no cursor past them, so "browse the channel instead" is a route for a recent reply
+        and a loop for an older one: browse, not find it, read the same advice, browse again. So the
+        window is named and the terminus is stated here, where the handle that can fail is minted.
+        """
+        described = search_messages.MessageHit.model_fields["uri"].description
+        assert described is not None
+
+        assert "browse_channel" in described, "the one tool that can, when the reply is recent"
+        assert f"only the newest {MAX_REPLIES_PER_POST} replies" in described, (
+            "and where it stops, in the number the browser actually applies rather than in prose "
+            + "of its own"
+        )
+        assert "no route to its full text" in described
+        assert "browsing again returns the same window" in described
+        assert "stop looking" in described
+
 
 class TestWhatTheCallerIsTold:
     async def test_a_chat_hit_carries_a_chat_handle_and_a_channel_hit_a_channel_one(
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
-        """The handle is what names the exact message Graph matched, since the search projection
-        has no body — and the ids in it are percent-encoded because a Teams id is full of `:` and
-        `@`."""
+        """The handle is the whole route to the message text, since the search projection has no
+        body — and the ids in it are percent-encoded because a Teams id is full of `:` and `@`."""
         graph.post("/search/query").mock(
             return_value=httpx.Response(
                 200,
@@ -439,8 +459,8 @@ class TestWhatTheCallerIsTold:
         self, client: GraphServiceClient, graph: respx.MockRouter
     ) -> None:
         """Graph does occasionally return a hit with no chatId and no channelIdentity. Its snippet
-        is still an answer, so it is reported — with a null `uri` saying it cannot be addressed at
-        all, rather than being dropped or given a handle that names nothing."""
+        is still an answer, so it is reported — with a null `uri` saying it cannot be read in
+        full, rather than being dropped or given a handle that would 404."""
         hit = chat_hit(chat_id=None)
         graph.post("/search/query").mock(
             return_value=httpx.Response(200, json=search_response([hit]))


### PR DESCRIPTION
## What this answers

"What is going on in #release."

No tool on this server could answer it. `search_messages` finds messages by keyword across every
chat and channel at once and cannot be scoped to one of them; `read_message` reads a message
somebody already holds a handle for; `list_channels` names a channel and then stops. `browse_channel`
takes the `team_id` and `channel_id` that pair already returns and answers with the channel's posts,
each followed by the replies to it, every message whole — the same shape and the same
Teams-HTML-normalised text `read_message` returns, so nothing that comes back needs a second call to
read.

It adds no permission to the consent screen. `ChannelMessage.Read.All` is what `search_messages` and
`read_message` already declare, so `GRAPH_SCOPES` comes out of the registry unchanged: same tuple,
same order, same cached On-Behalf-Of token keys, and no tenant has to re-consent to deploy this.

## The decisions worth knowing

**One request, never a sweep.** Graph allows about one request a second on a given channel for the
whole app per tenant. That budget is per *app*, not per user, so a loop over a team's channels
degrades every other user of this connector, and following `@odata.nextLink` down one channel spends
that channel's whole tenant budget on one caller. So the tool issues exactly one request. `$top` is
the window; `$expand=replies` makes a thread part of that one request instead of a round trip per
post; both cursors Graph offers — the collection's, and a post's own `replies@odata.nextLink` — are
read and not followed. A caller who needs more raises `limit`, up to Graph's own ceiling. A caller
who needs to reach across channels was always meant to use `search_messages`, which covers every
channel for the price of the request it was making anyway. The description says all of this in as
many words, because a budget is only a bound if the caller can see it.

**The order is thread activity, not post recency.** Graph sorts this collection by the last modified
date of the *entire reply chain*, so a two-year-old post returns to the front the moment somebody
replies to it. The list is not reordered here — reordering would be inventing an order Graph did not
give — and the description tells the model to read `created_at` rather than the position, and not to
report the top of the list as the latest news in the channel. This is also the second reason there
is no walk: "stop paging once a page is older than X" is unsound on a collection ordered this way,
so paging is bounded by a count and never by a date.

**No date parameter, and that is Microsoft's limit rather than an omission.** `$top` and
`$expand=replies` are the only parameters this collection takes — no `$filter`, no `$orderby` — so
rather than faking a date bound out of client-side filtering, the tool has none and points at
`search_messages`, which puts the date into the search index instead. Two assertions in the tests are
about parameters that must *not* go on the wire, for exactly that reason.

**This is the one answer here that cannot say whether it was everything.** Everywhere else on this
connector a page short of `limit` is the end of the collection, because the walk underneath followed
Graph's paging to it. Here nothing is followed, and system messages are dropped out of the page after
Graph has counted them into it — so a short answer says neither "that was the channel" nor "there is
more". Graph's own `@odata.nextLink` on that page does say, accurately, so it is reported: read,
never followed.

It is reported as two fields rather than one, and only when asked for. Two, because
`more_posts_in_channel` ("the channel holds more, and nothing here reaches it — search back in
time") and `posts_cut_to_limit` ("this window closed over posts Graph did send — raise `limit`") have
opposite remedies, and one boolean over both is the ambiguous flag no answer on this server carries.
Opt-in, because a field that is null for almost every answer is one a model need not reason about;
only the caller whose question turns on completeness pays for it, and asking changes what is
reported and never what was read.

**Every claim the prose makes about Graph is settled by a test, not carried across.** One request
per browse whatever the channel holds; the cursor read and the second page never fetched; a post's
own reply cursor not chased; the reply-chain order preserved with `created_at` telling the truth;
the same page answering differently with and without `@odata.nextLink`; system messages dropped from
posts *and* from replies. The end-to-end walk goes teams → channels → posts → a reply read back by
its own handle, over the real MCP protocol, with each id taken from the previous answer.

## What it adds to `shared/`, and why that is vocabulary

**The channel-reply handle shape.** Graph addresses a reply in a channel thread *under* the post it
answers, and the search projection carries no `replyToId` — so a search hit that is really a reply
gets the root-post shape, which Graph answers 404 to. `browse_channel` walks a channel post by post
and therefore knows each reply's parent, which makes it the only tool on this connector that can mint
the shape at all. It still lives in `shared/handles.py`, with the other three, because a handle one
tool mints and another reads is only readable while there is exactly one definition of it: two
spellers would not look like a disagreement, they would look like a handle one tool produced and
another 404s. `read_message` gains the nested request that resolves it in the same PR, because a
shape whose reader does not exist is a dead link dressed as an answer.

**`MAX_REPLIES_PER_POST`.** One tool applies it; two others can only *describe* it. When a search hit
is a reply, `read_message`'s 404 has to tell the model where a reply's own handle can be obtained and
where that runs out, and `search_messages` has to say the same on the field that mints the failing
handle. A second spelling of the number would be a refusal sending a caller to a window the browser
does not actually reach — and nothing would fail. That is precisely the test for shared vocabulary:
two files would each need a copy, and a difference between the copies is a bug a caller can see.

Neither of these is a layer. `shared/` publishes no `__all__` and is entered by module, so every
consumer names at its import line which piece of vocabulary it depends on; the visibility is the
point. What stayed in the tool file is everything one tool could own — the name, the description, the
permission, the arguments, the answer shape, the Graph request and every refusal only this tool can
explain.

## Layering rules

**No rule becomes newly assertable here, and that is the honest answer.** The one rule of the
finished set still absent — nothing may address a single meeting recording — needs a recordings
listing to be the surface it protects, and arrives with the tool that lists them. The numbering is
left as it is so that arriving costs a class and changes nothing else.

What does change is how much rule 6 forbids. "One speller per handle family" now covers four shapes
minted between three tools, and its guard checks both halves: that `handles.py` still writes every
family the rule gives it, and that no other module under `src/` builds or parses one. The reply shape
is the strongest case the rule has — the only tool that can mint it and the only tool that resolves
it are different files, and neither spells the URI.

Rules 1 and 4 are the ones a tool like this is most likely to break, and both still hold by
construction: `browse_channel` imports `shared/`, `graph_client/` and FastMCP and nothing else of
this package, and the registry is still the one place every tool module is named — which is where the
consent screen's scopes come from.

