### PR TITLE
feat(office-mcp): read a Teams meeting's transcript in speaker turns

### DIFF
--- a/services/office-mcp/README.md
+++ b/services/office-mcp/README.md
@@ -2,14 +2,15 @@
 
 An MCP server for Microsoft 365 via Microsoft Graph API.
 
-Users sign in with their own Microsoft account and the server acts as them. It exposes eight MCP
+Users sign in with their own Microsoft account and the server acts as them. It exposes nine MCP
 tools so far — `get_me`, the signed-in user's own profile; `list_chats`, their Microsoft Teams chats
 most recently active first; `list_teams`, the teams they are a member of; `list_channels`, the
 channels of one of those teams; `browse_channel`, what was posted in one of those channels;
 `search_messages`, full-text search across every Teams message they can see; `read_message`,
-one of those messages in full; and `list_meeting_transcripts`, whether a Teams meeting was
-transcribed and a handle for each transcript — each one a file of its own, and more land in later
-PRs, stacked on top of this one, one tool per PR.
+one of those messages in full; `list_meeting_transcripts`, whether a Teams meeting was
+transcribed and a handle for each transcript; and `read_transcript`, what was said in one of those
+meetings as speaker-attributed, timestamped turns — each one a file of its own, and more land in
+later PRs, stacked on top of this one, one tool per PR.
 
 ## Layout
 
@@ -85,7 +86,7 @@ Tools redeem permissions per call via On-Behalf-Of. No permission = no consent =
 | `Channel.ReadBasic.All` | Delegated | No | `list_channels` |
 | `ChannelMessage.Read.All` | Delegated | Yes, in most tenants | `browse_channel`, `search_messages`, `read_message` (channels) |
 | `OnlineMeetings.Read` | Delegated | No | `list_meeting_transcripts` (resolving a join URL to a meeting) |
-| `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** | `list_meeting_transcripts` |
+| `OnlineMeetingTranscript.Read.All` | Delegated | **Yes** | `list_meeting_transcripts`, `read_transcript` |
 
 Multiple tools naming the same permission is normal. It is not duplication to remove. Each tool
 declares its own tuple because that tuple words its own 403 and AADSTS65001 messages.
@@ -103,14 +104,19 @@ access, or `Set-CsTeamsMeetingConfiguration -EnableGraphTranscriptAccess $true -
 There is no Graph API to set it and no request-side workaround, so it is an onboarding step next to
 admin consent rather than something this connector can fix; `services/teams-mcp` learned this in PR
 #762 and `docs/recordings-and-transcripts/operator.md` documents it. Until it is on, every call to
-`list_meeting_transcripts` fails with that remedy named — and only that tool: Microsoft scopes the
-setting to transcript resources, so nothing else here is affected.
+`list_meeting_transcripts` and `read_transcript` fails with that remedy named — and only those two:
+Microsoft scopes the setting to transcript resources, so nothing else here is affected. The
+neighbouring `-EnableAttributedTranscripts` setting is *not* a prerequisite: when it is off,
+`read_transcript` degrades to Microsoft's unattributed format and reports `speaker_attribution:
+false` rather than failing.
 
 The two meeting permissions are separate scopes and are granted independently, which is the point of
 asking for both: `OnlineMeetings.Read` is the least privilege Microsoft documents for resolving a
-join URL to a meeting and needs no administrator, while reading the transcript collection needs one.
+join URL to a meeting and needs no administrator, while reading a transcript resource needs one.
 A tenant can grant the first and withhold the second, and the tool's 403 then names the one its own
-request was made under.
+request was made under. Only the lister spends both — `read_transcript` is handed a meeting id
+somebody already resolved, so it declares the admin-consented one alone and still answers in a
+tenant that withholds `OnlineMeetings.Read`.
 
 `Chat.Read` not `Chat.ReadBasic`: listing chats by recency needs `$expand=lastMessagePreview`.
 A preview is a message; "read chat names" doesn't cover it.

--- a/services/office-mcp/src/office_mcp/shared/__init__.py
+++ b/services/office-mcp/src/office_mcp/shared/__init__.py
@@ -2,7 +2,7 @@
 
 Every tool in `tools/` is a file of its own — its name, its description, its Graph permissions, its
 arguments, its answer shape, its Graph request and its own error wording all in one place, so that
-adding the ninth tool is adding one file and reading the eighth is reading one file. That is the
+adding the tenth tool is adding one file and reading the ninth is reading one file. That is the
 whole point, and it has exactly one cost: two files are free to disagree. This package is the list
 of things they must not.
 
@@ -23,11 +23,12 @@ difference between the copies would be a bug a caller could see:
   it, and `search_messages` and `read_message` both have to describe it to explain why a reply a
   search found may have no handle that reads.
 * `meetings.py` — how a meeting is reached, which occurrence was asked about, and how far "newest
-  first" is true. The only entry here whose second caller has not landed yet, and deliberately so:
-  none of the three is a fact about transcripts, they are facts about a meeting and the artifact
-  collections Graph hangs off one, and a second tool over the same meeting would otherwise re-derive
-  all of them. Leaving them in the tool file would make their eventual move a refactor rather than a
-  decision, and a tool's private helper is exactly what a second tool copies rather than imports.
+  first" is true. None of those is a fact about transcripts: they are facts about a meeting and the
+  artifact collections Graph hangs off one, and a second tool over the same meeting would otherwise
+  re-derive all of them. `read_transcript` is the first tool to arrive and take a name from here
+  without touching the rest, which is what the split was for — the permission a transcript resource
+  costs is the resource's rather than one tool's request's, so it is spelled where neither of the
+  two tools that name it owns it.
 * `identity.py` — who the signed-in user is. `get_me` reports it; it is also the fact every other
   answer on this connector is correlated against, so a second tool asking it with a `GET /me` of
   its own would be a second answer to one question.

--- a/services/office-mcp/src/office_mcp/shared/meetings.py
+++ b/services/office-mcp/src/office_mcp/shared/meetings.py
@@ -8,10 +8,13 @@ a second tool over the same meeting would otherwise make for itself, and the cos
 test for belonging here: a caller cannot see two tools disagreeing about "the latest occurrence", it
 can only see one of them being wrong.
 
-That is also why this is here while one tool calls it. The alternative is not "keep it in the tool
-file and move it when a second caller arrives" — it is a later diff that moves a promise, reviewed
-as a refactor rather than as a decision, with the window spending that whole time as one tool's
-private helper. A private helper is exactly what the second caller copies.
+`read_transcript` is the second caller, and it takes exactly one name from here — the permission a
+transcript resource costs — while the resolve, the window and the ordering stay the lister's to
+call. That is the split working rather than an argument for undoing it: the reader is handed a
+meeting id somebody else resolved, so it must not repeat the resolve, and the permission it declares
+is still the permission the *resource* costs rather than the permission one tool's request costs.
+Had that name lived in the tool file it would have been a string spelled twice, because rule 4
+forbids the second tool importing the first to find out how the first spelled it.
 
 ## How a meeting is addressed, and the one place the chain can break
 
@@ -135,14 +138,14 @@ from office_mcp.shared.handles import MeetingHandle
 MEETING_PERMISSION = "OnlineMeetings.Read"
 
 # Reading a transcript resource, which is admin-consented and grantable independently of the
-# resolve above. Spelled here rather than in the tool file that declares it because it is the
-# permission the *resource* costs rather than the permission one tool's request costs: anything
-# else reaching a `callTranscript` needs exactly this one, and rule 4 forbids it importing a tool
-# file to find out. A tool-side constant is therefore a string spelled twice by construction, and
-# two spellings of a permission is not a tidiness problem — the authorize request carries whatever
-# they say, and a typo in one of them is a scope Entra rejects and a sign-in that fails for
-# everybody (see `shared/seam.py`'s `REQUESTABLE_PERMISSIONS`, which is what holds the spelling to
-# Microsoft's).
+# resolve above. Spelled here rather than in a tool file because it is the permission the *resource*
+# costs rather than the permission one tool's request costs, and two tools reach that resource:
+# `list_meeting_transcripts` lists a meeting's transcripts under it and `read_transcript` reads one
+# of them. Rule 4 forbids the second importing the first to find out how it was spelled, so a
+# tool-side constant is a string spelled twice by construction — and two spellings of a permission
+# is not a tidiness problem: the authorize request carries whatever they say, and a typo in one of
+# them is a scope Entra rejects and a sign-in that fails for everybody (see `shared/seam.py`'s
+# `REQUESTABLE_PERMISSIONS`, which is what holds the spelling to Microsoft's).
 #
 # Declaring is still each tool's own: a tool's `GRAPH_PERMISSIONS` tuple is what its 403 and its
 # AADSTS65001 are worded from, so it names the permissions its own request is made under and takes

--- a/services/office-mcp/src/office_mcp/shared/meetings.py
+++ b/services/office-mcp/src/office_mcp/shared/meetings.py
@@ -17,10 +17,14 @@ Graph documents exactly three delegated ways to reach an `onlineMeeting`
 (https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get): by its own `id`, by `joinWebUrl`,
 or by `joinMeetingIdSettings/joinMeetingId`. Only the join URL path works from Teams' conversation
 side. Only place delegated callers get one: `chat.onlineMeetingInfo.joinWebUrl` in default
-`GET /me/chats`. Chat id is not a route; neither is chat `webUrl`.
+`GET /me/chats`. That collection supports `$expand`, `$top`, `$filter`, and `$orderby` only. It has
+no `$select`, so the field could not be requested even if it were absent. Chat id is not a route;
+neither is chat `webUrl`.
 
-Verified: meeting chats are enumerable with `topic` and recency. **Not verified**: `joinWebUrl` is
-populated, especially for non-organisers. Null join URL is first-class outcome, not impossible.
+Verified: meeting chats are enumerable with `topic` and recency. Graph documents `joinWebUrl` as
+empty when the chat is not a meeting's chat at all. **Not verified**: `joinWebUrl` is populated
+when the chat is a meeting's chat, especially for non-organisers. Null join URL is first-class
+outcome, not impossible.
 No fallback or second route documented. `onlineMeeting.chatInfo.threadId` is filterable in code but
 not in Graph docs, so we skip that invented path.
 
@@ -32,9 +36,11 @@ policy roughly 60 days after a one-off
 ## The `$filter` on the join URL, and the bug class around it
 
 Graph: "joinWebUrl must be URL encoded". A `%3a` in the stored URL arrives as `%253a` (% is
-escaped). Wrong code doubles quotes then hands raw URL to concatenation without encoding, making
-`&` or `#` in the URL parse as truncated filter — Graph answers `200 OK` with empty `value`,
-indistinguishable from "no such meeting" (silent failure).
+escaped). `services/teams-mcp` has this defect today, in
+`src/transcript/tools/ingest-meeting.tool.ts`. It doubles the quote. Then it hands the raw URL to a
+JavaScript SDK that does not encode query parameters. A join URL with `&` or `#` then parses as a
+truncated filter. Graph answers `200 OK` with an empty `value`, indistinguishable from "no such
+meeting" (silent failure).
 
 Two transforms, only the first ours:
 1. OData literal escape: double single quotes inside string literals. Required for correctness and
