### PR TITLE
feat(backstop-mcp): carry the resource id on every projected include

### DIFF
--- a/services/backstop-mcp/src/backstop_mcp/features/includes/resolve.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/includes/resolve.py
@@ -12,7 +12,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from types import UnionType
-from typing import get_args, get_origin, overload
+from typing import cast, get_args, get_origin, overload
 
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
@@ -166,8 +166,23 @@ def _side_loaded[AttrT](
     ]
 
 
+def _with_resource_id(raw: dict[str, object]) -> object:
+    """A resource's `attributes`, with its JSON:API `id` folded in.
+
+    `id` is a top-level member of a resource object, not one of its attributes, so a projection
+    that wants to name the record it came from has to be handed it. It wins over any `id` already
+    inside `attributes` — Backstop puts foreign keys there, not this resource's own identity —
+    and a model that declares no `id` field drops it again under `extra="ignore"`.
+    """
+    attributes = raw.get("attributes")
+    if not isinstance(attributes, dict):
+        return attributes
+    entries = cast("dict[object, object]", attributes)
+    return {**{str(key): value for key, value in entries.items()}, "id": raw.get("id")}
+
+
 def _project(*, raw: dict[str, object], planned: _PlannedInclude) -> BaseModel | None:
-    """One side-loaded resource's `attributes` as the field's model, or `None` if unusable."""
+    """One side-loaded resource as the field's model, or `None` if unusable."""
     if raw.get("type") != planned.include.resource_type:
         logger.warning(
             "includes.side_load.unexpected_type",
@@ -179,7 +194,7 @@ def _project(*, raw: dict[str, object], planned: _PlannedInclude) -> BaseModel |
         )
         return None
     try:
-        return planned.model.model_validate(raw.get("attributes"))
+        return planned.model.model_validate(_with_resource_id(raw))
     except ValidationError as exc:
         logger.warning(
             "includes.side_load.unreadable",

--- a/services/backstop-mcp/src/backstop_mcp/features/includes/responses.py
+++ b/services/backstop-mcp/src/backstop_mcp/features/includes/responses.py
@@ -3,6 +3,15 @@
 These are the entity documentation. Every model carries a docstring and every field a
 `description`, so FastMCP publishes them in the tools' output schema.
 
+Every model leads with `id`, the JSON:API resource id of the record it projects. That is a
+top-level member of a resource object rather than one of its attributes, which is why
+`resolve._project` folds it in explicitly. Without it a projection is a dead end:
+`ContactCardResponse` and `CompanyRefResponse` both tell the reader to call `get_person` /
+`get_organization` for the full record, and both of those refuse a `party_id` they did not hand
+out ("never invent or guess"), leaving only a name to search by and the ambiguity that comes with
+it. The ids are in the right space for that — `primary_contact` side-loads `people` and `company`
+side-loads `organizations`, which is what those two tools resolve against.
+
 `extra="ignore"` does the trimming: a `contact-locations` resource ships 17 attributes and
 `ContactLocationResponse` keeps 8; a person ships 31 and `ContactCardResponse` keeps 5. Where
 Backstop stores one fact twice — `city`/`cityResolvedName`, `state`/`stateResolvedName`,
@@ -55,6 +64,10 @@ class ContactLocationResponse(OmitNoneModel):
 
     model_config: ClassVar[ConfigDict] = _PROJECTION_CONFIG
 
+    id: _CleanStr = Field(
+        default=None,
+        description="Backstop `contact-locations` id for this address.",
+    )
     location_title: _CleanStr = Field(
         default=None,
         alias="locationTitle",
@@ -99,6 +112,10 @@ class ContactEmailResponse(OmitNoneModel):
 
     model_config: ClassVar[ConfigDict] = _PROJECTION_CONFIG
 
+    id: _CleanStr = Field(
+        default=None,
+        description="Backstop `contact-emails` id for this address book entry.",
+    )
     email: _CleanStr = Field(default=None, description="The email address.")
     # No default: an address whose status is unknown is worse than one that is missing. A
     # `contact-emails` resource without `retired` fails validation and is dropped by the
@@ -116,11 +133,19 @@ class ContactCardResponse(OmitNoneModel):
     """Who a person is, in the few fields needed to recognise and reach them.
 
     A summary attached to another record (an organization's primary contact), not the full
-    person — call `get_person` for that.
+    person — call `get_person` with this record's `id` for that.
     """
 
     model_config: ClassVar[ConfigDict] = _PROJECTION_CONFIG
 
+    id: _CleanStr = Field(
+        default=None,
+        description=(
+            "Backstop person id. Pass it as `party_id` to `get_person` for the full record — it "
+            + "is a `people` id, so leave `search_type` at its default. Use this rather than "
+            + "searching by name: the name alone can match more than one person."
+        ),
+    )
     name: _CleanStr = Field(
         default=None,
         description="Display name as Backstop stores it, usually 'Last, First'.",
@@ -147,11 +172,19 @@ class CompanyRefResponse(OmitNoneModel):
     """The organization a person works at, in the few fields needed to identify it.
 
     A summary attached to a person record, not the full organization — call `get_organization`
-    for that.
+    with this record's `id` for that.
     """
 
     model_config: ClassVar[ConfigDict] = _PROJECTION_CONFIG
 
+    id: _CleanStr = Field(
+        default=None,
+        description=(
+            "Backstop organization id. Pass it as `party_id` to `get_organization` for the full "
+            + "record. Use this rather than searching by name: the name alone can match more "
+            + "than one organization."
+        ),
+    )
     name: _CleanStr = Field(default=None, description="Organization name as commonly used.")
     legal_name: _CleanStr = Field(
         default=None,
@@ -175,6 +208,10 @@ class InternalOwnerResponse(OmitNoneModel):
 
     model_config: ClassVar[ConfigDict] = _PROJECTION_CONFIG
 
+    id: _CleanStr = Field(
+        default=None,
+        description="Backstop `system-users` id for this colleague at our own firm.",
+    )
     name: _CleanStr = Field(default=None, description="Full name of our account owner.")
     user_name: _CleanStr = Field(
         default=None, alias="userName", description="Their Backstop login name."

--- a/services/backstop-mcp/tests/features/includes/test_resolve.py
+++ b/services/backstop-mcp/tests/features/includes/test_resolve.py
@@ -149,6 +149,7 @@ class TestProjectToMany:
         locations = included.locations
         assert locations is not None
         assert locations[0].model_dump() == {
+            "id": "loc-1",
             "location_title": "Business",
             "address": "18867 North Thompson Peak Parkway, Suite 250",
             "city": "Scottsdale",
@@ -247,6 +248,7 @@ class TestProjectToOne:
         card = included.primary_contact
         assert card is not None
         assert card.model_dump() == {
+            "id": "p1",
             "name": "Voss, Kent",
             "job_title": "Managing Director, Research",
             "email": "vossk@kochinvests.com",
@@ -279,6 +281,7 @@ class TestProjectToOne:
         owner = included.representative
         assert owner is not None
         assert owner.model_dump() == {
+            "id": "u1",
             "name": "Margaret Lucas",
             "user_name": "mlucas",
             "email": "margaret.lucas@capstoneco.com",
@@ -293,6 +296,86 @@ class TestProjectToOne:
         )
 
         assert included.company is None
+
+
+class TestAProjectionCarriesTheRecordsOwnId:
+    """Without it a projection is a dead end: the tools it points at refuse a guessed id."""
+
+    def test_the_primary_contact_carries_the_people_id_get_person_takes(self) -> None:
+        document = _organization(
+            relationships={"primaryContact": {"data": {"type": "people", "id": "341688185"}}},
+            included=[{"type": "people", "id": "341688185", "attributes": {"name": "Voss, Kent"}}],
+        )
+
+        included = include_plan(
+            OrganizationIncludesResponse, requested=["primary_contact"]
+        ).project(document=document)
+
+        card = included.primary_contact
+        assert card is not None
+        assert card.id == "341688185"
+
+    def test_the_company_carries_the_organizations_id_get_organization_takes(self) -> None:
+        document = _organization(
+            relationships={"company": {"data": {"type": "organizations", "id": "341208613"}}},
+            included=[
+                {
+                    "type": "organizations",
+                    "id": "341208613",
+                    "attributes": {"name": "Koch Investments Group"},
+                }
+            ],
+        )
+
+        included = include_plan(PersonIncludesResponse, requested=["company"]).project(
+            document=document
+        )
+
+        company = included.company
+        assert company is not None
+        assert company.id == "341208613"
+
+    def test_the_resource_id_wins_over_an_id_inside_attributes(self) -> None:
+        """Backstop puts foreign keys in `attributes`; the resource's own identity is above it."""
+        document = _organization(
+            relationships={"primaryContact": {"data": {"type": "people", "id": "p1"}}},
+            included=[
+                {
+                    "type": "people",
+                    "id": "p1",
+                    "attributes": {"id": "some-foreign-key", "name": "Voss, Kent"},
+                }
+            ],
+        )
+
+        included = include_plan(
+            OrganizationIncludesResponse, requested=["primary_contact"]
+        ).project(document=document)
+
+        card = included.primary_contact
+        assert card is not None
+        assert card.id == "p1"
+
+    def test_each_side_loaded_row_keeps_its_own_id(self) -> None:
+        document = _organization(
+            relationships={
+                "contactLocations": {
+                    "data": [
+                        {"type": "contact-locations", "id": "loc-1"},
+                        {"type": "contact-locations", "id": "loc-2"},
+                    ]
+                }
+            },
+            included=[_location("loc-1", "Business"), _location("loc-2", "Home")],
+        )
+
+        included = include_plan(OrganizationIncludesResponse, requested=["locations"]).project(
+            document=document
+        )
+
+        locations = included.locations
+        assert locations is not None
+        assert [location.id for location in locations] == ["loc-1", "loc-2"]
 
 
 class TestAMalformedSideLoadIsDroppedNotFatal:
@@ -441,7 +524,7 @@ class TestAPlanAnswersInTheModelItWasBuiltFrom:
         ).project(document=document)
 
         assert isinstance(included, OrganizationIncludesResponse)
-        assert included.primary_contact == ContactCardResponse(name="Voss, Kent")
+        assert included.primary_contact == ContactCardResponse(id="p1", name="Voss, Kent")
 
     def test_a_plan_built_from_the_person_model_answers_in_it(self) -> None:
         document = _organization(

--- a/services/backstop-mcp/tests/features/includes/test_responses.py
+++ b/services/backstop-mcp/tests/features/includes/test_responses.py
@@ -279,6 +279,28 @@ class TestInternalOwner:
         assert "not the investor" in docstring
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        ContactLocationResponse,
+        ContactCardResponse,
+        CompanyRefResponse,
+        InternalOwnerResponse,
+    ],
+)
+def test_the_id_is_optional_so_a_bare_attributes_payload_still_validates(
+    model: type[BaseModel],
+) -> None:
+    """`id` is a resource member, not an attribute — a payload without one is still readable.
+
+    Through `project` a record always has one, because `follow_included` found it by that id.
+    `ContactEmailResponse` is excluded: it requires `retired` for its own reasons.
+    """
+    projected = model.model_validate({})
+
+    assert projected.model_dump() == {}
+
+
 class TestTheIncludesModelsAreTheAllowlist:
     """One field per exposed include, and the field's metadata is the whole Backstop side."""
 

--- a/services/backstop-mcp/tests/server/tools/test_get_organization.py
+++ b/services/backstop-mcp/tests/server/tools/test_get_organization.py
@@ -382,6 +382,7 @@ class TestGetOrganizationIncludes:
             ("Home", False),
         ]
         assert locations[0].model_dump() == {
+            "id": "loc-1",
             "location_title": "Business",
             "address": "18867 North Thompson Peak Parkway, Suite 250",
             "city": "Scottsdale",
@@ -467,6 +468,7 @@ class TestGetOrganizationIncludes:
         card = included.primary_contact
         assert card is not None
         assert card.model_dump() == {
+            "id": "p1",
             "name": "Voss, Kent",
             "job_title": "Managing Director, Research",
             "email": "vossk@kochinvests.com",
@@ -523,6 +525,7 @@ class TestGetOrganizationIncludes:
         owner = included.representative
         assert isinstance(owner, InternalOwnerResponse)
         assert owner.model_dump() == {
+            "id": "u1",
             "name": "Margaret Lucas",
             "user_name": "mlucas",
             "email": "margaret.lucas@capstoneco.com",


### PR DESCRIPTION
## Problem

`features/includes/` projects a side-loaded resource to its **attributes only** — `_project` returned `planned.model.model_validate(raw.get("attributes"))`, so the JSON:API resource `id` it arrived under was dropped.

That makes two of the five projections dead ends. Their own docstrings point at another tool:

- `ContactCardResponse` — *"not the full person — call `get_person` for that"*
- `CompanyRefResponse` — *"not the full organization — call `get_organization` for that"*

Both of those tools take `party_id` and say **"Never invent or guess a party_id."** With no id on the projection, the only path left is `search=` by name — the ambiguity that `party_resolver` exists to avoid.

More generally: a record you cannot refer to afterwards is a record you can only read.

## Change

`_project` folds the resource `id` into the payload before validating, and all five projection models declare it.

The id is a top-level member of a resource object, not an attribute, which is why it has to be merged explicitly. It wins over any `id` inside `attributes` — Backstop puts foreign keys there, not the resource's own identity.

The ids are in the right space for the tools they point at, which matters because `get_person` warns that "a contact or employee id is not a people id":

| include | JSON:API type | consumer |
|---|---|---|
| `primary_contact` | `people` | `get_person(party_id=…)`, default `search_type` |
| `company` | `organizations` | `get_organization(party_id=…)`, pins `search_type="organizations"` |

The other three (`contact-locations`, `contact-emails`, `system-users`) have no tool taking them today. They carry the id for the same reason, and because a uniform rule is easier to keep than an exception list.

## Notes

- `id` is optional on the models, so a bare attributes payload still validates. Through `project` a record always has one — `follow_included` found it *by* that id.
- `OmitNoneModel` means a missing id is an omitted key, never `null`.
- Output-schema change for `get_person` and `get_organization`: `included.*` entries gain an `id`. Additive.

## Testing

`897 passed`, ruff clean, basedpyright 0 errors.

New coverage for the ids being carried, each row keeping its own, and the resource id winning over an `attributes.id`. Four existing exact-shape assertions updated to expect the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)