@@ -221,7 +227,8 @@ async def newest_in_window[T: MeetingArtifact](
     """Limit newest artifacts of meeting in window, newest first.
 
     Read everything window holds, sort, cut to limit — Graph has no orderby. Stop-at-limit-before-
-    sort is undetectable wrong answer. Capped: read stopped at MAX_ARTIFACT_SCAN; nothing else.
+    sort is undetectable wrong answer. `capped` means only that the scan hit `MAX_ARTIFACT_SCAN`.
+    It does not mean the window held more than `limit` artifacts. Read the returned count for that.
 
     Where promise stops being "newest of this meeting" and starts being "newest of read ones". With
     no orderby, only reading everything makes newest exact. Cap prevents unbounded walk on

--- a/services/office-mcp/src/office_mcp/shared/meetings.py
+++ b/services/office-mcp/src/office_mcp/shared/meetings.py
@@ -1,119 +1,86 @@
 """How a meeting is reached, which occurrence was asked about, and what "newest" is worth.
 
-None of those three is a fact about transcripts. They are facts about the *meeting*, and about the
-artifacts Graph hangs off one: a `callTranscript` collection and a `callRecording` collection on the
-same `onlineMeeting`, reached through the same resolve, ordered the same way (which is to say not at
-all), and answered empty in the same ambiguous way. Everything in this module is therefore a promise
-a second tool over the same meeting would otherwise make for itself, and the cost of that is the
-test for belonging here: a caller cannot see two tools disagreeing about "the latest occurrence", it
-can only see one of them being wrong.
+Three facts about the *meeting*, not transcripts. They are meeting promises no second tool should
+make for itself — a caller cannot see two tools disagreeing about "the latest occurrence", only one
+being wrong. `callTranscript` and `callRecording` collections share one `onlineMeeting`, reach it
+the same way, and answer empty ambiguously.
 
-`read_transcript` is the second caller, and it takes exactly one name from here — the permission a
-transcript resource costs — while the resolve, the window and the ordering stay the lister's to
-call. That is the split working rather than an argument for undoing it: the reader is handed a
-meeting id somebody else resolved, so it must not repeat the resolve, and the permission it declares
-is still the permission the *resource* costs rather than the permission one tool's request costs.
-Had that name lived in the tool file it would have been a string spelled twice, because rule 4
-forbids the second tool importing the first to find out how the first spelled it.
+`read_transcript` takes one name from here: the permission a transcript resource costs. It does not
+resolve (the handle carries the resolved id) or order (the lister called). That is the working
+split: the reader cannot repeat the resolve, and the permission it declares is the resource cost,
+not the request cost. Had that name lived in a tool file it would be spelled twice (rule 4 forbids
+tool files sharing a constant).
 
 ## How a meeting is addressed, and the one place the chain can break
 
 Graph documents exactly three delegated ways to reach an `onlineMeeting`
 (https://learn.microsoft.com/en-us/graph/api/onlinemeeting-get): by its own `id`, by `joinWebUrl`,
-or by `joinMeetingIdSettings/joinMeetingId`. A chat id is not one of them, and neither is a chat's
-`webUrl`. So the only route from Teams' conversation side to the meeting side is the join URL, and
-the only place a delegated caller is given one is `chat.onlineMeetingInfo.joinWebUrl` — a property
-of the `chat` resource, present in the default projection of `GET /me/chats` (that collection
-supports `$expand`, `$top`, `$filter` and `$orderby` and nothing else, so it could not be asked for
-explicitly even if it were absent), and documented as "empty" when the chat is not a meeting's.
+or by `joinMeetingIdSettings/joinMeetingId`. Only the join URL path works from Teams' conversation
+side. Only place delegated callers get one: `chat.onlineMeetingInfo.joinWebUrl` in default
+`GET /me/chats`. Chat id is not a route; neither is chat `webUrl`.
 
-**What is verified and what is not.** Meeting chats being enumerable with a descriptive `topic` and
-a recency timestamp is confirmed against a live tenant. That `onlineMeetingInfo.joinWebUrl` is
-*populated* — in general, and specifically for a meeting the signed-in user did not organise — is
-**not**: the property is documented on the resource and modelled by the SDK, and no doc says it is
-organiser-only, but no live call has been made that asked for it. So a null join URL is a first-
-class outcome rather than an impossible one: `list_chats` reports no `meeting_uri` for that chat,
-and there is no fallback, because there is no documented second route. `onlineMeeting` does carry a
-`chatInfo.threadId`, and a `$filter` on it would be exactly the invented path this module refuses
-to ship: Graph documents neither that property as filterable nor any lookup by it.
+Verified: meeting chats are enumerable with `topic` and recency. **Not verified**: `joinWebUrl` is
+populated, especially for non-organisers. Null join URL is first-class outcome, not impossible.
+No fallback or second route documented. `onlineMeeting.chatInfo.threadId` is filterable in code but
+not in Graph docs, so we skip that invented path.
 
-Two further limits belong to the caller rather than to the code. The resolve step is documented for
-attendees — "These request URLs accept both the organizer's and the invited attendee's user token
-(delegated permission)" — but the transcript *list* is not: its reference page documents
-`OnlineMeetingTranscript.Read.All` and says nothing about non-organisers, so a participant may be
-refused where the organiser succeeds. And every artifact API "works for a meeting only if the
-meeting has not expired", which is roughly 60 days for a one-off
+Two limits belong to caller: resolve is documented for attendees; transcript list is not (may refuse
+non-organisers). Every artifact API works only if meeting has not expired, depending on tenant
+policy roughly 60 days after a one-off
 (https://learn.microsoft.com/en-us/microsoftteams/limits-specifications-teams#meeting-expiration).
 
 ## The `$filter` on the join URL, and the bug class around it
 
-Graph's note is one line — "**joinWebUrl** must be URL encoded" — and its worked example shows how
-far that goes: a `%3a` already inside the stored URL arrives as `%253a`, because the `%` is itself
-escaped. `services/teams-mcp` gets this wrong today (`src/transcript/tools/ingest-meeting.tool.ts`
-doubles the quote and then hands the raw URL to a JavaScript SDK that concatenates query parameters
-without encoding), and the failure is silent: a join URL carrying `&` or `#` — real ones do — makes
-Graph parse a truncated filter and answer `200 OK` with an empty `value`, which reads exactly like
-"no such meeting".
+Graph: "joinWebUrl must be URL encoded". A `%3a` in the stored URL arrives as `%253a` (% is
+escaped). Wrong code doubles quotes then hands raw URL to concatenation without encoding, making
+`&` or `#` in the URL parse as truncated filter — Graph answers `200 OK` with empty `value`,
+indistinguishable from "no such meeting" (silent failure).
 
-Here the two transforms are separated, and only the first is ours:
+Two transforms, only the first ours:
+1. OData literal escape: double single quotes inside string literals. Required for correctness and
+to stop a crafted URL closing the literal and injecting predicates.
+2. Percent-encoding: Python SDK does it correctly, so we do not repeat it. Query parameters use
+form-style expansion, escaping everything outside unreserved set. Double-encoding produces `%2525…`
+and again an empty value. Tests pin bytes on the wire because this is the failure that looks like
+success.
 
-1. **OData literal escape.** A single quote inside an OData string literal is doubled. Required for
-   correctness and to stop a crafted URL closing the literal and appending predicates of its own.
-2. **Percent-encoding**, which the Python SDK does correctly and which is therefore not repeated:
-   `$filter` is a query parameter of a URI template, and form-style expansion escapes everything
-   outside the unreserved set — including `%`, `&`, `#`, `?` and `=`. Encoding it a second time
-   would produce `%2525…` and, again, an empty `value`. The tests pin the bytes that reach the
-   wire, because this is the failure that looks like an answer.
-
-`200 OK` with `value: []` is Graph's documented "no match" for this filter — it never 404s — so it
-is reported as its own outcome and not as an error.
+`200 OK` with `value: []` is Graph's documented "no match" for this filter (never 404s). Reported as
+its own outcome, not an error.
 
 ## The occurrence window, and the shapes a model actually sends
 
-`started_after`/`started_before` exist for one reason: a recurring series is a single meeting to
-Graph, so its occurrences share one artifact collection and the only thing telling them apart is
-when the artifact began. That makes the window the thing a model reaches for most, and it arrives
-in whatever shape the model wrote — `2026-08-11T09:00:00+02:00`, but just as often
-`2026-08-11T09:00:00` or `2026-08-11`, because that is how a date gets written when nobody is
-watching. All three are accepted and resolved against UTC, in `OccurrenceWindow` and nowhere else:
-Graph timestamps every artifact in UTC, so UTC is the assumption that needs no second piece of
-information, and resolving once at the edge is what stops anything downstream comparing a naive
-datetime with an aware one — which is a `TypeError` raised at a caller who did nothing wrong, not a
-wrong answer it could notice. A bare date is a whole UTC day rather than its first instant, because
-writing the same date in both bounds is how one occurrence gets bracketed and midnight-to-midnight
-would be an empty window reported as an answer. The assumption is stated in each tool's own
-parameter descriptions, where a model reads it: `09:00` is a different instant in Zurich, and a
-window quietly built in the wrong zone is worse than one that was refused.
+`started_after`/`started_before` exist because recurring series are one meeting to Graph, so
+occurrences share one collection distinguished only by artifact start time. Models write in any
+shape: `2026-08-11T09:00:00+02:00`, `2026-08-11T09:00:00`, or `2026-08-11`. All three accepted,
+resolved against UTC in `OccurrenceWindow` and nowhere else: Graph timestamps artifacts in UTC, so
+UTC is the assumption needing no second info. Resolving once at the edge stops downstream comparing
+naive with aware datetime (TypeError to caller). Bare date is whole UTC day, not first instant:
+same date in both bounds brackets one occurrence; midnight-to-midnight would be empty. The
+assumption is stated in each tool's parameter descriptions: `09:00` is different in Zurich; a
+window quietly built in wrong zone is worse than one refused.
 
 ## Newest first, exactly as far as it is true
 
-"The latest transcript of this series" is the question a lister exists for, so the order has to be
-a property of what was *read* and not of the page Graph happened to answer with — Graph documents
-`$select`, `$filter` and `$top` on these collections and no `$orderby` at all
-(https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-transcripts), and a walk that
-stopped at `limit` before sorting would return an arbitrary `limit` artifacts sorted among
-themselves and call them the newest. That is a wrong answer with the shape of a right one, which is
-the whole reason `newest_in_window` is a named function rather than four lines inside a tool: the
-mistake is invisible in the answer, so the place it is not made has to be one place.
+"The latest transcript" is why a lister exists. Order must be a property of what was read, not the
+page Graph happened to return. Graph documents `$select`, `$filter`, `$top` on transcripts but no
+`$orderby`. A walk stopped at limit before sorting returns arbitrary limit artifacts sorted among
+themselves, wrong answer with right shape. That is why `newest_in_window` is a named function not
+four lines in a tool: the mistake is invisible, so the place it is not made must be one place.
 
-What the promise is worth is bounded by `MAX_ARTIFACT_SCAN`, and every sentence a model reads is
-worded to that bound rather than to "the newest of this meeting". Up to that many artifacts are
-read, in whatever order Graph chose; for a meeting with no more than that they are the whole
-collection and the first entry is the latest outright, which covers every meeting but a series
-recorded daily for the better part of a year. Past it the first entry is the newest of the
-artifacts that were *read*, and a newer one can sit in the part that was not. Raising the cap would
-move that boundary rather than remove it: with no `$orderby` to ask the newest for, nothing short of
-reading the whole collection makes the word exact, and Graph publishes no ceiling on how large that
-collection can be.
+Promise bounded by `MAX_ARTIFACT_SCAN`; sentences worded to that, not "newest of this meeting". Up
+to that many artifacts read in whatever order Graph chose. Meetings under the cap: these are the
+whole collection, first entry is latest. Series recorded daily for most of a year exceed the cap;
+first entry is newest of the read ones; newer ones sit unread. Raising the cap moves the boundary,
+not removes it: without `$orderby`, only reading the whole collection makes "newest" exact. Graph
+publishes no ceiling on collection size.
 
 ## Whether an empty answer means "wait" or "there is none"
 
-`settled` is that inference and it is deliberately not the verdict: the verdict is a different word
-per artifact — `not_transcribed` is one of them — and the tool that answers owns its own vocabulary.
-What must not exist twice is the *inference*. Reading it off the meeting instead of off the window
-was a wrong answer no caller could detect — a recurring series whose `endDateTime` is in the future
-made every empty window "still processing", including one bracketing an occurrence that ended weeks
-ago and was never transcribed, which is an instruction to poll forever.
+`settled` is that inference; deliberately not the verdict. Verdict is different per artifact; tool
+owns vocabulary. The *inference* must not exist twice. Reading off meeting instead of window was
+wrong answer no caller could detect: series with future `endDateTime` made every empty window
+"still processing", including one bracketing an ended occurrence never transcribed — instruction
+to poll forever.
 """
 
 from dataclasses import dataclass
@@ -130,67 +97,36 @@ from msgraph.graph_service_client import GraphServiceClient
 from office_mcp.graph_client import CollectedItems, GraphCollection, collect_pages
 from office_mcp.shared.handles import MeetingHandle
 
-# Resolving a join URL to a meeting is `OnlineMeetings.Read`, the least privilege Graph documents
-# for the filter, and it needs no admin consent. It lives with the resolve rather than in a tool
-# file because it is the permission `resolve_meeting` spends, whichever artifact the tool that
-# called it went on to ask about — reading either artifact is a further, admin-consented permission
-# that the tool declares for itself.
+# Resolving join URL to meeting: OnlineMeetings.Read, least privilege for filter, no admin consent.
+# Lives with resolve, not tool file, because resolve_meeting pays it regardless of artifact type.
 MEETING_PERMISSION = "OnlineMeetings.Read"
 
-# Reading a transcript resource, which is admin-consented and grantable independently of the
-# resolve above. Spelled here rather than in a tool file because it is the permission the *resource*
-# costs rather than the permission one tool's request costs, and two tools reach that resource:
-# `list_meeting_transcripts` lists a meeting's transcripts under it and `read_transcript` reads one
-# of them. Rule 4 forbids the second importing the first to find out how it was spelled, so a
-# tool-side constant is a string spelled twice by construction — and two spellings of a permission
-# is not a tidiness problem: the authorize request carries whatever they say, and a typo in one of
-# them is a scope Entra rejects and a sign-in that fails for everybody (see `shared/seam.py`'s
-# `REQUESTABLE_PERMISSIONS`, which is what holds the spelling to Microsoft's).
-#
-# Declaring is still each tool's own: a tool's `GRAPH_PERMISSIONS` tuple is what its 403 and its
-# AADSTS65001 are worded from, so it names the permissions its own request is made under and takes
-# the name from here rather than re-typing it.
+# Reading a transcript resource: admin-consented, independent from resolve. Spelled here because
+# it is resource cost, not request cost, and two tools read it. Rule 4 forbids tool files sharing
+# constants. Tool's GRAPH_PERMISSIONS tuple names its request permissions; gets name from here.
+# Typo in one is Entra scope rejection, sign-in fails for everybody.
 TRANSCRIPT_PERMISSION = "OnlineMeetingTranscript.Read.All"
 
-# How many of a meeting's artifacts one listing may look at, whichever artifact it is. This is what
-# "newest first" costs: Graph documents no `$orderby` on either collection, so the newest can only
-# be known by looking at the collection, and a walk that stopped at `limit` would be sorting an
-# arbitrary handful of it (see `newest_in_window`). The bound is on artifacts rather than on
-# requests because that is what `collect_pages` can bound — Graph chooses the page size here and
-# publishes none — so the honest statement of the cost is "at most this many artifacts are looked
-# at, in however many pages Graph answers them in".
-#
-# 200 is four times the largest `limit` a lister offers and far past any real meeting: a meeting
-# accumulates one artifact per occurrence, so reaching this takes a series that has run daily for
-# the better part of a year *and* been recorded every time. A meeting that does exceed it is not
-# answered with a guess — the scan is reported as incomplete, no absence is asserted, and "newest
-# first" is stated as what it then is, an order over the artifacts that were read.
-#
-# Raising it is not the fix for either of those, which is why the number is boring: a bigger cap
-# moves the boundary and leaves both statements needing the same qualification, because Graph
-# offers no `$orderby` to ask the newest for and no date `$filter` to make the window the server's.
+# Artifacts one listing may scan. This is "newest first" cost: no orderby, only looking at the
+# collection reveals newest. Bound on artifacts not requests (what collect_pages can bound). Graph
+# chooses page size. 200 is 4x largest limit offered; meets/series recorded daily for most of a
+# year hit the cap. Exceeding it: scan incomplete, no guess, "newest" of the read ones.
 MAX_ARTIFACT_SCAN = 200
 
-# How long after a window closes — or after a meeting ends, where no window was asked for — a
-# missing artifact is still called "not ready" rather than "never made". Microsoft publishes no SLA
-# and no "processing" status for the availability of a transcript or of a recording, so this is not
-# a promise about Graph — it is which of two opposite pieces of advice to give when the evidence is
-# the same empty collection. Generous on purpose: telling a caller to wait once when nothing will
-# ever arrive costs one call, while telling it a transcript does not exist when it is ten minutes
-# away is a wrong answer it cannot detect.
+# How long after window closes or meeting ends does missing artifact stay "not ready" not "never
+# made". Microsoft publishes no SLA or "processing" status. Generous: wait once when nothing
+# arrives (one call cost) beats saying "no transcript" when it arrives in ten minutes
+# (undetectable wrong).
 ARTIFACT_DELAY_ALLOWANCE = timedelta(hours=4)
 
 type _MeetingsQuery = OnlineMeetingsRequestBuilder.OnlineMeetingsRequestBuilderGetQueryParameters
 
 
 class MeetingArtifact(Protocol):
-    """The one property a window needs of a meeting artifact: when it began.
+    """The one property a window needs: when artifact began.
 
-    Structural rather than nominal because there are two of these in Graph and they are unrelated
-    generated classes: `callTranscript` and `callRecording` both carry `createdDateTime` and nothing
-    else below is read. Naming the property rather than one of the classes is what keeps this module
-    about a meeting rather than about transcripts — the window scopes an occurrence, and which
-    artifact was hung off that occurrence is not its business.
+    Structural not nominal: callTranscript and callRecording are unrelated generated classes both
+    carrying createdDateTime.
     """
 
     @property
@@ -199,14 +135,10 @@ class MeetingArtifact(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class OccurrenceWindow:
-    """Which occurrence was asked about, as two instants that are always timezone-aware.
+    """Which occurrence was asked about, as two timezone-aware instants.
 
-    A type rather than two arguments threaded through, because the window decides two things that
-    have to agree: which artifacts are kept, and — when none are — whether an empty answer means
-    "wait" or "there is none".
-
-    `of` is the only constructor a caller should use: it takes the shapes a model actually sends and
-    resolves them, so that no comparison downstream can meet a naive datetime.
+    Type not two args because window decides what is kept and whether empty means "wait" or "never
+    made". Use `of` constructor.
     """
 
     started_after: datetime | None
@@ -216,19 +148,13 @@ class OccurrenceWindow:
     def of(
         cls, started_after: date | datetime | None, started_before: date | datetime | None
     ) -> Self:
-        """A window from bounds as given, resolving anything that named no timezone against UTC.
-
-        A bare date names a whole UTC day: `started_after` takes its first instant and
-        `started_before` its last, so the same date in both is that one day rather than the empty
-        span between one midnight and itself.
-        """
+        """Window from bounds, resolving naive datetimes against UTC. Bare date is whole UTC day."""
         return cls(_first_instant(started_after), _last_instant(started_before))
 
     def holds(self, artifact: MeetingArtifact) -> bool:
-        """Whether this transcript or recording began inside the window.
+        """Whether artifact began inside window.
 
-        An artifact Graph gave no `createdDateTime` for is kept when no window was asked for and
-        dropped when one was: it cannot be shown to be the occurrence the caller meant.
+        Missing createdDateTime kept when no window asked for, dropped when one was.
         """
         if self.started_after is None and self.started_before is None:
             return True
@@ -243,31 +169,25 @@ class OccurrenceWindow:
         return not (self.started_before is not None and began > self.started_before)
 
     def settled(self, meeting: OnlineMeeting) -> bool:
-        """Whether an empty answer for this window means "there is none" rather than "not yet".
+        """Whether empty answer means "there is none" not "not yet".
 
-        Two independent pieces of evidence, either of which settles it: the window's own end is far
-        enough past that anything falling inside it would have landed, or the *meeting* is — the
-        second being what answers a caller who asked for no window at all, and what stops a window
-        mistakenly set in the future promising an artifact for a meeting that is long over.
+        Two independent pieces of evidence either settles it: window's end far past (anything
+        falling in would land) or meeting's end far past. Answers caller who asked no window.
+        Absent evidence never settles (that is cheaper wrong answer).
 
-        Absent evidence never settles anything: no `started_before` and no `endDateTime` both mean
-        nothing says the meeting's artifacts have finished being made, and of the two wrong answers
-        the one that costs a caller a second call is the cheaper one.
-
-        A predicate rather than the verdict itself, because the verdict is a different word per
-        artifact and the tool that answers owns its own vocabulary — the *inference* is what must
-        not exist twice.
+        Trap: a series with future `endDateTime` makes any empty window "still processing"
+        including one bracketing an ended occurrence never transcribed — check window settlement
+        separately.
         """
         now = datetime.now(UTC)
         return _settled_by(self.started_before, now) or _settled_by(meeting.end_date_time, now)
 
 
 def as_utc(moment: datetime) -> datetime:
-    """`moment` as an aware datetime, reading one that named no timezone as already being UTC.
+    """Moment as aware datetime, reading naive as UTC.
 
-    Public because the UTC assumption belongs to the window and the window has one home: anything
-    comparing or subtracting Graph timestamps resolves them through this and cannot meet a naive
-    one.
+    UTC assumption belongs to window; resolving here prevents downstream naive-aware comparison
+    TypeError.
     """
     return moment.replace(tzinfo=UTC) if moment.tzinfo is None else moment
 
@@ -275,14 +195,9 @@ def as_utc(moment: datetime) -> datetime:
 async def resolve_meeting(
     client: GraphServiceClient, handle: MeetingHandle
 ) -> OnlineMeeting | None:
-    """The meeting whose stored `joinWebUrl` is `handle`'s, or None if Graph matched none.
+    """Meeting whose joinWebUrl is handle's, or None if Graph matched none.
 
-    One request, spending `MEETING_PERMISSION`, and the `$filter` above must exist exactly once —
-    see the module docstring for the encoding bug class it sits on top of.
-
-    Graph documents this filter as returning "a collection that contains only one onlineMeeting
-    object", and no match as `200 OK` with an empty `value` rather than a 404 — so None here is an
-    answer and never an error.
+    One request. Filter must exist exactly once. 200 OK with empty value is "no match", not 404.
     """
     escaped = handle.join_web_url.replace("'", "''")
     configuration = RequestConfiguration[_MeetingsQuery](
@@ -303,34 +218,14 @@ async def newest_in_window[T: MeetingArtifact](
     window: OccurrenceWindow,
     limit: int,
 ) -> CollectedItems[T]:
-    """The `limit` newest artifacts of a meeting that fall inside `window`, newest first.
+    """Limit newest artifacts of meeting in window, newest first.
 
-    **Newest first is a property of what was read, not of the page Graph chose to answer with.**
-    Graph documents no `$orderby` on either collection, so it answers in an order of its own; a
-    walk that stopped at `limit` and sorted afterwards would return an arbitrary `limit` artifacts
-    sorted among themselves, which is the opposite of what "the latest transcript of this series"
-    asks for and is undetectable — the answer looks exactly like the right one. So the walk keeps
-    everything the window holds, sorts, and only then cuts to `limit`.
+    Read everything window holds, sort, cut to limit — Graph has no orderby. Stop-at-limit-before-
+    sort is undetectable wrong answer. Capped: read stopped at MAX_ARTIFACT_SCAN; nothing else.
 
-    **What was read is the collection up to `MAX_ARTIFACT_SCAN` artifacts, and no further.** That
-    bound is where the promise stops being "the newest of this meeting" and starts being "the
-    newest of the artifacts read": for a collection no larger than the cap the two coincide, which
-    is every meeting bar a daily series recorded for most of a year, and past it the artifacts
-    never read are in Graph's arbitrary order and can hold a newer one. Nothing in this function
-    can close that gap — with no `$orderby`, the only way to know the newest is to read everything,
-    and the cap exists because a collection with no documented ceiling must not turn one tool call
-    into an unbounded walk. So the gap is not hidden: it is what `capped` means below, and every
-    description over a lister is worded to the prefix rather than to the collection.
-
-    **`capped` means the scan stopped at the cap, and nothing else.** The tempting second meaning
-    is "the window held more than `limit`", which is a different fact with the opposite remedy —
-    raise `limit` for that one, nothing at all for this one — and a caller told only "there is
-    more" cannot tell which it was told, so it has to be warned that the first entry may not be the
-    meeting's latest even in the ordinary case. The ordinary case is what the returned count
-    already says (a full `limit` may have more behind it), so it is left there rather than merged
-    in, and what comes back is the cap alone: the one thing a caller cannot see and the one with no
-    remedy. A lister's absence verdict reads it for the same reason, an absence over a prefix being
-    no absence.
+    Where promise stops being "newest of this meeting" and starts being "newest of read ones". With
+    no orderby, only reading everything makes newest exact. Cap prevents unbounded walk on
+    unceilinged collection.
     """
     collected = await collect_pages(
         first_page,
@@ -344,17 +239,16 @@ async def newest_in_window[T: MeetingArtifact](
 
 
 def _first_instant(bound: date | datetime | None) -> datetime | None:
-    """The earliest instant `bound` includes, or None where there is no bound."""
+    """Earliest instant bound includes, or None."""
     if bound is None:
         return None
-    # `datetime` subclasses `date`, so this order is the whole of the distinction.
     if isinstance(bound, datetime):
         return as_utc(bound)
     return datetime.combine(bound, time.min, tzinfo=UTC)
 
 
 def _last_instant(bound: date | datetime | None) -> datetime | None:
-    """The latest instant `bound` includes, or None where there is no bound."""
+    """Latest instant bound includes, or None."""
     if bound is None:
         return None
     if isinstance(bound, datetime):
@@ -363,15 +257,14 @@ def _last_instant(bound: date | datetime | None) -> datetime | None:
 
 
 def _settled_by(moment: datetime | None, now: datetime) -> bool:
-    """Whether `moment` is far enough past that an artifact belonging to it would have arrived."""
+    """Whether moment is far past enough that artifact would have arrived."""
     return moment is not None and as_utc(moment) + ARTIFACT_DELAY_ALLOWANCE < now
 
 
 def _began_at(artifact: MeetingArtifact) -> datetime:
-    """The sort key: when the artifact began, or the beginning of time where Graph did not say.
+    """Sort key: when artifact began, or epoch if Graph didn't say.
 
-    Aware for the same reason `OccurrenceWindow.holds` is — one naive value among aware ones makes
-    the sort itself raise, which is a crash in the middle of an answer that was already complete.
+    Aware (prevents sort TypeError).
     """
     began = artifact.created_date_time
     return as_utc(began) if began is not None else datetime.min.replace(tzinfo=UTC)

--- a/services/office-mcp/src/office_mcp/tools/__init__.py
+++ b/services/office-mcp/src/office_mcp/tools/__init__.py
@@ -23,6 +23,7 @@ from office_mcp.tools import (
     list_meeting_transcripts,
     list_teams,
     read_message,
+    read_transcript,
     search_messages,
 )
 
@@ -47,6 +48,7 @@ _TOOL_MODULES: tuple[ToolModule, ...] = (
     search_messages,
     read_message,
     list_meeting_transcripts,
+    read_transcript,
 )
 
 GRAPH_SCOPES: tuple[str, ...] = tuple(

--- a/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
+++ b/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
@@ -1,16 +1,16 @@
 """`list_meeting_transcripts` — whether a Teams meeting was transcribed, and a handle for each.
 
-Reports what exists and none of what was said. A transcript is large, so this tool answers as a
-separate step, not as a field on the meeting. A recurring series is one meeting to Graph, so every
-occurrence's transcript lands in one collection. No default occurrence exists. Distinguish
-occurrences with `started_after`/`started_before`.
+This is the first half of reading a meeting. It says what exists; `read_transcript` returns what was
+said. Two tools rather than one because a transcript is large and because a recurring series is a
+single meeting to Graph — every occurrence's transcript lands in the same collection, distinguished
+only by when transcription started — so which one to read is a decision rather than a default.
 
-Shared code in `shared/meetings.py` and `shared/handles.py` documents how meetings are reached,
-how the join URL encodes, what an occurrence window is, and how "newest first" is bounded. These
-are facts about the meeting, not about transcripts, so they live outside this file. Handle grammar
-lives there too, for the same reason. A second spelling of a handle would work in the tool that
-mints it and fail in the tool that reads it. This file owns the answer's vocabulary: "was not
-transcribed" is a fact about one artifact, never about the meeting.
+How a meeting is addressed, how the join URL is escaped onto the wire, what an occurrence window is,
+and how far "newest first" is true are all `shared/meetings.py`: they are promises about the meeting
+rather than about its transcripts, and this file is only the first tool to need them. The handle
+grammar itself is `shared/handles.py`, for the same reason one step further out: the transcript
+handle this file mints is the one `read_transcript` parses, and a second speller would look like a
+handle one tool produced and another answers 404 to.
 
 ## Five answers that need different action
 
@@ -74,14 +74,17 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_meeting_transcripts"
 
-# Both permissions come from `shared/meetings.py`, not typed here. A permission belongs to its
-# resource. No sibling module may import this file to learn its spelling (see
-# tests/test_layering.py, rule 4).
+# Reading a transcript resource is an admin-consented permission, and a different one from the
+# resolve that precedes it: a tenant can grant one and withhold the other. `read_transcript` names
+# this same one, because it reads the same resource — two tools declaring one permission is what the
+# registry's deduplication is for, and neither may leave it out. The name comes from
+# `shared/meetings.py` for that reason: rule 4 forbids the two tools sharing a constant of their
+# own, so a permission each of them declares is spelled where neither owns it.
 #
-# The resolve and list are redeemed together, under one token, or not at all. The transcript
-# handle minted below already carries the resolved meeting id. A future tool that reads
-# transcript content needs only TRANSCRIPT_PERMISSION. Withholding OnlineMeetings.Read would not
-# block that.
+# What listing a meeting's transcripts costs: the resolve and the list, in that order, under one
+# token — Entra redeems them together or not at all. Reading content needs only the second, since
+# the handle minted below already carries the resolved meeting id, which is why `read_transcript`
+# declares that one alone and can still answer in a tenant that withholds `OnlineMeetings.Read`.
 GRAPH_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
 
 # Built at import: a call inside a parameter default rebuilds it on every registration.
@@ -94,19 +97,31 @@ _DESCRIPTION = f"""\
 Find whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
 `meeting_uri` that list_chats reports on a meeting chat.
 
-Reports what exists, none of what was said. A recurring meeting is one meeting to Microsoft — \
-every occurrence's transcript lands in the same collection. Use \
-`started_after`/`started_before` to reach one occurrence when `meeting_type` is `recurring`.
+This is the first half of reading a meeting: this tool says what exists, read_transcript returns \
+what was said. Two calls rather than one because a transcript is large and because a recurring \
+meeting is a single meeting to Microsoft — every occurrence's transcript lands in the same \
+collection, distinguished only by when transcription started — so which one to read is a decision, \
+not a default. Scope to one occurrence with `started_after`/`started_before` when \
+`meeting_type` comes back `recurring`; a one-off meeting has a single transcript and needs \
+neither. Both bounds take a date (`2026-08-11`, meaning that whole UTC day) or a timestamp, with \
+or without a timezone offset — one without is read as UTC, so pass the offset when you are working \
+from a local time.
 
-**Read `status` first. It has five values, each meaning a different action:**
-- `available` — transcripts are listed, newest first. "Newest" is over the transcripts this call \
-read, up to {MAX_ARTIFACT_SCAN} — set `include_scan_completeness` if the answer turns on that.
-- `not_ready` — nothing is there for the window you asked about and something still might. Wait \
-and call again later. This is NOT "there is no transcript". A window that is already well past \
-never answers this — a series whose end date is in the future does not make a last-month \
-occurrence "still processing".
-- `not_transcribed` — the window is over, nothing is there. It was not recorded or not \
-transcribed. Retrying will not help.
+**Read `status` before anything else. It has five values and they mean five different actions:**
+- `available` — transcripts are listed, newest first; read one with read_transcript. "Newest" is \
+over the transcripts this call read, which is every transcript the meeting has unless the meeting \
+holds more of them than the cap below — set `include_scan_completeness` if the answer turns on that.
+- `not_ready` — nothing has landed for the window you asked about and something still might: that \
+window has only just closed, or you asked for no window and the meeting has not ended or ended \
+recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
+is wrong: Microsoft publishes no availability SLA, so this tool infers it from how recently the \
+window (or the meeting) ended and errs towards telling you to wait. An occurrence window that is \
+already well past never answers this — a series whose end date is in the future does not make a \
+last-month occurrence "still processing".
+- `not_transcribed` — the window you asked about is over and nothing is there: it was not recorded \
+or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
+meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
+transcripts once the meeting expires, roughly 60 days after a one-off.)
 - `scan_incomplete` — this meeting has more transcripts than one call reads \
 ({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether one \
 exists there is not known. The window is applied after Microsoft has answered, not in the request, \
@@ -129,8 +144,7 @@ separately: a tenant can grant one and withhold the other.\
 """
 
 # Error message for invalid meeting_uri. Unique to this tool to prevent a caller being sent to
-# the wrong tool. A shared message would rebuild a shared tools module one import at a time (see
-# tests/test_layering.py, rule 4).
+# the wrong tool.
 _NOT_A_MEETING_HANDLE = (
     "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
     + "and this is not one. A meeting handle has exactly one shape:\n"
@@ -140,7 +154,7 @@ _NOT_A_MEETING_HANDLE = (
     + "so call list_chats, find the `meeting` chat for the meeting in question, and pass its "
     + "`meeting_uri` verbatim. A chat id, a chat topic, a Teams web link and a "
     + "`teams:///transcripts/...` handle are none of them a meeting handle — that last one is "
-    + "what this tool produces rather than what it takes. Retrying this value will fail "
+    + "read_transcript's, and this tool is what produces it. Retrying this value will fail "
     + "identically."
 )
 
@@ -148,8 +162,8 @@ _NOT_A_MEETING_HANDLE = (
 class TranscriptSummary(BaseModel):
     uri: str = Field(
         description=(
-            "This connector's handle for the transcript: what identifies it across calls. "
-            + "Nothing here contains the words that were said."
+            "A handle for this transcript. Pass it verbatim to read_transcript, which is the only "
+            + "route to the words that were said — nothing here contains any of them."
         )
     )
     transcript_id: str = Field(
@@ -259,15 +273,12 @@ async def list_meeting_transcripts(
     """Transcripts of the meeting `handle` addresses, and what a caller should do about them.
 
     Makes at most two Graph requests: resolve the join URL, then list transcripts. Lists all
-    transcripts without filtering. Graph documents no date filter on this collection, and an
-    unsupported filter can still answer `200 OK` with an empty list, not an error. A caller could
-    not tell a bad filter from a true absence, so no filter is sent. The window is applied while
-    paging instead. The window bounds are instants (naive ones read as UTC). The same window
+    transcripts without filtering (Graph documents no date filter on transcripts), then applies the
+    window while paging. The window bounds are instants (naive ones read as UTC). The same window
     decides which transcripts are kept and what an empty answer means.
 
     `include_scan_completeness` only changes whether `scan_incomplete` is reported, not what is
-    read. It defaults to false. The field matters for one rare meeting shape only, and a field
-    that is null everywhere else is one a model can ignore.
+    read.
     """
     assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
     window = OccurrenceWindow.of(started_after, started_before)
@@ -333,11 +344,7 @@ def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport.
-
-    `transport` is a shared, long-lived client. This tool borrows it per call and does not own
-    it. `create_app` closes it on shutdown.
-    """
+    """Declare this tool against the shared Graph transport."""
 
     @mcp.tool(
         name=TOOL_NAME,

--- a/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
+++ b/services/office-mcp/src/office_mcp/tools/list_meeting_transcripts.py
@@ -1,53 +1,26 @@
-"""`list_meeting_transcripts` — whether a Teams meeting was transcribed, and a handle for each.
+"""`list_meeting_transcripts` — transcripts a Teams meeting holds, and whether it was transcribed.
 
-This is the first half of reading a meeting. It says what exists; `read_transcript` returns what was
-said. Two tools rather than one because a transcript is large and because a recurring series is a
-single meeting to Graph — every occurrence's transcript lands in the same collection, distinguished
-only by when transcription started — so which one to read is a decision rather than a default.
+First half of reading: this says what exists; `read_transcript` returns what was said. Two tools
+because transcripts are large and recurring meetings are one meeting to Graph — occurrences share
+one collection, distinguished only by transcription start time.
 
-How a meeting is addressed, how the join URL is escaped onto the wire, what an occurrence window is,
-and how far "newest first" is true are all `shared/meetings.py`: they are promises about the meeting
-rather than about its transcripts, and this file is only the first tool to need them. The handle
-grammar itself is `shared/handles.py`, for the same reason one step further out: the transcript
-handle this file mints is the one `read_transcript` parses, and a second speller would look like a
-handle one tool produced and another answers 404 to.
+Meeting address, join-URL escaping, occurrence window, and "newest first" promises are in
+`shared/meetings.py` — they are meeting facts, shared with a second artifact reader if one came.
+Transcript handle grammar is in `shared/handles.py` — the handle this tool mints is what
+`read_transcript` parses.
 
-## Five answers that need different action
+Five answers, five actions: GraphAccessToTranscriptsDisabled (off by default, admin-only fix) /
+available (newest first over those read) / not_transcribed (never recorded or transcribed, no
+retry) / not_ready (window just closed; retry permitted; Graph publishes no SLA) /
+scan_incomplete (more transcripts than one call reads; none match window; stop).
 
-`GET …/transcripts` returning nothing means exactly one of five things:
+Newest first: Graph has no orderby on transcripts. Read up to MAX_ARTIFACT_SCAN, sort, cut to
+limit. For meetings under the cap, first entry is latest. A walk stopped at limit before sorting
+would return wrong answer with right shape. This is what makes newest_in_window a named function.
 
-* **`GraphAccessToTranscriptsDisabled`** — a `403` with no fix on this server. Microsoft Graph
-  access to transcripts is off by default across the tenant and requires a Teams administrator to
-  turn on. Re-consent does not help. Detected by code in `shared/seam.py`. Microsoft scopes this
-  switch to transcripts only, not recordings, so a refusal here says nothing about whether the
-  meeting was recorded.
-* **`available`** — transcripts exist and are listed, newest first (of the ones read up to
-  `MAX_ARTIFACT_SCAN`).
-* **`not_transcribed`** — the meeting was never recorded or never transcribed. Retrying does not
-  help.
-* **`not_ready`** — the window just closed or the meeting just ended. Retrying is the only option.
-  Graph publishes no SLA for availability, so this is an inference: if the window is still fresh
-  (within ~5–60 days of the meeting, depending on tenant policy), the lack of a transcript may mean
-  transcription is still in progress. A window that is demonstrably old (the meeting ended more than
-  60 days ago, or a one-time meeting has passed its 60-day expiration) never gives this answer.
-  Do not report this status as "there is no transcript" — it means "not ready yet".
-* **`scan_incomplete`** — the meeting holds more than `MAX_ARTIFACT_SCAN` transcripts and none of
-  the ones read fall in your window, so whether one exists there is not known. The window is applied
-  *after* Microsoft answers, not in the request, so a narrower window reads the same transcripts and
-  returns this same answer. Stop here. There is nothing to try.
-
-## Newest first is bounded by what was read
-
-Graph documents no `$orderby` on transcripts, so it answers in its own order. The code reads up to
-`MAX_ARTIFACT_SCAN` transcripts, sorts them, and cuts to `limit`. For meetings with no more
-transcripts than that cap (every meeting except a series recorded daily for most of a year), the
-first entry is the latest. A walk that stopped at `limit` before sorting would return wrong answer
-with right shape.
-
-`include_scan_completeness` is opt-in because it tells one thing a caller cannot infer: whether the
-read reached the end of the meeting's transcripts. A full `limit` means the window may hold older
-ones. Fewer than `limit` means these are the whole window. But "the read stopped at the cap" must be
-explicit.
+include_scan_completeness is opt-in: it reports one thing the caller cannot see: did the read
+reach the end? Full limit means older ones may exist; fewer than limit means this is the whole
+window. The "read hit the cap" fact must be explicit.
 """
 
 from datetime import date, datetime
@@ -74,114 +47,78 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "list_meeting_transcripts"
 
-# Reading a transcript resource is an admin-consented permission, and a different one from the
-# resolve that precedes it: a tenant can grant one and withhold the other. `read_transcript` names
-# this same one, because it reads the same resource — two tools declaring one permission is what the
-# registry's deduplication is for, and neither may leave it out. The name comes from
-# `shared/meetings.py` for that reason: rule 4 forbids the two tools sharing a constant of their
-# own, so a permission each of them declares is spelled where neither owns it.
-#
-# What listing a meeting's transcripts costs: the resolve and the list, in that order, under one
-# token — Entra redeems them together or not at all. Reading content needs only the second, since
-# the handle minted below already carries the resolved meeting id, which is why `read_transcript`
-# declares that one alone and can still answer in a tenant that withholds `OnlineMeetings.Read`.
+# Two permissions: resolve and read. Both under one token; Entra redeems together or not at all.
+# read_transcript declares the second alone (handles the resolved id). Transcript permission shared
+# with read_transcript; named in shared/meetings.py (rule 4 keeps tool files apart).
 GRAPH_PERMISSIONS: tuple[str, ...] = (MEETING_PERMISSION, TRANSCRIPT_PERMISSION)
 
 # Built at import: a call inside a parameter default rebuilds it on every registration.
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
-# Maximum transcripts to return. Graph documents `$top` but publishes no ceiling, so this is ours.
+# Max transcripts to return per call. No Graph ceiling; this is ours.
 MAX_TRANSCRIPTS = 50
 
 _DESCRIPTION = f"""\
-Find whether a Teams meeting was transcribed, and get a handle for each transcript. Takes the \
-`meeting_uri` that list_chats reports on a meeting chat.
+List transcripts a Teams meeting has, if any. Takes the `meeting_uri` from list_chats.
 
-This is the first half of reading a meeting: this tool says what exists, read_transcript returns \
-what was said. Two calls rather than one because a transcript is large and because a recurring \
-meeting is a single meeting to Microsoft — every occurrence's transcript lands in the same \
-collection, distinguished only by when transcription started — so which one to read is a decision, \
-not a default. Scope to one occurrence with `started_after`/`started_before` when \
-`meeting_type` comes back `recurring`; a one-off meeting has a single transcript and needs \
-neither. Both bounds take a date (`2026-08-11`, meaning that whole UTC day) or a timestamp, with \
-or without a timezone offset — one without is read as UTC, so pass the offset when you are working \
-from a local time.
+First half of reading: this lists what exists; read_transcript returns the words. Two calls because
+transcripts are large and recurring meetings are one collection to Microsoft.
 
-**Read `status` before anything else. It has five values and they mean five different actions:**
-- `available` — transcripts are listed, newest first; read one with read_transcript. "Newest" is \
-over the transcripts this call read, which is every transcript the meeting has unless the meeting \
-holds more of them than the cap below — set `include_scan_completeness` if the answer turns on that.
-- `not_ready` — nothing has landed for the window you asked about and something still might: that \
-window has only just closed, or you asked for no window and the meeting has not ended or ended \
-recently. Wait and call again later. This is NOT "there is no transcript", and reporting it as one \
-is wrong: Microsoft publishes no availability SLA, so this tool infers it from how recently the \
-window (or the meeting) ended and errs towards telling you to wait. An occurrence window that is \
-already well past never answers this — a series whose end date is in the future does not make a \
-last-month occurrence "still processing".
-- `not_transcribed` — the window you asked about is over and nothing is there: it was not recorded \
-or not transcribed. Retrying will not help. Say the meeting has no transcript rather than that the \
-meeting did not happen. (One other cause is indistinguishable: Microsoft stops serving a meeting's \
-transcripts once the meeting expires, roughly 60 days after a one-off.)
-- `scan_incomplete` — this meeting has more transcripts than one call reads \
-({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether one \
-exists there is not known. The window is applied after Microsoft has answered, not in the request, \
-so a narrower `started_after`/`started_before` reads the same transcripts and returns this same \
-answer. Stop here. There is nothing to try. Never report it as "there is no transcript".
-- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can see. Do not \
-retry and do not rebuild the handle.
+**Read `status` before anything else. Five values, five actions:**
+- `available` — transcripts are listed, newest first. Use read_transcript.
+- `not_ready` — nothing is there yet for the window you asked about and something might still
+arrive. Wait and call again later. This is NOT "there is no transcript". Microsoft publishes no
+availability SLA; this tool infers timing from the window (or meeting) end and errs towards "wait".
+An occurrence window that is already well past never answers this.
+- `not_transcribed` — the window is over, nothing is there, nothing is expected.
+Retrying will not help. Say the meeting has no transcript, not that the meeting did not happen.
+- `scan_incomplete` — this meeting holds more than {MAX_ARTIFACT_SCAN} transcripts and none read
+fall in your window, so whether one exists there is not known. Window applies after Microsoft
+answers, not in the request, so narrower `started_after`/`started_before`
+reads the same transcripts and returns this same answer. Stop here. There is nothing to try.
+Never report it as "there is no transcript" — that is not what this status means.
+- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can see.
 
-This tool answers about transcripts only. Whether the meeting was recorded is a separate question \
-that Microsoft gates independently via a different permission (`OnlineMeetingRecording.Read.All`), \
-so a refusal on transcripts says nothing about whether a recording exists or is accessible. \
-No video is returned; a transcript is better for questions about a meeting.
+For recurring meetings, scope to one occurrence with `started_after`/`started_before`; a one-off
+meeting has a single transcript and needs neither. Both bounds take a date (that whole UTC day) or
+a timestamp, with or without offset — no offset reads as UTC.
 
-Reading transcripts over Microsoft Graph is an organisation-wide Teams setting, OFF by default. \
-When off, the error names the administrator who can turn it on. Separately, Microsoft documents \
-transcript access under {TRANSCRIPT_PERMISSION} without stating participants get it, so a \
-participant may be refused where the organiser would succeed. The two meeting permissions \
-(`OnlineMeetings.Read` and `OnlineMeetingTranscript.Read.All`) are independent scopes granted \
-separately: a tenant can grant one and withhold the other.\
+This tool answers transcripts only. Recording exists is a separate question (different permission),
+so transcript refusal says nothing about whether a recording exists. Transcript reading is an org-
+wide Teams setting, OFF by default. When off, the error names the admin who can turn it on.
+Participants may be refused where the organiser succeeds. The two permissions are independent.
 """
 
-# Error message for invalid meeting_uri. Unique to this tool to prevent a caller being sent to
-# the wrong tool.
+# Error: wrong tool called with wrong handle shape. Prevent confusion with read_transcript handles.
 _NOT_A_MEETING_HANDLE = (
-    "list_meeting_transcripts takes the `meeting_uri` that list_chats reports on a meeting chat, "
-    + "and this is not one. A meeting handle has exactly one shape:\n"
-    + "  teams:///meetings/{join_web_url}\n"
-    + "with the join URL percent-encoded. It cannot be assembled — Microsoft addresses a "
-    + "meeting by the join URL of the Teams meeting itself, which only Microsoft can supply — "
-    + "so call list_chats, find the `meeting` chat for the meeting in question, and pass its "
-    + "`meeting_uri` verbatim. A chat id, a chat topic, a Teams web link and a "
-    + "`teams:///transcripts/...` handle are none of them a meeting handle — that last one is "
-    + "read_transcript's, and this tool is what produces it. Retrying this value will fail "
-    + "identically."
+    "list_meeting_transcripts takes teams:///meetings/{join_web_url} from list_chats, not this "
+    + "shape. Call list_chats and use its `meeting_uri`. A `teams:///transcripts/...` handle is "
+    + "not a meeting handle — that last one is read_transcript's, and this tool is what produces "
+    + "it. Retrying this value will fail identically."
 )
 
 
 class TranscriptSummary(BaseModel):
     uri: str = Field(
         description=(
-            "A handle for this transcript. Pass it verbatim to read_transcript, which is the only "
-            + "route to the words that were said — nothing here contains any of them."
+            "Handle for this transcript. Pass to read_transcript to get the words. Nothing here "
+            "contains them."
         )
     )
     transcript_id: str = Field(
-        description="The transcript's Graph id. Use `uri` to identify a transcript, not this alone."
+        description="Transcript Graph id. Use `uri` to identify a transcript, not this alone."
     )
     started_at: datetime | None = Field(
         description=(
-            "When transcription began. For a recurring meeting this tells one occurrence from "
-            + "another: all occurrences share one collection, and Microsoft gives no occurrence id."
+            "Transcription start. For recurring meetings, distinguishes one occurrence from "
+            "another."
         )
     )
-    ended_at: datetime | None = Field(description="When transcription ended.")
+    ended_at: datetime | None = Field(description="Transcription end.")
     content_correlation_id: str | None = Field(
         description=(
-            "Microsoft's identifier linking this transcript to the recording of the same call. "
-            + "Two transcripts sharing this value are two views of one call, not two separate "
-            + "calls. Presence of this id does not guarantee a recording exists; use this only to "
-            + "correlate transcript and recording if you already have both."
+            "Microsoft's id linking this transcript to the recording of the same call. Two "
+            "transcripts with the same id are two views of one call."
         )
     )
 
@@ -190,73 +127,55 @@ class MeetingTranscripts(BaseModel):
     status: str = Field(
         description=(
             "What was found, and what to do next. One of:\n"
-            + "- `available` — `transcripts` lists them, newest first.\n"
-            + "- `not_ready` — nothing is there yet and something may still arrive. Microsoft "
-            + "publishes no availability SLA, so this is inferred. A window that has demonstrably "
-            + "passed is never reported this way, however far in the future a recurring series "
-            + "runs.\n"
-            + "- `not_transcribed` — the window is over, nothing is there, nothing is expected. "
+            + "- `available` — transcripts are listed, newest first.\n"
+            + "- `not_ready` — nothing is there yet and something may still arrive. A window that "
+            + "has demonstrably passed is never reported this way, however far in the future a "
+            + "recurring series runs. This is inferred; Microsoft publishes no availability SLA.\n"
+            + "- `not_transcribed` — the window is over, nothing is there, nothing expected. "
             + "Retrying will not change this.\n"
             + "- `scan_incomplete` — this meeting has more transcripts than one call reads "
-            + f"({MAX_ARTIFACT_SCAN}) and none of the ones read fall in your window, so whether "
-            + "one exists there is NOT known. There is nothing to try: changing "
-            + "`started_after`/`started_before` reads the same transcripts and returns this same "
-            + "status. Stop and report that the collection is too large to scan completely and "
-            + "whether a transcript exists in that window cannot be determined. This status is "
-            + "final and cannot be retried or worked around by narrowing the window. Never report "
-            + "this as 'there is no transcript'.\n"
+            + f"({MAX_ARTIFACT_SCAN}) and none read fall in your window, so whether one exists "
+            + "there is NOT known. There is nothing to try. Changing `started_after`/"
+            + "`started_before` reads the same transcripts and returns this same status. This "
+            + "status is final and cannot be retried or worked around by narrowing the window. "
+            + "Never report this as 'there is no transcript'.\n"
             + "- `meeting_not_found` — Microsoft matched the join URL to no meeting this user can "
             + "see. Do not retry and do not rebuild the handle."
         )
     )
     meeting_id: str | None = Field(
         description=(
-            "The resolved meeting's Graph id, or null when `status` is `meeting_not_found`. "
-            + "A transcript's `uri` carries this already. This id is opaque; "
-            + "no MCP tool here builds or interprets it."
+            "Resolved meeting's Graph id, or null if `status` is `meeting_not_found`. Transcript "
+            "`uri` carries this."
         )
     )
     subject: str | None = Field(
-        description=(
-            "The meeting's subject as Microsoft holds it. Confirm this is the meeting you meant."
-        )
+        description="Meeting subject as Microsoft holds it. Confirm this is the right meeting."
     )
     meeting_type: str | None = Field(
         description=(
             "`scheduled`, `recurring`, `adhoc`, `meetNow`, `broadcast`, or null. When `recurring`, "
-            + "every occurrence's transcript is in one collection. Use "
-            + "`started_after`/`started_before` to reach a single occurrence."
+            "use `started_after`/`started_before` to reach one occurrence."
         )
     )
     started_at: datetime | None = Field(
-        description=(
-            "When the meeting starts. For a recurring series this is Microsoft's value for the "
-            + "whole series, not the occurrence you asked about."
-        )
+        description="Meeting start. For recurring series, Microsoft's value for the whole series."
     )
-    ended_at: datetime | None = Field(
-        description="When the meeting ends (same caveat as `started_at`)."
-    )
+    ended_at: datetime | None = Field(description="Meeting end (same caveat as `started_at`).")
     transcripts: list[TranscriptSummary] = Field(
         description=(
-            "Transcripts in the requested window, newest first. Ordered over every transcript "
-            + f"read (up to {MAX_ARTIFACT_SCAN}), not over one page of Microsoft's answer. For "
-            + f"meetings with no more transcripts than {MAX_ARTIFACT_SCAN}, these are all of "
-            + "them. A full `limit` means the window may hold older ones — raise `limit` up to "
-            + f"{MAX_TRANSCRIPTS}. Fewer than `limit` means these are the whole window. Empty "
-            + "for every status other than `available`. No cursor available."
+            "Transcripts in the window, newest first. Ordered over those read (up to "
+            f"{MAX_ARTIFACT_SCAN}), not a Microsoft page. Full `limit` means older may exist; "
+            "fewer than `limit` means this is the whole window. Empty except when status is "
+            "`available`."
         )
     )
     scan_incomplete: bool | None = Field(
         description=(
-            f"Whether the read stopped at {MAX_ARTIFACT_SCAN} transcripts (true), or read the "
-            + "whole collection (false), or null when `include_scan_completeness` was not set. "
-            + "Only set when `include_scan_completeness` is true. When true, `transcripts` is "
-            + "ordered over the ones read, not the whole meeting. When false, the order and any "
-            + "absence within the window are exact. Note: `status` reports `scan_incomplete` "
-            + "when nothing was found and the read "
-            + "stopped short, regardless of this field's value — this field only matters when "
-            + "`status` is `available` and shows whether the result set is complete."
+            f"Whether read stopped at {MAX_ARTIFACT_SCAN} transcripts (true), read all (false), "
+            "or null if not requested. Set only when `include_scan_completeness` is true. True "
+            "means transcripts ordered over those read, not the meeting. False means order and "
+            "absence are exact."
         )
     )
 
@@ -270,15 +189,9 @@ async def list_meeting_transcripts(
     limit: int,
     include_scan_completeness: bool,
 ) -> MeetingTranscripts:
-    """Transcripts of the meeting `handle` addresses, and what a caller should do about them.
+    """Transcripts of the meeting and what to do about them.
 
-    Makes at most two Graph requests: resolve the join URL, then list transcripts. Lists all
-    transcripts without filtering (Graph documents no date filter on transcripts), then applies the
-    window while paging. The window bounds are instants (naive ones read as UTC). The same window
-    decides which transcripts are kept and what an empty answer means.
-
-    `include_scan_completeness` only changes whether `scan_incomplete` is reported, not what is
-    read.
+    At most two Graph requests: resolve URL, then list. Window is applied after fetching.
     """
     assert 1 <= limit <= MAX_TRANSCRIPTS, f"limit must be within 1..{MAX_TRANSCRIPTS}, got {limit}"
     window = OccurrenceWindow.of(started_after, started_before)
@@ -322,10 +235,7 @@ async def list_meeting_transcripts(
 def _absence(*, scan_stopped_short: bool, settled: bool) -> str:
     """Which empty answer to give.
 
-    If the scan hit the cap, artifacts past it might hold the one asked for. Nothing about absence
-    is known, so return `scan_incomplete` — never `not_transcribed`. If settled, the window is
-    old enough that any transcript falling in it would have appeared; return `not_transcribed`.
-    Otherwise return `not_ready` — the window is still fresh.
+    Hit cap? scan_incomplete. Window settled? not_transcribed. Otherwise not_ready.
     """
     if scan_stopped_short:
         return "scan_incomplete"
@@ -344,7 +254,7 @@ def _summary(meeting_id: str, transcript: CallTranscript) -> TranscriptSummary:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport."""
+    """Register this tool against the shared Graph transport."""
 
     @mcp.tool(
         name=TOOL_NAME,
@@ -358,9 +268,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The meeting to list, exactly as list_chats reported `meeting_uri`: "
-                    + "`teams:///meetings/{join_web_url}`. Copy it verbatim. Microsoft matches "
-                    + "the join URL character for character, and nothing else identifies a meeting."
+                    "The meeting from list_chats: teams:///meetings/{join_web_url}. Copy "
+                    "verbatim. Microsoft matches character for character."
                 ),
             ),
         ],
@@ -368,12 +277,10 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             date | datetime | None,
             Field(
                 description=(
-                    "Reach one occurrence of a recurring meeting by filtering transcripts. Three "
-                    + "shapes accepted: `2026-08-11T09:00:00+02:00` is that instant; "
-                    + "`2026-08-11T09:00:00` with no offset IS READ AS UTC; `2026-08-11` is that "
-                    + "whole UTC day, starting at its first instant. Pass the offset when you "
-                    + "know a local time — 09:00 in Zurich is 07:00Z. A window in the wrong zone "
-                    + "answers about the wrong hours."
+                    "Scope to one occurrence by filtering transcripts start time. Shapes: "
+                    "2026-08-11T09:00:00+02:00 (with offset) or 2026-08-11T09:00:00 (IS READ AS "
+                    "UTC) or 2026-08-11 (whole UTC day, first instant). Pass offset for local "
+                    "time — 09:00 in Zurich is 07:00Z."
                 )
             ),
         ] = None,
@@ -381,9 +288,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             date | datetime | None,
             Field(
                 description=(
-                    "Upper bound for transcription start time. Pair with `started_after` to reach "
-                    + "one occurrence. A bare `2026-08-11` means the END of that UTC day — so the "
-                    + "same date in both bounds is that whole day."
+                    "Upper bound for transcription start. Pair with `started_after`. A bare "
+                    "`2026-08-11` means the END of that UTC day — same date in both bounds is "
+                    "that whole day."
                 )
             ),
         ] = None,
@@ -393,10 +300,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=MAX_TRANSCRIPTS,
                 description=(
-                    f"Maximum to return (default 20, maximum {MAX_TRANSCRIPTS}). Results are the "
-                    + f"newest of the window. Transcripts are read (up to {MAX_ARTIFACT_SCAN}, "
-                    + "this call's cost) and sorted before cutting to limit. A full list means "
-                    + "older transcripts may exist; fewer than limit means none exist beyond."
+                    f"Max to return (default 20, max {MAX_TRANSCRIPTS}). Newest of window. Read "
+                    f"(up to {MAX_ARTIFACT_SCAN}) and sorted before cutting. Full list means "
+                    "older may exist; fewer means none beyond."
                 ),
             ),
         ] = 20,
@@ -404,11 +310,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             bool,
             Field(
                 description=(
-                    "Report `scan_incomplete` in the answer: whether the read reached the end of "
-                    + f"this meeting's transcripts (may be limited to {MAX_ARTIFACT_SCAN} total). "
-                    + "Off by default. You do not need it to trust an empty answer: `status` "
-                    + "already reports `scan_incomplete` when nothing was found and the read "
-                    + "stopped short."
+                    "Report `scan_incomplete`: did read reach the end (may be limited to "
+                    f"{MAX_ARTIFACT_SCAN})? Off by default. `status` already reports "
+                    "`scan_incomplete` when nothing was found and read stopped short."
                 )
             ),
         ] = False,

--- a/services/office-mcp/src/office_mcp/tools/read_transcript.py
+++ b/services/office-mcp/src/office_mcp/tools/read_transcript.py
@@ -1,11 +1,15 @@
 """`read_transcript` — speaker-attributed, timestamped turns from a Teams meeting transcript.
 
-The handle holds both the meeting id and transcript id, so one call reaches `/content`. The reader
-does not resolve the join URL again; `list_meeting_transcripts` already did that. Speaker
-attribution degrades rather than fails: a tenant can forbid speaker names and the call asks for the
-unattributed format as Microsoft documents. Filtering (seconds, speaker) is applied after the
-whole transcript arrives and is parsed, then paged — no call cheaper. Two reject-at-call
-conditions prevent empty pages: inverted time bounds and blank speaker filter.
+The handle holds both the meeting id and transcript id, so one call reaches `/content`. The
+reader does not resolve the join URL again. `list_meeting_transcripts` already did that. A reader
+that took the meeting's `meeting_uri` instead would repeat the resolve. It would spend a second
+permission. Its 403 could point to either failure. This tool declares only
+`OnlineMeetingTranscript.Read.All`. A tenant can withhold `OnlineMeetings.Read` and this tool still
+answers. Speaker attribution degrades rather than fails: a tenant can forbid speaker names and the
+call asks for the unattributed format as Microsoft documents. `services/teams-mcp` still has this
+gap — it hardcodes `Accept: text/vtt`. Filtering (seconds, speaker) is applied after the whole
+transcript arrives and is parsed, then paged — no call cheaper. Two reject-at-call conditions
+prevent empty pages: inverted time bounds and blank speaker filter.
 """
 
 import html
@@ -206,7 +210,13 @@ _UNATTRIBUTED_FORMAT = "application/vnd.microsoft.graph.transcript+text"
 async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tuple[bytes, bool]:
     """Transcript bytes and whether they carry speaker names.
 
-    Retries on speaker-attribution refusal only.
+    Retries once, only for the `SpeakerAttributionNotAllowed` inner code. The tenant-wide switch
+    that blocks transcripts answers with the same `403`. It has no retry that fixes it. Retrying
+    that case would waste a call and report the wrong remedy.
+
+    Each attempt uses its own `graph_errors()` block. The raw SDK error carries no inner code
+    before translation. One block around both attempts would let the first failure pass the
+    `except` clause untranslated.
     """
     endpoint = (
         client.me.online_meetings.by_online_meeting_id(handle.meeting_id)

--- a/services/office-mcp/src/office_mcp/tools/read_transcript.py
+++ b/services/office-mcp/src/office_mcp/tools/read_transcript.py
@@ -1,46 +1,11 @@
-"""`read_transcript` — what was said in a Teams meeting, as speaker-attributed, timestamped turns.
+"""`read_transcript` — speaker-attributed, timestamped turns from a Teams meeting transcript.
 
-This is the payoff of the whole meeting path and the one surface where a delegated connector can
-answer better than a link. Microsoft's own M365 connector reaches a transcript through an opaque URI
-obtained from a calendar read and returns whatever that yields; the chain here ends in
-`/transcripts/{id}/content`, which Graph answers with WebVTT carrying `<v Speaker>` voice tags and
-cue timestamps — who said what, when.
-
-Four things make this tool what it is, and each of them is a decision rather than a detail.
-
-**It reads and it does not resolve.** The handle carries the meeting id and the transcript id, so
-this call is one Graph request against `/content`. A reader that took the meeting's `meeting_uri`
-instead would repeat the join-URL resolve `list_meeting_transcripts` already did, spend a second
-request and a second permission, and give a 403 that could be about either of them. That is why
-this tool declares `OnlineMeetingTranscript.Read.All` and nothing else, and why a tenant that
-withholds `OnlineMeetings.Read` can still read a transcript it was handed a handle for.
-
-**Speaker attribution degrades instead of failing.** A tenant can permit transcripts and forbid
-speaker names; Graph's documented remedy is to ask again for
-`application/vnd.microsoft.graph.transcript+text`, which `_content` does exactly once and only for
-that inner code. `speaker_attribution: false` then says the words and the timings are all there and
-the names are not — the gap `services/teams-mcp` still has, since it hardcodes `Accept: text/vtt`.
-The tenant-wide switch that blocks transcripts altogether answers with the same `403` and has no
-workaround at all, which is why the retry is keyed on the code and never on the status.
-
-**Filtering makes the answer smaller and never the call cheaper.** `/content` is one stream with no
-ranged contract, so every page refetches and reparses the whole transcript; `from_seconds`,
-`to_seconds` and `speaker` are applied to the parsed turns. They are applied *before* the page is
-cut, and `next_offset` is counted over what they left — the only version of "there is more" a
-caller can act on. Paging the meeting while filtering each page would make the offset mean "more of
-the meeting" while the turns meant "the ones you asked for", and a caller following `next_offset`
-to the end would walk pages that hold nothing.
-
-**Two arguments a schema cannot refuse are refused here.** A `from_seconds` later than
-`to_seconds`, and a `speaker` that is nothing but spaces. Each would otherwise be answered with an
-empty page, and an empty page is indistinguishable from a meeting in which nobody said anything —
-the one failure a model reads as a real answer.
-
-What this file does not own is the handle grammar (`shared/handles.py`, so that the transcript
-`list_meeting_transcripts` names is the transcript this reads) and the token and refusal wording
-(`shared/seam.py`, so this tool's 403 sounds like every other tool's). Everything else — the name,
-the description, the arguments, the answer shape, the request, the parser and every refusal below —
-is here.
+The handle holds both the meeting id and transcript id, so one call reaches `/content`. The reader
+does not resolve the join URL again; `list_meeting_transcripts` already did that. Speaker
+attribution degrades rather than fails: a tenant can forbid speaker names and the call asks for the
+unattributed format as Microsoft documents. Filtering (seconds, speaker) is applied after the
+whole transcript arrives and is parsed, then paged — no call cheaper. Two reject-at-call
+conditions prevent empty pages: inverted time bounds and blank speaker filter.
 """
 
 import html
@@ -62,155 +27,106 @@ from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
 
 TOOL_NAME = "read_transcript"
 
-# The one delegated permission this tool's one request needs. Admin-consented in its own right, and
-# separately from every other meeting permission: a tenant can grant transcript access and withhold
-# recording access, or the other way round. `list_meeting_transcripts` names this one too, because
-# listing reads the same resource — two tools declaring one permission is what the registry's
-# deduplication is for, and neither may leave it out. The name itself comes from
-# `shared/meetings.py`: rule 4 keeps these two files apart, so a permission both of them declare is
-# spelled where neither owns it rather than typed out once each.
+# One permission this tool's one request needs. Admin-consented and independent from recording
+# permissions. `list_meeting_transcripts` also declares it; both tools read the same resource.
+# Named in `shared/meetings.py` to avoid duplication across tool files (rule 4 keeps them apart).
 GRAPH_PERMISSIONS: tuple[str, ...] = (TRANSCRIPT_PERMISSION,)
 
 _TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
 
-# How many turns one read returns, and the ceiling on `limit`. A turn is one WebVTT cue — a sentence
-# or two — so an hour of meeting is some hundreds of them and a 30-hour one (Teams' own limit) is
-# tens of thousands. The whole transcript is fetched either way; this bounds what crosses into a
-# model's context per call.
+# Max turns per call. Bounds context size; whole transcript fetches either way.
 MAX_TURNS = 500
 
 _DESCRIPTION = f"""\
-Read what was said in a Teams meeting: the transcript as speaker-attributed, timestamped turns. \
-Takes the `uri` of a transcript that list_meeting_transcripts returned.
+Read the words from a Teams meeting transcript: speaker-attributed, timestamped turns. \
+Takes the `uri` from list_meeting_transcripts.
 
-This is the payoff of the whole meeting path, and it returns the words themselves rather than a \
-link to them — who spoke, in order, with the offset into the meeting at which they spoke. Quote it \
-as you would quote a message: it is what people actually said, verbatim, and Microsoft's \
-speech-to-text is not perfect, so an odd word is likelier a mis-transcription than a real one.
+The `uri` shape is teams:///transcripts/{{meeting_id}}/{{transcript_id}}. Only this tool and \
+list_meeting_transcripts mint this shape. read_message is a different reader with a different \
+handle.
 
-`uri` takes a handle this connector produced, in exactly one shape:
-  teams:///transcripts/{{meeting_id}}/{{transcript_id}}
-Nothing else is readable here, and nothing turns a meeting's name, its date, its chat or its \
-`meeting_uri` into one — call list_meeting_transcripts and pass its `uri` verbatim. read_message \
-is the reader for a Teams message and takes a different handle; neither tool accepts the other's.
+Seconds are offsets from transcription start, not wall-clock times and not offsets from meeting \
+start. They can be negative (Microsoft uses that when transcription began after conversation did). \
+Add them to the transcript's `started_at` if you need absolute time.
 
-`start_seconds` and `end_seconds` are offsets in seconds from the moment transcription began, not \
-wall-clock times and not offsets from the start of the meeting; add them to the transcript's \
-`started_at` from list_meeting_transcripts if an absolute time is needed. They can be negative, \
-which Microsoft defines as transcription having started after the conversation did.
+`speaker_attribution` is false when your organisation turned speaker names off. Words and timings \
+still arrive; every `speaker` is null. Do not guess who spoke from content. **A `speaker` filter \
+matches NOTHING on such a transcript** — every turn's `speaker` is null by construction. When \
+filtering yields nothing, read the `speaker_attribution` flag before saying the person did not \
+speak.
 
-`speaker_attribution` is false when the organisation has turned speaker names off. The words and \
-timings still come back and every `speaker` is null: do not infer who spoke from the content, and \
-say the transcript is unattributed if the answer turns on who said something. **A `speaker` filter \
-matches nothing at all on such a transcript** — there is no name on any turn for it to match — so \
-read an empty answer next to this flag before reporting that the person never spoke, and drop the \
-filter to see the turns themselves.
+`from_seconds`, `to_seconds`, `speaker` narrow the answer. The whole transcript fetches either \
+way, so these make the answer smaller, not the call cheaper. Time bounds are inclusive and match \
+by overlap — a turn already under way at `from_seconds` keeps whole. Speaker matches any part of \
+the display name, ignoring case. `next_offset` pages through MATCHING turns, not the meeting.
 
-`from_seconds`/`to_seconds` and `speaker` narrow what comes back, and everything else is counted \
-over what they left: `next_offset` pages through the MATCHING turns rather than through the \
-meeting. The time bounds are inclusive and match by overlap, so a turn already under \
-way at `from_seconds` is kept whole instead of being cut at it; `speaker` matches any part of the \
-name Teams shows, ignoring case, because a display name is not something to spell from memory. \
-Filtering does not make the call cheaper — the whole transcript is fetched and parsed either \
-way — it makes the answer smaller.
-
-A long meeting is more turns than fit in one answer. `next_offset` says both that there are more \
-and where to continue: it is null on the last page and set on every other, which is the same \
-convention search_messages pages by. Each call re-fetches the whole transcript from Microsoft, so \
-a wider `limit` (up to {MAX_TURNS}) costs less than paging through it, and a page with \
-`next_offset` set must never be summarised as the whole meeting.\
+Paging: each call re-fetches from Microsoft. A wider `limit` (up to {MAX_TURNS}) costs less than \
+paging. `next_offset` is null on the last page and set on all others — the same as \
+search_messages. A page with `next_offset` set is not the whole meeting.\
 """
 
-# What this tool says when its `uri` is not one of its own handles. Its own text rather than a
-# shared one, because the failure it has to prevent is a caller being sent to the wrong tool: the
-# message-handle families and this one are read by different tools under different permissions.
+# Prevent caller being sent to wrong tool: different tools read different handle shapes.
 _NOT_A_TRANSCRIPT_HANDLE = (
-    "read_transcript takes the `uri` of a transcript that list_meeting_transcripts returned, and "
-    + "this is not one. A transcript handle has exactly one shape:\n"
-    + "  teams:///transcripts/{meeting_id}/{transcript_id}\n"
-    + "with both ids percent-encoded. Call list_meeting_transcripts with a meeting chat's "
-    + "`meeting_uri` and pass the `uri` of the transcript you want, verbatim. A `meeting_uri` is "
-    + "not a transcript handle — one meeting can have many transcripts — and neither is a Teams "
-    + "message handle. Retrying this value will fail identically."
+    "read_transcript takes teams:///transcripts/{meeting_id}/{transcript_id} from "
+    + "list_meeting_transcripts. This is not that shape. Call list_meeting_transcripts and use its "
+    + "`uri`, not the meeting's `meeting_uri` or a Teams message handle. Retrying will fail "
+    + "identically."
 )
 
 _INVERTED_TIME_WINDOW = (
-    "read_transcript was given a `from_seconds` later than its `to_seconds`, which selects no part "
-    + "of the meeting: no turn can both end after the one and start before the other, so this "
-    + "would come back empty and read like a silent meeting. Both are offsets in seconds from the "
-    + "moment transcription began, counting upwards, so the earlier moment is the smaller number — "
-    + "swap them if they were written the wrong way round, or drop one to leave that end open."
+    "from_seconds is later than to_seconds — no turn matches both. Swap them or drop one. "
+    + "Both are offsets from transcription start, counting up."
 )
 
 _BLANK_SPEAKER = (
-    "read_transcript was given a blank `speaker`. A blank filter is not the same as no filter, and "
-    + "it is not treated as one: omit `speaker` entirely to read every turn, or pass any part of "
-    + "the name Teams shows for the person — matching ignores case and matches anywhere in the "
-    + "display name, so `ada` finds `Ada Lovelace`. Note that a transcript whose "
-    + "`speaker_attribution` is false carries no names at all, and any `speaker` filter matches "
-    + "nothing on it."
+    "blank speaker filter is not treated as no filter: omit it entirely to read every turn, or "
+    + "pass any part of the display name (case-insensitive, matches anywhere)."
 )
 
-# Graph's 404 on a well-formed transcript handle. Distinct advice from the message reader's, because
-# the causes are different: a transcript is not deleted by a user, it ages out with its meeting.
+# Transcript not deleted by user; ages out with meeting (~60 days after one-off). Say the meeting
+# "expires", not "expired": the policy is what makes it unreadable, not a past event.
 _TRANSCRIPT_UNREADABLE = (
-    "Microsoft 365 would not return this transcript. The handle is well formed, so this is not a "
-    + "bad argument. The likeliest cause is age: Microsoft stops serving a meeting's transcripts "
-    + "once the meeting expires, about 60 days after a one-off meeting, and it answers that "
-    + "identically to a transcript that was removed or that this user may not see. Call "
-    + "list_meeting_transcripts for the meeting again to see what it still has; if the transcript "
-    + "is no longer listed there, it is out of reach and retrying will not bring it back."
+    "Microsoft 365 will not return this transcript. The handle is well formed. Most likely the "
+    + "meeting expires after about 60 days for a one-off; transcripts age out with it. Call "
+    + "list_meeting_transcripts again to see what remains. If not listed there, retrying will not "
+    + "help."
 )
 
 
 class TranscriptTurn(BaseModel):
     speaker: str | None = Field(
         description=(
-            "Who spoke, as Teams attributed them. Null when this transcript has no speaker "
-            + "attribution at all (see `speaker_attribution`) and null for the occasional turn "
-            + "Microsoft attributed to nobody — a null is not an unidentified person."
+            "Who spoke. Null if transcript has no speaker attribution or Microsoft did not name "
+            "this turn."
         )
     )
     start_seconds: float = Field(
-        description=(
-            "When this turn starts, in seconds from the beginning of transcription — not from the "
-            + "start of the meeting, and not a wall-clock time. Add it to the transcript's "
-            + "`started_at` for that. It can be NEGATIVE: Microsoft documents negative offsets as "
-            + "meaning transcription began while the conversation was already under way."
-        )
+        description="Turn start in seconds from transcription start. Can be negative."
     )
-    end_seconds: float = Field(description="When this turn ends, on the same scale.")
-    text: str = Field(description="What was said, with Teams' own cue markup removed.")
+    end_seconds: float = Field(description="Turn end, same scale.")
+    text: str = Field(description="Spoken words without cue markup.")
 
 
 class Transcript(BaseModel):
-    uri: str = Field(description="The handle this transcript was read by, echoed back.")
-    meeting_id: str = Field(description="The meeting this transcript belongs to.")
-    transcript_id: str = Field(description="The transcript's Graph id.")
+    uri: str = Field(description="The handle used to read this, echoed back.")
+    meeting_id: str = Field(description="Meeting id.")
+    transcript_id: str = Field(description="Transcript Graph id.")
     speaker_attribution: bool = Field(
         description=(
-            "True when Microsoft named the speakers, which is the normal case. False when this "
-            + "tenant has speaker attribution switched off: the words and the timings are all "
-            + "still here and every `speaker` is null. Do not guess who spoke from the content, "
-            + "and say so if the answer depends on who said something."
+            "True if speakers named. False if tenant turned speaker names off. All `speaker` "
+            "values null when false."
         )
     )
     turns: list[TranscriptTurn] = Field(
         description=(
-            "What was said, in order, one turn per utterance Microsoft timestamped — the turns "
-            + "matching `from_seconds`, `to_seconds` and `speaker` where any of those was given, "
-            + "and every turn of the transcript where none was. Empty means nothing matched what "
-            + "was asked for, which is not the same as the meeting having no words in it."
+            "Matching turns (or all turns if no filter). Empty means none matched, not that the "
+            "meeting was silent."
         )
     )
     next_offset: int | None = Field(
         description=(
-            "The `offset` that reaches the next matching turns, or null when these are the last of "
-            + "them. A value here is what says more turns match than this page holds: pass it back "
-            + "as `offset` to continue, and never summarise a page with one set as the whole "
-            + "meeting. It counts the turns left after `from_seconds`, `to_seconds` and `speaker` "
-            + "were applied, so it indexes what was asked for rather than the meeting — send the "
-            + "same filters back with it, since changing one renumbers what it points at."
+            "Offset for next page of matching turns, or null if this is the last page. Pass the "
+            "same filters."
         )
     )
 
@@ -225,13 +141,9 @@ async def read_transcript(
     to_seconds: float | None = None,
     speaker: str | None = None,
 ) -> Transcript:
-    """The turns of one transcript matching the filters, from `offset`, up to `limit` of them.
+    """Matching turns from offset, up to limit.
 
-    One Graph request, or two where the tenant refuses speaker attribution. Paging is over the
-    parsed turns rather than over Graph — `/content` is a single stream with no ranged contract —
-    so a later page costs the same fetch again, which is what makes `limit` worth widening rather
-    than looping. The filters are the same bargain: the whole transcript is fetched and parsed
-    whatever they are, so they make the answer smaller and never the call cheaper.
+    One Graph request, or two for speaker attribution refusal.
     """
     assert 1 <= limit <= MAX_TURNS, f"limit must be within 1..{MAX_TURNS}, got {limit}"
     assert offset >= 0, f"offset must not be negative, got {offset}"
@@ -268,25 +180,9 @@ def _matching(
     to_seconds: float | None,
     speaker: str | None,
 ) -> list[TranscriptTurn]:
-    """The turns of `turns` that all of the given filters keep, in the order they were said.
+    """Turns matching all filters.
 
-    **The time test is overlap, and both bounds are inclusive.** A turn is one utterance of a
-    sentence or two, and the moment a caller asks about lands in the middle of one about as often
-    as it lands between two — so a turn that straddles a bound is kept whole rather than dropped or
-    cut. Comparing a turn's *start* to both bounds instead would silently lose the sentence already
-    under way at `from_seconds`, which is exactly the sentence that says what the stretch is about.
-
-    **The speaker test is a case-insensitive substring of the display name.** A model asking about
-    a person has a name it read somewhere, not the string Teams stores, and those differ by case,
-    by a middle name, by a title or by the parenthesised suffix a tenant appends. An exact match
-    would answer "that person said nothing" to a spelling difference.
-
-    A turn Microsoft attributed to nobody never matches a speaker filter: `speaker` is null there,
-    and there is nothing to compare. Neither does *any* turn of a transcript from a tenant with
-    speaker attribution switched off, where every `speaker` is null by construction — this is not
-    refused and not degraded to "everything", because a filter that quietly stopped filtering would
-    be worse than an empty answer. `Transcript.speaker_attribution` is the flag that explains that
-    answer, and every description over this argument says to read the two together.
+    Time test is overlap (both bounds inclusive). Speaker test is substring, case-insensitive.
     """
     wanted = speaker.casefold() if speaker is not None else None
     return [
@@ -298,33 +194,19 @@ def _matching(
     ]
 
 
-# The inner code Graph sends when a tenant permits transcripts but forbids speaker names. Branched
-# on rather than the message, as Microsoft's own documentation instructs.
+# Graph inner code: tenant permits transcripts but forbids speaker names.
 _SPEAKER_ATTRIBUTION_REFUSED = "SpeakerAttributionNotAllowed"
 
-# The two formats `/content` serves. VTT is the default and the one worth having — it is the only
-# one carrying `<v Speaker>` voice tags. The other is the documented fallback for a tenant with
-# speaker attribution switched off, and is selectable *only* by this header ("the
-# application/vnd.microsoft.graph.transcript+text format is supported only through this header"),
-# which is why neither is requested with `$format`.
+# Formats. VTT is default and the only one with <v Speaker> tags. Unattributed is fallback only
+# when tenant forbids names; select by header only (no $format).
 _ATTRIBUTED_FORMAT = "text/vtt"
 _UNATTRIBUTED_FORMAT = "application/vnd.microsoft.graph.transcript+text"
 
 
 async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tuple[bytes, bool]:
-    """The transcript's bytes, and whether they carry speaker names.
+    """Transcript bytes and whether they carry speaker names.
 
-    The attributed format is asked for first because it is the one worth having and the default. The
-    single retry is Graph's own documented remedy for a tenant that permits transcripts and forbids
-    speaker names — "Retry the same request asking for the unattributed format … which succeeds" —
-    and it is scoped to that inner code alone: the tenant-wide switch reports itself the same way
-    (`403 Forbidden`) and has no request-side workaround, so retrying it would be one wasted call
-    and a message about the wrong remedy.
-
-    Each attempt gets its own `graph_errors` rather than one around both. The branch is on a
-    *classified* failure — the SDK's raw `APIError` has no inner code on it — so the translation has
-    to have happened before the `except` can decide anything, which a block enclosing the whole
-    function would defer until after it had already given up.
+    Retries on speaker-attribution refusal only.
     """
     endpoint = (
         client.me.online_meetings.by_online_meeting_id(handle.meeting_id)
@@ -348,45 +230,27 @@ async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tupl
 
 
 def _accepting(media_type: str) -> HeadersCollection:
-    """A `HeadersCollection` of our own asking for `media_type`.
-
-    Built per request: `RequestConfiguration.headers` defaults to one instance shared by every
-    configuration in the process, so adding to the default would add to every other Graph request
-    this connector makes. The generated builder adds its own `Accept` with `try_add`, which is a
-    no-op once this one is present — which is how a format gets selected at all.
-    """
+    """HeadersCollection requesting media_type. Built per request to avoid sharing state."""
     headers = HeadersCollection()
     headers.add("Accept", media_type)
     return headers
 
 
-# One WebVTT cue's timing line. The hours field is optional in WebVTT and Teams omits it in some
-# transcripts; the leading sign is what Microsoft's "negative offsets" note requires.
+# WebVTT cue timing line. Hours optional; leading sign for negative offsets.
 _TIMESTAMP = r"-?(?:\d+:)?\d{1,2}:\d{1,2}[.,]\d{1,3}"
 _CUE_TIMING = re.compile(rf"^(?P<start>{_TIMESTAMP})\s*-->\s*(?P<end>{_TIMESTAMP})")
 
-# A voice span, which is where a speaker's name lives: `<v Ada Lovelace>text</v>`. The class suffix
-# (`<v.loud Ada>`) is part of WebVTT and Teams may emit it.
+# Voice span: `<v Speaker>text</v>`. Can include class suffix like `<v.loud Name>`.
 _VOICE = re.compile(r"<v(?:\.[^\s>]+)?\s+(?P<speaker>[^>]*)>(?P<said>.*?)(?:</v>|\Z)", re.DOTALL)
 
-# Every other cue-payload tag: `<i>`, `<c.colorE5E5E5>`, `<00:00:01.000>` timestamps, `<lang en>`.
+# Other cue tags: `<i>`, `<c>`, `<00:00:01.000>` timestamps, `<lang>`.
 _MARKUP = re.compile(r"<[^>]*>")
 
 _BLANK_LINE = re.compile(r"\n[ \t]*\n")
 
 
 def _turns(content: bytes, *, attributed: bool) -> list[TranscriptTurn]:
-    """`content` as speaker-attributed, timestamped turns.
-
-    One cue is one turn: Teams emits an utterance per cue, so merging them would be inventing a
-    grouping Microsoft did not make. Anything that is not a cue — the `WEBVTT` header, `NOTE`,
-    `STYLE` and `REGION` blocks, a cue identifier line — is skipped rather than guessed at, and a
-    cue with a timing line but no words is dropped: an empty turn reads as a silence somebody sat
-    through.
-
-    `attributed` is what the request asked for, and it decides whether an unparsed `<v …>` could
-    have been there at all — the unattributed format has none by construction.
-    """
+    """Content as turns. One cue per turn. Skip non-cue blocks. Drop empty turns."""
     text = content.decode("utf-8-sig", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
     turns: list[TranscriptTurn] = []
     for block in _BLANK_LINE.split(text):
@@ -397,7 +261,7 @@ def _turns(content: bytes, *, attributed: bool) -> list[TranscriptTurn]:
 
 
 def _turn(block: str, *, attributed: bool) -> TranscriptTurn | None:
-    """One cue block as a turn, or None if it is not a cue (or is one with nothing said)."""
+    """Cue block as a turn, or None if not a cue or has no words."""
     lines = [line for line in block.split("\n") if line.strip()]
     timing = next(
         ((index, match) for index, line in enumerate(lines) if (match := _CUE_TIMING.match(line))),
@@ -418,13 +282,7 @@ def _turn(block: str, *, attributed: bool) -> TranscriptTurn | None:
 
 
 def _spoken(payload: str, *, attributed: bool) -> tuple[str | None, str]:
-    """A cue payload as (speaker, words).
-
-    The voice span is read before the markup is stripped, because stripping it first would take the
-    speaker's name with it. An attributed transcript whose cue carries no voice span keeps a null
-    speaker rather than borrowing the previous turn's: Teams does leave some utterances
-    unattributed, and attributing them to whoever spoke last would put words in someone's mouth.
-    """
+    """Payload as (speaker, words). Extract speaker before stripping markup."""
     voice = _VOICE.search(payload) if attributed else None
     speaker = voice.group("speaker").strip() if voice is not None else None
     said = voice.group("said") if voice is not None else payload
@@ -433,11 +291,7 @@ def _spoken(payload: str, *, attributed: bool) -> tuple[str | None, str]:
 
 
 def _seconds(timestamp: str) -> float:
-    """A WebVTT timestamp as seconds, keeping its sign.
-
-    `HH:MM:SS.mmm` and `MM:SS.mmm` are both legal; the comma decimal separator is not WebVTT but is
-    what SubRip uses and costs nothing to accept.
-    """
+    """WebVTT timestamp as seconds, keeping sign. Accept both HH:MM:SS.mmm and MM:SS.mmm."""
     negative = timestamp.startswith("-")
     parts = timestamp.lstrip("-").replace(",", ".").split(":")
     total = 0.0
@@ -447,11 +301,7 @@ def _seconds(timestamp: str) -> float:
 
 
 def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
-    """Declare this tool against the shared Graph transport.
-
-    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
-    borrows it per call and never owns it. `create_app` closes it on shutdown.
-    """
+    """Register this tool against the shared Graph transport."""
 
     @mcp.tool(
         name=TOOL_NAME,
@@ -465,9 +315,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "The transcript to read, exactly as list_meeting_transcripts reported its "
-                    + "`uri`: `teams:///transcripts/{meeting_id}/{transcript_id}`. A meeting's "
-                    + "`meeting_uri` is not one of these, and no other shape is readable here."
+                    "The transcript from list_meeting_transcripts: "
+                    "teams:///transcripts/{meeting_id}/{transcript_id}. A `meeting_uri` is not "
+                    "readable here."
                 ),
             ),
         ],
@@ -476,8 +326,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 ge=0,
                 description=(
-                    "How many turns to skip. Start at 0 and pass the previous response's "
-                    + "`next_offset` to continue through a long meeting."
+                    "Turns to skip. Start at 0; pass the previous response's `next_offset` to "
+                    "continue."
                 ),
             ),
         ] = 0,
@@ -487,10 +337,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
                 ge=1,
                 le=MAX_TURNS,
                 description=(
-                    "How many turns to return. Default 200, maximum "
-                    + f"{MAX_TURNS}. Every call fetches the whole transcript from "
-                    + "Microsoft, so widening this is cheaper than paging. It counts the turns "
-                    + "left after `from_seconds`, `to_seconds` and `speaker`, not the meeting's."
+                    f"Turns to return (default 200, max {MAX_TURNS}). Whole transcript fetches "
+                    "either way; wider limit is cheaper than paging."
                 ),
             ),
         ] = 200,
@@ -498,14 +346,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             float | None,
             Field(
                 description=(
-                    "Only turns reaching this moment or later, in seconds from when transcription "
-                    + "began — the same scale as a turn's `start_seconds`, which is NOT a "
-                    + "wall-clock time and NOT an offset from the start of the meeting. Inclusive, "
-                    + "and matched by overlap: a turn already under way at this moment is kept "
-                    + "whole rather than cut at it, which is usually the sentence that says what "
-                    + "the stretch is about. Negative values are legal — Microsoft uses them for "
-                    + "transcription that began after the conversation did. This narrows the "
-                    + "answer, not the call: the whole transcript is fetched and parsed either way."
+                    "Only turns from this moment (seconds from transcription start). Inclusive, "
+                    "matched by overlap. Negative is legal. Narrows answer, not call."
                 )
             ),
         ] = None,
@@ -513,11 +355,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             float | None,
             Field(
                 description=(
-                    "Only turns beginning at this moment or earlier, on the same scale and the "
-                    + "same inclusive overlap rule: a turn still running at this moment is kept "
-                    + "whole. Pair it with `from_seconds` to read one stretch of a long meeting, "
-                    + "and keep the two in that order — a `from_seconds` later than this is "
-                    + "refused rather than answered with an empty page."
+                    "Only turns until this moment. Inclusive, matched by overlap. Pair with "
+                    "`from_seconds` to read one stretch."
                 )
             ),
         ] = None,
@@ -526,16 +365,9 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
             Field(
                 min_length=1,
                 description=(
-                    "Only turns whose speaker's name contains this, ignoring case — `ada` matches "
-                    + "`Ada Lovelace`. A substring rather than a whole name on purpose: Teams "
-                    + "display names carry middle names, titles and tenant suffixes, and an exact "
-                    + "match would answer 'they said nothing' to a spelling difference. **If the "
-                    + "transcript's `speaker_attribution` is false this matches NOTHING** — that "
-                    + "organisation records no speaker names, so every turn's `speaker` is null "
-                    + "and no filter can match one. Read an empty answer together with that flag "
-                    + "before concluding the person did not speak, and drop this filter to see the "
-                    + "turns themselves. Omit it to read every speaker; a blank value is refused "
-                    + "rather than read as 'everyone'."
+                    "Only turns whose speaker's name contains this (substring, case-insensitive). "
+                    "**If `speaker_attribution` is false this matches NOTHING** — every turn's "
+                    "`speaker` is null. Omit to read all speakers."
                 ),
             ),
         ] = None,
@@ -544,9 +376,8 @@ def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
         handle = transcript_handle(uri)
         if handle is None:
             raise ToolError(_NOT_A_TRANSCRIPT_HANDLE)
-        # The two rules a schema cannot carry, refused here for the reason search_messages refuses
-        # a criterion-less search: each would otherwise be answered with an empty page, and an
-        # empty page is indistinguishable from a meeting in which nobody said anything.
+        # Reject inverted time window and blank speaker: both would return empty, indistinguishable
+        # from a silent meeting — the schema cannot carry these rules.
         if from_seconds is not None and to_seconds is not None and from_seconds > to_seconds:
             raise ToolError(_INVERTED_TIME_WINDOW)
         if speaker is not None and not speaker.strip():

--- a/services/office-mcp/src/office_mcp/tools/read_transcript.py
+++ b/services/office-mcp/src/office_mcp/tools/read_transcript.py
@@ -1,0 +1,563 @@
+"""`read_transcript` — what was said in a Teams meeting, as speaker-attributed, timestamped turns.
+
+This is the payoff of the whole meeting path and the one surface where a delegated connector can
+answer better than a link. Microsoft's own M365 connector reaches a transcript through an opaque URI
+obtained from a calendar read and returns whatever that yields; the chain here ends in
+`/transcripts/{id}/content`, which Graph answers with WebVTT carrying `<v Speaker>` voice tags and
+cue timestamps — who said what, when.
+
+Four things make this tool what it is, and each of them is a decision rather than a detail.
+
+**It reads and it does not resolve.** The handle carries the meeting id and the transcript id, so
+this call is one Graph request against `/content`. A reader that took the meeting's `meeting_uri`
+instead would repeat the join-URL resolve `list_meeting_transcripts` already did, spend a second
+request and a second permission, and give a 403 that could be about either of them. That is why
+this tool declares `OnlineMeetingTranscript.Read.All` and nothing else, and why a tenant that
+withholds `OnlineMeetings.Read` can still read a transcript it was handed a handle for.
+
+**Speaker attribution degrades instead of failing.** A tenant can permit transcripts and forbid
+speaker names; Graph's documented remedy is to ask again for
+`application/vnd.microsoft.graph.transcript+text`, which `_content` does exactly once and only for
+that inner code. `speaker_attribution: false` then says the words and the timings are all there and
+the names are not — the gap `services/teams-mcp` still has, since it hardcodes `Accept: text/vtt`.
+The tenant-wide switch that blocks transcripts altogether answers with the same `403` and has no
+workaround at all, which is why the retry is keyed on the code and never on the status.
+
+**Filtering makes the answer smaller and never the call cheaper.** `/content` is one stream with no
+ranged contract, so every page refetches and reparses the whole transcript; `from_seconds`,
+`to_seconds` and `speaker` are applied to the parsed turns. They are applied *before* the page is
+cut, and `next_offset` is counted over what they left — the only version of "there is more" a
+caller can act on. Paging the meeting while filtering each page would make the offset mean "more of
+the meeting" while the turns meant "the ones you asked for", and a caller following `next_offset`
+to the end would walk pages that hold nothing.
+
+**Two arguments a schema cannot refuse are refused here.** A `from_seconds` later than
+`to_seconds`, and a `speaker` that is nothing but spaces. Each would otherwise be answered with an
+empty page, and an empty page is indistinguishable from a meeting in which nobody said anything —
+the one failure a model reads as a real answer.
+
+What this file does not own is the handle grammar (`shared/handles.py`, so that the transcript
+`list_meeting_transcripts` names is the transcript this reads) and the token and refusal wording
+(`shared/seam.py`, so this tool's 403 sounds like every other tool's). Everything else — the name,
+the description, the arguments, the answer shape, the request, the parser and every refusal below —
+is here.
+"""
+
+import html
+import re
+from typing import Annotated
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+from kiota_abstractions.headers_collection import HeadersCollection
+from msgraph.graph_service_client import GraphServiceClient
+from pydantic import BaseModel, Field
+
+from office_mcp.graph_client import GraphForbidden, graph_client_for, graph_errors
+from office_mcp.shared.handles import TranscriptHandle, transcript_handle
+from office_mcp.shared.meetings import TRANSCRIPT_PERMISSION
+from office_mcp.shared.seam import READ_ONLY, graph_token, graph_tool_errors
+
+TOOL_NAME = "read_transcript"
+
+# The one delegated permission this tool's one request needs. Admin-consented in its own right, and
+# separately from every other meeting permission: a tenant can grant transcript access and withhold
+# recording access, or the other way round. `list_meeting_transcripts` names this one too, because
+# listing reads the same resource — two tools declaring one permission is what the registry's
+# deduplication is for, and neither may leave it out. The name itself comes from
+# `shared/meetings.py`: rule 4 keeps these two files apart, so a permission both of them declare is
+# spelled where neither owns it rather than typed out once each.
+GRAPH_PERMISSIONS: tuple[str, ...] = (TRANSCRIPT_PERMISSION,)
+
+_TOKEN: str = graph_token(*GRAPH_PERMISSIONS)
+
+# How many turns one read returns, and the ceiling on `limit`. A turn is one WebVTT cue — a sentence
+# or two — so an hour of meeting is some hundreds of them and a 30-hour one (Teams' own limit) is
+# tens of thousands. The whole transcript is fetched either way; this bounds what crosses into a
+# model's context per call.
+MAX_TURNS = 500
+
+_DESCRIPTION = f"""\
+Read what was said in a Teams meeting: the transcript as speaker-attributed, timestamped turns. \
+Takes the `uri` of a transcript that list_meeting_transcripts returned.
+
+This is the payoff of the whole meeting path, and it returns the words themselves rather than a \
+link to them — who spoke, in order, with the offset into the meeting at which they spoke. Quote it \
+as you would quote a message: it is what people actually said, verbatim, and Microsoft's \
+speech-to-text is not perfect, so an odd word is likelier a mis-transcription than a real one.
+
+`uri` takes a handle this connector produced, in exactly one shape:
+  teams:///transcripts/{{meeting_id}}/{{transcript_id}}
+Nothing else is readable here, and nothing turns a meeting's name, its date, its chat or its \
+`meeting_uri` into one — call list_meeting_transcripts and pass its `uri` verbatim. read_message \
+is the reader for a Teams message and takes a different handle; neither tool accepts the other's.
+
+`start_seconds` and `end_seconds` are offsets in seconds from the moment transcription began, not \
+wall-clock times and not offsets from the start of the meeting; add them to the transcript's \
+`started_at` from list_meeting_transcripts if an absolute time is needed. They can be negative, \
+which Microsoft defines as transcription having started after the conversation did.
+
+`speaker_attribution` is false when the organisation has turned speaker names off. The words and \
+timings still come back and every `speaker` is null: do not infer who spoke from the content, and \
+say the transcript is unattributed if the answer turns on who said something. **A `speaker` filter \
+matches nothing at all on such a transcript** — there is no name on any turn for it to match — so \
+read an empty answer next to this flag before reporting that the person never spoke, and drop the \
+filter to see the turns themselves.
+
+`from_seconds`/`to_seconds` and `speaker` narrow what comes back, and everything else is counted \
+over what they left: `next_offset` pages through the MATCHING turns rather than through the \
+meeting. The time bounds are inclusive and match by overlap, so a turn already under \
+way at `from_seconds` is kept whole instead of being cut at it; `speaker` matches any part of the \
+name Teams shows, ignoring case, because a display name is not something to spell from memory. \
+Filtering does not make the call cheaper — the whole transcript is fetched and parsed either \
+way — it makes the answer smaller.
+
+A long meeting is more turns than fit in one answer. `next_offset` says both that there are more \
+and where to continue: it is null on the last page and set on every other, which is the same \
+convention search_messages pages by. Each call re-fetches the whole transcript from Microsoft, so \
+a wider `limit` (up to {MAX_TURNS}) costs less than paging through it, and a page with \
+`next_offset` set must never be summarised as the whole meeting.\
+"""
+
+# What this tool says when its `uri` is not one of its own handles. Its own text rather than a
+# shared one, because the failure it has to prevent is a caller being sent to the wrong tool: the
+# message-handle families and this one are read by different tools under different permissions.
+_NOT_A_TRANSCRIPT_HANDLE = (
+    "read_transcript takes the `uri` of a transcript that list_meeting_transcripts returned, and "
+    + "this is not one. A transcript handle has exactly one shape:\n"
+    + "  teams:///transcripts/{meeting_id}/{transcript_id}\n"
+    + "with both ids percent-encoded. Call list_meeting_transcripts with a meeting chat's "
+    + "`meeting_uri` and pass the `uri` of the transcript you want, verbatim. A `meeting_uri` is "
+    + "not a transcript handle — one meeting can have many transcripts — and neither is a Teams "
+    + "message handle. Retrying this value will fail identically."
+)
+
+_INVERTED_TIME_WINDOW = (
+    "read_transcript was given a `from_seconds` later than its `to_seconds`, which selects no part "
+    + "of the meeting: no turn can both end after the one and start before the other, so this "
+    + "would come back empty and read like a silent meeting. Both are offsets in seconds from the "
+    + "moment transcription began, counting upwards, so the earlier moment is the smaller number — "
+    + "swap them if they were written the wrong way round, or drop one to leave that end open."
+)
+
+_BLANK_SPEAKER = (
+    "read_transcript was given a blank `speaker`. A blank filter is not the same as no filter, and "
+    + "it is not treated as one: omit `speaker` entirely to read every turn, or pass any part of "
+    + "the name Teams shows for the person — matching ignores case and matches anywhere in the "
+    + "display name, so `ada` finds `Ada Lovelace`. Note that a transcript whose "
+    + "`speaker_attribution` is false carries no names at all, and any `speaker` filter matches "
+    + "nothing on it."
+)
+
+# Graph's 404 on a well-formed transcript handle. Distinct advice from the message reader's, because
+# the causes are different: a transcript is not deleted by a user, it ages out with its meeting.
+_TRANSCRIPT_UNREADABLE = (
+    "Microsoft 365 would not return this transcript. The handle is well formed, so this is not a "
+    + "bad argument. The likeliest cause is age: Microsoft stops serving a meeting's transcripts "
+    + "once the meeting expires, about 60 days after a one-off meeting, and it answers that "
+    + "identically to a transcript that was removed or that this user may not see. Call "
+    + "list_meeting_transcripts for the meeting again to see what it still has; if the transcript "
+    + "is no longer listed there, it is out of reach and retrying will not bring it back."
+)
+
+
+class TranscriptTurn(BaseModel):
+    speaker: str | None = Field(
+        description=(
+            "Who spoke, as Teams attributed them. Null when this transcript has no speaker "
+            + "attribution at all (see `speaker_attribution`) and null for the occasional turn "
+            + "Microsoft attributed to nobody — a null is not an unidentified person."
+        )
+    )
+    start_seconds: float = Field(
+        description=(
+            "When this turn starts, in seconds from the beginning of transcription — not from the "
+            + "start of the meeting, and not a wall-clock time. Add it to the transcript's "
+            + "`started_at` for that. It can be NEGATIVE: Microsoft documents negative offsets as "
+            + "meaning transcription began while the conversation was already under way."
+        )
+    )
+    end_seconds: float = Field(description="When this turn ends, on the same scale.")
+    text: str = Field(description="What was said, with Teams' own cue markup removed.")
+
+
+class Transcript(BaseModel):
+    uri: str = Field(description="The handle this transcript was read by, echoed back.")
+    meeting_id: str = Field(description="The meeting this transcript belongs to.")
+    transcript_id: str = Field(description="The transcript's Graph id.")
+    speaker_attribution: bool = Field(
+        description=(
+            "True when Microsoft named the speakers, which is the normal case. False when this "
+            + "tenant has speaker attribution switched off: the words and the timings are all "
+            + "still here and every `speaker` is null. Do not guess who spoke from the content, "
+            + "and say so if the answer depends on who said something."
+        )
+    )
+    turns: list[TranscriptTurn] = Field(
+        description=(
+            "What was said, in order, one turn per utterance Microsoft timestamped — the turns "
+            + "matching `from_seconds`, `to_seconds` and `speaker` where any of those was given, "
+            + "and every turn of the transcript where none was. Empty means nothing matched what "
+            + "was asked for, which is not the same as the meeting having no words in it."
+        )
+    )
+    next_offset: int | None = Field(
+        description=(
+            "The `offset` that reaches the next matching turns, or null when these are the last of "
+            + "them. A value here is what says more turns match than this page holds: pass it back "
+            + "as `offset` to continue, and never summarise a page with one set as the whole "
+            + "meeting. It counts the turns left after `from_seconds`, `to_seconds` and `speaker` "
+            + "were applied, so it indexes what was asked for rather than the meeting — send the "
+            + "same filters back with it, since changing one renumbers what it points at."
+        )
+    )
+
+
+async def read_transcript(
+    client: GraphServiceClient,
+    *,
+    handle: TranscriptHandle,
+    offset: int,
+    limit: int,
+    from_seconds: float | None = None,
+    to_seconds: float | None = None,
+    speaker: str | None = None,
+) -> Transcript:
+    """The turns of one transcript matching the filters, from `offset`, up to `limit` of them.
+
+    One Graph request, or two where the tenant refuses speaker attribution. Paging is over the
+    parsed turns rather than over Graph — `/content` is a single stream with no ranged contract —
+    so a later page costs the same fetch again, which is what makes `limit` worth widening rather
+    than looping. The filters are the same bargain: the whole transcript is fetched and parsed
+    whatever they are, so they make the answer smaller and never the call cheaper.
+    """
+    assert 1 <= limit <= MAX_TURNS, f"limit must be within 1..{MAX_TURNS}, got {limit}"
+    assert offset >= 0, f"offset must not be negative, got {offset}"
+    assert from_seconds is None or to_seconds is None or from_seconds <= to_seconds, (
+        f"from_seconds must not be after to_seconds, got {from_seconds} and {to_seconds}"
+    )
+
+    # TODO: every page refetches and reparses the whole transcript, because `/content` has no
+    # ranged contract. Caching the parsed turns per handle is the fix.
+    content, attributed = await _content(client, handle)
+
+    turns = _matching(
+        _turns(content, attributed=attributed),
+        from_seconds=from_seconds,
+        to_seconds=to_seconds,
+        speaker=speaker,
+    )
+    page = turns[offset : offset + limit]
+    more_to_come = offset + len(page) < len(turns)
+    return Transcript(
+        uri=handle.uri,
+        meeting_id=handle.meeting_id,
+        transcript_id=handle.transcript_id,
+        speaker_attribution=attributed,
+        turns=page,
+        next_offset=offset + len(page) if more_to_come else None,
+    )
+
+
+def _matching(
+    turns: list[TranscriptTurn],
+    *,
+    from_seconds: float | None,
+    to_seconds: float | None,
+    speaker: str | None,
+) -> list[TranscriptTurn]:
+    """The turns of `turns` that all of the given filters keep, in the order they were said.
+
+    **The time test is overlap, and both bounds are inclusive.** A turn is one utterance of a
+    sentence or two, and the moment a caller asks about lands in the middle of one about as often
+    as it lands between two — so a turn that straddles a bound is kept whole rather than dropped or
+    cut. Comparing a turn's *start* to both bounds instead would silently lose the sentence already
+    under way at `from_seconds`, which is exactly the sentence that says what the stretch is about.
+
+    **The speaker test is a case-insensitive substring of the display name.** A model asking about
+    a person has a name it read somewhere, not the string Teams stores, and those differ by case,
+    by a middle name, by a title or by the parenthesised suffix a tenant appends. An exact match
+    would answer "that person said nothing" to a spelling difference.
+
+    A turn Microsoft attributed to nobody never matches a speaker filter: `speaker` is null there,
+    and there is nothing to compare. Neither does *any* turn of a transcript from a tenant with
+    speaker attribution switched off, where every `speaker` is null by construction — this is not
+    refused and not degraded to "everything", because a filter that quietly stopped filtering would
+    be worse than an empty answer. `Transcript.speaker_attribution` is the flag that explains that
+    answer, and every description over this argument says to read the two together.
+    """
+    wanted = speaker.casefold() if speaker is not None else None
+    return [
+        turn
+        for turn in turns
+        if (from_seconds is None or turn.end_seconds >= from_seconds)
+        and (to_seconds is None or turn.start_seconds <= to_seconds)
+        and (wanted is None or (turn.speaker is not None and wanted in turn.speaker.casefold()))
+    ]
+
+
+# The inner code Graph sends when a tenant permits transcripts but forbids speaker names. Branched
+# on rather than the message, as Microsoft's own documentation instructs.
+_SPEAKER_ATTRIBUTION_REFUSED = "SpeakerAttributionNotAllowed"
+
+# The two formats `/content` serves. VTT is the default and the one worth having — it is the only
+# one carrying `<v Speaker>` voice tags. The other is the documented fallback for a tenant with
+# speaker attribution switched off, and is selectable *only* by this header ("the
+# application/vnd.microsoft.graph.transcript+text format is supported only through this header"),
+# which is why neither is requested with `$format`.
+_ATTRIBUTED_FORMAT = "text/vtt"
+_UNATTRIBUTED_FORMAT = "application/vnd.microsoft.graph.transcript+text"
+
+
+async def _content(client: GraphServiceClient, handle: TranscriptHandle) -> tuple[bytes, bool]:
+    """The transcript's bytes, and whether they carry speaker names.
+
+    The attributed format is asked for first because it is the one worth having and the default. The
+    single retry is Graph's own documented remedy for a tenant that permits transcripts and forbids
+    speaker names — "Retry the same request asking for the unattributed format … which succeeds" —
+    and it is scoped to that inner code alone: the tenant-wide switch reports itself the same way
+    (`403 Forbidden`) and has no request-side workaround, so retrying it would be one wasted call
+    and a message about the wrong remedy.
+
+    Each attempt gets its own `graph_errors` rather than one around both. The branch is on a
+    *classified* failure — the SDK's raw `APIError` has no inner code on it — so the translation has
+    to have happened before the `except` can decide anything, which a block enclosing the whole
+    function would defer until after it had already given up.
+    """
+    endpoint = (
+        client.me.online_meetings.by_online_meeting_id(handle.meeting_id)
+        .transcripts.by_call_transcript_id(handle.transcript_id)
+        .content
+    )
+    try:
+        with graph_errors():
+            attributed = await endpoint.get(
+                request_configuration=RequestConfiguration(headers=_accepting(_ATTRIBUTED_FORMAT))
+            )
+    except GraphForbidden as refusal:
+        if refusal.inner_code != _SPEAKER_ATTRIBUTION_REFUSED:
+            raise
+        with graph_errors():
+            unattributed = await endpoint.get(
+                request_configuration=RequestConfiguration(headers=_accepting(_UNATTRIBUTED_FORMAT))
+            )
+        return (unattributed or b"", False)
+    return (attributed or b"", True)
+
+
+def _accepting(media_type: str) -> HeadersCollection:
+    """A `HeadersCollection` of our own asking for `media_type`.
+
+    Built per request: `RequestConfiguration.headers` defaults to one instance shared by every
+    configuration in the process, so adding to the default would add to every other Graph request
+    this connector makes. The generated builder adds its own `Accept` with `try_add`, which is a
+    no-op once this one is present — which is how a format gets selected at all.
+    """
+    headers = HeadersCollection()
+    headers.add("Accept", media_type)
+    return headers
+
+
+# One WebVTT cue's timing line. The hours field is optional in WebVTT and Teams omits it in some
+# transcripts; the leading sign is what Microsoft's "negative offsets" note requires.
+_TIMESTAMP = r"-?(?:\d+:)?\d{1,2}:\d{1,2}[.,]\d{1,3}"
+_CUE_TIMING = re.compile(rf"^(?P<start>{_TIMESTAMP})\s*-->\s*(?P<end>{_TIMESTAMP})")
+
+# A voice span, which is where a speaker's name lives: `<v Ada Lovelace>text</v>`. The class suffix
+# (`<v.loud Ada>`) is part of WebVTT and Teams may emit it.
+_VOICE = re.compile(r"<v(?:\.[^\s>]+)?\s+(?P<speaker>[^>]*)>(?P<said>.*?)(?:</v>|\Z)", re.DOTALL)
+
+# Every other cue-payload tag: `<i>`, `<c.colorE5E5E5>`, `<00:00:01.000>` timestamps, `<lang en>`.
+_MARKUP = re.compile(r"<[^>]*>")
+
+_BLANK_LINE = re.compile(r"\n[ \t]*\n")
+
+
+def _turns(content: bytes, *, attributed: bool) -> list[TranscriptTurn]:
+    """`content` as speaker-attributed, timestamped turns.
+
+    One cue is one turn: Teams emits an utterance per cue, so merging them would be inventing a
+    grouping Microsoft did not make. Anything that is not a cue — the `WEBVTT` header, `NOTE`,
+    `STYLE` and `REGION` blocks, a cue identifier line — is skipped rather than guessed at, and a
+    cue with a timing line but no words is dropped: an empty turn reads as a silence somebody sat
+    through.
+
+    `attributed` is what the request asked for, and it decides whether an unparsed `<v …>` could
+    have been there at all — the unattributed format has none by construction.
+    """
+    text = content.decode("utf-8-sig", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+    turns: list[TranscriptTurn] = []
+    for block in _BLANK_LINE.split(text):
+        turn = _turn(block, attributed=attributed)
+        if turn is not None:
+            turns.append(turn)
+    return turns
+
+
+def _turn(block: str, *, attributed: bool) -> TranscriptTurn | None:
+    """One cue block as a turn, or None if it is not a cue (or is one with nothing said)."""
+    lines = [line for line in block.split("\n") if line.strip()]
+    timing = next(
+        ((index, match) for index, line in enumerate(lines) if (match := _CUE_TIMING.match(line))),
+        None,
+    )
+    if timing is None:
+        return None
+    index, match = timing
+    speaker, said = _spoken("\n".join(lines[index + 1 :]), attributed=attributed)
+    if not said:
+        return None
+    return TranscriptTurn(
+        speaker=speaker,
+        start_seconds=_seconds(match.group("start")),
+        end_seconds=_seconds(match.group("end")),
+        text=said,
+    )
+
+
+def _spoken(payload: str, *, attributed: bool) -> tuple[str | None, str]:
+    """A cue payload as (speaker, words).
+
+    The voice span is read before the markup is stripped, because stripping it first would take the
+    speaker's name with it. An attributed transcript whose cue carries no voice span keeps a null
+    speaker rather than borrowing the previous turn's: Teams does leave some utterances
+    unattributed, and attributing them to whoever spoke last would put words in someone's mouth.
+    """
+    voice = _VOICE.search(payload) if attributed else None
+    speaker = voice.group("speaker").strip() if voice is not None else None
+    said = voice.group("said") if voice is not None else payload
+    words = html.unescape(_MARKUP.sub("", said)).replace("\xa0", " ")
+    return (speaker or None, " ".join(words.split()))
+
+
+def _seconds(timestamp: str) -> float:
+    """A WebVTT timestamp as seconds, keeping its sign.
+
+    `HH:MM:SS.mmm` and `MM:SS.mmm` are both legal; the comma decimal separator is not WebVTT but is
+    what SubRip uses and costs nothing to accept.
+    """
+    negative = timestamp.startswith("-")
+    parts = timestamp.lstrip("-").replace(",", ".").split(":")
+    total = 0.0
+    for part in parts:
+        total = total * 60 + float(part)
+    return -total if negative else total
+
+
+def register(mcp: FastMCP, transport: httpx.AsyncClient) -> None:
+    """Declare this tool against the shared Graph transport.
+
+    `transport` is the long-lived `httpx.AsyncClient` from `create_graph_transport`; the tool
+    borrows it per call and never owns it. `create_app` closes it on shutdown.
+    """
+
+    @mcp.tool(
+        name=TOOL_NAME,
+        title="Read a Meeting Transcript",
+        description=_DESCRIPTION,
+        annotations=READ_ONLY,
+    )
+    async def read_meeting_transcript(
+        uri: Annotated[
+            str,
+            Field(
+                min_length=1,
+                description=(
+                    "The transcript to read, exactly as list_meeting_transcripts reported its "
+                    + "`uri`: `teams:///transcripts/{meeting_id}/{transcript_id}`. A meeting's "
+                    + "`meeting_uri` is not one of these, and no other shape is readable here."
+                ),
+            ),
+        ],
+        offset: Annotated[
+            int,
+            Field(
+                ge=0,
+                description=(
+                    "How many turns to skip. Start at 0 and pass the previous response's "
+                    + "`next_offset` to continue through a long meeting."
+                ),
+            ),
+        ] = 0,
+        limit: Annotated[
+            int,
+            Field(
+                ge=1,
+                le=MAX_TURNS,
+                description=(
+                    "How many turns to return. Default 200, maximum "
+                    + f"{MAX_TURNS}. Every call fetches the whole transcript from "
+                    + "Microsoft, so widening this is cheaper than paging. It counts the turns "
+                    + "left after `from_seconds`, `to_seconds` and `speaker`, not the meeting's."
+                ),
+            ),
+        ] = 200,
+        from_seconds: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Only turns reaching this moment or later, in seconds from when transcription "
+                    + "began — the same scale as a turn's `start_seconds`, which is NOT a "
+                    + "wall-clock time and NOT an offset from the start of the meeting. Inclusive, "
+                    + "and matched by overlap: a turn already under way at this moment is kept "
+                    + "whole rather than cut at it, which is usually the sentence that says what "
+                    + "the stretch is about. Negative values are legal — Microsoft uses them for "
+                    + "transcription that began after the conversation did. This narrows the "
+                    + "answer, not the call: the whole transcript is fetched and parsed either way."
+                )
+            ),
+        ] = None,
+        to_seconds: Annotated[
+            float | None,
+            Field(
+                description=(
+                    "Only turns beginning at this moment or earlier, on the same scale and the "
+                    + "same inclusive overlap rule: a turn still running at this moment is kept "
+                    + "whole. Pair it with `from_seconds` to read one stretch of a long meeting, "
+                    + "and keep the two in that order — a `from_seconds` later than this is "
+                    + "refused rather than answered with an empty page."
+                )
+            ),
+        ] = None,
+        speaker: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                description=(
+                    "Only turns whose speaker's name contains this, ignoring case — `ada` matches "
+                    + "`Ada Lovelace`. A substring rather than a whole name on purpose: Teams "
+                    + "display names carry middle names, titles and tenant suffixes, and an exact "
+                    + "match would answer 'they said nothing' to a spelling difference. **If the "
+                    + "transcript's `speaker_attribution` is false this matches NOTHING** — that "
+                    + "organisation records no speaker names, so every turn's `speaker` is null "
+                    + "and no filter can match one. Read an empty answer together with that flag "
+                    + "before concluding the person did not speak, and drop this filter to see the "
+                    + "turns themselves. Omit it to read every speaker; a blank value is refused "
+                    + "rather than read as 'everyone'."
+                ),
+            ),
+        ] = None,
+        graph_token: str = _TOKEN,
+    ) -> Transcript:
+        handle = transcript_handle(uri)
+        if handle is None:
+            raise ToolError(_NOT_A_TRANSCRIPT_HANDLE)
+        # The two rules a schema cannot carry, refused here for the reason search_messages refuses
+        # a criterion-less search: each would otherwise be answered with an empty page, and an
+        # empty page is indistinguishable from a meeting in which nobody said anything.
+        if from_seconds is not None and to_seconds is not None and from_seconds > to_seconds:
+            raise ToolError(_INVERTED_TIME_WINDOW)
+        if speaker is not None and not speaker.strip():
+            raise ToolError(_BLANK_SPEAKER)
+        with graph_tool_errors(*GRAPH_PERMISSIONS, not_found=_TRANSCRIPT_UNREADABLE):
+            return await read_transcript(
+                graph_client_for(transport, graph_token),
+                handle=handle,
+                offset=offset,
+                limit=limit,
+                from_seconds=from_seconds,
+                to_seconds=to_seconds,
+                speaker=speaker,
+            )

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -2201,6 +2201,26 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert "fail identically" in message, "and it is not worth retrying"
 
     @pytest.mark.usefixtures("obo")
+    async def test_the_transcript_listers_refusal_keeps_the_sentence_only_it_can_say(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The one sentence in that refusal no other tool could write: the shape it just rejected
+        is read by read_transcript, and this is the tool that produces one. Before the reader
+        existed the sentence had to stop at "what this tool produces rather than what it takes",
+        which named the shape and left a model with nowhere to take it."""
+        result = await mcp_client.call_tool(
+            "list_meeting_transcripts",
+            {"meeting_uri": "teams:///transcripts/a/b"},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        assert (
+            "that last one is read_transcript's, and this tool is what produces it"
+            in _error_text(result)
+        )
+
+    @pytest.mark.usefixtures("obo")
     async def test_a_transcript_graph_will_not_return_blames_the_meeting_window_not_the_handle(
         self,
         mcp_client: Client[FastMCPTransport],

--- a/services/office-mcp/tests/test_mcp_tools.py
+++ b/services/office-mcp/tests/test_mcp_tools.py
@@ -281,6 +281,7 @@ _MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
 _TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
 _MEETINGS_PATH = "/me/onlineMeetings"
 _TRANSCRIPTS_PATH = f"/me/onlineMeetings/{_MEETING_ID}/transcripts"
+_CONTENT_PATH = f"{_TRANSCRIPTS_PATH}/{_TRANSCRIPT_ID}/content"
 
 _MEETING_CHATS = {
     "value": [
@@ -397,6 +398,15 @@ def _daily_series() -> dict[str, object]:
 # the handle a model copies from one tool is the argument another takes is the contract between
 # them, and deriving it here would assert only that the test agrees with itself.
 _MEETING_URI = "teams:///meetings/" + quote(_JOIN_WEB_URL, safe="")
+
+_TRANSCRIPT_VTT = """WEBVTT
+
+00:00:16.246 --> 00:00:19.900
+<v Grace Hopper>We should raise the floor price by three per cent.</v>
+
+00:01:02.000 --> 00:01:04.500
+<v Ada Lovelace>Agreed, that works.</v>
+"""
 
 
 class _StubOboCredential:
@@ -611,6 +621,7 @@ class TestTheToolsThisServerAdvertises:
             "search_messages",
             "read_message",
             "list_meeting_transcripts",
+            "read_transcript",
         }
         for tool in tools.values():
             assert "graph_token" not in _properties(tool.inputSchema)
@@ -686,6 +697,14 @@ class TestTheToolsThisServerAdvertises:
             "transcripts",
             "scan_incomplete",
         }
+        assert set(_properties(tools["read_transcript"].outputSchema)) == {
+            "uri",
+            "meeting_id",
+            "transcript_id",
+            "speaker_attribution",
+            "turns",
+            "next_offset",
+        }
 
     async def test_the_whole_surface_speaks_one_language(
         self, mcp_client: Client[FastMCPTransport]
@@ -700,7 +719,8 @@ class TestTheToolsThisServerAdvertises:
         the length of its window, which is only honest because its walk follows Microsoft's paging
         to the end of the collection; `search_messages` cannot say it that way at all, because
         Microsoft reports a page count rather than a match total for Teams messages — so it says it
-        with `next_offset` and that field is asserted to be there.
+        with `next_offset`, and `read_transcript` says it the same way over the turns of a
+        transcript Graph serves in one piece. That field is asserted to be on both.
 
         Where a completeness fact is NOT derivable from the answer it survives as an opt-in field,
         which is asserted too: the flag that asks for it defaults to off, so no ordinary answer
@@ -720,7 +740,7 @@ class TestTheToolsThisServerAdvertises:
                 assert re.fullmatch(r"[a-z][a-z0-9]*(_[a-z0-9]+)*", field), f"{field} is not snake"
         for name, tool in tools.items():
             assert "truncated" not in _properties(tool.outputSchema), name
-        for name in ("search_messages",):
+        for name in ("search_messages", "read_transcript"):
             assert "next_offset" in _properties(tools[name].outputSchema), name
         for name, flag in (
             ("browse_channel", "include_window_completeness"),
@@ -880,6 +900,47 @@ class TestTheToolsThisServerAdvertises:
         )
         assert "search_messages" in description
         assert "browse_channel" in description, "the reply shape has exactly one source"
+
+    async def test_read_transcript_takes_a_handle_and_a_window_and_names_its_one_shape(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """A second reader, deliberately: a transcript is read under a different permission from a
+        message, and a token is exchanged per tool — so one polymorphic reader would have to redeem
+        transcript access to read a chat message. Its handle shape is therefore its own, and the
+        description has to name it and say which tool mints it."""
+        tools = _named(await mcp_client.list_tools())
+        schema = tools["read_transcript"].inputSchema
+        description = tools["read_transcript"].description
+        assert description is not None
+
+        assert set(_properties(schema)) == {
+            "uri",
+            "offset",
+            "limit",
+            "from_seconds",
+            "to_seconds",
+            "speaker",
+        }
+        assert schema.get("required") == ["uri"]
+        assert "teams:///transcripts/{meeting_id}/{transcript_id}" in description
+        assert "list_meeting_transcripts" in description
+        assert "read_message" in description, "the two readers must not be confusable"
+
+    async def test_read_transcript_narrows_by_seconds_and_by_speaker_in_its_own_schema(
+        self, mcp_client: Client[FastMCPTransport]
+    ) -> None:
+        """The turns are already timestamped and attributed in the answer, so the filters are named
+        in the same units the answer reports: seconds from the meeting's start, and the speaker as
+        the transcript spells them. A model narrows only what it can see, and every one of these is
+        optional — the unfiltered read stays the default."""
+        tools = _named(await mcp_client.list_tools())
+        properties = _properties(tools["read_transcript"].inputSchema)
+
+        for bound in ("from_seconds", "to_seconds"):
+            assert _optional_type(properties[bound])["type"] == "number", bound
+        assert _optional_type(properties["speaker"])["type"] == "string"
+        for name in ("from_seconds", "to_seconds", "speaker"):
+            assert _object(properties[name]).get("description"), f"{name} is undescribed"
 
     async def test_browse_channel_needs_both_ids_and_bounds_its_page_where_graph_does(
         self, mcp_client: Client[FastMCPTransport]
@@ -1581,18 +1642,19 @@ class TestCallingThem:
         assert not route.called
         assert not obo.requested_scopes
 
-    async def test_a_model_walks_from_a_meeting_chat_to_the_meetings_transcripts(
+    async def test_a_model_walks_from_a_meeting_chat_to_what_was_said_in_the_meeting(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
         obo: _StubOboCredential,
     ) -> None:
-        """The path this tool exists to complete, over the real protocol, with every value taken
-        from the previous answer exactly as a model would take it: which meetings are there
-        (list_chats, because a meeting chat *is* the index), and then what transcripts this one has.
+        """The flagship path of this piece, over the real protocol, with every value taken from the
+        previous answer exactly as a model would take it: which meetings are there (list_chats,
+        because a meeting chat *is* the index), what transcripts does this one have, and then the
+        words — speaker-attributed and timestamped, not a link to a file.
 
-        The connector this was compared against reaches a meeting only through an opaque URI it got
-        from a calendar read; this walk needs no calendar permission at all.
+        The oracle connector reaches a transcript only through an opaque URI it got from a calendar
+        read; this walk needs no calendar permission at all, and it ends in text.
         """
         chats_route = graph.get("/me/chats").mock(
             return_value=httpx.Response(200, json=_MEETING_CHATS)
@@ -1601,6 +1663,11 @@ class TestCallingThem:
         listing = graph.get(_TRANSCRIPTS_PATH).mock(
             return_value=httpx.Response(200, json=_TRANSCRIPTS)
         )
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                200, content=_TRANSCRIPT_VTT.encode(), headers={"content-type": "text/vtt"}
+            )
+        )
 
         listed = _structured(await mcp_client.call_tool("list_chats", {"limit": 5}))
         found = cast("Sequence[Mapping[str, object]]", listed["chats"])
@@ -1608,24 +1675,37 @@ class TestCallingThem:
         available = _structured(
             await mcp_client.call_tool("list_meeting_transcripts", {"meeting_uri": meeting_uri})
         )
+        listed_transcripts = cast("Sequence[Mapping[str, object]]", available["transcripts"])
+        read = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": listed_transcripts[0]["uri"]})
+        )
 
-        assert all(route.called for route in (chats_route, meeting, listing))
+        assert all(route.called for route in (chats_route, meeting, listing, content))
         assert found[0]["chat_type"] == "meeting"
         assert meeting_uri == _MEETING_URI, "the handle one tool minted is what the other took"
         assert available["status"] == "available"
         assert available["subject"] == "Pricing review"
         assert available["meeting_id"] == _MEETING_ID
         assert available["scan_incomplete"] is None, "nobody asked how far the read got"
-        transcripts = cast("Sequence[Mapping[str, object]]", available["transcripts"])
-        assert [item["transcript_id"] for item in transcripts] == [_TRANSCRIPT_ID]
-        assert listing.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert [item["transcript_id"] for item in listed_transcripts] == [_TRANSCRIPT_ID]
+        assert read["speaker_attribution"] is True
+        turns = cast("Sequence[Mapping[str, object]]", read["turns"])
+        assert [(turn["speaker"], turn["start_seconds"]) for turn in turns] == [
+            ("Grace Hopper", 16.246),
+            ("Ada Lovelace", 62.0),
+        ]
+        assert turns[0]["text"] == "We should raise the floor price by three per cent."
+        assert read["next_offset"] is None
+        assert content.calls.last.request.headers["authorization"] == f"Bearer {OBO_TOKEN}"
+        assert content.calls.last.request.headers["accept"] == "text/vtt"
         assert obo.requested_scopes == [
             ("https://graph.microsoft.com/Chat.Read",),
             (
                 "https://graph.microsoft.com/OnlineMeetings.Read",
                 "https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",
             ),
-        ], "resolving the join URL and reading the collection are two permissions, one exchange"
+            ("https://graph.microsoft.com/OnlineMeetingTranscript.Read.All",),
+        ], "the reader needs only transcript access; resolving a join URL is the lister's job"
 
     @pytest.mark.usefixtures("obo")
     async def test_asking_for_the_latest_of_a_series_answers_with_the_latest(
@@ -1719,6 +1799,107 @@ class TestCallingThem:
         assert wide["status"] == "scan_incomplete"
         assert narrow["status"] == wide["status"], "a narrower window reads the same transcripts"
         assert wide["transcripts"] == [] and narrow["transcripts"] == []
+
+    @pytest.mark.usefixtures("obo")
+    async def test_the_transcript_text_reaches_the_caller_and_no_log_or_span(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A transcript is the most sensitive content this connector touches — a verbatim record of
+        what people said in a room — so the rule search and read are held to is tightest here: the
+        words reach the caller and no log line and no span attribute anywhere in the process."""
+        exporter = InMemorySpanExporter()
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace.set_tracer_provider(provider)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        secret = "acquisition-of-northwind-traders"
+        vtt = f"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Ada Lovelace>{secret}</v>\n"
+        graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        graph.get(_TRANSCRIPTS_PATH).mock(return_value=httpx.Response(200, json=_TRANSCRIPTS))
+        _ = graph.get(_CONTENT_PATH).mock(return_value=httpx.Response(200, content=vtt.encode()))
+        caplog.set_level(logging.DEBUG)
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
+        )
+
+        turns = cast("Sequence[Mapping[str, object]]", _structured(result)["turns"])
+        assert turns[0]["text"] == secret, "the transcript has to have been returned"
+        for record in caplog.records:
+            assert secret not in _record_text(record), f"logged by {record.name}"
+        for span in exporter.get_finished_spans():
+            assert secret not in str(span.attributes)
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_transcript_is_read_narrowed_to_a_speaker_and_to_a_stretch_of_the_meeting(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """Over the real protocol, in the two shapes a model reaches for: "what did she say" and
+        "what was said after that point". An hour of meeting is thousands of turns and a model that
+        can only ask for all of them spends its context on the transcript instead of the answer.
+        """
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
+        uri = f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"
+
+        by_speaker = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": uri, "speaker": "grace"})
+        )
+        by_time = _structured(
+            await mcp_client.call_tool("read_transcript", {"uri": uri, "from_seconds": 20})
+        )
+
+        assert [
+            turn["speaker"] for turn in cast("Sequence[Mapping[str, object]]", by_speaker["turns"])
+        ] == ["Grace Hopper"]
+        assert by_speaker["speaker_attribution"] is True
+        assert by_speaker["next_offset"] is None, "one turn matched and one turn came back"
+        turns = cast("Sequence[Mapping[str, object]]", by_time["turns"])
+        assert [turn["start_seconds"] for turn in turns] == [62.0]
+        assert content.call_count == 2, "paging and filtering are over the parsed turns, not Graph"
+
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("filters", "named"),
+        [
+            ({"from_seconds": 60, "to_seconds": 30}, "from_seconds"),
+            ({"speaker": ""}, "speaker"),
+            ({"speaker": "   "}, "speaker"),
+        ],
+        ids=["inverted-window", "empty-speaker", "blank-speaker"],
+    )
+    async def test_a_filter_no_transcript_could_satisfy_is_refused_before_any_graph_request(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+        filters: Mapping[str, object],
+        named: str,
+    ) -> None:
+        """A window that ends before it starts, and a speaker that names nobody, both match nothing
+        by construction — answering them with an empty page would read as "she said nothing in the
+        meeting", which is a wrong answer nobody can detect. The refusal names the parameter, and it
+        costs no Graph request."""
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}", **filters},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        assert named in _error_text(result), _error_text(result)
+        assert not content.called
 
 
 class TestTheTransportTheToolsShare:
@@ -1927,19 +2108,26 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         assert not route.called, "no token means no search was ever made"
 
     @pytest.mark.usefixtures("obo")
-    async def test_the_transcript_tenant_switch_names_a_different_administrator(
+    @pytest.mark.parametrize(
+        "tool", ["list_meeting_transcripts", "read_transcript"], ids=["listing", "reading"]
+    )
+    async def test_the_tenant_transcript_switch_sends_the_caller_to_a_teams_administrator(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
+        tool: str,
     ) -> None:
-        """The refusal every other 403 on this server would be answered wrongly for, end to end.
+        """The refusal every other 403 on this server would be answered wrongly for, end to end,
+        and now on both of the calls that can meet it.
 
         Microsoft Graph access to Teams meeting transcripts is a tenant-wide Teams setting that is
         OFF BY DEFAULT, and Graph reports it with the same status and the same outer code as a
         missing permission. In the commonest tenant, therefore, this is the *first* answer a model
-        gets from this tool — so it has to name the Teams admin centre rather than a Graph
+        gets from either tool — so it has to name the Teams admin centre rather than a Graph
         permission, and it has to rule out re-consent, which is what a model would otherwise infer
-        from every other refusal here.
+        from every other refusal here. The reader meets it on a different endpoint from the lister,
+        which is the whole reason both are driven: a remedy that reached only the listing would
+        leave the reader answering the ordinary 403.
         """
         graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
         graph.get(_TRANSCRIPTS_PATH).mock(
@@ -1947,10 +2135,17 @@ class TestWhatAModelIsToldWhenGraphRefuses:
                 403, headers={"request-id": "synthetic-request-id"}, json=_TENANT_SWITCH_OFF
             )
         )
-
-        refused = await mcp_client.call_tool(
-            "list_meeting_transcripts", {"meeting_uri": _MEETING_URI}, raise_on_error=False
+        graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                403, headers={"request-id": "synthetic-request-id"}, json=_TENANT_SWITCH_OFF
+            )
         )
+        arguments = {
+            "list_meeting_transcripts": {"meeting_uri": _MEETING_URI},
+            "read_transcript": {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
+        }[tool]
+
+        refused = await mcp_client.call_tool(tool, arguments, raise_on_error=False)
 
         assert refused.is_error
         message = _error_text(refused)
@@ -1962,31 +2157,79 @@ class TestWhatAModelIsToldWhenGraphRefuses:
         )
         assert "synthetic-request-id" in message, "an operator still needs the evidence"
 
-    async def test_a_meeting_handle_that_was_never_one_is_refused_before_graph(
+    @pytest.mark.usefixtures("obo")
+    @pytest.mark.parametrize(
+        ("tool", "argument", "uri"),
+        [
+            ("list_meeting_transcripts", "meeting_uri", "teams:///transcripts/a/b"),
+            ("list_meeting_transcripts", "meeting_uri", "19:meeting_x@thread.v2"),
+            ("read_transcript", "uri", "teams:///meetings/https%3A%2F%2Fx.invalid%2Fa"),
+            ("read_transcript", "uri", "teams:///chats/19%3Ax%40thread.v2/messages/1"),
+        ],
+    )
+    async def test_each_meeting_tool_refuses_the_other_ones_handle_and_says_where_to_get_its_own(
         self,
         mcp_client: Client[FastMCPTransport],
         graph: respx.MockRouter,
-        obo: _StubOboCredential,
+        tool: str,
+        argument: str,
+        uri: str,
     ) -> None:
-        """A handle this tool cannot use is its own failure to explain, and the explanation has to
-        send the caller back to where handles come from rather than invite a retry. The transcript
-        shape is named as *not* one, because it is the shape this tool emits and therefore the one
-        most likely to be passed back in."""
-        route = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        """Two meeting handle families now exist, one minted by each of these tools and read by the
+        other, and a model will mix them up. Each refusal has to name the one shape this tool reads
+        and the one tool that mints it — "invalid handle" would leave a model guessing, and guessing
+        between families is exactly what produces a loop."""
+        meetings = graph.get(_MEETINGS_PATH).mock(return_value=httpx.Response(200, json=_MEETING))
+        content = graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(200, content=_TRANSCRIPT_VTT.encode())
+        )
 
-        refused = await mcp_client.call_tool(
-            "list_meeting_transcripts",
-            {"meeting_uri": "19:meeting_TjAwMDAwMDAwMDAwMA@thread.v2"},
+        result = await mcp_client.call_tool(tool, {argument: uri}, raise_on_error=False)
+
+        assert result.is_error
+        assert not meetings.called and not content.called, "a bad handle costs no Graph request"
+        message = _error_text(result)
+        expected = {
+            "list_meeting_transcripts": ("teams:///meetings/{join_web_url}", "list_chats"),
+            "read_transcript": (
+                "teams:///transcripts/{meeting_id}/{transcript_id}",
+                "list_meeting_transcripts",
+            ),
+        }[tool]
+        for fragment in expected:
+            assert fragment in message, message
+        assert "fail identically" in message, "and it is not worth retrying"
+
+    @pytest.mark.usefixtures("obo")
+    async def test_a_transcript_graph_will_not_return_blames_the_meeting_window_not_the_handle(
+        self,
+        mcp_client: Client[FastMCPTransport],
+        graph: respx.MockRouter,
+    ) -> None:
+        """A 404 on a well-formed transcript handle is almost always age: Microsoft stops serving a
+        meeting's artifacts once the meeting expires. The message-reader's advice would be wrong
+        here in both directions — a transcript is not deleted by a user, and browsing a channel is
+        not a route to one."""
+        graph.get(_CONTENT_PATH).mock(
+            return_value=httpx.Response(
+                404,
+                headers={"request-id": "synthetic-request-id"},
+                json={"error": {"code": "NotFound", "message": "Not Found"}},
+            )
+        )
+
+        result = await mcp_client.call_tool(
+            "read_transcript",
+            {"uri": f"teams:///transcripts/{_MEETING_ID}/{_TRANSCRIPT_ID}"},
             raise_on_error=False,
         )
 
-        assert refused.is_error
-        message = _error_text(refused)
-        assert "list_chats" in message, "where a meeting handle comes from"
-        assert "teams:///meetings/" in message
-        assert "fail identically" in message, "and it is not worth retrying"
-        assert not route.called, "nothing reached Graph"
-        assert obo.requested_scopes, "the handle is parsed inside the tool, after the exchange"
+        assert result.is_error
+        message = _error_text(result)
+        assert "expires" in message
+        assert "list_meeting_transcripts" in message
+        assert "browse_channel" not in message
+        assert "synthetic-request-id" in message
 
     @pytest.mark.parametrize(
         "uri",

--- a/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
+++ b/services/office-mcp/tests/tools/test_list_meeting_transcripts.py
@@ -523,7 +523,7 @@ class TestScopingToOneOccurrence:
         described = str(lister.MeetingTranscripts.model_fields["status"].description)
 
         assert "There is nothing to try" in described
-        assert "Stop and report" in described
+        assert "Never report this as 'there is no transcript'" in described
         assert "This status is final and cannot be retried" in described
         assert "Narrow `started_after`/`started_before` to the occurrence you mean" not in described
 
@@ -669,8 +669,8 @@ class TestScopingToOneOccurrence:
         described = str(lister.MeetingTranscripts.model_fields["transcripts"].description)
 
         assert str(meetings.MAX_ARTIFACT_SCAN) in described
-        assert "Ordered over every transcript read" in described
-        assert "not over one page of Microsoft's answer" in described
+        assert "Ordered over those read" in described
+        assert "not a Microsoft page" in described
         assert "The order is over the whole collection" not in described
 
     async def test_a_limit_above_the_ceiling_is_a_programming_error(

--- a/services/office-mcp/tests/tools/test_read_transcript.py
+++ b/services/office-mcp/tests/tools/test_read_transcript.py
@@ -1,0 +1,502 @@
+"""`read_transcript`: the words that come back, and what narrows them.
+
+Every payload is synthesised. A transcript is the most sensitive thing this connector touches, so
+nothing here came from a meeting: the speakers are historical figures, the words are invented, and
+the ids are obviously fake.
+"""
+
+import httpx
+import pytest
+import respx
+from msgraph.graph_service_client import GraphServiceClient
+
+from office_mcp.graph_client import GraphForbidden
+from office_mcp.shared import identity
+from office_mcp.shared.handles import TranscriptHandle
+from office_mcp.tools import read_transcript as reader
+
+from .conftest import ME
+
+MEETING_ID = "MSpiYTMyMWUwZC03OWVlLTQ3OGQtOGUyOC04NWExOTUwN2Y0NTYqMCoq"
+
+_TRANSCRIPT_ID = "MSMjMCMjSYNTHETIC0001"
+_CONTENT = f"/me/onlineMeetings/{MEETING_ID}/transcripts/{_TRANSCRIPT_ID}/content"
+
+_TENANT_SWITCH_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": "Graph API access to transcripts is disabled for this tenant.",
+        "innerError": {"code": "GraphAccessToTranscriptsDisabled"},
+    }
+}
+
+_ATTRIBUTION_OFF = {
+    "error": {
+        "code": "Forbidden",
+        "message": (
+            "Speaker-attributed transcript content is disabled for this tenant. Retry with Accept "
+            + "'application/vnd.microsoft.graph.transcript+text'."
+        ),
+        "innerError": {"code": "SpeakerAttributionNotAllowed"},
+    }
+}
+
+# A synthetic WebVTT transcript in the shape Graph's `/content` returns, exercising everything the
+# parser has to survive: the header, a NOTE block, cue identifier lines, a voice tag with a class,
+# a cue wrapped over two lines, escaped entities, inline markup, a cue nobody was attributed for,
+# and the negative offset Microsoft documents for transcription that started mid-conversation.
+# Nothing anybody said: the speakers are long dead and the words are invented.
+TRANSCRIPT_VTT = """WEBVTT
+
+NOTE this transcript is synthetic
+
+-00:00:02.500 --> 00:00:01.250
+<v Ada Lovelace>Sorry, joining late &amp; muted.</v>
+
+f1f0c0de-0001
+00:00:16.246 --> 00:00:19.900
+<v.loud Grace Hopper>We should <i>raise</i> the floor price
+by three per cent.</v>
+
+f1f0c0de-0002
+00:01:02.000 --> 00:01:04.500
+<v Ada Lovelace>Agreed &lt;that&gt; works.</v>
+
+f1f0c0de-0003
+01:00:00.000 --> 01:00:02.000
+Nobody was attributed for this one.
+
+f1f0c0de-0004
+01:00:03.000 --> 01:00:04.000
+<v Ada Lovelace></v>
+"""
+
+# The same transcript as the unattributed format returns it: cue timings, no voice tags at all.
+TRANSCRIPT_UNATTRIBUTED = """00:00:16.246 --> 00:00:19.900
+We should raise the floor price by three per cent.
+
+00:01:02.000 --> 00:01:04.500
+Agreed that works.
+"""
+
+
+def _transcript() -> TranscriptHandle:
+    """The handle `list_meeting_transcripts` would have minted for the transcript below."""
+    return TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID)
+
+
+def _spoken(graph: respx.MockRouter) -> respx.Route:
+    """The words, answered to every read: `/content` is one stream and each call fetches it all."""
+    return graph.get(_CONTENT).mock(
+        return_value=httpx.Response(200, content=TRANSCRIPT_VTT.encode())
+    )
+
+
+def _spoken_by_nobody(graph: respx.MockRouter) -> respx.Route:
+    """The same endpoint in a tenant with speaker attribution off, which is where it is decided.
+
+    The attributed format is refused and the plain one served, exactly as Graph does it — serving
+    unattributed bytes to the attributed request would say `speaker_attribution` is true, which is
+    the field a caller reads to find out why a speaker filter matched nothing.
+    """
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.headers["accept"] == "text/vtt":
+            return httpx.Response(403, json=_ATTRIBUTION_OFF)
+        return httpx.Response(200, content=TRANSCRIPT_UNATTRIBUTED.encode())
+
+    return graph.get(_CONTENT).mock(side_effect=respond)
+
+
+class TestReadingTheWords:
+    async def test_vtt_becomes_speaker_attributed_timestamped_turns(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The whole differentiator, and every parsing trap in one transcript: the `WEBVTT` header,
+        a `NOTE` block, cue identifier lines, a voice tag with a class, a cue wrapped over two
+        lines, HTML entities, inline markup, an unattributed cue, an empty one, and the negative
+        offset Microsoft documents for transcription that started mid-conversation."""
+        route = graph.get(_CONTENT).mock(
+            return_value=httpx.Response(
+                200, content=TRANSCRIPT_VTT.encode(), headers={"content-type": "text/vtt"}
+            )
+        )
+
+        read = await reader.read_transcript(
+            client,
+            handle=TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert read.speaker_attribution is True
+        assert [(turn.speaker, turn.text) for turn in read.turns] == [
+            ("Ada Lovelace", "Sorry, joining late & muted."),
+            ("Grace Hopper", "We should raise the floor price by three per cent."),
+            ("Ada Lovelace", "Agreed <that> works."),
+            (None, "Nobody was attributed for this one."),
+        ]
+        assert read.turns[0].start_seconds == -2.5, "transcription began mid-conversation"
+        assert (read.turns[1].start_seconds, read.turns[1].end_seconds) == (16.246, 19.9)
+        assert read.turns[3].start_seconds == 3600.0, "an hour in, from the HH:MM:SS form"
+        assert read.next_offset is None
+        assert route.calls.last.request.headers["accept"] == "text/vtt"
+
+    async def test_the_turns_page_without_refusing_a_long_meeting(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_CONTENT).mock(return_value=httpx.Response(200, content=TRANSCRIPT_VTT.encode()))
+        handle = TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID)
+
+        first = await reader.read_transcript(client, handle=handle, offset=0, limit=2)
+        second = await reader.read_transcript(
+            client, handle=handle, offset=first.next_offset or 0, limit=2
+        )
+
+        assert first.next_offset == 2, "the offset is the whole of 'there are more turns'"
+        assert [turn.speaker for turn in first.turns] == ["Ada Lovelace", "Grace Hopper"]
+        assert second.next_offset is None, "and null on the last page is the whole of saying so"
+        assert [turn.speaker for turn in second.turns] == ["Ada Lovelace", None]
+
+    async def test_a_tenant_that_forbids_speaker_names_degrades_instead_of_failing(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Graph's own documented remedy: ask again for the unattributed format, which succeeds.
+        `services/teams-mcp` hardcodes `Accept: text/vtt` and so loses the transcript entirely in
+        such a tenant."""
+        attempts: list[str] = []
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            accept = request.headers["accept"]
+            attempts.append(accept)
+            if accept == "text/vtt":
+                return httpx.Response(403, json=_ATTRIBUTION_OFF)
+            return httpx.Response(200, content=TRANSCRIPT_UNATTRIBUTED.encode())
+
+        graph.get(_CONTENT).mock(side_effect=respond)
+
+        read = await reader.read_transcript(
+            client,
+            handle=TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert attempts == ["text/vtt", "application/vnd.microsoft.graph.transcript+text"]
+        assert read.speaker_attribution is False
+        assert [turn.speaker for turn in read.turns] == [None, None]
+        assert read.turns[0].text == "We should raise the floor price by three per cent."
+        assert read.turns[0].start_seconds == 16.246, "the timings survive; only the names are gone"
+
+    async def test_the_tenant_switch_is_not_retried_in_another_format(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The other 403 on the same endpoint. Microsoft says there is no request-side workaround,
+        so a second request would be a wasted call and the advice for it names an administrator
+        rather than a format — which means the retry must be scoped to the inner code, not to 403.
+        """
+        route = graph.get(_CONTENT).mock(return_value=httpx.Response(403, json=_TENANT_SWITCH_OFF))
+
+        with pytest.raises(GraphForbidden) as raised:
+            _ = await reader.read_transcript(
+                client,
+                handle=TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+                offset=0,
+                limit=200,
+            )
+
+        assert raised.value.inner_code == "GraphAccessToTranscriptsDisabled"
+        assert route.call_count == 1
+
+    async def test_the_accept_header_is_not_added_to_every_other_graph_request(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The claim `_accepting` is written on, checked rather than believed. kiota's
+        `RequestConfiguration.headers` defaults to ONE `HeadersCollection` shared by every
+        configuration in the process — two configurations built here are the same object — so an
+        `Accept` added to the default is added to every Graph call this connector goes on to make,
+        and the generated builders' own `try_add("Accept", "application/json")` is then a no-op that
+        cannot take it back. `Accept: text/vtt` on a JSON call is not a header nobody reads: it is
+        every other tool answering with a deserialisation failure, from a request this one made.
+
+        The unrelated call is `shared/identity.py`'s `GET /me`, and what makes it a witness rather
+        than a passenger is that it passes a `RequestConfiguration` of its own — a call passing none
+        would send Graph's default `Accept` whether or not this one had polluted the shared object,
+        so it would keep passing while the leak came back.
+        """
+        _spoken(graph)
+        profile = graph.get("/me").mock(return_value=httpx.Response(200, json=ME))
+
+        _ = await reader.read_transcript(client, handle=_transcript(), offset=0, limit=200)
+        _ = await identity.signed_in_user(client)
+
+        assert "text/vtt" not in profile.calls.last.request.headers["accept"]
+
+    async def test_an_empty_transcript_is_no_turns_rather_than_a_blank_one(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        graph.get(_CONTENT).mock(return_value=httpx.Response(200, content=b"WEBVTT\n\n"))
+
+        read = await reader.read_transcript(
+            client,
+            handle=TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+            offset=0,
+            limit=200,
+        )
+
+        assert read.turns == []
+        assert read.next_offset is None
+
+    async def test_a_limit_above_the_ceiling_is_a_programming_error(
+        self, client: GraphServiceClient
+    ) -> None:
+        with pytest.raises(AssertionError):
+            _ = await reader.read_transcript(
+                client,
+                handle=TranscriptHandle(MEETING_ID, _TRANSCRIPT_ID),
+                offset=0,
+                limit=reader.MAX_TURNS + 1,
+            )
+
+
+class TestNarrowingWhatComesBack:
+    """The filters, over the one transcript that carries every shape the parser survives.
+
+    An hour of meeting is thousands of turns and a model reads it to answer one question, so the
+    narrowing has to happen here rather than in the model's context. What is asserted is the part a
+    caller cannot check for itself: which turns a bound admits, and that the page and its
+    `next_offset` are counted over what survived the filter rather than over the whole transcript.
+    """
+
+    async def test_a_lower_bound_keeps_everything_still_running_at_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Overlap and not containment: the turn that was mid-sentence when the clock struck is the
+        one a caller asking "from here" most wants, and dropping it would silently cut the sentence
+        their question is about."""
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=1.0
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "We should raise the floor price by three per cent.",
+            "Agreed <that> works.",
+            "Nobody was attributed for this one.",
+        ], "the first turn started at -2.5 and was still running at 1.0"
+        assert read.turns[0].start_seconds == -2.5
+
+    async def test_a_lower_bound_drops_what_had_finished_before_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=16.0
+        )
+
+        assert [turn.speaker for turn in read.turns] == ["Grace Hopper", "Ada Lovelace", None]
+        assert read.next_offset is None
+
+    async def test_an_upper_bound_keeps_the_turn_that_starts_exactly_on_it(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """Inclusive at both ends, for the same reason: a bound a caller read off a previous answer
+        names a turn that exists, and excluding it would make the two ends disagree."""
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, to_seconds=62.0
+        )
+
+        assert [turn.start_seconds for turn in read.turns] == [-2.5, 16.246, 62.0]
+
+    async def test_both_bounds_together_cut_a_window_out_of_the_middle(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=20.0, to_seconds=64.0
+        )
+
+        assert [turn.text for turn in read.turns] == ["Agreed <that> works."]
+
+    async def test_a_speaker_filter_keeps_only_that_speakers_turns(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker="Ada Lovelace"
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "Agreed <that> works.",
+        ]
+        assert read.speaker_attribution is True
+
+    @pytest.mark.parametrize(
+        "speaker",
+        ["ada", "ADA LOVELACE", "lovelace", "Lovelace"],
+        ids=["given", "shouted", "sur", "cased"],
+    )
+    async def test_a_speaker_is_matched_case_insensitively_and_by_part_of_the_name(
+        self, client: GraphServiceClient, graph: respx.MockRouter, speaker: str
+    ) -> None:
+        """A model writes the name it read in a previous answer, or the half of it the caller said.
+        An exact, case-sensitive match would answer "nobody said that" to a question about somebody
+        who spoke — a wrong answer with the shape of a right one."""
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker=speaker
+        )
+
+        assert [turn.speaker for turn in read.turns] == ["Ada Lovelace", "Ada Lovelace"]
+
+    async def test_a_speaker_and_a_window_narrow_together(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """All three at once, which is the question this exists for: what did she say in that
+        stretch. Each filter has to hold, not the last one written."""
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client,
+            handle=_transcript(),
+            offset=0,
+            limit=200,
+            from_seconds=10.0,
+            to_seconds=100.0,
+            speaker="ada",
+        )
+
+        assert [turn.text for turn in read.turns] == ["Agreed <that> works."]
+
+    async def test_a_page_is_cut_from_what_survived_the_filter(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """A `next_offset` counted over the whole transcript would offer more where the filter
+        already returned everything it matched, and a model would page for turns that cannot come.
+        """
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=2, speaker="ada"
+        )
+
+        assert [turn.text for turn in read.turns] == [
+            "Sorry, joining late & muted.",
+            "Agreed <that> works.",
+        ]
+        assert read.next_offset is None, "two matched, two returned; the other turns are not more"
+
+    async def test_the_next_offset_of_a_filtered_page_continues_the_filtered_sequence(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The offset a caller sends back has to index the same sequence it was cut from. Counted
+        over the unfiltered turns it would land in the middle of them: offset 2 of this transcript
+        is Ada's second turn, and offset 2 of what `from_seconds=2.0` matched is the unattributed
+        one."""
+        _spoken(graph)
+        handle = _transcript()
+
+        first = await reader.read_transcript(
+            client, handle=handle, offset=0, limit=2, from_seconds=2.0
+        )
+        second = await reader.read_transcript(
+            client, handle=handle, offset=first.next_offset or 0, limit=2, from_seconds=2.0
+        )
+
+        assert first.next_offset == 2
+        assert [turn.speaker for turn in first.turns] == ["Grace Hopper", "Ada Lovelace"]
+        assert [turn.text for turn in second.turns] == ["Nobody was attributed for this one."]
+        assert second.next_offset is None
+
+    async def test_a_window_nothing_falls_in_is_no_turns_rather_than_a_refusal(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=7200.0
+        )
+
+        assert read.turns == []
+        assert read.next_offset is None
+
+    async def test_a_speaker_filter_in_a_tenant_with_no_speakers_matches_nothing_and_says_why(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The one empty answer that must not read as "she never spoke". Where the tenant forbids
+        attribution every `speaker` is null, so the filter legitimately matches nothing — and
+        `speaker_attribution` false is the field that explains it. Refusing the call instead would
+        deny a filter the transcript itself supports for time."""
+        _spoken_by_nobody(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, speaker="ada"
+        )
+
+        assert read.turns == []
+        assert read.speaker_attribution is False, "the reason the page is empty"
+        assert read.next_offset is None
+
+    async def test_time_still_filters_where_the_speakers_are_gone(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        _spoken_by_nobody(graph)
+
+        read = await reader.read_transcript(
+            client, handle=_transcript(), offset=0, limit=200, from_seconds=30.0
+        )
+
+        assert [turn.start_seconds for turn in read.turns] == [62.0]
+
+    async def test_filters_left_unset_return_the_whole_transcript(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """The default is the answer this tool gave before the filters existed, and passing the
+        absent value explicitly is what a model does when it has nothing to narrow by."""
+        _spoken(graph)
+
+        read = await reader.read_transcript(
+            client,
+            handle=_transcript(),
+            offset=0,
+            limit=200,
+            from_seconds=None,
+            to_seconds=None,
+            speaker=None,
+        )
+
+        assert [turn.speaker for turn in read.turns] == [
+            "Ada Lovelace",
+            "Grace Hopper",
+            "Ada Lovelace",
+            None,
+        ]
+        assert read.next_offset is None
+
+    async def test_a_window_that_ends_before_it_starts_is_a_programming_error(
+        self, client: GraphServiceClient, graph: respx.MockRouter
+    ) -> None:
+        """No transcript can satisfy it, so it is a mistake in the caller rather than an empty
+        answer — and the tool layer refuses it before this is ever reached."""
+        content = _spoken(graph)
+
+        with pytest.raises(AssertionError):
+            _ = await reader.read_transcript(
+                client,
+                handle=_transcript(),
+                offset=0,
+                limit=200,
+                from_seconds=60.0,
+                to_seconds=30.0,
+            )
+
+        assert not content.called, "an impossible window costs no Graph request"


### PR DESCRIPTION
Add the `read_transcript` tool. This tool turns a transcript handle into speaker-attributed, timestamped turns.

The tool reads the handle and does not resolve the meeting. The handle carries both ids needed for one Graph request to `/transcripts/{id}/content`. Resolving the meeting again would be a second request and a second permission.

The tool asks for `text/vtt` format first. If the tenant forbids speaker names, Graph answers with inner code `SpeakerAttributionNotAllowed`. The tool retries, asking for `application/vnd.microsoft.graph.transcript+text`. The tenant-wide switch that blocks all transcripts has no request-side workaround, so the retry is keyed on the inner code only.

Filters narrow the answer. The endpoint is one stream with no range contract. Every page refetches the whole transcript. Filters are applied to parsed turns before paging. The `next_offset` counts matching turns, not all turns.

The tool refuses an inverted time window before any request. The tool refuses a blank speaker before any request. Both would return an empty page that looks like a silent meeting.

Updates `list_meeting_transcripts` documentation. Names the new tool where the lister could not before. Records the shared permission.

## Role in the stack

This PR adds the reader for transcript handles. It builds on `office-mcp/feat/transcripts`, which lists transcripts for a meeting.

`read_transcript` completes the meeting path. A model calls `list_chats` to find meetings, `list_meeting_transcripts` to find their transcripts, and `read_transcript` to get the words — speaker-attributed and timestamped.

This is the surface where a delegated connector beats a link. No further work is needed on this tool.

